### PR TITLE
Improve isOffScreen() detection

### DIFF
--- a/lib/commons/dom/is-offscreen.js
+++ b/lib/commons/dom/is-offscreen.js
@@ -13,6 +13,11 @@ dom.isOffscreen = function (element) {
 	if (coords.bottom < 0) {
 		return true;
 	}
+	
+	if (coords.left === 0 && coords.right === 0) {
+		//This is an edge case, an empty (zero-width) element that isn't positioned 'off screen'.
+		return false;
+	}
 
 	if (dir === 'ltr') {
 		if (coords.right <= 0) {

--- a/lib/commons/dom/is-offscreen.js
+++ b/lib/commons/dom/is-offscreen.js
@@ -15,13 +15,13 @@ dom.isOffscreen = function (element) {
 	}
 
 	if (dir === 'ltr') {
-		if (coords.right < 0) {
+		if (coords.right <= 0) {
 			return true;
 		}
 	} else {
 
 		leftBoundary = Math.max(docElement.scrollWidth, dom.getViewportSize(window).width);
-		if (coords.left > leftBoundary) {
+		if (coords.left >= leftBoundary) {
 			return true;
 		}
 	}

--- a/test/commons/dom/is-offscreen.js
+++ b/test/commons/dom/is-offscreen.js
@@ -14,6 +14,20 @@ describe('dom.isOffscreen', function () {
 		assert.isTrue(axe.commons.dom.isOffscreen(el));
 	});
 
+	it('should detect elements positioned to but not beyond the left edge', function () {
+		fixture.innerHTML = '<div id="target" style="position: absolute; width: 50px; left: -50px;">Offscreen?</div>';
+		var el = document.getElementById('target');
+
+		assert.isTrue(axe.commons.dom.isOffscreen(el));
+	});
+
+	it('should not detect elements at the left edge with a zero width', function () {
+		fixture.innerHTML = '<div id="target" style="width: 0px; left: 0px;"></div>';
+		var el = document.getElementById('target');
+
+		assert.isFalse(axe.commons.dom.isOffscreen(el));
+	});
+
 	it('should detect elements positioned outside the top edge', function () {
 		fixture.innerHTML = '<div id="target" style="position: absolute; height: 50px; top: -51px;">Offscreen?</div>';
 		var el = document.getElementById('target');


### PR DESCRIPTION
From my tests, an element should be considered 'off the screen' if it is a non-zero-width element and its right edge is <= 0, not just < 0. 