### PR TITLE
prevent the double escaping

### DIFF
--- a/doc/handlebars_reason.md
+++ b/doc/handlebars_reason.md
@@ -41,7 +41,7 @@ function messageFromRelatedNodes(relatedNodes) {
 		var list = relatedNodes.map(function (node) {
 			return {
 				targetArrayString: JSON.stringify(node.target),
-				targetString: node.target.join(' ').replace(/</gi, '&lt;').replace(/>/gi, '&gt;')
+				targetString: node.target.join(' ')
 			};
 		});
 		retVal += compiledRelatedListTemplate({relatedNodeList: list});
@@ -111,7 +111,7 @@ reasonHtml = summary(node);
 <tr>
 	<th scope="row" class="help">
 		<a href="javascript:;" class="rule" data-index="{{index}}">
-			{{help}}
+			{{{help}}}
 		</a>
 	</th>
 	<td scope="row">


### PR DESCRIPTION
The HTML angle brackets were being double escaped. Mad changes to prevent this