### PR TITLE
Fix false positive for th[scope=col] in tfoot and th[scope=row] in last column

### DIFF
--- a/lib/checks/tables/th-has-data-cells.js
+++ b/lib/checks/tables/th-has-data-cells.js
@@ -29,6 +29,13 @@ var headers = cells.filter(function (cell) {
 
 var tableGrid = tableUtils.toGrid(node);
 
+var isRowHeader = false;
+var dataCellIsNotEmpty = function (out, cell) {
+	var isHeader = isRowHeader ? tableUtils.isRowHeader : tableUtils.isColumnHeader;
+	return out || (cell.textContent.trim() !== '' &&
+		!isHeader(cell));
+};
+
 // Look for all the bad headers
 return headers.reduce(function (res, header) {
 	if (header.id && reffedHeaders.indexOf(header.id) !== -1) {
@@ -40,20 +47,20 @@ return headers.reduce(function (res, header) {
 
 	// Look for any data cells or row headers that this might refer to
 	if (tableUtils.isColumnHeader(header)) {
+		isRowHeader = false;
 		hasCell = tableUtils.traverse('down', pos, tableGrid)
-		.reduce((out, cell) => {
-			return out || (cell.textContent.trim() !== '' &&
-				!tableUtils.isColumnHeader(cell));
-		}, false);
+		.reduce(dataCellIsNotEmpty, false) ||
+			tableUtils.traverse('up', pos, tableGrid)
+			.reduce(dataCellIsNotEmpty, false);
 	}
 
 	// Look for any data cells or column headers that this might refer to
 	if (!hasCell && tableUtils.isRowHeader(header)) {
+		isRowHeader = true;
 		hasCell = tableUtils.traverse('right', pos, tableGrid)
-		.reduce((out, cell) => {
-			return out || (cell.textContent.trim() !== '' &&
-				!tableUtils.isRowHeader(cell));
-		}, false);
+		.reduce(dataCellIsNotEmpty, false) ||
+			tableUtils.traverse('left', pos, tableGrid)
+			.reduce(dataCellIsNotEmpty, false);
 	}
 
 	// report the node as having failed

--- a/test/checks/tables/th-has-data-cells.js
+++ b/test/checks/tables/th-has-data-cells.js
@@ -24,6 +24,8 @@ describe('th-has-data-cells', function () {
 			'<table>' +
 			'  <tr> <th>hi</th> <td>hello</td> </tr>' +
 			'  <tr> <th>hi</th> <td>hello</td> </tr>' +
+			'  <tr> <td>hello</td> <th>hi</th> </tr>' +
+			'  <tr> <td>hello</td> <th>hi</th> </tr>' +
 			'</table>';
 
 		var node = fixture.querySelector('table');
@@ -33,8 +35,9 @@ describe('th-has-data-cells', function () {
 	it('should return true each non-empty column header has a cell', function (){
 		fixture.innerHTML =
 			'<table>' +
-			'  <tr> <th>H</th> <th>H</th> </tr>' +
-			'  <tr> <td>hi</td> <td>hello</td></tr>' +
+			'  <thead> <tr> <th>H</th> <th>H</th> </tr> </thead>' +
+			'  <tfoot> <tr> <th>H</th> <th>H</th> </tr> </tfoot>' +
+			'  <tbody> <tr> <td>hi</td> <td>hello</td> </tr> </tbody>' +
 			'</table>';
 
 		var node = fixture.querySelector('table');

--- a/test/integration/rules/th-has-data-cells/th-has-data-cells.html
+++ b/test/integration/rules/th-has-data-cells/th-has-data-cells.html
@@ -30,19 +30,19 @@
   <tr> <th>AXE</th> <td>aXe</td> </tr>
 </table>
 
-<table id="fail1">
+<table id="pass7">
   <tr> <td>aXe</td> <th>AXE</th> </tr>
 </table>
 
-<table id="fail2">
+<table id="fail1">
   <tr> <th>AXE</th> </tr>
   <tr> <th>AXE</th> </tr>
 </table>
 
-<table id="fail3">
+<table id="fail2">
   <tr> <th>AXE</th> <th>AXE</th> </tr>
 </table>
 
-<table id="fail4">
+<table id="fail3">
   <tr> <td>aXe</td> <td role="columnheader">AXE</th> </tr>
 </table>

--- a/test/integration/rules/th-has-data-cells/th-has-data-cells.json
+++ b/test/integration/rules/th-has-data-cells/th-has-data-cells.json
@@ -1,6 +1,6 @@
 {
 	"description": "th-has-data-cells test",
 	"rule": "th-has-data-cells",
-	"violations": [["#fail1"], ["#fail2"], ["#fail3"], ["#fail4"]],
-	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"], ["#pass6"]]
+	"violations": [["#fail1"], ["#fail2"], ["#fail3"]],
+	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"], ["#pass6"], ["#pass7"]]
 }


### PR DESCRIPTION
When a `th[scope=col]` element is in the `tfoot` and has no `td` cells
following it in the column, or when a `th[scope=row]` element is the
last child in the row, the `th-has-data-cells` check fails because it
doesn’t check for preceding cells in the column or row.