### PR TITLE
docs(typescript): fix path and update usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,11 @@ grunt build
 
 ## Using aXe with TypeScript
 
-The TypeScript definition file for axe-core can be found in [typings/axe-core](./typings/axe-core).
+### aXe Development
 
-To develop with TypeScript you must first install it (globally recommended):
+The TypeScript definition file for axe-core is distributed with this module [axe.d.ts](./axe.d.ts). It currently supports TypeScript 2.0+.
+
+To maintain aXe support for TypeScript you must first install it (globally recommended):
 ```
 sudo npm -g install typescript
 ```
@@ -110,4 +112,20 @@ sudo npm -g install typescript
 Once that's installed, you can run TypeScript definition tests (with the optional `--noImplicitAny` flag):
 ```
 tsc --noImplicitAny typings/axe-core/axe-core-tests.ts
+```
+
+## Including aXe's type definition in tests
+
+Installing aXe to run accessibility tests in your TypeScript project should be as simple as importing the module:
+
+```javascript
+import * as axe from 'axe-core';
+
+describe('Module', () => {
+	it('should have no accessibility violations', () => {
+		axe.a11yCheck(compiledFixture, {}, (results) => {
+			expect(results.violations.length).toBe(0);
+		});
+	});
+});
 ```


### PR DESCRIPTION
The fix for #248 is already on master but we need to publish it in a new release. This PR updates documentation for consuming the aXe TypeScript definition, which is now available at the root of the directory instead of inside the `typings` folder. The tests are still in that directory but they are excluded in `.npmignore`. 

I tested the aXe definition with both our TypeScript tests and this demo project: https://github.com/marcysutton/ng2-test-seed.

More info about publishing `d.ts` files: http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html