### PR TITLE
TypeScript namespace restructuring

### DIFF
--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -14,23 +14,26 @@ axe.a11yCheck({include: [['#id1'], ['#id2']]}, {}, (results) => {
 axe.a11yCheck({exclude: [$fixture[0]]}, {}, (results) => {
 	console.log(results)
 })
+var tagConfigRunOnly: axe.RunOnly = {
+	type: 'tag',
+	values: ['wcag2a']
+}; 
 var tagConfig = {
-	runOnly: {
-		type: 'tag',
-		values: ['wcag2a']
-	}
+	runOnly: tagConfigRunOnly
 }
 axe.a11yCheck(context, tagConfig, (results) => {
 	console.log(results)
 })
-var includeExcludeTagsConfig = {
-	runOnly: {
-		type: 'tags',
-		value: {
-			include: ['wcag2a', 'wcag2aa'],
-			exclude: ['experimental']
-		}
+
+var includeExcludeTagsRunonly: axe.RunOnly = {
+	type: 'tags',
+	value: {
+		include: ['wcag2a', 'wcag2aa'],
+		exclude: ['experimental']
 	}
+}
+var includeExcludeTagsConfig = {
+	runOnly: includeExcludeTagsRunonly
 }
 axe.a11yCheck(context, includeExcludeTagsConfig, (results) => {
 	console.log(results)
@@ -46,7 +49,7 @@ axe.a11yCheck(context, someRulesConfig, (results) => {
 })
 
 // axe.configure
-var spec = {
+var spec: axe.Spec = {
 	branding: {
 		brand: 'foo',
 		application: 'bar'

--- a/typings/axe-core/axe-core.d.ts
+++ b/typings/axe-core/axe-core.d.ts
@@ -3,112 +3,111 @@
 // Definitions by: Marcy Sutton <https://github.com/marcysutton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type ImpactValue = "minor" | "moderate" | "serious" | "critical" | "null";
+declare namespace axe {
+	export type ImpactValue = "minor" | "moderate" | "serious" | "critical" | "null";
 
-export type TagValue = "wcag2a" | "wcag2aa" | "section508" | "best-practice";
+	export type TagValue = "wcag2a" | "wcag2aa" | "section508" | "best-practice";
 
-export type ReporterVersion = "v1" | "v2";
+	export type ReporterVersion = "v1" | "v2";
 
-export type RunOnlyType = "rule" | "rules" | "tag" | "tags";
+	export type RunOnlyType = "rule" | "rules" | "tag" | "tags";
 
-interface ElementContext {
-	node?: Object,
-	selector?: string,
-	include?: any[],
-	exclude?: any[]
-}
-interface RunOnly {
-	type: RunOnlyType,
-	value?: {
-		include?: string[],
-		exclude?: string[]
+	export interface ElementContext {
+		node?: Object,
+		selector?: string,
+		include?: any[],
+		exclude?: any[]
 	}
-	values?: TagValue[]
-}
-interface AxeResults {
-	url: string,
-	timestamp: string,
-	passes: Pass[],
-	violations: Violation[]
-}
-interface Pass {
-	description: string,
-	help: string,
-	helpUrl: string,
-	id: string,
-	impact: ImpactValue,
-	tags: TagValue[],
-	nodes: NodeResult[]
-}
-interface Violation {
-	description: string,
-	help: string,
-	helpUrl: string,
-	id: string,
-	impact: ImpactValue,
-	tags: TagValue[],
-	nodes: NodeResult[]
-}
-interface NodeResult {
-	html: string,
-	impact: ImpactValue,
-	target: string[],
-	any: CheckResult[],
-	all: CheckResult[],
-	none: CheckResult[]
-}
-interface CheckResult {
-	id: string,
-	impact: string,
-	message: string,
-	data: any,
-	relatedNodes?: RelatedNode[]
-}
-interface RelatedNode {
-	target: string[],
-	html: string
-}
-interface Spec {
-	branding?: {
-		brand: string,
-		application: string
-	},
-	reporter?: ReporterVersion,
-	checks?: Check[],
-	rules?: Rule[]
-}
-interface Check {
-	id: string,
-	evaluate: Function,
-	after?: Function,
-	options?: any,
-	matches?: string,
-	enabled?: boolean
-}
-interface Rule {
-	id: string,
-	selector?: string,
-	excludeHidden?: boolean,
-	enabled?: boolean,
-	pageLevel?: boolean,
-	any?: string[],
-	all?: string[],
-	none?: string[],
-	tags?: string[],
-	matches?: string
-}
-interface AxePlugin {
-	id: string,
-	run(...args:any[]): any,
-	commands: {
+	export interface RunOnly {
+		type: RunOnlyType,
+		value?: {
+			include?: string[],
+			exclude?: string[]
+		}
+		values?: TagValue[]
+	}
+	export interface AxeResults {
+		url: string,
+		timestamp: string,
+		passes: Pass[],
+		violations: Violation[]
+	}
+	export interface Pass {
+		description: string,
+		help: string,
+		helpUrl: string,
 		id: string,
-		callback(...args:any[]): void
-	}[],
-	cleanup?(callback:Function): void
-}
-
-interface Axe {
-	plugins: any
+		impact: ImpactValue,
+		tags: TagValue[],
+		nodes: NodeResult[]
+	}
+	export interface Violation {
+		description: string,
+		help: string,
+		helpUrl: string,
+		id: string,
+		impact: ImpactValue,
+		tags: TagValue[],
+		nodes: NodeResult[]
+	}
+	export interface NodeResult {
+		html: string,
+		impact: ImpactValue,
+		target: string[],
+		any: CheckResult[],
+		all: CheckResult[],
+		none: CheckResult[]
+	}
+	export interface CheckResult {
+		id: string,
+		impact: string,
+		message: string,
+		data: any,
+		relatedNodes?: RelatedNode[]
+	}
+	export interface RelatedNode {
+		target: string[],
+		html: string
+	}
+	export interface Spec {
+		branding?: {
+			brand: string,
+			application: string
+		},
+		reporter?: ReporterVersion,
+		checks?: Check[],
+		rules?: Rule[]
+	}
+	export interface Check {
+		id: string,
+		evaluate: Function,
+		after?: Function,
+		options?: any,
+		matches?: string,
+		enabled?: boolean
+	}
+	export interface Rule {
+		id: string,
+		selector?: string,
+		excludeHidden?: boolean,
+		enabled?: boolean,
+		pageLevel?: boolean,
+		any?: string[],
+		all?: string[],
+		none?: string[],
+		tags?: string[],
+		matches?: string
+	}
+	export interface AxePlugin {
+		id: string,
+		run(...args:any[]): any,
+		commands: {
+			id: string,
+			callback(...args:any[]): void
+		}[],
+		cleanup?(callback:Function): void
+	}
+	export let plugins: any
 
 	/**
 	 * Starts analysis on the current document and its subframes
@@ -118,41 +117,39 @@ interface Axe {
 	 * @param  {Function} callback The function to invoke when analysis is complete.
 	 * @returns {Object}  results  The aXe results object
 	 */
-	a11yCheck(context: ElementContext, options: {runOnly?: RunOnly, rules?: Object}, callback: (results:AxeResults) => void): AxeResults
+	export function a11yCheck(context: ElementContext, options: {runOnly?: RunOnly, rules?: Object}, callback: (results:AxeResults) => void): AxeResults
 
 	/**
 	 * Method for configuring the data format used by aXe. Helpful for adding new
 	 * rules, which must be registered with the library to execute.
 	 * @param  {Spec}       Spec Object with valid `branding`, `reporter`, `checks` and `rules` data
 	 */
-	configure(spec: Spec): void
+	export function configure(spec: Spec): void
 
 	/**
 	 * Searches and returns rules that contain a tag in the list of tags.
 	 * @param  {Array}  tags  Optional array of tags
 	 * @return {Array}  Array of rules
 	 */
-	getRules(tags?: string[]): Object[]
+	export function getRules(tags?: string[]): Object[]
 
 	/**
 	 * Restores the default axe configuration
 	 */
-	reset(): void
+	export function reset(): void
 
 	/**
 	 * Function to register a plugin configuration in document and its subframes
 	 * @param  {Object}    plugin    A plugin configuration object
 	 */
-	registerPlugin(plugin: AxePlugin): void
+	export function registerPlugin(plugin: AxePlugin): void
 
 	/**
 	 * Function to clean up plugin configuration in document and its subframes
 	 */
-	cleanup(): void
+	export function cleanup(): void
 
 }
-
-declare var axe:Axe;
 
 // axe is also available as a module
 declare module "axe-core" {


### PR DESCRIPTION
This PR moves the `.d.ts` file to use namespaces. The reason that you saw some issues with not being able to import/find certain things correctly is because as soon as you have a top-level `export` or `import`, the file becomes a module.

Once you have a module, your variables are no longer available in the global scope. So this moves all of your declarations into a namespace (which actually reflects the way that Axe itself was written!), and then use `export =` on that namespace to say that the module version has the same shape as the namespace.

I also fixed up the tests to use literal types. The problem is that strings only get literal types if they're getting assigned to something that's known to have a literal type. We're working on making this easier to use, but until then this will do it.