### PR TITLE
Allow axe to optionally be require()'d or define()'d

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,12 +16,6 @@ module.exports = function (grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		clean: ['dist', 'tmp'],
-		nodeify: {
-			core: {
-				src: ['<%= concat.engine.dest %>'],
-				dest: 'dist/index.js'
-			}
-		},
 		'update-help': {
 			options: {
 				version: '<%=pkg.version%>'
@@ -238,7 +232,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default', ['build']);
 
 	grunt.registerTask('build', ['clean', 'validate', 'concat:commons', 'configure',
-		'concat:engine', 'copy', 'nodeify', 'uglify']);
+		'concat:engine', 'copy', 'uglify']);
 
 	grunt.registerTask('test', ['build',  'testconfig', 'fixture', 'connect',
 		'mocha', 'jshint']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,6 +16,12 @@ module.exports = function (grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		clean: ['dist', 'tmp'],
+		nodeify: {
+			core: {
+				src: ['<%= concat.engine.dest %>'],
+				dest: 'dist/index.js'
+			}
+		},
 		'update-help': {
 			options: {
 				version: '<%=pkg.version%>'
@@ -136,6 +142,9 @@ module.exports = function (grunt) {
 				}, {
 					src: ['LICENSE'],
 					dest: 'dist/'
+				}, {
+					src: ['dist/axe.js'],
+					dest: 'dist/index.js'
 				}]
 			}
 		},
@@ -232,7 +241,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default', ['build']);
 
 	grunt.registerTask('build', ['clean', 'validate', 'concat:commons', 'configure',
-		'concat:engine', 'copy', 'uglify']);
+		'concat:engine', 'copy', 'nodeify', 'uglify']);
 
 	grunt.registerTask('test', ['build',  'testconfig', 'fixture', 'connect',
 		'mocha', 'jshint']);

--- a/build/tasks/nodeify.js
+++ b/build/tasks/nodeify.js
@@ -10,7 +10,9 @@ module.exports = function (grunt) {
 				return grunt.file.read(fn);
 			}).join('\n');
 
-			grunt.file.write(fileset.dest, 'exports.source = ' + JSON.stringify(source) + ';');
+			var file = grunt.file.read(fileset.dest);
+
+			grunt.file.write(fileset.dest, file + 'module.exports.source = ' + JSON.stringify(source) + ';');
 		});
 	});
 };

--- a/lib/core/export.js
+++ b/lib/core/export.js
@@ -1,3 +1,2 @@
 /*global axe */
 axe.version = 'dev';
-window.axe = axe;

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -4,6 +4,3 @@ var axe = {};
 
 // local namespace for common functions
 var commons;
-
-// locally override require and define to prevent conflicts with pages utilizing RequireJS
-var require, define;

--- a/lib/outro.stub
+++ b/lib/outro.stub
@@ -1,3 +1,4 @@
 
 	axe.version = '<%= pkg.version %>';
+	if (typeof define === "function" && define.amd) this.axe = axe, define(axe); else if (typeof module === "object" && module.exports) module.exports = axe; else window.axe = axe;
 }(window, window.document));

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bdd",
     "aXe"
   ],
-  "main": "index.js",
+  "main": "axe.js",
   "dependencies": {},
   "scripts": {
     "build": "grunt",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bdd",
     "aXe"
   ],
-  "main": "axe.js",
+  "main": "index.js",
   "dependencies": {},
   "scripts": {
     "build": "grunt",

--- a/test/core/export.js
+++ b/test/core/export.js
@@ -1,9 +1,6 @@
 describe('export', function () {
 	'use strict';
 
-	it('should publish a global `axe` variable', function () {
-		assert.isDefined(window.axe);
-	});
 	it('should define version', function () {
 		assert.equal(axe.version, 'dev');
 	});

--- a/test/core/index.js
+++ b/test/core/index.js
@@ -1,10 +1,3 @@
 describe('index', function () {
 	'use strict';
-
-	it('should redefine `define`', function () {
-		assert.equal(typeof define, 'undefined');
-	});
-	it('should redefine `require`', function () {
-		assert.equal(typeof require, 'undefined');
-	});
 });


### PR DESCRIPTION
Currently, it's very difficult to use Axe with node.  While window and document are not normally defined, they can be defined with packages such as [jsdom](https://github.com/tmpvar/jsdom), which is useful when testing various front end frameworks.

This small change will keep axe's default behavior of being attached to window(in absence of a require type tool), but also allow it to be imported via require in node, as well as front end forms of importing packages.