### PR TITLE
test(typescript-def): add source and AxeResults

### DIFF
--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -4,16 +4,16 @@ var context:any = document
 var $fixture:any = {}
 
 // axe.a11yCheck config
-axe.a11yCheck(context, {}, (results) => {
+axe.a11yCheck(context, {}, (results: axe.AxeResults) => {
 	// axe's results object
 	console.log(results.passes.length)
 	console.log(results.violations.length)
 });
 // axe.a11yCheck include/exclude
-axe.a11yCheck({include: [['#id1'], ['#id2']]}, {}, (results) => {
+axe.a11yCheck({include: [['#id1'], ['#id2']]}, {}, (results: axe.AxeResults) => {
 	console.log(results)
 })
-axe.a11yCheck({exclude: [$fixture[0]]}, {}, (results) => {
+axe.a11yCheck({exclude: [$fixture[0]]}, {}, (results: axe.AxeResults) => {
 	console.log(results)
 })
 var tagConfigRunOnly: axe.RunOnly = {
@@ -23,7 +23,7 @@ var tagConfigRunOnly: axe.RunOnly = {
 var tagConfig = {
 	runOnly: tagConfigRunOnly
 }
-axe.a11yCheck(context, tagConfig, (results) => {
+axe.a11yCheck(context, tagConfig, (results: axe.AxeResults) => {
 	console.log(results)
 })
 var includeExcludeTagsRunOnly: axe.RunOnly = {
@@ -36,7 +36,7 @@ var includeExcludeTagsRunOnly: axe.RunOnly = {
 var includeExcludeTagsConfig = {
 	runOnly: includeExcludeTagsRunOnly
 }
-axe.a11yCheck(context, includeExcludeTagsConfig, (results) => {
+axe.a11yCheck(context, includeExcludeTagsConfig, (results: axe.AxeResults) => {
 	console.log(results)
 })
 var someRulesConfig = {
@@ -45,7 +45,7 @@ var someRulesConfig = {
 		"heading-order": {enabled: 'true'}
 	}
 }
-axe.a11yCheck(context, someRulesConfig, (results) => {
+axe.a11yCheck(context, someRulesConfig, (results: axe.AxeResults) => {
 	console.log(results)
 })
 
@@ -68,6 +68,8 @@ var spec: axe.Spec = {
 	}]
 }
 axe.configure(spec)
+
+var source = axe.source;
 
 axe.reset()
 

--- a/typings/axe-core/axe-core.d.ts
+++ b/typings/axe-core/axe-core.d.ts
@@ -112,6 +112,16 @@ declare namespace axe {
 	export let plugins: any
 
 	/**
+	 * Source string to use as an injected script in Selenium
+	 */
+	export let source: string
+
+	/**
+	 * Object for aXe Results
+	 */
+	export var AxeResults: AxeResults
+
+	/**
 	 * Starts analysis on the current document and its subframes
 	 *
 	 * @param  {Object}   context  The `Context` specification object @see Context


### PR DESCRIPTION
Need to publish this to npm so we can utilize the typings for both axe-core and avoid a second definition for axe-webdriverjs (for now).