### PR TITLE
Fix preserveComments in uglify which was not removing any comments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,7 +132,10 @@ module.exports = function (grunt) {
 					dest: './axe.min.js'
 				}],
 				options: {
-					preserveComments: 'some',
+					preserveComments: function(node, comment) {
+						// preserve comments that start with a bang
+						return /^!/.test( comment.value );
+					},
 					mangle: {
 						except: ['commons', 'utils', 'axe', 'window', 'document']
 					}


### PR DESCRIPTION
https://github.com/gruntjs/grunt-contrib-uglify/issues/366

This change very specifically defines which comments will be kept - which only includes those starting with /*!

This has been tested in the building of axe.min.js