### PR TITLE
fix: remove circular dep from incompleteData

### DIFF
--- a/lib/checks/color/link-in-text-block.js
+++ b/lib/checks/color/link-in-text-block.js
@@ -44,7 +44,6 @@ if (color.elementIsDistinct(node, parentBlock)) {
 		return true;
 	} else if (contrast >= 3.0) {
 		axe.commons.color.incompleteData.set('fgColor', {
-			node: nodeColor ? parentBlock : node,
 			reason: 'bgContrast'
 		});
 		this.data({
@@ -68,7 +67,6 @@ if (color.elementIsDistinct(node, parentBlock)) {
 			reason = 'bgContrast';
 		}
 		axe.commons.color.incompleteData.set('fgColor', {
-			node: nodeColor ? parentBlock : node,
 			reason: reason
 		});
 		this.data({

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -7,7 +7,6 @@ function elmHasImage(elm, style) {
 	var nodeName = elm.nodeName.toUpperCase();
 	if (graphicNodes.includes(nodeName)) {
 		axe.commons.color.incompleteData.set('bgColor', {
-			node: elm,
 			reason: 'imgNode'
 		});
 		return true;
@@ -19,7 +18,6 @@ function elmHasImage(elm, style) {
 	if (hasBgImage) {
 		var hasGradient = /gradient/.test(bgImageStyle);
 		axe.commons.color.incompleteData.set('bgColor', {
-			node: elm,
 			reason: (hasGradient ? 'bgGradient' : 'bgImage')
 		});
 	}
@@ -111,7 +109,6 @@ color.getBackgroundStack = function(elm) {
 	if (calculateObscuringAlpha(elmIndex, elmStack) >= 0.99) {
 		// if the total of the elements above our element results in total obscuring, return null
 		axe.commons.color.incompleteData.set('bgColor', {
-			node: elm,
 			reason: 'bgOverlap'
 		});
 		return null;

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -20,7 +20,6 @@ color.getForegroundColor = function (node, noScroll) {
 	if (bgColor === null) {
 		var reason = axe.commons.color.incompleteData.get('bgColor').reason;
 		axe.commons.color.incompleteData.set('fgColor', {
-			node: node,
 			reason: reason
 		});
 		return null;

--- a/lib/commons/color/incomplete-data.js
+++ b/lib/commons/color/incomplete-data.js
@@ -10,7 +10,6 @@ color.incompleteData = (function() {
 		 * Store incomplete data by key with a data object value
 		 * @param {String} key 						Identifier for missing data point (fgColor, bgColor, etc.)
 		 * @param {Object} dataObj 				Missing data information
-		 * @param {Element} dataObj.node 	Node being tested for data point
 		 * @param {String} dataObj.reason Key for reason we couldn't tell
 		 */
 		set: function(key, dataObj) {


### PR DESCRIPTION
The incompleteData API for color-contrast was causing a circular dependency by including nodes. They weren't being used, so they're gone with this commit.