### PR TITLE
fix: add copyright banner back in to axe.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,7 +193,7 @@ module.exports = function (grunt) {
 						bracketize: true,
 						quote_style: 1
 					},
-					preserveComments: 'some'
+					preserveComments: /^!/
 				}
 			},
 			minify: {


### PR DESCRIPTION
Uglify:beautify wasn't picking up the custom preserveComments function for axe.js. This fix adds the banner back in to that file. 