### PR TITLE
Angular ng click rule

### DIFF
--- a/doc/rule-descriptions.md
+++ b/doc/rule-descriptions.md
@@ -1,6 +1,7 @@
 | Rule ID | Description | Tags | Enabled by default |
 | :------- | :------- | :------- | :------- |
 | accesskeys | Ensures every accesskey attribute value is unique | wcag2a, wcag211 | true |
+| angular-ng-click | Ensures ng-click is used on accessible elements | wcag2aa, wcag21, wcag412 | false |
 | area-alt | Ensures &lt;area&gt; elements of image maps have alternate text | wcag2a, wcag111, section508, section508.22.a | true |
 | aria-allowed-attr | Ensures ARIA attributes are allowed for an element&apos;s role | wcag2a, wcag411, wcag412 | true |
 | aria-required-attr | Ensures elements with ARIA roles have all required ARIA attributes | wcag2a, wcag411, wcag412 | true |

--- a/lib/checks/keyboard/angular-ng-click.js
+++ b/lib/checks/keyboard/angular-ng-click.js
@@ -1,0 +1,20 @@
+
+var tabIndex = node.getAttribute('tabindex'),
+	focusableWithTabindex = axe.commons.dom.isFocusable(node) && tabIndex > -1;
+
+// if the element is natively focusable without tabindex, it passes
+if (axe.commons.dom.isFocusable(node) && tabIndex === null) {
+	return true;
+}
+var accRoles = ['button', 'checkbox', 'tab', 'menuitem', 'menuitemcheckbox'],
+	roleAttr = node.getAttribute('role');
+
+node.hasAccessibleRole = false;
+
+for (var i=0; i<accRoles.length; i++) {
+	// if node has accessible role and is focusable, it passes
+	if (roleAttr && roleAttr === accRoles[i] && focusableWithTabindex) {
+		node.hasAccessibleRole = true;
+	}
+}
+return node.hasAccessibleRole;

--- a/lib/checks/keyboard/angular-ng-click.js
+++ b/lib/checks/keyboard/angular-ng-click.js
@@ -1,20 +1,59 @@
+var originalNode = node;
 
-var tabIndex = node.getAttribute('tabindex'),
-	focusableWithTabindex = axe.commons.dom.isFocusable(node) && tabIndex > -1;
+function getEventHandler(node) {
+	return node.getAttribute('ng-click') || node.getAttribute('(click)');
+}
 
-// if the element is natively focusable without tabindex, it passes
-if (axe.commons.dom.isFocusable(node) && tabIndex === null) {
+function testNodeForA11y(currentNode) {
+	var tabIndex = currentNode.getAttribute('tabindex'),
+		focusableWithTabindex = axe.commons.dom.isFocusable(currentNode) && tabIndex > -1;
+
+	// if the element is natively focusable without tabindex, it passes
+	if (axe.commons.dom.isFocusable(currentNode) && tabIndex === null) {
+		return true;
+	}
+	var accRoles = ['button', 'checkbox', 'tab', 'menuitem', 'menuitemcheckbox'],
+		roleAttr = currentNode.getAttribute('role');
+
+	currentNode.hasAccessibleRole = false;
+
+	for (var i=0; i<accRoles.length; i++) {
+		// if currentNode has accessible role and is focusable, it passes
+		if (roleAttr && roleAttr === accRoles[i] && focusableWithTabindex) {
+			currentNode.hasAccessibleRole = true;
+		}
+	}
+	return currentNode.hasAccessibleRole;
+}
+
+// if original node isn't focusable, try one of the children
+// and look for the same event handler on an interactive element
+
+var origHandler = getEventHandler(originalNode);
+
+if (testNodeForA11y(originalNode) === false) {
+	// ensure we're looking at an element node
+	if (originalNode.children.length) {
+		var childStatus = [];
+		axe.commons.dom.walkDomNode(originalNode, function (currNode) {
+			if (currNode.nodeType === 1) {
+				// if child node has accessible event handler, pass it
+				var childHandler = getEventHandler(currNode);
+				if (testNodeForA11y(currNode) && origHandler === childHandler) {
+					childStatus.push(true);
+				} else {
+					childStatus.push(false);
+				}
+			}
+		});
+		return childStatus.some(function(isAMatch) {
+			return isAMatch === true;
+		});
+	} else {
+		// original node fails, and it has no children to check
+		return false;
+	}
+} else {
+	// top level node is good, pass the check
 	return true;
 }
-var accRoles = ['button', 'checkbox', 'tab', 'menuitem', 'menuitemcheckbox'],
-	roleAttr = node.getAttribute('role');
-
-node.hasAccessibleRole = false;
-
-for (var i=0; i<accRoles.length; i++) {
-	// if node has accessible role and is focusable, it passes
-	if (roleAttr && roleAttr === accRoles[i] && focusableWithTabindex) {
-		node.hasAccessibleRole = true;
-	}
-}
-return node.hasAccessibleRole;

--- a/lib/checks/keyboard/angular-ng-click.json
+++ b/lib/checks/keyboard/angular-ng-click.json
@@ -1,0 +1,12 @@
+{
+   "id": "angular-ng-click",
+   "options": [],
+   "evaluate": "angular-ng-click.js",
+   "metadata": {
+    "impact": "critical",
+    "messages": {
+      "pass": "ng-click is focusable and has an accessible role",
+      "fail": "ng-click is not focusable or missing an accessible role"
+    }
+  }
+}

--- a/lib/commons/dom/is-in-text-block.js
+++ b/lib/commons/dom/is-in-text-block.js
@@ -11,6 +11,7 @@ function walkDomNode(node, functor) {
         node = node.nextSibling;
     }
 }
