### PR TITLE
Fix npm TypeScript definition for Angular 2 apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ axe.min.js
 axe.es2016.js
 *.tgz
 npm-shrinkwrap.json
+typings/axe-core/axe-core-tests.js

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ lib
 test
 *.tgz
 bower.json
+typings/axe-core

--- a/axe.d.ts
+++ b/axe.d.ts
@@ -1,9 +1,8 @@
-// Type definitions for axe-core 2.0.5
+// Type definitions for axe-core 2.0.8
 // Project: https://github.com/dequelabs/axe-core
 // Definitions by: Marcy Sutton <https://github.com/marcysutton>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace axe {
+declare module axe {
 
 	export type ImpactValue = "minor" | "moderate" | "serious" | "critical";
 
@@ -163,7 +162,4 @@ declare namespace axe {
 
 }
 
-// axe is also available as a module
-declare module "axe-core" {
-    export = axe;
-}
+export = axe;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "aXe"
   ],
   "main": "axe.js",
-  "typings": "./typings/axe-core/axe-core.d.ts",
+  "typings": "axe.d.ts",
   "scripts": {
     "build": "grunt",
     "test": "grunt test"

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="axe-core.d.ts" />
+import * as axe from '../../axe'
 
 var context:any = document
 var $fixture:any = {}


### PR DESCRIPTION
This PR fixes axe-core import in Angular 2 app tests when distributed through npm instead of DefinitelyTyped. There were problems importing the definitions into Angular 2 from npm, so after troubleshooting I moved the definition to the root and added some .npmignore/.gitignore rules for extraneous files. I kept axe's TypeScript export as-is to support a wider variety of compiler versions (`export = axe` instead of `export default axe`). 

TypeScript usage: `import * as axe from 'axe-core'`