### PR TITLE
Renaming await to awat to avoid collision with await reserved keyword…

### DIFF
--- a/lib/core/utils/queue.js
+++ b/lib/core/utils/queue.js
@@ -10,7 +10,7 @@
 		var tasks = [],
 			started = 0,
 			remaining = 0, // number of tasks not yet finished
-			await = noop;
+			awt = noop;
 
 		function pop() {
 			var length = tasks.length;
@@ -33,7 +33,7 @@
 		}
 
 		function notify() {
-			await(tasks);
+			awt(tasks);
 		}
 
 		return {
@@ -54,7 +54,7 @@
 			 * values of each of the "deferred" functions
 			 */
 			then: function (f) {
-				await = f;
+				awt = f;
 				if (!remaining) {
 					notify();
 				}
@@ -64,7 +64,7 @@
 			 * @param  {Function} fn The callback to execute; receives an array of the results which have completed
 			 */
 			abort: function (fn) {
-				await = noop;
+				awt = noop;
 				fn(tasks);
 			}
 		};


### PR DESCRIPTION
… (ES2016)