### PR TITLE
Exclude DOM Nodes when testing for arrays in parseSelectorArray

### DIFF
--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -128,7 +128,7 @@ function parseSelectorArray(context, type) {
 		if (typeof item === 'string') {
 			result = result.concat(utils.toArray(document.querySelectorAll(item)));
 			break;
-		} else if (item && item.length) {
+		} else if (item && item.length && !(item instanceof Node)) {
 
 			if (item.length > 1) {
 				pushUniqueFrameSelector(context, type, item);

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -51,7 +51,33 @@ describe('Context', function() {
 
 		});
 
-		it('should accept an array of node reference', function() {
+              it('should accept a node reference consisting of nested divs', function() {
+                     var div1 = document.createElement('div');
+                     var div2 = document.createElement('div');
+
+                     div1.appendChild(div2);
+                     fixture.appendChild(div1);
+
+                     var result = new Context(div1);
+
+                     assert.deepEqual(result.include, [div1]);
+
+              });
+
+              it('should accept a node reference consisting of a form with nested controls', function() {
+                     var form = document.createElement('form');
+                     var input = document.createElement('input');
+
+                     form.appendChild(input);
+                     fixture.appendChild(form);
+
+                     var result = new Context(form);
+
+                     assert.deepEqual(result.include, [form]);
+
+              });
+
+		it('should accept an array of node references', function() {
 			fixture.innerHTML = '<div id="foo"><div id="bar"></div></div>';
 
 			var result = new Context([$id('foo'), $id('bar')]);
@@ -342,7 +368,7 @@ describe('Context', function() {
 			var spec = document.implementation.createHTMLDocument('ie is dumb');
 			spec.hasOwnProperty = undefined;
 			var result = new Context(spec);
-			
+
 			assert.lengthOf(result.include, 1);
 			assert.equal(result.include[0], spec);
 


### PR DESCRIPTION
I came across this issue while using `axe-core` in the `ember-a11y-testing` project, and I [made some notes](https://github.com/ember-a11y/ember-a11y-testing/issues/29) there that may make for a useful reference, but to elaborate...

When axe.a11yCheck is passed an HTMLFormElement node as its context, and when that element contains nested controls (for example: `HTMLInputElement` nodes), an error will be thrown within the `parseSelectorArray` function because it's [currently checking](https://github.com/dequelabs/axe-core/blob/4ef74435ac92a88c602690ac1e243c404f750d00/lib/core/base/context.js#L131) whether or not the `item` is an array with `if (item && item.length)`, and `length` also happens to be a [property of `HTMLFormElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/length). 

From `ember-a11y-testing` when I placed a `button` inside of a `form` (Although any [control type](https://www.w3.org/TR/html401/interact/forms.html#h-17.2.1) element will do the trick):
<img width="793" alt="screen shot 2016-06-17 at 12 59 28 am" src="https://cloud.githubusercontent.com/assets/5483853/16147664/69d68a08-3439-11e6-9353-c2a3871df338.png">


This PR proposes checking for Arrays by using `Array.isArray`, and also adds a passing test for this behavior that will indeed fail if it's run with the current implementation. Also, this is my first time really digging into the `axe-core` project itself, so if anyone has pointers on how this should truly be tested and whether or not the current test additions could be improved, I'd love to get feedback on that as well. 
