### PR TITLE
Avoid calling `DqElement` unnecessarily when gathering results

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -151,10 +151,7 @@ Rule.prototype.run = function (context, options, resolve, reject) {
 
 				checkQueue.then(function (results) {
 					if (results.length) {
-						var hasResults = false,
-							result = {
-								node: new axe.utils.DqElement(node)
-							};
+						var hasResults = false, result = {};
 						results.forEach(function (r) {
 							var res = r.results.filter(function (result) {
 								return result;
@@ -165,6 +162,7 @@ Rule.prototype.run = function (context, options, resolve, reject) {
 							}
 						});
 						if (hasResults) {
+							result.node = new axe.utils.DqElement(node);
 							ruleResult.nodes.push(result);
 						}
 					}

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -313,7 +313,95 @@ describe('Rule', function() {
 				}, {}, function(r) {
 					assert.lengthOf(r.nodes, 0);
 				}, isNotCalled);
+			});
 
+			describe('DqElement', function() {
+				var origDqElement;
+				var isDqElementCalled;
+
+				beforeEach(function() {
+					isDqElementCalled = false;
+					origDqElement = axe.utils.DqElement;
+					axe.utils.DqElement = function() {
+						isDqElementCalled = true;
+					};
+					fixture.innerHTML = '<blink>Hi</blink>';
+				});
+
+				afterEach(function() {
+					axe.utils.DqElement = origDqElement;
+				});
+
+				it('is created for matching nodes', function(done) {
+					var rule = new Rule({
+						all: ['cats']
+					}, {
+						checks: {
+							cats: new Check({
+								id: 'cats',
+								enabled: true,
+								evaluate: function() {
+									return true;
+								},
+								matches: function() {
+									return true;
+								}
+							})
+						}
+					});
+					rule.run({
+						include: [fixture]
+					}, {}, function() {
+						assert.isTrue(isDqElementCalled);
+						done();
+					}, isNotCalled);
+				});
+
+				it('is not created for disabled checks', function(done) {
+					var rule = new Rule({
+						all: ['cats']
+					}, {
+						checks: {
+							cats: new Check({
+								id: 'cats',
+								enabled: false,
+								evaluate: function() {},
+								matches: function() {
+									return true;
+								}
+							})
+						}
+					});
+					rule.run({
+						include: [fixture]
+					}, {}, function() {
+						assert.isFalse(isDqElementCalled);
+						done();
+					}, isNotCalled);
+				});
+
+				it('is not created for un-matching nodes', function(done) {
+					var rule = new Rule({
+						all: ['cats']
+					}, {
+						checks: {
+							cats: new Check({
+								id: 'cats',
+								enabled: true,
+								evaluate: function() {},
+								matches: function() {
+									return false;
+								}
+							})
+						}
+					});
+					rule.run({
+						include: [fixture]
+					}, {}, function() {
+						assert.isFalse(isDqElementCalled);
+						done();
+					}, isNotCalled);
+				});
 			});
 
 			it('should pass thrown errors to the reject param', function (done) {

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -1,4 +1,4 @@
-/*global Rule */
+/*global Rule, Check */
 describe('Rule', function() {
 	'use strict';
 


### PR DESCRIPTION
This diff will modify Rule#run so that the `DqElement` wrapping of a node when gathering rule check results is deferred until it's been established that the result will actually be used.

This seems to have some performance impact since (at least in my own tests) the vast majority of runs ends up with a non empty aggregate result set, but with only empty results. This situation leads to a lot of work being spent finding the selector of a node unnecessarily.