### PR TITLE
Make project root the packable tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 tmp
-dist
 bower_components
 node_modules
+axe.js
+axe.min.js
 test/*/index.html
 test/integration/*/index.html
 .grunt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,23 +141,6 @@ module.exports = function (grunt) {
 				}
 			}
 		},
-		copy: {
-			manifests: {
-				files: [{
-					src: ['package.json'],
-					dest: 'dist/'
-				}, {
-					src: ['README.md'],
-					dest: 'dist/'
-				}, {
-					src: ['bower.json'],
-					dest: 'dist/'
-				}, {
-					src: ['LICENSE'],
-					dest: 'dist/'
-				}]
-			}
-		},
 		watch: {
 			files: ['lib/**/*', 'test/**/*.js', 'Gruntfile.js'],
 			tasks: ['build', 'testconfig', 'fixture']
@@ -251,7 +234,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default', ['build']);
 
 	grunt.registerTask('build', ['clean', 'validate', 'concat:commons', 'configure',
-		'concat:engine', 'babel', 'copy', 'uglify']);
+		'concat:engine', 'babel', 'uglify']);
 
 	grunt.registerTask('test', ['build', 'testconfig', 'fixture', 'connect',
 		'mocha', 'jshint']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,6 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-concat');
 	grunt.loadNpmTasks('grunt-contrib-connect');
-	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-contrib-watch');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
 
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
-		clean: ['dist', 'tmp'],
+		clean: ['axe.js', 'axe.min.js', 'tmp'],
 		babel: {
 			core: {
                 files: [{
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
 					'lib/core/export.js',
 					'lib/outro.stub'
 				],
-				dest: 'dist/axe.js',
+				dest: 'axe.js',
 				options: {
 					process: true
 				}
@@ -133,7 +133,7 @@ module.exports = function (grunt) {
 			lib: {
 				files: [{
 					src: ['<%= concat.engine.dest %>'],
-					dest: 'dist/axe.min.js'
+					dest: 'axe.min.js'
 				}],
 				options: {
 					preserveComments: 'some'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bdd",
     "aXe"
   ],
-  "main": "dist/index.js",
+  "main": "dist/axe.js",
   "files": [ "dist", "bower.json" ],
   "dependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "bdd",
     "aXe"
   ],
-  "main": "index.js",
+  "main": "dist/index.js",
+  "files": [ "dist", "bower.json" ],
   "dependencies": {},
   "scripts": {
     "build": "grunt",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-concat": "~1.0.0",
     "grunt-contrib-connect": "~1.0.1",
-    "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "~1.0.1",
     "grunt-contrib-watch": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "bdd",
     "aXe"
   ],
-  "main": "dist/axe.js",
-  "files": [ "dist", "bower.json" ],
+  "main": "axe.js",
+  "files": [ "axe.js", "axe.min.js", "bower.json" ],
   "dependencies": {},
   "scripts": {
     "build": "grunt",


### PR DESCRIPTION
- Stop copying manifest files into dist
- main is now in dist/index.js relative to package.json
- Explicitly specify the files to be included in the tarball