+dom.walkDomNode = walkDomNode;
 
 var blockLike = ['block', 'list-item', 'table', 'flex', 'grid', 'inline-block'];
 function isBlock(elm) {

--- a/lib/rules/angular-ngclick.json
+++ b/lib/rules/angular-ngclick.json
@@ -1,0 +1,15 @@
+{
+ "id": "angular-ng-click",
+ "enabled": false,
+ "metadata": {
+  "description": "Ensures ng-click is used on accessible elements",
+  "help": "ng-click must be used on accessible elements"
+ },
+ "selector": "[ng-click], [(click)]",
+ "any": [],
+ "all": ["angular-ng-click"],
+ "none": ["focusable-no-name"],
+ "tags": [
+  "wcag2aa", "wcag21", "wcag412"
+ ]
+}

--- a/test/checks/keyboard/angular-ng-click.js
+++ b/test/checks/keyboard/angular-ng-click.js
@@ -37,7 +37,7 @@ describe('angular-ng-click', function () {
 		assert.isFalse(checks['angular-ng-click'].evaluate(node));
 	});
 
-	it('should pass if Angular 2 role=button is missing tabindex', function () {
+	it('should fail if Angular 2 role=button is missing tabindex', function () {
 		fixture.innerHTML = '<div role="button" (click)="func()">div button</div>';
 		var node = fixture.querySelector('div');
 		assert.isFalse(checks['angular-ng-click'].evaluate(node));
@@ -51,6 +51,18 @@ describe('angular-ng-click', function () {
 
 	it('should fail if Angular 2 DIV', function () {
 		fixture.innerHTML = '<div (click)="func()"></div>';
+		var node = fixture.querySelector('div');
+		assert.isFalse(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should pass if ng-click function on wrapper is also provided on child interactive element', function () {
+		fixture.innerHTML = '<div ng-click="func()"><button ng-click="func()">button</button></div>';
+		var node = fixture.querySelector('div');
+		assert.isTrue(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should fail if ng-click function on wrapper is not provided on child interactive element', function () {
+		fixture.innerHTML = '<div ng-click="func()"><button ng-click="otherFunc()">button</button></div>';
 		var node = fixture.querySelector('div');
 		assert.isFalse(checks['angular-ng-click'].evaluate(node));
 	});

--- a/test/checks/keyboard/angular-ng-click.js
+++ b/test/checks/keyboard/angular-ng-click.js
@@ -1,0 +1,57 @@
+describe('angular-ng-click', function () {
+	'use strict';
+
+	var fixture = document.getElementById('fixture');
+
+	afterEach(function () {
+		fixture.innerHTML = '';
+	});
+
+	it('should pass if Angular 2 button', function () {
+		fixture.innerHTML = '<button (click)="func()">button</button>';
+		var node = fixture.querySelector('button');
+		assert.isTrue(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should pass if Angular 1 button', function () {
+		fixture.innerHTML = '<button ng-click="func()">button</button>';
+		var node = fixture.querySelector('button');
+		assert.isTrue(checks['angular-ng-click'].evaluate(node));
+	});
+	
+	it('should pass if Angular 1 role=button', function () {
+		fixture.innerHTML = '<div role="button" tabindex="0" ng-click="func()">div button</div>';
+		var node = fixture.querySelector('div');
+		assert.isTrue(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should pass if Angular 2 role=button', function () {
+		fixture.innerHTML = '<div role="button" tabindex="0" (click)="func()">div button</div>';
+		var node = fixture.querySelector('div');
+		assert.isTrue(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should fail if Angular 1 role=button is missing tabindex', function () {
+		fixture.innerHTML = '<div role="button" ng-click="func()">div button</div>';
+		var node = fixture.querySelector('div');
+		assert.isFalse(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should pass if Angular 2 role=button is missing tabindex', function () {
+		fixture.innerHTML = '<div role="button" (click)="func()">div button</div>';
+		var node = fixture.querySelector('div');
+		assert.isFalse(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should fail if Angular 1 DIV', function () {
+		fixture.innerHTML = '<div ng-click="func()"></div>';
+		var node = fixture.querySelector('div');
+		assert.isFalse(checks['angular-ng-click'].evaluate(node));
+	});
+
+	it('should fail if Angular 2 DIV', function () {
+		fixture.innerHTML = '<div (click)="func()"></div>';
+		var node = fixture.querySelector('div');
+		assert.isFalse(checks['angular-ng-click'].evaluate(node));
+	});
+});


### PR DESCRIPTION
This rule checks click handlers in both Angular 1 and 2 to ensure they are bound to interactive elements, a big use case I tried (and failed) to cover with ngAria. 

It's disabled by default to only target Angular developers–but it made a lot of sense to use our infrastructure for test coverage and other check reuse, such as `focusable-no-name`. 

I added support for nested click events in case the developer has bound a click event to a DIV for a larger hit area but bound the same event handler to an accessible child element–that should not raise a violation. 