### PR TITLE
Uglify nodefied index.js script

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,12 +16,6 @@ module.exports = function (grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		clean: ['dist', 'tmp'],
-		nodeify: {
-			core: {
-				src: ['<%= concat.engine.dest %>'],
-				dest: 'dist/index.js'
-			}
-		},
 		'update-help': {
 			options: {
 				version: '<%=pkg.version%>'
@@ -101,15 +95,6 @@ module.exports = function (grunt) {
 			}
 		},
 		uglify: {
-			lib: {
-				files: [{
-					src: ['<%= concat.engine.dest %>'],
-					dest: 'dist/axe.min.js'
-				}],
-				options: {
-					preserveComments: 'some'
-				}
-			},
 			beautify: {
 				files: [{
 					src: ['<%= concat.engine.dest %>'],
@@ -126,9 +111,44 @@ module.exports = function (grunt) {
 					},
 					preserveComments: 'some'
 				}
+			},
+			lib: {
+				files: [{
+					src: ['<%= concat.engine.dest %>'],
+					dest: 'dist/axe.min.js'
+				}],
+				options: {
+					preserveComments: 'some'
+				}
+			},
+			index: {
+				files: [{
+					src: ['tmp/index.js'],
+					dest: 'tmp/index.js'
+				}],
+				options: {
+					mangle: false,
+					compress: true,
+					beautify: {
+						beautify: false
+					},
+					preserveComments: 'some'
+				}
+			}
+		},
+		nodeify: {
+			core: {
+				src: ['tmp/index.js'],
+				dest: 'dist/index.js'
 			}
 		},
 		copy: {
+			index: {
+				files: [{
+					src: ['<%= concat.engine.dest %>'],
+					dest: 'tmp/index.js'
+				}]
+			},
 			manifests: {
 				files: [{
 					src: ['package.json'],
@@ -238,7 +258,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default', ['build']);
 
 	grunt.registerTask('build', ['clean', 'validate', 'concat:commons', 'configure',
-		'concat:engine', 'copy', 'nodeify', 'uglify']);
+		'concat:engine', 'copy', 'uglify', 'nodeify']);
 
 	grunt.registerTask('test', ['build',  'testconfig', 'fixture', 'connect',
 		'mocha', 'jshint']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,11 +127,6 @@ module.exports = function (grunt) {
 					dest: 'tmp/index.js'
 				}],
 				options: {
-					mangle: false,
-					compress: true,
-					beautify: {
-						beautify: false
-					},
 					preserveComments: 'some'
 				}
 			}


### PR DESCRIPTION
To reduce the file size of axe-core/index.js, I updated Grunt to send this file through its own minify/uglify path. Previously, it was "nodefied" before being stripped of comments, so those all ended up in the exported module.

This change reduces the exported module's filesize from 235kb to 112kb.