### PR TITLE
Fix bugs with implicit labels and TRs for color contrast

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -83,3 +83,7 @@ v2.2.2:
 	changes:
 		- Stabilize incompleteData API for backwards compatibility
 		- Change impact of duplicate-id rule to moderate
+v2.2.3:
+  date: 2017-06-01
+  changes:
+    - Removed the disable property from link-in-text-block

--- a/axe.d.ts
+++ b/axe.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for axe-core 2.2.2
+// Type definitions for axe-core 2.2.3
 // Project: https://github.com/dequelabs/axe-core
 // Definitions by: Marcy Sutton <https://github.com/marcysutton>
 

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -28,3 +28,4 @@ Add your project/integration to this file and submit a pull request.
 1. [Intern](https://github.com/theintern/intern-a11y)
 1. [Protractor-axe-report Plugin](https://github.com/E1Edatatracker/protractor-axe-report-plugin)
 1. [Rocket Validator](https://rocketvalidator.com)
+1. [aXe Reports](https://github.com/louis-reed/axe-reports)

--- a/doc/rule-descriptions.md
+++ b/doc/rule-descriptions.md
@@ -32,7 +32,7 @@
 | label-title-only | Ensures that every form element is not solely labeled using the title or aria-describedby attributes | cat.forms, best-practice | false |
 | label | Ensures every form element has a label | cat.forms, wcag2a, wcag332, wcag131, section508, section508.22.n | true |
 | layout-table | Ensures presentational &lt;table&gt; elements do not use &lt;th&gt;, &lt;caption&gt; elements or the summary attribute | cat.semantics, wcag2a, wcag131 | true |
-| link-in-text-block | Links can be distinguished without relying on color | cat.color, experimental, wcag2a, wcag141 | false |
+| link-in-text-block | Links can be distinguished without relying on color | cat.color, experimental, wcag2a, wcag141 | true |
 | link-name | Ensures links have discernible text | cat.name-role-value, wcag2a, wcag111, wcag412, section508, section508.22.a | true |
 | list | Ensures that lists are structured correctly | cat.structure, wcag2a, wcag131 | true |
 | listitem | Ensures &lt;li&gt; elements are used semantically | cat.structure, wcag2a, wcag131 | true |

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -12,7 +12,7 @@
         "imgNode": "Element's background color could not be determined because element contains an image node",
         "bgOverlap": "Element's background color could not be determined because it is overlapped by another element",
         "fgAlpha" : "Element's foreground color could not be determined because of alpha transparency",
-        "elmOutsideParent": "Element's background color could not be determined because it extends beyond a parent node",
+        "elmPartiallyObscured": "Element's background color could not be determined because it's partially obscured by another element",
         "default": "Unable to determine contrast ratio"
       }
     }

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -12,6 +12,7 @@
         "imgNode": "Element's background color could not be determined because element contains an image node",
         "bgOverlap": "Element's background color could not be determined because it is overlapped by another element",
         "fgAlpha" : "Element's foreground color could not be determined because of alpha transparency",
+        "elmOutsideParent": "Element's background color could not be determined because it extends beyond a parent node",
         "default": "Unable to determine contrast ratio"
       }
     }

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -125,6 +125,7 @@ function includeMissingElements(elmStack, elm) {
 	const tagArray = elmStack.map((elm) => {
 		return elm.tagName;
 	});
+	let bgNodes = elmStack;
 	for (let candidate in elementMap) {
 		if (elementMap.hasOwnProperty(candidate)) {
 			// tagName matches key
@@ -134,17 +135,18 @@ function includeMissingElements(elmStack, elm) {
 					// found an ancestor not in elmStack, and it overlaps
 					let overlaps = axe.commons.dom.visuallyOverlaps(elm.getBoundingClientRect(), ancestorMatch);
 					if (overlaps) {
-						elmStack.splice(elmStack.indexOf(elm) + 1, 0, ancestorMatch);
+						bgNodes.splice(elmStack.indexOf(elm) + 1, 0, ancestorMatch);
 					}
 				}
 			}
 			// tagName matches value
 			// (such as LABEL, when matching itself. It should be in the list, but Phantom skips it)
 			if (elm.tagName === elementMap[candidate] && tagArray.indexOf(elm.tagName) === -1) {
-				elmStack.splice(tagArray.indexOf(candidate) + 1, 0, elm);
+				bgNodes.splice(tagArray.indexOf(candidate) + 1, 0, elm);
 			}
 		}
 	}
+	return bgNodes;
 }
 
 /**
@@ -152,8 +154,10 @@ function includeMissingElements(elmStack, elm) {
  * @private
  * @param {Array} elmStack
  */
