### PR TITLE
check for window object

### DIFF
--- a/lib/utils/respondable.js
+++ b/lib/utils/respondable.js
@@ -88,6 +88,8 @@
 		};
 	}
 
+if (typeof window !== 'undefined') {
+
 	window.addEventListener('message', function (e) {
 
 		if (typeof e.data !== 'string') {
@@ -111,7 +113,8 @@
 
 		publish(e, data);
 	}, false);
-
+	
+}
 	exports.respondable = respondable;
 
 }(utils));


### PR DESCRIPTION
It checks the window object to avoid an undefined error when you use from a Node application.