### PR TITLE
corrects minor typo in docs

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -294,7 +294,7 @@ The options parameter is flexible way to configure how `a11yCheck` operates. The
 	}
 	```
 
-	This example will disable the rules with the id of `ruleId1` and `ruleId2`. All other rules will run. The list of valid rule IDs is specified in the section below.
+	This example will disable the rules with the ids of `color-contrast` and `valid-lang`. All other rules will run. The list of valid rule ids is specified in the section below.
 
 ##### C. Callback Parameter
 


### PR DESCRIPTION
This corrects a small point of confusion in the documentation in which an example uses specific rule ids, but the text describing the example uses generic variable names.