### PR TITLE
ignore color contrast requirements for disabled elements

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -9,7 +9,7 @@ if (fgColor === null || bgColor === null) {
 
 var nodeStyle = window.getComputedStyle(node);
 
-if(node.getAttribute('disabled') === 'disabled' || node.getAttribute('aria-disabled') === 'true') {
+if(node.hasAttribute('disabled') || node.getAttribute('aria-disabled') === 'true') {
     return true;
 }
 

--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -9,7 +9,7 @@ if (fgColor === null || bgColor === null) {
 
 var nodeStyle = window.getComputedStyle(node);
 
-if(nodeStyle.getPropertyValue('disabled') === 'disabled' || nodeStyle.getPropertyValue('aria-disabled') === 'true') {
+if(node.getAttribute('disabled') === 'disabled' || node.getAttribute('aria-disabled') === 'true') {
     return true;
 }
 

--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -9,7 +9,7 @@ if (fgColor === null || bgColor === null) {
 
 var nodeStyle = window.getComputedStyle(node);
 
-if(nodeStyle.getPropertyValue('disabled') == 'disabled' || nodeStyle.getPropertyValue('aria-disabled') == 'true') {
+if(nodeStyle.getPropertyValue('disabled') === 'disabled' || nodeStyle.getPropertyValue('aria-disabled') === 'true') {
     return true;
 }
 

--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -8,6 +8,11 @@ if (fgColor === null || bgColor === null) {
 }
 
 var nodeStyle = window.getComputedStyle(node);
+
+if(nodeStyle.getPropertyValue('disabled') == 'disabled' || nodeStyle.getPropertyValue('aria-disabled') == 'true') {
+    return true;
+}
+
 var fontSize = parseFloat(nodeStyle.getPropertyValue('font-size'));
 var fontWeight = nodeStyle.getPropertyValue('font-weight');
 var bold = (['bold', 'bolder', '600', '700', '800', '900'].indexOf(fontWeight) !== -1);

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -103,6 +103,20 @@ describe('color-contrast', function () {
 		assert.deepEqual(checkContext._relatedNodes, [target]);
 	});
 
+	it('should return true when there is not sufficient contrast, but the element has been disabled with the disabled attribute', function() {
+		fixture.innerHTML = '<a style="color: yellow; background-color: white;" id="target" disabled>My text</a>';
+		var target = fixture.querySelector('#target');
+		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.deepEqual(checkContext._relatedNodes, []);
+	});
+
+	it('should return true when there is not sufficient contrast, but the element has been disabled with the aria-disabled attribute', function() {
+		fixture.innerHTML = '<a style="color: yellow; background-color: white;" id="target" aria-disabled="true">My text</a>';
+		var target = fixture.querySelector('#target');
+		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.deepEqual(checkContext._relatedNodes, []);
+	});
+
 	describe('matches', function () {
 
 		it('should not match when there is no text', function () {


### PR DESCRIPTION
as per this page: http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html

"Text or images of text that are part of an inactive user interface component, that are pure decoration, that are not visible to anyone, or that are part of a picture that contains significant other visual content, have no contrast requirement."

and, semi-relatedly, this: http://www.w3.org/WAI/PF/aria/states_and_properties#aria-disabled

"In addition to setting the aria-disabled attribute, authors SHOULD change the appearance (grayed out, etc.) to indicate that the item has been disabled."