-function consultDocumentBody(elmStack) {
+function sortPageBackground(elmStack) {
 	let bodyIndex = elmStack.indexOf(document.body);
+
+	let bgNodes = elmStack;
 
 	if (// Check that the body background is the page's background
 		bodyIndex > 1 && // only if there are negative z-index elements
@@ -161,12 +165,13 @@ function consultDocumentBody(elmStack) {
 		getBgColor(document.documentElement).alpha === 0
 	) {
 		// Remove body and html from it's current place
-		elmStack.splice(bodyIndex, 1);
-		elmStack.splice( elmStack.indexOf(document.documentElement), 1);
+		bgNodes.splice(bodyIndex, 1);
+		bgNodes.splice( elmStack.indexOf(document.documentElement), 1);
 
 		// Put the body background as the lowest element
-		elmStack.push(document.body);
+		bgNodes.push(document.body);
 	}
+	return bgNodes;
 }
 
 /**
@@ -190,10 +195,9 @@ color.getBackgroundStack = function(elm) {
 			window.innerHeight - 1);
 
 	let elmStack = document.elementsFromPoint(x, y);
-	includeMissingElements(elmStack, elm);
+	elmStack = includeMissingElements(elmStack, elm);
 	elmStack = dom.reduceToElementsBelowFloating(elmStack, elm);
-
-	consultDocumentBody(elmStack);
+	elmStack = sortPageBackground(elmStack);
 
 	// Return all elements BELOW the current element, null if the element is undefined
 	let elmIndex = elmStack.indexOf(elm);

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -38,16 +38,27 @@ function getBgColor(elm, elmStyle) {
 	return bgColor;
 }
 
-function calculateObscuringAlpha(elmIndex, elmStack) {
+function contentOverlapped(targetElement) {
+	// Get dimensions of text content box.
+	// Subsequent clientRects are bounding boxes, if different than content box
+	var targetRect = targetElement.getClientRects()[0];
+	var elementAtPoint = document.elementFromPoint(targetRect.left, targetRect.top);
+	if (elementAtPoint !== null && elementAtPoint.innerHTML !== targetElement.innerHTML) {
+		return true;
+	}
+	return false;
+}
+
+function calculateObscuringAlpha(elmIndex, elmStack, originalElm) {
 	var totalAlpha = 0;
 
 	if (elmIndex > 0) {
-		// there are elements above our element, check if they are contribute to the background
+		// there are elements above our element, check if they contribute to the background
 		for (var i = elmIndex - 1; i >= 0; i--) {
 			let bgElm = elmStack[i];
 			let bgElmStyle = window.getComputedStyle(bgElm);
 			let bgColor = getBgColor(bgElm, bgElmStyle);
-			if (bgColor.alpha) {
+			if (bgColor.alpha && contentOverlapped(originalElm, bgElm)) {
 				totalAlpha += bgColor.alpha;
 			} else {
 				// remove elements not contributing to the background
@@ -102,7 +113,7 @@ color.getBackgroundStack = function(elm) {
 
 	// Return all elements BELOW the current element, null if the element is undefined
 	let elmIndex = elmStack.indexOf(elm);
-	if (calculateObscuringAlpha(elmIndex, elmStack) >= 0.99) {
+	if (calculateObscuringAlpha(elmIndex, elmStack, elm) >= 0.99) {
 		// if the total of the elements above our element results in total obscuring, return null
 		axe.commons.color.incompleteData.set('bgColor', 'bgOverlap');
 		return null;

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -1,4 +1,5 @@
 /* global axe, color, dom */
+/*jshint maxstatements: 22 */
 const graphicNodes = [
 	'IMG', 'CANVAS', 'OBJECT', 'IFRAME', 'VIDEO', 'SVG'
 ];
@@ -80,7 +81,38 @@ function elmOutsideParent(elm, bgElm, bgColor) {
 	return outside;
 }
 
+// document.elementsFromPoint misses some elements we need
+// i.e. TR is missing from table elementStack and leaves out bgColor
+// https://github.com/dequelabs/axe-core/issues/273
+function includeMissingElements(elmStack, elm) {
+	const elementMap = {'TD': 'TR', 'INPUT': 'LABEL'};
+	let bgSplice = [];
+	elmStack.forEach(function(bgNode) {
+		if (bgNode.nodeType === 1) {
+			for (var elmTagName in elementMap) {
+				if (elm.tagName === elmTagName) {
+					let tagMatch = elementMap[elmTagName];
+					if (elmStack.indexOf(tagMatch) === -1 && bgNode.tagName === elmTagName) {
+						// look up the tree for a parent that matches
+						let ancestorMatch = axe.commons.dom.findUp(bgNode, tagMatch);
+						if (ancestorMatch) {
+							bgSplice.push([elmStack.indexOf(bgNode) + 1, ancestorMatch]);
+						}
+					}
+				}
+			}
+		}
+	});
+	for (var i=0; i<bgSplice.length; i++) {
+		let startIndex = bgSplice[i][0], ancestorMatch = bgSplice[i][1];
+		elmStack.splice(startIndex, 0, ancestorMatch);
+	}
+	// Phantom misses inline label elements
+	if (elm.nodeName === 'LABEL' && elmStack.indexOf(elm) === -1) {
+		elmStack.splice(0, 0, elm);
+	}
 }
+
 /**
  * Get all elements rendered underneath the current element,
  * in the order in which it is rendered
@@ -102,6 +134,7 @@ color.getBackgroundStack = function(elm) {
 			window.innerHeight - 1);
 
 	let elmStack = document.elementsFromPoint(x, y);
+	includeMissingElements(elmStack, elm);
 	elmStack = dom.reduceToElementsBelowFloating(elmStack, elm);
 
 	let bodyIndex = elmStack.indexOf(document.body);

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -3,6 +3,13 @@ const graphicNodes = [
 	'IMG', 'CANVAS', 'OBJECT', 'IFRAME', 'VIDEO', 'SVG'
 ];
 
+/**
+ * Reports if an element has a background image or gradient
+ * @private
+ * @param {Element} elm
+ * @param {Object|null} style
+ * @return {Boolean}
+ */
 function elmHasImage(elm, style) {
 	var nodeName = elm.nodeName.toUpperCase();
 	if (graphicNodes.includes(nodeName)) {
@@ -22,6 +29,7 @@ function elmHasImage(elm, style) {
 
 /**
  * Returns the non-alpha-blended background color of an element
+ * @private
  * @param {Element} elm
  * @return {Color}
  */
@@ -38,9 +46,16 @@ function getBgColor(elm, elmStyle) {
 	return bgColor;
 }
 
+/**
+ * Determines overlap of node's content with a bgNode. Used for inline elements
+ * @private
+ * @param {Element} targetElement
+ * @param {Element} bgNode
+ * @return {Boolean}
+ */
 function contentOverlapping(targetElement, bgNode) {
 	// get content box of target element
-	// check to see if the current bgNode is on top
+	// check to see if the current bgNode is overlapping
 	var targetRect = targetElement.getClientRects()[0];
 	var obscuringElements = document.elementsFromPoint(targetRect.left, targetRect.top);
 	if (obscuringElements) {
@@ -52,7 +67,14 @@ function contentOverlapping(targetElement, bgNode) {
 	}
 	return false;
 }
-
+/**
+ * Calculate alpha transparency of a background element obscuring the current node
+ * @private
+ * @param {Number} elmIndex
+ * @param {Array} elmStack
+ * @param {Element} originalElm
+ * @return {Number|undefined}
+ */
 function calculateObscuringAlpha(elmIndex, elmStack, originalElm) {
 	var totalAlpha = 0;
 
@@ -72,7 +94,14 @@ function calculateObscuringAlpha(elmIndex, elmStack, originalElm) {
 	}
 	return totalAlpha;
 }
-
+/**
+ * Determine if element is partially overlapped, triggering a Can't Tell result
+ * @private
+ * @param {Element} elm
+ * @param {Element} bgElm
+ * @param {Object} bgColor
+ * @return {Boolean}
+ */
 function elmPartiallyObscured(elm, bgElm, bgColor) {
 	var obscured = (elm !== bgElm && !dom.visuallyContains(elm, bgElm) && bgColor.alpha !== 0);
 	if (obscured) {
@@ -86,6 +115,10 @@ function elmPartiallyObscured(elm, bgElm, bgColor) {
  * document.elementsFromPoint misses some elements we need
  * i.e. TR is missing from table elementStack and leaves out bgColor
  * https://github.com/dequelabs/axe-core/issues/273
+ *
+ * @private
+ * @param {Array} elmStack
+ * @param {Element} elm
  */
 function includeMissingElements(elmStack, elm) {
 	const elementMap = {'TD': 'TR', 'INPUT': 'LABEL'};
@@ -116,6 +149,8 @@ function includeMissingElements(elmStack, elm) {
 
 /**
  * Look at document and body elements for relevant background information
+ * @private
+ * @param {Array} elmStack
  */
 function consultDocumentBody(elmStack) {
 	let bodyIndex = elmStack.indexOf(document.body);

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -1,5 +1,4 @@
 /* global axe, color, dom */
-/*jshint maxstatements: 22 */
 const graphicNodes = [
 	'IMG', 'CANVAS', 'OBJECT', 'IFRAME', 'VIDEO', 'SVG'
 ];
@@ -82,9 +81,12 @@ function elmPartiallyObscured(elm, bgElm, bgColor) {
 	return obscured;
 }
 
-// document.elementsFromPoint misses some elements we need
-// i.e. TR is missing from table elementStack and leaves out bgColor
-// https://github.com/dequelabs/axe-core/issues/273
+/**
+ * Include nodes missing from initial gathering because
+ * document.elementsFromPoint misses some elements we need
+ * i.e. TR is missing from table elementStack and leaves out bgColor
+ * https://github.com/dequelabs/axe-core/issues/273
+ */
 function includeMissingElements(elmStack, elm) {
 	const elementMap = {'TD': 'TR', 'INPUT': 'LABEL'};
 	const tagArray = elmStack.map((elm) => {
@@ -113,6 +115,26 @@ function includeMissingElements(elmStack, elm) {
 }
 
 /**
+ * Look at document and body elements for relevant background information
+ */
+function consultDocumentBody(elmStack) {
+	let bodyIndex = elmStack.indexOf(document.body);
+
+	if (// Check that the body background is the page's background
+		bodyIndex > 1 && // only if there are negative z-index elements
+		!elmHasImage(document.documentElement) &&
+		getBgColor(document.documentElement).alpha === 0
+	) {
+		// Remove body and html from it's current place
+		elmStack.splice(bodyIndex, 1);
+		elmStack.splice( elmStack.indexOf(document.documentElement), 1);
+
+		// Put the body background as the lowest element
+		elmStack.push(document.body);
+	}
+}
+
+/**
  * Get all elements rendered underneath the current element,
  * in the order in which it is rendered
  */
@@ -136,20 +158,7 @@ color.getBackgroundStack = function(elm) {
 	includeMissingElements(elmStack, elm);
 	elmStack = dom.reduceToElementsBelowFloating(elmStack, elm);
 
-	let bodyIndex = elmStack.indexOf(document.body);
-
-	if (// Check that the body background is the page's background
-		bodyIndex > 1 && // only if there are negative z-index elements
-		!elmHasImage(document.documentElement) &&
-		getBgColor(document.documentElement).alpha === 0
-	) {
-		// Remove body and html from it's current place
-		elmStack.splice(bodyIndex, 1);
-		elmStack.splice( elmStack.indexOf(document.documentElement), 1);
-
-		// Put the body background as the lowest element
-		elmStack.push(document.body);
-	}
+	consultDocumentBody(elmStack);
 
 	// Return all elements BELOW the current element, null if the element is undefined
 	let elmIndex = elmStack.indexOf(elm);

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -39,13 +39,17 @@ function getBgColor(elm, elmStyle) {
 	return bgColor;
 }
 
-function contentOverlapped(targetElement) {
-	// Get dimensions of text content box.
-	// Subsequent clientRects are bounding boxes, if different than content box
+function contentOverlapping(targetElement, bgNode) {
+	// get content box of target element
+	// check to see if the current bgNode is on top
 	var targetRect = targetElement.getClientRects()[0];
-	var elementAtPoint = document.elementFromPoint(targetRect.left, targetRect.top);
-	if (elementAtPoint !== null && elementAtPoint.innerHTML !== targetElement.innerHTML) {
-		return true;
+	var obscuringElements = document.elementsFromPoint(targetRect.left, targetRect.top);
+	if (obscuringElements) {
+		for(var i = 0; i < obscuringElements.length; i++) {
+			if (obscuringElements[i] !== targetElement && obscuringElements[i] === bgNode) {
+				return true;
+			}
+		}
 	}
 	return false;
 }
@@ -59,7 +63,7 @@ function calculateObscuringAlpha(elmIndex, elmStack, originalElm) {
 			let bgElm = elmStack[i];
 			let bgElmStyle = window.getComputedStyle(bgElm);
 			let bgColor = getBgColor(bgElm, bgElmStyle);
-			if (bgColor.alpha && contentOverlapped(originalElm, bgElm)) {
+			if (bgColor.alpha && contentOverlapping(originalElm, bgElm)) {
 				totalAlpha += bgColor.alpha;
 			} else {
 				// remove elements not contributing to the background
@@ -83,30 +87,28 @@ function elmPartiallyObscured(elm, bgElm, bgColor) {
 // https://github.com/dequelabs/axe-core/issues/273
 function includeMissingElements(elmStack, elm) {
 	const elementMap = {'TD': 'TR', 'INPUT': 'LABEL'};
-	let bgSplice = [];
-	elmStack.forEach(function(bgNode) {
-		if (bgNode.nodeType === 1) {
-			for (var elmTagName in elementMap) {
-				if (elm.tagName === elmTagName) {
-					let tagMatch = elementMap[elmTagName];
-					if (elmStack.indexOf(tagMatch) === -1 && bgNode.tagName === elmTagName) {
-						// look up the tree for a parent that matches
-						let ancestorMatch = axe.commons.dom.findUp(bgNode, tagMatch);
-						if (ancestorMatch) {
-							bgSplice.push([elmStack.indexOf(bgNode) + 1, ancestorMatch]);
-						}
+	const tagArray = elmStack.map((elm) => {
+		return elm.tagName;
+	});
+	for (let candidate in elementMap) {
+		if (elementMap.hasOwnProperty(candidate)) {
+			// tagName matches key
+			if (elm.tagName === candidate) {
+				let ancestorMatch = axe.commons.dom.findUp(elm, elementMap[candidate]);
+				if (ancestorMatch && elmStack.indexOf(ancestorMatch) === -1) {
+					// found an ancestor not in elmStack, and it overlaps
+					let overlaps = axe.commons.dom.visuallyOverlaps(elm.getBoundingClientRect(), ancestorMatch);
+					if (overlaps) {
+						elmStack.splice(elmStack.indexOf(elm) + 1, 0, ancestorMatch);
 					}
 				}
 			}
+			// tagName matches value
+			// (such as LABEL, when matching itself. It should be in the list, but Phantom skips it)
+			if (elm.tagName === elementMap[candidate] && tagArray.indexOf(elm.tagName) === -1) {
+				elmStack.splice(tagArray.indexOf(candidate) + 1, 0, elm);
+			}
 		}
-	});
-	for (var i=0; i<bgSplice.length; i++) {
-		let startIndex = bgSplice[i][0], ancestorMatch = bgSplice[i][1];
-		elmStack.splice(startIndex, 0, ancestorMatch);
-	}
-	// Phantom misses inline label elements
-	if (elm.nodeName === 'LABEL' && elmStack.indexOf(elm) === -1) {
-		elmStack.splice(0, 0, elm);
 	}
 }
 

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -70,8 +70,16 @@ function calculateObscuringAlpha(elmIndex, elmStack, originalElm) {
 }
 
 function elmOutsideParent(elm, bgElm, bgColor) {
-	var visible = (elm !== bgElm && !dom.visuallyContains(elm, bgElm) && bgColor.alpha !== 0);
-	return visible;
+	var outside = (elm !== bgElm && !dom.visuallyContains(elm, bgElm) && bgColor.alpha !== 0);
+	if (outside) {
+		axe.commons.color.incompleteData.set('bgColor', {
+			node: elm,
+			reason: 'elmOutsideParent'
+		});
+	}
+	return outside;
+}
+
 }
 /**
  * Get all elements rendered underneath the current element,

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -70,15 +70,12 @@ function calculateObscuringAlpha(elmIndex, elmStack, originalElm) {
 	return totalAlpha;
 }
 
-function elmOutsideParent(elm, bgElm, bgColor) {
-	var outside = (elm !== bgElm && !dom.visuallyContains(elm, bgElm) && bgColor.alpha !== 0);
-	if (outside) {
-		axe.commons.color.incompleteData.set('bgColor', {
-			node: elm,
-			reason: 'elmOutsideParent'
-		});
+function elmPartiallyObscured(elm, bgElm, bgColor) {
+	var obscured = (elm !== bgElm && !dom.visuallyContains(elm, bgElm) && bgColor.alpha !== 0);
+	if (obscured) {
+		axe.commons.color.incompleteData.set('bgColor', 'elmPartiallyObscured');
 	}
-	return outside;
+	return obscured;
 }
 
 // document.elementsFromPoint misses some elements we need
@@ -176,8 +173,8 @@ color.getBackgroundColor = function(elm, bgElms = [], noScroll = false) {
 		// Get the background color
 		let bgColor = getBgColor(bgElm, bgElmStyle);
 
-		if (// abort if a node is outside it's parent and its parent has a background
-			elmOutsideParent(elm, bgElm, bgColor) ||
+		if (// abort if a node is partially obscured and obscuring element has a background
+			elmPartiallyObscured(elm, bgElm, bgColor) ||
 			// OR if the background elm is a graphic
 			elmHasImage(bgElm, bgElmStyle)
 		) {

--- a/lib/commons/dom/visually-contains.js
+++ b/lib/commons/dom/visually-contains.js
@@ -1,5 +1,5 @@
 /* global dom */
-/* jshint maxcomplexity: 11 */
+/* jshint maxcomplexity: 12 */
 
 /**
  * Checks whether a parent element visually contains its child, either directly or via scrolling.
@@ -27,6 +27,13 @@ dom.visuallyContains = function (node, parent) {
 		right: parentLeft - parent.scrollLeft + parent.scrollWidth
 	};
 
+	var style = window.getComputedStyle(parent);
+
+	// if parent element is inline, scrollArea will be too unpredictable
+	if (style.getPropertyValue('display') === 'inline') {
+    return true;
+  }
+
 	//In theory, we should just be able to look at the scroll area as a superset of the parentRect,
 	//but that's not true in Firefox
 	if ((rect.left < parentScrollArea.left && rect.left < parentRect.left) ||
@@ -35,8 +42,6 @@ dom.visuallyContains = function (node, parent) {
 		(rect.bottom > parentScrollArea.bottom && rect.bottom > parentRect.bottom)) {
 		return false;
 	}
-
-	var style = window.getComputedStyle(parent);
 
 	if (rect.right > parentRect.right || rect.bottom > parentRect.bottom) {
 		return (style.overflow === 'scroll' || style.overflow === 'auto' ||

--- a/lib/rules/link-in-text-block.json
+++ b/lib/rules/link-in-text-block.json
@@ -3,7 +3,6 @@
   "selector": "a[href]:not([role]), *[role=link]",
   "matches": "link-in-text-block-matches.js",
   "excludeHidden": false,
-  "enabled": false,
   "tags": [
     "cat.color",
     "experimental",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axe-core",
   "description": "Accessibility engine for automated Web UI testing",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MPL-2.0",
   "contributors": [
     {

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -157,4 +157,39 @@ describe('color-contrast', function () {
 		assert.equal(checkContext._data.missingData, 'bgGradient');
 		assert.equal(checkContext._data.contrastRatio, 0);
 	});
+
+	it('should return undefined when there are elements overlapping', function () {
+		fixture.innerHTML = '<div style="color: black; background-color: white; width: 200px; height: 100px; position: relative;" id="target">' +
+			'My text <div style="position: absolute; top:0; left: 0; background-color: white; width: 100%; height: 100%;"></div></div>';
+		var target = fixture.querySelector('#target');
+		assert.isUndefined(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.equal(checkContext._data.missingData[0].reason, 'bgOverlap');
+		assert.equal(checkContext._data.contrastRatio, 0);
+	});
+
+	it('should return true when a form wraps mixed content', function() {
+		fixture.innerHTML = '<form id="pass6"><p>Some text</p><label for="input6">Text</label><input id="input6"></form>';
+		var target = fixture.querySelector('#pass6');
+		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+	});
+
+	it('should return true when a label wraps a text input', function () {
+		fixture.innerHTML = '<label style="color: black; background-color: white;" id="target">' +
+			'My text <input type="text"></label>';
+		var target = fixture.querySelector('#target');
+		var result = checks['color-contrast'].evaluate.call(checkContext, target);
+		assert.isTrue(result);
+	});
+
+	it('should return undefined if element overlaps text content', function () {
+		fixture.innerHTML = '<div style="background-color: white; height: 60px; width: 80px; border:1px solid;position: relative;">' +
+			'<div id="target" style="color: white; height: 40px; width: 60px; border:1px solid red;">Hi</div>' +
+			'<div style="position: absolute; top: 0; width: 60px; height: 40px;background-color: #000"></div>' +
+		'</div>';
+		var target = fixture.querySelector('#target');
+		var actual = checks['color-contrast'].evaluate.call(checkContext, target);
+		assert.isUndefined(actual);
+		assert.equal(checkContext._data.missingData[0].reason, 'bgOverlap');
+		assert.equal(checkContext._data.contrastRatio, 0);
+	});
 });

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -162,8 +162,9 @@ describe('color-contrast', function () {
 		fixture.innerHTML = '<div style="color: black; background-color: white; width: 200px; height: 100px; position: relative;" id="target">' +
 			'My text <div style="position: absolute; top:0; left: 0; background-color: white; width: 100%; height: 100%;"></div></div>';
 		var target = fixture.querySelector('#target');
-		assert.isUndefined(checks['color-contrast'].evaluate.call(checkContext, target));
-		assert.equal(checkContext._data.missingData[0].reason, 'bgOverlap');
+		var result = checks['color-contrast'].evaluate.call(checkContext, target);
+		assert.isUndefined(result);
+		assert.equal(checkContext._data.missingData, 'bgOverlap');
 		assert.equal(checkContext._data.contrastRatio, 0);
 	});
 
@@ -181,6 +182,14 @@ describe('color-contrast', function () {
 		assert.isTrue(result);
 	});
 
+	it('should return true when a label wraps a text input but doesn\'t overlap', function () {
+		fixture.innerHTML = '<label id="target">' +
+			'My text <input type="text" style="position: absolute; top: 200px;"></label>';
+		var target = fixture.querySelector('#target');
+		var result = checks['color-contrast'].evaluate.call(checkContext, target);
+		assert.isTrue(result);
+	});
+
 	it('should return undefined if element overlaps text content', function () {
 		fixture.innerHTML = '<div style="background-color: white; height: 60px; width: 80px; border:1px solid;position: relative;">' +
 			'<div id="target" style="color: white; height: 40px; width: 60px; border:1px solid red;">Hi</div>' +
@@ -189,7 +198,7 @@ describe('color-contrast', function () {
 		var target = fixture.querySelector('#target');
 		var actual = checks['color-contrast'].evaluate.call(checkContext, target);
 		assert.isUndefined(actual);
-		assert.equal(checkContext._data.missingData[0].reason, 'bgOverlap');
+		assert.equal(checkContext._data.missingData, 'bgOverlap');
 		assert.equal(checkContext._data.contrastRatio, 0);
 	});
 });

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -174,7 +174,7 @@ describe('color-contrast', function () {
 	});
 
 	it('should return true when a label wraps a text input', function () {
-		fixture.innerHTML = '<label style="color: black; background-color: white;" id="target">' +
+		fixture.innerHTML = '<label id="target">' +
 			'My text <input type="text"></label>';
 		var target = fixture.querySelector('#target');
 		var result = checks['color-contrast'].evaluate.call(checkContext, target);

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -190,6 +190,64 @@ describe('color.getBackgroundColor', function () {
 		assert.deepEqual(bgNodes, [target]);
 	});
 
+	it('should count a tr as a background element', function () {
+		fixture.innerHTML = '<div style="background-color: #007acc;">' +
+		'<table style="width:100%">' +
+			'<tr style="background-color: #f3f3f3; height:40px;" id="parent">' +
+        '<td style="display: table-cell; color:#007acc" id="target">' +
+					'Cell content</td>' +
+        '</tr>' +
+      '</table></div>';
+		var target = fixture.querySelector('#target'),
+				parent = fixture.querySelector('#parent');
+		var bgNodes = [];
+		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
+		var expected = new axe.commons.color.Color(243, 243, 243, 1);
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+		assert.deepEqual(bgNodes, [parent]);
+	});
+
+	it('should handle multiple ancestors of the same name', function () {
+		fixture.innerHTML = '<div style="background-color: #007acc;">' +
+		'<table style="width: 100%;">' +
+			'<tr style="background-color: #fff;"><td>' +
+			'<table style="width:100%">' +
+				'<tr style="background-color: #f3f3f3; height:40px;" id="parent">' +
+	        '<td style="display: table-cell; color:#007acc" id="target">' +
+						'Cell content</td>' +
+	        '</tr>' +
+	      '</table>' +
+	    '</td></tr>' +
+	  '</table></div>';
+		var target = fixture.querySelector('#target'),
+				parent = fixture.querySelector('#parent');
+		var bgNodes = [];
+		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
+		var expected = new axe.commons.color.Color(243, 243, 243, 1);
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+		assert.deepEqual(bgNodes, [parent]);
+	});
+
+	it('should count an implicit label as a background element', function () {
+		fixture.innerHTML = '<label id="target" style="background-color: #fff;">My label' +
+		'<input type="text">' +
+			'</label>';
+		var target = fixture.querySelector('#target');
+		var bgNodes = [];
+		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
+		var expected = new axe.commons.color.Color(255, 255, 255, 1);
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+	});
+
 	it('should use hierarchical DOM traversal if possible', function () {
 		fixture.innerHTML =
 		'<div id="parent" style="height: 40px; width: 30px; ' +
@@ -388,10 +446,8 @@ describe('color.getBackgroundColor', function () {
 
 	});
 
-
-
 	it('returns the html background', function () {
-		fixture.innerHTML = '<div id="target">elm</div>';
+		fixture.innerHTML = '<div id="target"><label>elm<input></label></div>';
 		var orig = document.documentElement.style.background;
 		document.documentElement.style.background = '#0F0';
 
@@ -406,5 +462,4 @@ describe('color.getBackgroundColor', function () {
 		assert.closeTo(actual.alpha, expected.alpha, 0.1);
 
 	});
-
 });

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -5,6 +5,7 @@ describe('color.getBackgroundColor', function () {
 
 	afterEach(function () {
 		document.getElementById('fixture').innerHTML = '';
+		axe.commons.color.incompleteData.clear();
 	});
 
 	it('should return the blended color if it has no background set', function () {
@@ -190,11 +191,11 @@ describe('color.getBackgroundColor', function () {
 		assert.deepEqual(bgNodes, [target]);
 	});
 
-	it('should count a tr as a background element', function () {
-		fixture.innerHTML = '<div style="background-color: #007acc;">' +
+	it('should count a TR as a background element', function () {
+		fixture.innerHTML = '<div style="background-color:#007acc;">' +
 		'<table style="width:100%">' +
-			'<tr style="background-color: #f3f3f3; height:40px;" id="parent">' +
-        '<td style="display: table-cell; color:#007acc" id="target">' +
+			'<tr style="background-color:#f3f3f3; height:40px;" id="parent">' +
+        '<td style="color:#007acc" id="target">' +
 					'Cell content</td>' +
         '</tr>' +
       '</table></div>';
@@ -208,6 +209,54 @@ describe('color.getBackgroundColor', function () {
 		assert.equal(actual.blue, expected.blue);
 		assert.equal(actual.alpha, expected.alpha);
 		assert.deepEqual(bgNodes, [parent]);
+	});
+
+	it('should ignore TR elements that don\'t overlap', function () {
+		fixture.innerHTML = '<table style="position:relative; width:100%;">' +
+		'<tr style="background-color:black; height:10px; width:100%;" id="parent">' +
+			'<td style="position:absolute; top: 14px;" id="target">Content</td>'+
+		'</tr></table>';
+		var bgNodes = [];
+		var target = fixture.querySelector('#target');
+		var parent = fixture.querySelector('#parent');
+		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
+		var expected = new axe.commons.color.Color(255, 255, 255, 1);
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+		assert.notEqual(bgNodes, [parent]);
+	});
+
+	it('should count an implicit label as a background element', function () {
+		fixture.innerHTML = '<label id="target" style="background-color: #fff;">My label' +
+		'<input type="text">' +
+			'</label>';
+		var target = fixture.querySelector('#target');
+		var bgNodes = [];
+		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
+		var expected = new axe.commons.color.Color(255, 255, 255, 1);
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+	});
+
+	it('should ignore inline ancestors of non-overlapping elements', function () {
+		fixture.innerHTML = '<div style="position:relative;">'+
+		'<label style="background-color:black;" id="parent">Label' +
+			'<input style="position:absolute; top:20px;" id="target">'+
+		'</label></div>';
+		var target = fixture.querySelector('#target');
+		var parent = fixture.querySelector('#parent');
+		var bgNodes = [];
+		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
+		var expected = new axe.commons.color.Color(255, 255, 255, 1);
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+		assert.notEqual(bgNodes, [parent]);
 	});
 
 	it('should handle multiple ancestors of the same name', function () {
@@ -232,20 +281,6 @@ describe('color.getBackgroundColor', function () {
 		assert.equal(actual.blue, expected.blue);
 		assert.equal(actual.alpha, expected.alpha);
 		assert.deepEqual(bgNodes, [parent]);
-	});
-
-	it('should count an implicit label as a background element', function () {
-		fixture.innerHTML = '<label id="target" style="background-color: #fff;">My label' +
-		'<input type="text">' +
-			'</label>';
-		var target = fixture.querySelector('#target');
-		var bgNodes = [];
-		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
-		var expected = new axe.commons.color.Color(255, 255, 255, 1);
-		assert.equal(actual.red, expected.red);
-		assert.equal(actual.green, expected.green);
-		assert.equal(actual.blue, expected.blue);
-		assert.equal(actual.alpha, expected.alpha);
 	});
 
 	it('should use hierarchical DOM traversal if possible', function () {

--- a/test/commons/dom/visually-contains.js
+++ b/test/commons/dom/visually-contains.js
@@ -47,4 +47,12 @@ describe('dom.visuallyContains', function () {
 		assert.isTrue(axe.commons.dom.visuallyContains(target, target.parentNode));
 	});
 
+	it('should return true when element is inline', function () {
+		// result depends on the display property of the element
+		fixture.innerHTML = '<label>' +
+			'My label <input type="text" id="target">' +
+			'</label>';
+		var target = fixture.querySelector('#target');
+		assert.isTrue(axe.commons.dom.visuallyContains(target, target.parentNode));
+	});
 });

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -8,7 +8,10 @@
 	<div style="background-color: rgba(255, 255, 255, 0.1); color: white;" id="pass5">Pass.</div>
 </div>
 
-<label id="pass6">Default label<input type="text"></label>
+<label id="pass6">
+	Default label
+	<input type="text">
+</label>
 
 <div id="fail2" style="background-color: gray; color: white; font-size: 8px;">This is a fail.</div>
 <div id="fail3" style="background-color: yellow; color: white; font-size: 40px;">This is a fail.</div>

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -1,12 +1,17 @@
-<div style="background-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)">
 <div id="pass1" style="background-color: white; color: black">This is a pass.</div>
 <div id="pass2" style="background-color: gray; color: white; font-size: 40px;">This is a pass.</div>
 <div id="pass3" style="background-color: gray; color: white; font-size: 20px; font-weight: bold">This is a pass.</div>
+
 <div id="fail1" style="background-color: gray; color: white; font-size: 20px;">This is a fail.<b id="pass4">But this is a pass.</b></div>
+
+<div style="background-color: black;">
+	<div style="background-color: rgba(255, 255, 255, 0.1); color: white;" id="pass5">Pass.</div>
+</div>
+
+<label id="pass6">Default label<input type="text"></label>
+
 <div id="fail2" style="background-color: gray; color: white; font-size: 8px;">This is a fail.</div>
 <div id="fail3" style="background-color: yellow; color: white; font-size: 40px;">This is a fail.</div>
-<div style="background-color: black;"><div style="background-color: rgba(255, 255, 255, 0.1); color: white" id="pass5">Pass.</div></div>
-
 <div style="background-color: white;"><div style="background-color: rgba(255, 255, 255, 0.1); color: white" id="fail4">Fail.</div></div>
 <div style="background-color: white; height: 60px; width: 80px;"><div id="fail5" style="color: white; height: 40px; width: 60px;">Hi</div></div>
 <div style="background-color: white"><div id="fail6" style="opacity: 0.1; background-color: white; color: black">This is a fail.</div></div>
@@ -25,6 +30,7 @@
 <input id="fail16" type="submit" style="background: #000; color: #000" value="hello">
 <input id="fail17" style="background: #000; color: #000" value="hello">
 <div id="fail18" style="background: #000; color: #000" role="alert" aria-disabled="false">hello</div>
+
 <div id="fail19" style="background: #000; color: #000" aria-hidden="true">text</div>
 
 <!-- shouldnt run -->
@@ -33,18 +39,34 @@
 <input id="ignore2" style="background: #000; color: #000" value="hello" type="checkbox">
 <input id="ignore4" style="background: #000; color: #000" value="hello" type="hidden">
 <select id="ignore5" style="background: #000; color: #000"></select>
+
 <div id="ignore6" style="color: yellow; width: 100px; overflow: hidden; text-indent: 200px; background-color: white;">text</div>
-<label style="color: #fff">
-	Test
-	<input type="text" disabled>
-</label>
+
 <label for="disabled1">Hello</label>
 <input id="disabled1" disabled>
 <div id="disabled2">Hello</div>
 <input aria-labelledby="disabled2" disabled>
 <div id="disabled3" style="background: #000; color: #000" role="alert" aria-disabled="true">hello</div>
+<label style="color: #fff" id="disabled4">
+	Test
+	<input type="text" disabled>
+</label>
 
-<div style="background-color: rgba(255, 255, 255, 0.1); color: white" id="canttell1">Pass by default.</div>
-<div style="background-color: white; height: 20px; width: 80px;"><div id="canttell2" style="color: white; height: 40px; width: 60px;">Hi</div></div>
-<div style="background-color: white; height: 60px; width: 40px;"><div id="canttell3" style="color: white; height: 40px; width: 60px;">Hi</div></div>
-<div style="background-color: white; height: 60px; width: 80px;"><div id="canttell4" style="margin-left: 80px; color: white; height: 40px; width: 60px;">Hi</div></div>
+<div style="background-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)">
+	<div style="color: white" id="canttell1">Background image</div>
+</div>
+
+<div style="height:40px; position: relative;">
+	<div style="background-color: white; height: 60px; width: 40px;border: 1px solid;">
+		<div id="canttell2" style="color: white; height: 40px; width: 60px; border: 1px solid red;">Outside parent</div>
+	</div>
+</div>
+
+<div style="background-color: white; height: 60px; width: 40px;">
+	<div id="canttell3" style="color: white; height: 40px; width: 60px;">Background overlap</div>
+</div>
+
+<div style="background-color: white; height: 60px; width: 80px; border:1px solid;position: relative;">
+	<div id="canttell4" style="color: white; height: 40px; width: 60px; border:1px solid red;">Element overlap</div>
+	<div style="position: absolute; top: 0; width: 60px; height: 40px;background-color: #000"></div>
+</div>

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -13,6 +13,13 @@
 	<input type="text">
 </label>
 
+<div style="position:relative; height: 40px;">
+	<label style="background-color:black; color: white;" id="pass7">
+		Label
+		<input style="position:absolute; top:20px;">
+	</label>
+</div>
+
 <div id="fail2" style="background-color: gray; color: white; font-size: 8px;">This is a fail.</div>
 <div id="fail3" style="background-color: yellow; color: white; font-size: 40px;">This is a fail.</div>
 <div style="background-color: white;"><div style="background-color: rgba(255, 255, 255, 0.1); color: white" id="fail4">Fail.</div></div>

--- a/test/integration/rules/color-contrast/color-contrast.json
+++ b/test/integration/rules/color-contrast/color-contrast.json
@@ -27,7 +27,9 @@
 		["#pass2"],
 		["#pass3"],
 		["#pass4"],
-		["#pass5"]
+		["#pass5"],
+		["#pass6"],
+		["#pass6 > input"]
 	],
 	"incomplete": [
 		["#canttell1"],

--- a/test/integration/rules/color-contrast/color-contrast.json
+++ b/test/integration/rules/color-contrast/color-contrast.json
@@ -29,7 +29,9 @@
 		["#pass4"],
 		["#pass5"],
 		["#pass6"],
-		["#pass6 > input"]
+		["#pass6 > input"],
+		["#pass7"],
+		["#pass7 > input"]
 	],
 	"incomplete": [
 		["#canttell1"],


### PR DESCRIPTION
To address default implicit labels and inputs returning as Can't Tell (due to what it thinks is bgOverlap), this change adds some logic to the `calculateObscuringAlpha` function in `lib/commons/color/get-background-color.js` to check if an element's top left corner is actually overlapping in addition to returning the alpha value. I based it on the top left corner and not the center point because of the problem I was trying to solve–inputs being nested in implicit labels with the default styling causing an incomplete result.

I ran into issues with the integration tests because axe-core sometimes returns the label as the node, and sometimes the label and the input, depending on whether the tests are running in `grunt dev` or `grunt test-fast`. The runner used for our integration tests complicates debugging with one `axe.run` call for the entire fixture and flattening the results, so this test issue has taken more time than I'd like, hence submitting the code knowing there is a test failure. IMO aXe should just return the label and not the input, but I'm not quite sure where it's deciding on the relevant node when our test harness is being used.

I confirmed the fix in this PR works when I run it manually against a page like [this one](http://coc.kciprojects.com/analysis/implicit/), or [HHS.gov](hhs.gov) where it was originally reported.

Note: I also did some cleanup to the `color-contrast.html` file because it had a random DIV with a background image at the top but no closing tag. I'm surprised the tests worked at all.