### PR TITLE
Reorder Results/Parameters section in API doc

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -136,9 +136,9 @@ axe.a11yCheck(context, options, callback);
 
 #### Parameters
 
-* `context`: Defines the scope of the analysis - the part of the DOM that you would like to analyze. This will typically be the `document` or a specific selector such as class name, ID, selector, etc.
-* `options`: (optional) Set of options passed into rules or checks. [See below for more information](#a11ycheck-parameters)
-* `callback`: The callback function which receives on the [results object](#results-object) as a parameter when analysis is complete
+* [`context`](#context-parameter): Defines the scope of the analysis - the part of the DOM that you would like to analyze. This will typically be the `document` or a specific selector such as class name, ID, selector, etc.
+* [`options`](#options-parameter): (optional) Set of options passed into rules or checks.
+* [`callback`](#callback-parameter): The callback function which receives on the [results object](#results-object) as a parameter when analysis is complete
 
 ##### Context Parameter
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -140,43 +140,6 @@ axe.a11yCheck(context, options, callback);
 * `options`: (optional) Set of options passed into rules or checks. [See below for more information](#a11ycheck-parameters)
 * `callback`: The callback function which receives on the [results object](#results-object) as a parameter when analysis is complete
 
-#### Results Object
-
-The callback function passed in as the third parameter of `axe.allyCheck` runs on the results object. This object has two components – a passes array and a violations array.  The passes array keeps track of all the passed tests, along with detailed information on each one. This leads to more efficient testing, especially when used in conjunction with manual testing, as the user can easily find out what tests have already been passed. Similarly, the violations array keeps track of all the failed tests, along with detailed information on each one.
-
-###### `url`
-
-The URL of the page that was tested.
-
-###### `timestamp`
-
-The date and time that analysis was completed.
-
-###### `passes` and `violations` array
-
-* `description` - Text string that describes what the rule does
-* `help` - Help text that describes the test that was performed
-* `helpUrl` - URL that provides more information about the specifics of the violation. Links to a page on the Deque University site.
-* `id` - Unique identifier for the rule; [see the list of rules](rule-descriptions.md)
-* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the Rule failed or `null` if the check passed
-* `tags` - Array of tags that this rule is assigned. These tags can be used in the option structure to select which rules are run ([see `axe.allyCheck` parameters below for more information](#a11ycheck-parameters)).
-* `nodes` - Array of all elements the Rule tested
-	* `html` - Snippet of HTML of the Element
-	* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the test failed or `null` if the check passed
-	* `target` - Array of selectors that has each element correspond to one level of iframe or frame. If there is one iframe or frame, there should be two entries in `target`. If there are three iframe levels, there should be four entries in `target`.
-	* `any` - Array of checks that were made where at least one must have passed. Each entry in the array contains:
-		* `id` - Unique identifier for this check. Check ids may be the same as Rule ids
-		* `impact` - How serious this particular check is. Can be one of "minor", "moderate", "serious", or "critical". Each check that is part of a rule can have different impacts. The highest impact of all the checks that fail is reported for the rule
-		* `message` - Description of why this check passed or failed
-		* `data` - Additional information that is specific to the type of Check which is optional. For example, a color contrast check would include the foreground color, background color, contrast ratio, etc.
-		* `relatedNodes` - Optional array of information about other nodes that are related to this check. For example, a duplicate id check violation would list the other selectors that had this same duplicate id. Each entry in the array contains the following information:
-			* `target` - Array of selectors for the related node
-			* `html` - HTML source of the related node
-	* `all` - Array of checks that were made where all must have passed. Each entry in the array contains the same information as the 'any' array
-	* `none` - Array of checks that were made where all must have not passed. Each entry in the array contains the same information as the 'any' array
-
-#### a11yCheck Parameters
-
 ##### A. Context Parameter
 
 The context object can be passed one of the following:
@@ -223,6 +186,43 @@ In most cases, the component arrays will contain only one CSS selector. Multiple
 	  exclude: [['.exclude1'], ['.exclude2']]
 	}
 	```
+
+#### Results Object
+
+The callback function passed in as the third parameter of `axe.allyCheck` runs on the results object. This object has two components – a passes array and a violations array.  The passes array keeps track of all the passed tests, along with detailed information on each one. This leads to more efficient testing, especially when used in conjunction with manual testing, as the user can easily find out what tests have already been passed. Similarly, the violations array keeps track of all the failed tests, along with detailed information on each one.
+
+###### `url`
+
+The URL of the page that was tested.
+
+###### `timestamp`
+
+The date and time that analysis was completed.
+
+###### `passes` and `violations` array
+
+* `description` - Text string that describes what the rule does
+* `help` - Help text that describes the test that was performed
+* `helpUrl` - URL that provides more information about the specifics of the violation. Links to a page on the Deque University site.
+* `id` - Unique identifier for the rule; [see the list of rules](rule-descriptions.md)
+* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the Rule failed or `null` if the check passed
+* `tags` - Array of tags that this rule is assigned. These tags can be used in the option structure to select which rules are run ([see `axe.allyCheck` parameters below for more information](#a11ycheck-parameters)).
+* `nodes` - Array of all elements the Rule tested
+	* `html` - Snippet of HTML of the Element
+	* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the test failed or `null` if the check passed
+	* `target` - Array of selectors that has each element correspond to one level of iframe or frame. If there is one iframe or frame, there should be two entries in `target`. If there are three iframe levels, there should be four entries in `target`.
+	* `any` - Array of checks that were made where at least one must have passed. Each entry in the array contains:
+		* `id` - Unique identifier for this check. Check ids may be the same as Rule ids
+		* `impact` - How serious this particular check is. Can be one of "minor", "moderate", "serious", or "critical". Each check that is part of a rule can have different impacts. The highest impact of all the checks that fail is reported for the rule
+		* `message` - Description of why this check passed or failed
+		* `data` - Additional information that is specific to the type of Check which is optional. For example, a color contrast check would include the foreground color, background color, contrast ratio, etc.
+		* `relatedNodes` - Optional array of information about other nodes that are related to this check. For example, a duplicate id check violation would list the other selectors that had this same duplicate id. Each entry in the array contains the following information:
+			* `target` - Array of selectors for the related node
+			* `html` - HTML source of the related node
+	* `all` - Array of checks that were made where all must have passed. Each entry in the array contains the same information as the 'any' array
+	* `none` - Array of checks that were made where all must have not passed. Each entry in the array contains the same information as the 'any' array
+
+#### a11yCheck Parameters
 
 ##### B. Options Parameter
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -10,6 +10,10 @@
 	1. [API Name: axe.getRules](#api-name-axegetrules)
 	1. [API Name: axe.configure](#api-name-axeconfigure)
 	1. [API Name: axe.a11yCheck](#api-name-axea11ycheck)
+		1. [Parameters](#parameters-2)
+			1. [Context Parameter](#context-parameter)
+			2. [Options Parameter](#options-parameter)
+			3. [Callback Parameter](#callback-parameter)
 		1. [Results Object](#results-object)
 1. [Section 3: Example Reference](#section-3-example-reference)
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -140,7 +140,7 @@ axe.a11yCheck(context, options, callback);
 * `options`: (optional) Set of options passed into rules or checks. [See below for more information](#a11ycheck-parameters)
 * `callback`: The callback function which receives on the [results object](#results-object) as a parameter when analysis is complete
 
-##### A. Context Parameter
+##### Context Parameter
 
 The context object can be passed one of the following:
 
@@ -187,44 +187,7 @@ In most cases, the component arrays will contain only one CSS selector. Multiple
 	}
 	```
 
-#### Results Object
-
-The callback function passed in as the third parameter of `axe.allyCheck` runs on the results object. This object has two components – a passes array and a violations array.  The passes array keeps track of all the passed tests, along with detailed information on each one. This leads to more efficient testing, especially when used in conjunction with manual testing, as the user can easily find out what tests have already been passed. Similarly, the violations array keeps track of all the failed tests, along with detailed information on each one.
-
-###### `url`
-
-The URL of the page that was tested.
-
-###### `timestamp`
-
-The date and time that analysis was completed.
-
-###### `passes` and `violations` array
-
-* `description` - Text string that describes what the rule does
-* `help` - Help text that describes the test that was performed
-* `helpUrl` - URL that provides more information about the specifics of the violation. Links to a page on the Deque University site.
-* `id` - Unique identifier for the rule; [see the list of rules](rule-descriptions.md)
-* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the Rule failed or `null` if the check passed
-* `tags` - Array of tags that this rule is assigned. These tags can be used in the option structure to select which rules are run ([see `axe.allyCheck` parameters below for more information](#a11ycheck-parameters)).
-* `nodes` - Array of all elements the Rule tested
-	* `html` - Snippet of HTML of the Element
-	* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the test failed or `null` if the check passed
-	* `target` - Array of selectors that has each element correspond to one level of iframe or frame. If there is one iframe or frame, there should be two entries in `target`. If there are three iframe levels, there should be four entries in `target`.
-	* `any` - Array of checks that were made where at least one must have passed. Each entry in the array contains:
-		* `id` - Unique identifier for this check. Check ids may be the same as Rule ids
-		* `impact` - How serious this particular check is. Can be one of "minor", "moderate", "serious", or "critical". Each check that is part of a rule can have different impacts. The highest impact of all the checks that fail is reported for the rule
-		* `message` - Description of why this check passed or failed
-		* `data` - Additional information that is specific to the type of Check which is optional. For example, a color contrast check would include the foreground color, background color, contrast ratio, etc.
-		* `relatedNodes` - Optional array of information about other nodes that are related to this check. For example, a duplicate id check violation would list the other selectors that had this same duplicate id. Each entry in the array contains the following information:
-			* `target` - Array of selectors for the related node
-			* `html` - HTML source of the related node
-	* `all` - Array of checks that were made where all must have passed. Each entry in the array contains the same information as the 'any' array
-	* `none` - Array of checks that were made where all must have not passed. Each entry in the array contains the same information as the 'any' array
-
-#### a11yCheck Parameters
-
-##### B. Options Parameter
+##### Options Parameter
 
 The options parameter is flexible way to configure how `a11yCheck` operates. The different modes of operation are:
 
@@ -295,6 +258,44 @@ The options parameter is flexible way to configure how `a11yCheck` operates. The
 	```
 
 	This example will disable the rules with the ids of `color-contrast` and `valid-lang`. All other rules will run. The list of valid rule ids is specified in the section below.
+
+
+#### Results Object
+
+The callback function passed in as the third parameter of `axe.allyCheck` runs on the results object. This object has two components – a passes array and a violations array.  The passes array keeps track of all the passed tests, along with detailed information on each one. This leads to more efficient testing, especially when used in conjunction with manual testing, as the user can easily find out what tests have already been passed. Similarly, the violations array keeps track of all the failed tests, along with detailed information on each one.
+
+###### `url`
+
+The URL of the page that was tested.
+
+###### `timestamp`
+
+The date and time that analysis was completed.
+
+###### `passes` and `violations` array
+
+* `description` - Text string that describes what the rule does
+* `help` - Help text that describes the test that was performed
+* `helpUrl` - URL that provides more information about the specifics of the violation. Links to a page on the Deque University site.
+* `id` - Unique identifier for the rule; [see the list of rules](rule-descriptions.md)
+* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the Rule failed or `null` if the check passed
+* `tags` - Array of tags that this rule is assigned. These tags can be used in the option structure to select which rules are run ([see `axe.allyCheck` parameters below for more information](#a11ycheck-parameters)).
+* `nodes` - Array of all elements the Rule tested
+	* `html` - Snippet of HTML of the Element
+	* `impact` - How serious the violation is. Can be one of "minor", "moderate", "serious", or "critical" if the test failed or `null` if the check passed
+	* `target` - Array of selectors that has each element correspond to one level of iframe or frame. If there is one iframe or frame, there should be two entries in `target`. If there are three iframe levels, there should be four entries in `target`.
+	* `any` - Array of checks that were made where at least one must have passed. Each entry in the array contains:
+		* `id` - Unique identifier for this check. Check ids may be the same as Rule ids
+		* `impact` - How serious this particular check is. Can be one of "minor", "moderate", "serious", or "critical". Each check that is part of a rule can have different impacts. The highest impact of all the checks that fail is reported for the rule
+		* `message` - Description of why this check passed or failed
+		* `data` - Additional information that is specific to the type of Check which is optional. For example, a color contrast check would include the foreground color, background color, contrast ratio, etc.
+		* `relatedNodes` - Optional array of information about other nodes that are related to this check. For example, a duplicate id check violation would list the other selectors that had this same duplicate id. Each entry in the array contains the following information:
+			* `target` - Array of selectors for the related node
+			* `html` - HTML source of the related node
+	* `all` - Array of checks that were made where all must have passed. Each entry in the array contains the same information as the 'any' array
+	* `none` - Array of checks that were made where all must have not passed. Each entry in the array contains the same information as the 'any' array
+
+#### a11yCheck Parameters
 
 ##### C. Callback Parameter
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -259,6 +259,10 @@ The options parameter is flexible way to configure how `a11yCheck` operates. The
 
 	This example will disable the rules with the ids of `color-contrast` and `valid-lang`. All other rules will run. The list of valid rule ids is specified in the section below.
 
+##### Callback Parameter
+
+The callback parameter is a function that will be called when the asynchronous `axe.a11yCheck` function completes. The callback function is passed a single parameter - the results object of the `axe.a11yCheck` call.
+
 
 #### Results Object
 
@@ -294,13 +298,6 @@ The date and time that analysis was completed.
 			* `html` - HTML source of the related node
 	* `all` - Array of checks that were made where all must have passed. Each entry in the array contains the same information as the 'any' array
 	* `none` - Array of checks that were made where all must have not passed. Each entry in the array contains the same information as the 'any' array
-
-#### a11yCheck Parameters
-
-##### C. Callback Parameter
-
-The callback parameter is a function that will be called when the asynchronous `axe.a11yCheck` function completes. The callback function is passed a single parameter - the results object of the `axe.a11yCheck` call.
-
 
 #### Example 2
 


### PR DESCRIPTION
The API documentation originally had:

a11yCheck
  - purpose
  - description
  - synopsis
  - parameters
  - results
  - a11yCheck parameters
    - context
    - options
    - callback

The documentation for the a11yCheck parameters was split up. There was a brief 'overview' of the parameters after the synopsis, then the more detailed section about each individual parameter was *after* the return/results object documentation.

This change simply unifies the parameter documentation to a single location, following the same pattern as for the other documented public methods.

Additionally, with the simplified outline for the a11yCheck method, more deep-links were added to the TOC at the top. (deep linking to the parameters section itself, as well as to the details for each of the three parameters)

No changes to the actual documentation of the parameters or results have been made.