### PR TITLE
Return optimally suited implicit role for a node

### DIFF
--- a/lib/commons/aria/attributes.js
+++ b/lib/commons/aria/attributes.js
@@ -22,6 +22,7 @@ aria.allowedAttr = function (role) {
 	var roles = lookupTables.role[role],
 		attr = (roles && roles.attributes && roles.attributes.allowed) || [],
 		requiredAttr = (roles && roles.attributes && roles.attributes.required) || [];
+
 	return attr.concat(lookupTables.globalAttributes).concat(requiredAttr);
 };
 

--- a/lib/commons/aria/roles.js
+++ b/lib/commons/aria/roles.js
@@ -101,25 +101,74 @@ aria.implicitNodes = function (role) {
  * @param  {HTMLElement} node The node to test
  * @return {Mixed}      Either the role or `null` if there is none
  */
+
 aria.implicitRole = function (node) {
 	'use strict';
 
-	var role, r, candidate,
-		roles = lookupTables.role;
+	/*
+	 * Filter function to reduce a list of roles to a valid list of roles for a nodetype
+	 */
+	var isValidImplicitRole = function (set, role) {
+		if (!role.implicit) { return set; }
 
-	for (role in roles) {
-		if (roles.hasOwnProperty(role)) {
-			r = roles[role];
-			if (r.implicit) {
-				for (var index = 0, length = r.implicit.length; index < length; index++) {
-					candidate = r.implicit[index];
-					if (axe.utils.matchesSelector(node, candidate)) {
-						return role;
-					}
-				}
-			}
+		if (role.implicit.some( function (implicitNodeType) {
+			return axe.utils.matchesSelector(node, implicitNodeType);
+		})) {
+			set.push(role.name);
+			return set;
 		}
+
+		return set;
+	};
+
+	/*
+	 * Score a set of roles and aria-attributes by its optimal score
+	 * E.g. score: 0, name: aria-required
+	 */
+	var sortRolesByOptimalAriaContext = function (roles, ariaAttributes) {
+		var getScore = function (role) {
+			var allowedAriaAttributes = aria.allowedAttr(role);
+			return allowedAriaAttributes.reduce( function (score, attribute) {
+				return score + (ariaAttributes.indexOf(attribute) > -1 ? 1 : 0);
+			}, 0);
+		};
+
+		var scored = roles.map( function (role) {
+			return { score: getScore(role), name: role };
+		});
+
+		var sorted = scored.sort( function (scoredRoleA, scoredRoleB) {
+			return scoredRoleB.score - scoredRoleA.score;
+		});
+
+		return sorted.map( function (sortedRole) {
+			return sortedRole.name;
+		});
+	};
+
+	/*
+	 * Create a list of { name / implicit } role mappings to filter on
+	 */
+	var roles = Object.keys(lookupTables.role).map( function (role) {
+		var lookup = lookupTables.role[role];
+		return { name: role, implicit: lookup && lookup.implicit };
+	});
+
+	/* Build a list of valid implicit roles for this node */
+	var availableImplicitRoles = roles.reduce(isValidImplicitRole, []);
+
+	if (!availableImplicitRoles.length) { return null; }
+
+	var nodeAttributes = node.attributes;
+	var ariaAttributes = [];
+
+	/* Get all aria-attributes defined for this node */
+	/* Should be a helper function somewhere */
+	for (var i = 0, j = nodeAttributes.length; i < j; i++) {
+		var attr = nodeAttributes[i];
+		if (attr.name.match(/^aria-/)) { ariaAttributes.push( attr.name ); }
 	}
 
-	return null;
+	/* Sort roles by highest score, return the first */
+	return sortRolesByOptimalAriaContext(availableImplicitRoles, ariaAttributes).shift();
 };

--- a/lib/commons/aria/roles.js
+++ b/lib/commons/aria/roles.js
@@ -109,13 +109,12 @@ aria.implicitRole = function (node) {
 	 * Filter function to reduce a list of roles to a valid list of roles for a nodetype
 	 */
 	var isValidImplicitRole = function (set, role) {
-		if (!role.implicit) { return set; }
+		var validForNodeType = function (implicitNodeTypeSelector) {
+			return axe.utils.matchesSelector(node, implicitNodeTypeSelector);
+		};
 
-		if (role.implicit.some( function (implicitNodeType) {
-			return axe.utils.matchesSelector(node, implicitNodeType);
-		})) {
+		if (role.implicit && role.implicit.some(validForNodeType)) {
 			set.push(role.name);
-			return set;
 		}
 
 		return set;
@@ -123,7 +122,7 @@ aria.implicitRole = function (node) {
 
 	/*
 	 * Score a set of roles and aria-attributes by its optimal score
-	 * E.g. score: 0, name: aria-required
+	 * E.g. [{score: 2, name: button}, {score: 1, name: main}]
 	 */
 	var sortRolesByOptimalAriaContext = function (roles, ariaAttributes) {
 		var getScore = function (role) {

--- a/test/commons/aria/roles.js
+++ b/test/commons/aria/roles.js
@@ -189,19 +189,59 @@ describe('aria.implicitRole', function () {
 		axe.commons.aria._lut.role = orig;
 	});
 
-	it('should find the first matching role', function () {
+	it('should find the first optimal matching role', function () {
 		var node = document.createElement('div');
+		node.setAttribute('aria-required', 'true');
+
 		node.id = 'cats';
 		fixture.appendChild(node);
 
 		axe.commons.aria._lut.role = {
 			'cats': {
 				implicit: ['div[id="cats"]']
+			},
+			'dogs': {
+				implicit: ['div[id="cats"]']
+			},
+			'dinosaurs': {
+				attributes: {
+					allowed: ['aria-required']
+				},
+				implicit: ['div[id="cats"]']
 			}
 		};
-		assert.equal(axe.commons.aria.implicitRole(node), 'cats');
 
+		assert.equal(axe.commons.aria.implicitRole(node), 'dinosaurs');
 	});
+
+	it('should find the first optimal matching role when multiple optimal matches are available', function () {
+		var node = document.createElement('div');
+		node.setAttribute('aria-required', 'true');
+
+		node.id = 'cats';
+		fixture.appendChild(node);
+
+		axe.commons.aria._lut.role = {
+			'cats': {
+				implicit: ['div[id="cats"]']
+			},
+			'dogs': {
+				 attributes: {
+					allowed: ['aria-required']
+				},
+				implicit: ['div[id="cats"]']
+			},
+			'dinosaurs': {
+				attributes: {
+					allowed: ['aria-required']
+				},
+				implicit: ['div[id="cats"]']
+			}
+		};
+
+		assert.equal(axe.commons.aria.implicitRole(node), 'dogs');
+	});
+
 
 	it('should return null if there is no matching implicit role', function () {
 		var node = document.createElement('div');


### PR DESCRIPTION
This fixes #290.

This is my first PR to this repository; I would much appreciate a code review. See also code comments pertaining to helper functions.

In case of multiple implicit roles existing for a node, we need to infer the expected implicit context based on a combination of applied aria-attributes for the node, and which of these are applicable to the existing implicit roles.

Each implicit role is given a score based on the combination of aria-attributes for the role, and the list of aria-attributes for the node.

The highest scoring role is returned. When multiple equally highest scored roles exist, the first is returned.