### PR TITLE
Implicit tr role

### DIFF
--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -608,7 +608,8 @@ lookupTables.role = {
 			one: ['cell', 'columnheader', 'rowheader', 'gridcell']
 		},
 		nameFrom: ['author', 'contents'],
-		context:  ['rowgroup', 'grid', 'treegrid', 'table']
+		context:  ['rowgroup', 'grid', 'treegrid', 'table'],
+		implicit: ['tr']
 	},
 	'rowgroup': {
 		type: 'structure',

--- a/test/checks/aria/required-children.js
+++ b/test/checks/aria/required-children.js
@@ -73,6 +73,12 @@ describe('aria-required-children', function () {
 		assert.isTrue(checks['aria-required-children'].evaluate.call(checkContext, node));
 	});
 
+	it('should pass when a child with an implicit role is present', function () {
+		fixture.innerHTML = '<table role="grid" id="target"><tr><td>Nothing here.</td></tr></table>';
+		var node = fixture.querySelector('#target');
+		assert.isTrue(checks['aria-required-children'].evaluate.call(checkContext, node));
+	});
+
 	it('should pass direct existing required children', function () {
 		fixture.innerHTML = '<div role="list" id="target"><p role="listitem">Nothing here.</p></div>';
 		var node = fixture.querySelector('#target');


### PR DESCRIPTION
2 things contained in this PR:

- Firstly a test to assert that using a child with an implicit role, should pass the required child test.
  - This was a way to see a test fail when using `grid` and `tr` with no `role="row"`
- Add the `tr` element to the `row` role, as having an implicit role
  - Newly added test, now passes (yay!)