### PR TITLE
Fix viewport scroll bug

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -1,6 +1,7 @@
+var useScroll = !(options || {}).noScroll;
 var bgNodes = [],
-	bgColor = commons.color.getBackgroundColor(node, bgNodes),
-	fgColor = commons.color.getForegroundColor(node);
+	bgColor = commons.color.getBackgroundColor(node, bgNodes, useScroll),
+	fgColor = commons.color.getForegroundColor(node, useScroll);
 
 //We don't know, so we'll pass it provisionally
 if (fgColor === null || bgColor === null) {

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -1,5 +1,5 @@
 /*global dom, color */
-/* jshint maxstatements: 31, maxcomplexity: 14 */
+/* jshint maxstatements: 32, maxcomplexity: 15 */
 //TODO dsturley: too complex, needs refactor!!
 
 /**
@@ -108,10 +108,11 @@ var getVisualParents = function(node, rect) {
  * there is no opaque ancestor element visually containing it, or because background images are used.
  * @param {Element} node
  * @param {Array} bgNodes array to which all encountered nodes should be appended
+ * @param {Boolean} useScroll
  * @return {Color}
  */
 //TODO dsturley; why is this passing `bgNodes`?
-color.getBackgroundColor = function(node, bgNodes) {
+color.getBackgroundColor = function(node, bgNodes, useScroll) {
 	var parent, parentColor;
 
 	var bgColor = getBackgroundForSingleNode(node);
@@ -122,7 +123,10 @@ color.getBackgroundColor = function(node, bgNodes) {
 		return bgColor;
 	}
 
-	node.scrollIntoView();
+	if(useScroll) {
+		node.scrollIntoView();
+	}
+
 	var rect = node.getBoundingClientRect(),
 		currentNode = node,
 		colorStack = [{
@@ -172,5 +176,6 @@ color.getBackgroundColor = function(node, bgNodes) {
 	while ((currColorNode = colorStack.pop()) !== undefined) {
 		flattenedColor = color.flattenColors(currColorNode.color, flattenedColor);
 	}
+
 	return flattenedColor;
 };

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -4,9 +4,10 @@
  * Returns the flattened foreground color of an element, or null if it can't be determined because
  * of transparency
  * @param {Element} node
+ * @param {Boolean} useScroll
  * @return {Color}
  */
-color.getForegroundColor = function (node) {
+color.getForegroundColor = function (node, useScroll) {
 	var nodeStyle = window.getComputedStyle(node);
 
 	var fgColor = new color.Color();
@@ -15,7 +16,7 @@ color.getForegroundColor = function (node) {
 	fgColor.alpha = fgColor.alpha * opacity;
 	if (fgColor.alpha === 1) { return fgColor; }
 
-	var bgColor = color.getBackgroundColor(node);
+	var bgColor = color.getBackgroundColor(node, [], useScroll);
 	if (bgColor === null) { return null; }
 
 	return color.flattenColors(fgColor, bgColor);

--- a/lib/rules/color-contrast.json
+++ b/lib/rules/color-contrast.json
@@ -1,5 +1,8 @@
 {
   "id": "color-contrast",
+  "options": {
+    "noScroll": false
+  },
   "selector": "*",
   "tags": [
     "wcag2aa",

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -245,7 +245,7 @@ describe('color.getBackgroundColor', function () {
 		var shifted = fixture.querySelector('#shifted');
 		var parent = fixture.querySelector('#parent');
 		var bgNodes = [];
-		var actual = commons.color.getBackgroundColor(target, bgNodes);
+		var actual = commons.color.getBackgroundColor(target, bgNodes, true);
 		var expected = new commons.color.Color(0, 0, 0, 1);
 		if (commons.dom.supportsElementsFromPoint(document)) {
 			assert.deepEqual(bgNodes, [shifted]);
@@ -259,6 +259,31 @@ describe('color.getBackgroundColor', function () {
 		assert.closeTo(actual.alpha, expected.alpha, 0.1);
 	});
 
+	it('does not change the scroll when scroll is disabled', function() {
+		fixture.innerHTML = '<div id="parent" style="height: 40px; width: 30px; ' +
+		'background-color: white; position: relative; z-index: 5">' +
+		'<div id="target" style="position: relative; top: 1px; height: 20px; ' +
+		'width: 25px; z-index: 25;">' + '</div>';
+		var targetEl = fixture.querySelector('#target');
+		var bgNodes = [];
+		window.scroll(0, 0);
 
+		commons.color.getBackgroundColor(targetEl, bgNodes, false);
 
+		assert.equal(window.pageYOffset, 0);
+	});
+
+	it('scrolls into view when scroll is enabled', function() {
+		fixture.innerHTML = '<div id="parent" style="height: 5000px; width: 30px; ' +
+		'background-color: white; position: relative; z-index: 5">' +
+		'<div id="target" style="position: absolute; bottom: 0; height: 20px; ' +
+		'width: 25px; z-index: 25;">' + '</div>';
+		var targetEl = fixture.querySelector('#target');
+		var bgNodes = [];
+		window.scroll(0, 0);
+
+		commons.color.getBackgroundColor(targetEl, bgNodes, true);
+
+		assert.notEqual(window.pageYOffset, 0);
+	});
 });

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -14,7 +14,7 @@ describe('color.getForegroundColor', function () {
 			'This is my text' +
 			'</div></div>';
 		var target = fixture.querySelector('#target');
-		var actual = commons.color.getForegroundColor(target);
+		var actual = commons.color.getForegroundColor(target, true);
 		var expected = new commons.color.Color(32, 32, 64, 1);
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
@@ -29,7 +29,7 @@ describe('color.getForegroundColor', function () {
 			'This is my text' +
 			'</div></div>';
 		var target = fixture.querySelector('#target');
-		var actual = commons.color.getForegroundColor(target);
+		var actual = commons.color.getForegroundColor(target, true);
 		var expected = new commons.color.Color(32, 32, 64, 1);
 		assert.equal(actual.red, expected.red);
 		assert.equal(actual.green, expected.green);
@@ -43,7 +43,7 @@ describe('color.getForegroundColor', function () {
 			'<div id="target" style="height: 20px; width: 15px; color: blue; background-color: green; opacity: 0.5;">' +
 			'</div></div>';
 		var target = fixture.querySelector('#target');
-		var actual = commons.color.getForegroundColor(target);
+		var actual = commons.color.getForegroundColor(target, true);
 		assert.isNull(actual);
 	});
 
@@ -52,7 +52,7 @@ describe('color.getForegroundColor', function () {
 			'<div id="target" style="height: 20px; width: 15px; color: #000080; background-color: green;">' +
 			'</div></div>';
 		var target = fixture.querySelector('#target');
-		var actual = commons.color.getForegroundColor(target);
+		var actual = commons.color.getForegroundColor(target, true);
 		var expected = new commons.color.Color(0, 0, 128, 1);
 		assert.equal(actual.red, expected.red);
 		assert.equal(actual.green, expected.green);


### PR DESCRIPTION
- Running the audit before would scroll the viewport to the bottom of the page.

[Closes #147]