### PR TITLE
chore(deps): added grunt-cli as devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ node_js:
   - '4'
   - '5'
 before_install:
-  - npm install -g grunt-cli
-  - npm install
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
-  - grunt test
+  - npm test
 env:
   global:
     - secure: qjMwfcWDzEhGWxVhmGi5s0MlsU4N/SI96mx6Gj36/GySxgIUU9EFXeN4SZS2OvRmy2/+l0XSt5ln9PWp4Suh2LM8/GaR5I6FALs/9rOLU9py0/G9V1ImqNN9Z6Nk6PvS71SAwP7xOtR+xsywnUEdHZ7dCA3fYEIsOkyq4KRQ9M7JHWogP+h+WsHPcznjPeNxVBCfYCXW0KhrLDzL4ZA+b2UY/IMZDXITdZ99TZQA6XSKTfJg3xs/jqXEo91igHNKN6VxappBqPbDiFxf7az1RExq3oHAawCDTaKE7xxip+6UIxAeo63tiM0vgp92HVrVsIQETSQFBP4aqhl/pfxQ7d9lto7Mz5AlxKvJ3CIwDD/hspPzG5SNrj/FgQLgK7LrUOomMOjf8giRUg8XXLe7Rb1jmbePP3Z9DIEg4Z+ar3dpC2dNiWYFwBM14wY39GuU6tJpzImGRRUGCMPiO55TVTdRZacVeIq1XWRecIH0CabZThJCwOxyiGIT5ETiT5CVs0CgnbVe99l1qyi8wrMnbw4m4UAlMQ/5kytqtsL957RwxvcctCtX+LlshAgC3m1Aq/aF8V/wIYDcRlwOY2HbGiFQJewV7Aeln3t/S8VFjP9hHn8ZTsH9ez3VB57Q53YgrxFCr6CXEK4X3dkmRpx9in3oDI51TxW32tInwGTukSg=

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dot": "~1.0.3",
     "grunt": "~0.4.5",
     "grunt-babel": "^6.0.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-concat": "~1.0.0",
     "grunt-contrib-connect": "~1.0.1",


### PR DESCRIPTION
so that global grunt-cli installation is not required

---
`npm run build` expected to `grunt` in the `PATH` and failed as there was none. Installing grunt as a devDependencies solves the problem 

>In addition to the shell's pre-existing `PATH`, `npm run` adds `node_modules/.bin` to the `PATH` provided to scripts. Any binaries provided by `locally-installed` dependencies can be used without the `node_modules/.bin` prefix - [npm/run-script](https://docs.npmjs.com/cli/run-script#description)