### PR TITLE
Improve contrast detection for elements that are behind another element

### DIFF
--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -66,7 +66,8 @@ var getVisualParents = function(node, rect) {
 	if (dom.supportsElementsFromPoint(document)) {
 		visualParents = dom.elementsFromPoint(document,
 			Math.ceil(rect.left + 1),
-			Math.ceil(rect.top + 1));
+			Math.ceil(rect.top + 1),
+            node);
 		thisIndex = visualParents.indexOf(node);
 
 		// if the element is not present; then something is obscuring it thus making calculation impossible

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -67,7 +67,7 @@ var getVisualParents = function(node, rect) {
 		visualParents = dom.elementsFromPoint(document,
 			Math.ceil(rect.left + 1),
 			Math.ceil(rect.top + 1),
-            node);
+			node);
 		thisIndex = visualParents.indexOf(node);
 
 		// if the element is not present; then something is obscuring it thus making calculation impossible

--- a/lib/commons/dom/elements-from-point.js
+++ b/lib/commons/dom/elements-from-point.js
@@ -21,7 +21,11 @@ dom.supportsElementsFromPoint = function (doc) {
  * @return {Array} Array of Elements
  */
 dom.elementsFromPoint = function (doc, x, y, targetNode) {
-	var elements = [], finalElements = [], previousPointerEvents = [], current, i, d, targetFound = false, floatingPositions = ['fixed', 'sticky'], style, currentNode, index;
+	var elements = [],
+		previousPointerEvents = [],
+		current,
+		i,
+		d;
 
 	targetNode = targetNode || false;
 
@@ -48,10 +52,26 @@ dom.elementsFromPoint = function (doc, x, y, targetNode) {
 		elements[i].style.setProperty('pointer-events', d.value ? d.value : '', d.priority);
 	}
 
+	elements = dom.reduceToElementsBelowFloating(elements, targetNode);
+
+	// return our results
+	return dom.reduceToFirstOpaque(elements);
+};
+
+/**
+ * Reduce an array of elements to only those that are below a 'floating' element.
+ * 
+ * @param {Array} elements
+ * @param {Element} targetNode
+ * @returns {Array}
+ */
+dom.reduceToElementsBelowFloating = function (elements, targetNode) {
+	var floatingPositions = ['fixed', 'sticky'], finalElements = [], targetFound = false, index, currentNode, style;
+	
 	// Filter out elements that are temporarily floating above the target
-	for (var index = 0; index < elements.length; ++index) {
+	for (index = 0; index < elements.length; ++index) {
 		currentNode = elements[index];
-		if (currentNode == targetNode) {
+		if (currentNode === targetNode) {
 			targetFound = true;
 		}
 
@@ -65,11 +85,19 @@ dom.elementsFromPoint = function (doc, x, y, targetNode) {
 
 		finalElements.push(currentNode);
 	}
-
-	elements = finalElements;
-	finalElements = [];
 	
-	//Now only return elements to the first opaque
+	return finalElements;
+};
+
+/**
+ * Reduce an array of elements to only those before the first opaque
+ * 
+ * @param {Array} elements array of elements to reduce
+ * @returns {Array}
+ */
+dom.reduceToFirstOpaque = function (elements) {
+	var finalElements = [], currentNode, index;
+	
 	for (index = 0; index < elements.length; ++index) {
 		currentNode = elements[index];
 
@@ -79,7 +107,6 @@ dom.elementsFromPoint = function (doc, x, y, targetNode) {
 			break;
 		}
 	}
-
-	// return our results
+	
 	return finalElements;
 };

--- a/lib/commons/dom/elements-from-point.js
+++ b/lib/commons/dom/elements-from-point.js
@@ -17,10 +17,13 @@ dom.supportsElementsFromPoint = function (doc) {
  * @param {Document} doc The HTML document
  * @param {Element} x The x coordinate, as an integer
  * @param {Element} y The y coordinate, as an integer
+ * @param {Element} targetNode An element that you are targeting. Used to detect if the element is temporarily obscured by another element
  * @return {Array} Array of Elements
  */
-dom.elementsFromPoint = function (doc, x, y) {
-	var elements = [], finalElements = [], previousPointerEvents = [], current, i, d;
+dom.elementsFromPoint = function (doc, x, y, targetNode) {
+	var elements = [], finalElements = [], previousPointerEvents = [], current, i, d, targetFound = false, floatingPositions = ['fixed', 'sticky'], style, currentNode, index;
+
+	targetNode = targetNode || false;
 
 	if (doc.msElementsFromPoint) {
 		var nl = doc.msElementsFromPoint(x, y);
@@ -29,16 +32,6 @@ dom.elementsFromPoint = function (doc, x, y) {
 
 	// get all elements via elementFromPoint, and remove them from hit-testing in order
 	while ((current = doc.elementFromPoint(x, y)) && elements.indexOf(current) === -1 && current !== null) {
-
-		var style = window.getComputedStyle(current);
-		if ('fixed' === style.position) {
-			//reset elements, because everything before this was on top of this position:fixed element
-			finalElements = [];
-		} else {
-			// push the element and its current style
-			finalElements.push(current);
-		}
-
 		elements.push(current);
 
 		previousPointerEvents.push({
@@ -48,13 +41,43 @@ dom.elementsFromPoint = function (doc, x, y) {
 
 		// add "pointer-events: none", to get to the underlying element
 		current.style.setProperty('pointer-events', 'none', 'important');
-
-		if ('fixed' !== style.position && dom.isOpaque(current)) { break; }
 	}
 
 	// restore the previous pointer-events values
 	for (i = previousPointerEvents.length; !!(d = previousPointerEvents[--i]);) {
 		elements[i].style.setProperty('pointer-events', d.value ? d.value : '', d.priority);
+	}
+
+	// Filter out elements that are temporarily floating above the target
+	for (var index = 0; index < elements.length; ++index) {
+		currentNode = elements[index];
+		if (currentNode == targetNode) {
+			targetFound = true;
+		}
+
+		style = window.getComputedStyle(currentNode);
+
+		if (!targetFound && floatingPositions.indexOf(style.position) !== -1) {
+			//Target was not found yet, so it must be under this floating thing (and will not always be under it)
+			finalElements = [];
+			continue;
+		}
+
+		finalElements.push(currentNode);
+	}
+
+	elements = finalElements;
+	finalElements = [];
+	
+	//Now only return elements to the first opaque
+	for (index = 0; index < elements.length; ++index) {
+		currentNode = elements[index];
+
+		finalElements.push(currentNode);
+
+		if (dom.isOpaque(currentNode)) {
+			break;
+		}
 	}
 
 	// return our results

--- a/lib/commons/dom/elements-from-point.js
+++ b/lib/commons/dom/elements-from-point.js
@@ -20,7 +20,7 @@ dom.supportsElementsFromPoint = function (doc) {
  * @return {Array} Array of Elements
  */
 dom.elementsFromPoint = function (doc, x, y) {
-	var elements = [], previousPointerEvents = [], current, i, d;
+	var elements = [], finalElements = [], previousPointerEvents = [], current, i, d;
 
 	if (doc.msElementsFromPoint) {
 		var nl = doc.msElementsFromPoint(x, y);
@@ -30,7 +30,15 @@ dom.elementsFromPoint = function (doc, x, y) {
 	// get all elements via elementFromPoint, and remove them from hit-testing in order
 	while ((current = doc.elementFromPoint(x, y)) && elements.indexOf(current) === -1 && current !== null) {
 
-		// push the element and its current style
+		var style = window.getComputedStyle(current);
+		if ('fixed' === style.position) {
+			//reset elements, because everything before this was on top of this position:fixed element
+			finalElements = [];
+		} else {
+			// push the element and its current style
+			finalElements.push(current);
+		}
+
 		elements.push(current);
 
 		previousPointerEvents.push({
@@ -41,7 +49,7 @@ dom.elementsFromPoint = function (doc, x, y) {
 		// add "pointer-events: none", to get to the underlying element
 		current.style.setProperty('pointer-events', 'none', 'important');
 
-		if (dom.isOpaque(current)) { break; }
+		if ('fixed' !== style.position && dom.isOpaque(current)) { break; }
 	}
 
 	// restore the previous pointer-events values
@@ -50,5 +58,5 @@ dom.elementsFromPoint = function (doc, x, y) {
 	}
 
 	// return our results
-	return elements;
+	return finalElements;
 };

--- a/lib/commons/dom/elements-from-point.js
+++ b/lib/commons/dom/elements-from-point.js
@@ -68,7 +68,12 @@ dom.elementsFromPoint = function (doc, x, y, targetNode) {
  * @returns {Array}
  */
 dom.reduceToElementsBelowFloating = function (elements, targetNode) {
-	var floatingPositions = ['fixed', 'sticky'], finalElements = [], targetFound = false, index, currentNode, style;
+	var floatingPositions = ['fixed', 'sticky'],
+		finalElements = [],
+		targetFound = false,
+		index,
+		currentNode,
+		style;
 	
 	// Filter out elements that are temporarily floating above the target
 	for (index = 0; index < elements.length; ++index) {
@@ -98,7 +103,9 @@ dom.reduceToElementsBelowFloating = function (elements, targetNode) {
  * @returns {Array}
  */
 dom.reduceToFirstOpaque = function (elements) {
-	var finalElements = [], currentNode, index;
+	var finalElements = [],
+		currentNode,
+		index;
 	
 	for (index = 0; index < elements.length; ++index) {
 		currentNode = elements[index];

--- a/lib/commons/dom/elements-from-point.js
+++ b/lib/commons/dom/elements-from-point.js
@@ -36,6 +36,8 @@ dom.elementsFromPoint = function (doc, x, y, targetNode) {
 
 	// get all elements via elementFromPoint, and remove them from hit-testing in order
 	while ((current = doc.elementFromPoint(x, y)) && elements.indexOf(current) === -1 && current !== null) {
+		
+		// push the element and its current style
 		elements.push(current);
 
 		previousPointerEvents.push({

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -280,10 +280,10 @@ describe('color-contrast', function () {
 			assert.isFalse(checks['color-contrast'].matches(target));
 		});
 
-		it('should ignore position:fixed elements', function () {
-			fixture.innerHTML = '<div style="background-color: #e5f1e5;"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200;">header</div><div style="height: 600px;"></div><ul><li>stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 600px;"></div></div>';
-			var target = fixture.querySelector('#target');
-			assert.isTrue(checks['color-contrast'].matches(target));
+		it('should ignore position:fixed elements above the target', function () {
+			fixture.innerHTML = '<div style="background-color: #e5f1e5;"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200;">header</div><div style="height: 6000px;"></div><ul><li>stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 6000px;"></div></div>';
+			assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+			assert.deepEqual(checkContext._relatedNodes, []);
 		});
 	});
 

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -279,6 +279,12 @@ describe('color-contrast', function () {
 			var target = fixture.querySelector('div');
 			assert.isFalse(checks['color-contrast'].matches(target));
 		});
+
+		it('should ignore position:fixed elements', function () {
+			fixture.innerHTML = '<div style="background-color: #e5f1e5;"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200;">header</div><div style="height: 600px;"></div><ul><li>stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 600px;"></div></div>';
+			var target = fixture.querySelector('#target');
+			assert.isTrue(checks['color-contrast'].matches(target));
+		});
 	});
 
 });

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -103,6 +103,24 @@ describe('color-contrast', function () {
 		assert.deepEqual(checkContext._relatedNodes, [target]);
 	});
 
+
+	it('should ignore position:fixed elements above the target', function () {
+		fixture.innerHTML = '<div style="background-color: #e5f1e5;" id="background"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200; color:#fff" id="header">header</div><div style="height: 6000px;"></div><ul><li>stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 6000px;"></div></div>';
+		var target = fixture.querySelector('#target');
+		var expectedRelatedNodes = fixture.querySelector('#background')
+		assert.isFalse(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.deepEqual(checkContext._relatedNodes, [expectedRelatedNodes]);
+	});
+
+	it('should find contrast issues on position:fixed elements', function () {
+		fixture.innerHTML = '<div style="background-color: #e5f1e5;" id="background"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200; color:#fff" id="target">header</div><div style="height: 6000px;"></div><ul><li>stuff <span style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 6000px;"></div></div>';
+
+		var target = fixture.querySelector('#target');
+		assert.isFalse(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.deepEqual(checkContext._relatedNodes, [target]);
+
+	});
+
 	describe('matches', function () {
 
 		it('should not match when there is no text', function () {
@@ -278,12 +296,6 @@ describe('color-contrast', function () {
 			fixture.innerHTML = '<div id="t1">Test</div><input type="text" aria-labelledby="bob t1 fred" disabled>';
 			var target = fixture.querySelector('div');
 			assert.isFalse(checks['color-contrast'].matches(target));
-		});
-
-		it('should ignore position:fixed elements above the target', function () {
-			fixture.innerHTML = '<div style="background-color: #e5f1e5;"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200;">header</div><div style="height: 6000px;"></div><ul><li>stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 6000px;"></div></div>';
-			assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
-			assert.deepEqual(checkContext._relatedNodes, []);
 		});
 	});
 

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -105,15 +105,25 @@ describe('color-contrast', function () {
 
 
 	it('should ignore position:fixed elements above the target', function () {
-		fixture.innerHTML = '<div style="background-color: #e5f1e5;" id="background"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200; color:#fff" id="header">header</div><div style="height: 6000px;"></div><ul><li>stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 6000px;"></div></div>';
+		fixture.innerHTML = '<div style="background-color: #e5f1e5;" id="background">' +
+			'<div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; z-index: 200; color:#fff" >header</div>' +
+			'<div style="height: 6000px;"></div>' +
+			'stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span>' +
+			'<div style="height: 6000px;"></div>' +
+			'</div>';
 		var target = fixture.querySelector('#target');
-		var expectedRelatedNodes = fixture.querySelector('#background')
+		var expectedRelatedNodes = fixture.querySelector('#background');
 		assert.isFalse(checks['color-contrast'].evaluate.call(checkContext, target));
 		assert.deepEqual(checkContext._relatedNodes, [expectedRelatedNodes]);
 	});
 
 	it('should find contrast issues on position:fixed elements', function () {
-		fixture.innerHTML = '<div style="background-color: #e5f1e5;" id="background"><div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; border:1px solid #CCC; z-index: 200; color:#fff" id="target">header</div><div style="height: 6000px;"></div><ul><li>stuff <span style="color: rgba(91, 91, 90, 0.7)">This is some text</span></li></ul><div style="height: 6000px;"></div></div>';
+		fixture.innerHTML = '<div style="background-color: #e5f1e5;" id="background">' +
+			'<div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; z-index: 200; color:#fff" id="target">header</div>' +
+			'<div style="height: 6000px;"></div>' +
+			'stuff <span style="color: rgba(91, 91, 90, 0.7)">This is some text</span>' +
+			'<div style="height: 6000px;"></div>' +
+			'</div>';
 
 		var target = fixture.querySelector('#target');
 		assert.isFalse(checks['color-contrast'].evaluate.call(checkContext, target));


### PR DESCRIPTION
I was seeing false negatives (not seeing contrast errors that should be detected) on pages where there was a sticky header attached to the viewport, while using the axe chrome extension. After diving into the issue, I discovered that it was due to axe scrolling to the element while testing a page. Scrolling to the element would place the element at the top of the page, which would also place the element behind a sticky header. Because axe tries to be smart and determine the background via visual order, it was finding the sticky header instead of the element with bad contrast.

For example, view https://mfairchild365.github.io/axe-contrast-bug/
That example has two contrast errors, but axe only finds one (on the sticky header).

Note: I'm not confident that the automated tests will detect if this is not working, I'm not sure if it is because phantomjs does not support `elementFromPoint()` or perhaps phantomjs does not need to scroll because it is a headless browser.

