### PR TITLE
Allow `include` to be specified, but empty

### DIFF
--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -84,7 +84,7 @@ function normalizeContext(context) {
 
 		if (context.hasOwnProperty('include') || context.hasOwnProperty('exclude')) {
 			return {
-				include: context.include || [document],
+				include: (context.include && +context.include.length) ? context.include : [document],
 				exclude: context.exclude || []
 			};
 		}

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -316,6 +316,12 @@ describe('Context', function() {
 
 		});
 
+		it('should default empty-object include to document', function () {
+			var result = new Context({ include: {}, exclude: {} });
+			assert.lengthOf(result.include, 1);
+			assert.equal(result.include[0], document);
+		});
+
 	});
 
 	describe('initiator', function() {
@@ -342,7 +348,7 @@ describe('Context', function() {
 			var spec = document.implementation.createHTMLDocument('ie is dumb');
 			spec.hasOwnProperty = undefined;
 			var result = new Context(spec);
-			
+
 			assert.lengthOf(result.include, 1);
 			assert.equal(result.include[0], spec);
 

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -316,8 +316,8 @@ describe('Context', function() {
 
 		});
 
-		it('should default empty-object include to document', function () {
-			var result = new Context({ include: {}, exclude: {} });
+		it('should default empty include to document', function () {
+			var result = new Context({ include: [], exclude: [] });
 			assert.lengthOf(result.include, 1);
 			assert.equal(result.include[0], document);
 		});


### PR DESCRIPTION
Right now, if context is given as `{include: [], exclude[]}`, the `include` piece does not get properly defaulted to `[document]`.

The following are already accepted and work as expected:
- `{include: null}`
- `{include: undefined}`
- `{include: ""}`
- `{exclude: []}`

I don't think there is an appreciable difference for the `include` key between `null`, `undefined`, `""` and `[]`, so I think the following should be supported as well:

`{include: []}`

(To be fair, right now any falsey value for `include` would default to `[document]`, but I'm not suggesting that `0` or `false` should be supported, even though they current work.)

(code hand-edited directly on github, so it probably doesn't conform to style-guidelines)
