### PR TITLE
Handle missing data

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -33,7 +33,7 @@ var data = {
 	contrastRatio: cr ? truncatedResult : undefined,
 	fontSize: (fontSize * 72 / 96).toFixed(1) + 'pt',
 	fontWeight: bold ? 'bold' : 'normal',
-	missingData: missing
+	missingReason: missing[0]
 };
 
 this.data(data);

--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -19,12 +19,9 @@ var cr = axe.commons.color.hasValidContrastRatio(bgColor, fgColor, fontSize, bol
 var truncatedResult = Math.floor(cr.contrastRatio * 100) / 100;
 
 // if fgColor or bgColor are missing, get more information.
-var missing = [];
-if (fgColor === null) {
-	missing.push(axe.commons.color.incompleteData.get('fgColor'));
-}
+var missing;
 if (bgColor === null) {
-	missing.push(axe.commons.color.incompleteData.get('bgColor'));
+	missing = axe.commons.color.incompleteData.get('bgColor');
 }
 // need both independently in case both are missing
 var data = {
@@ -33,7 +30,7 @@ var data = {
 	contrastRatio: cr ? truncatedResult : undefined,
 	fontSize: (fontSize * 72 / 96).toFixed(1) + 'pt',
 	fontWeight: bold ? 'bold' : 'normal',
-	missingReason: missing[0]
+	missingReason: missing
 };
 
 this.data(data);
@@ -44,7 +41,7 @@ if (!cr.isValid) {
 
 //We don't know, so we'll put it into Can't Tell
 if (fgColor === null || bgColor === null) {
-	missing = [];
+	missing = null;
 	axe.commons.color.incompleteData.clear();
 	return undefined;
 }

--- a/lib/checks/color/link-in-text-block.js
+++ b/lib/checks/color/link-in-text-block.js
@@ -43,11 +43,9 @@ if (color.elementIsDistinct(node, parentBlock)) {
 	if (contrast === 1) {
 		return true;
 	} else if (contrast >= 3.0) {
-		axe.commons.color.incompleteData.set('fgColor', {
-			reason: 'bgContrast'
-		});
+		axe.commons.color.incompleteData.set('fgColor', 'bgContrast');
 		this.data({
-			missingData: [axe.commons.color.incompleteData.get('fgColor')]
+			missingReason: axe.commons.color.incompleteData.get('fgColor')
 		});
 		axe.commons.color.incompleteData.clear();
 		// User needs to check whether there is a hover and a focus style
@@ -61,16 +59,14 @@ if (color.elementIsDistinct(node, parentBlock)) {
 	if (!nodeColor || !parentColor || getContrast(nodeColor, parentColor) >= 3.0) {
 		let reason;
 		if (!nodeColor || !parentColor) {
-			reason = axe.commons.color.incompleteData.get('bgColor').reason;
+			reason = axe.commons.color.incompleteData.get('bgColor');
 		}
 		else {
 			reason = 'bgContrast';
 		}
-		axe.commons.color.incompleteData.set('fgColor', {
-			reason: reason
-		});
+		axe.commons.color.incompleteData.set('fgColor', reason);
 		this.data({
-			missingData: [axe.commons.color.incompleteData.get('fgColor')]
+			missingReason: axe.commons.color.incompleteData.get('fgColor')
 		});
 		axe.commons.color.incompleteData.clear();
 		return undefined;

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -6,9 +6,7 @@ const graphicNodes = [
 function elmHasImage(elm, style) {
 	var nodeName = elm.nodeName.toUpperCase();
 	if (graphicNodes.includes(nodeName)) {
-		axe.commons.color.incompleteData.set('bgColor', {
-			reason: 'imgNode'
-		});
+		axe.commons.color.incompleteData.set('bgColor', 'imgNode');
 		return true;
 	}
 
@@ -17,9 +15,7 @@ function elmHasImage(elm, style) {
 	var hasBgImage = bgImageStyle !== 'none';
 	if (hasBgImage) {
 		var hasGradient = /gradient/.test(bgImageStyle);
-		axe.commons.color.incompleteData.set('bgColor', {
-			reason: (hasGradient ? 'bgGradient' : 'bgImage')
-		});
+		axe.commons.color.incompleteData.set('bgColor', (hasGradient ? 'bgGradient' : 'bgImage'));
 	}
 	return hasBgImage;
 }
@@ -108,9 +104,7 @@ color.getBackgroundStack = function(elm) {
 	let elmIndex = elmStack.indexOf(elm);
 	if (calculateObscuringAlpha(elmIndex, elmStack) >= 0.99) {
 		// if the total of the elements above our element results in total obscuring, return null
-		axe.commons.color.incompleteData.set('bgColor', {
-			reason: 'bgOverlap'
-		});
+		axe.commons.color.incompleteData.set('bgColor', 'bgOverlap');
 		return null;
 	}
 	return elmIndex !== -1 ? elmStack : null;

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -18,10 +18,8 @@ color.getForegroundColor = function (node, noScroll) {
 
 	var bgColor = color.getBackgroundColor(node, [], noScroll);
 	if (bgColor === null) {
-		var reason = axe.commons.color.incompleteData.get('bgColor').reason;
-		axe.commons.color.incompleteData.set('fgColor', {
-			reason: reason
-		});
+		var reason = axe.commons.color.incompleteData.get('bgColor');
+		axe.commons.color.incompleteData.set('fgColor', reason);
 		return null;
 	}
 

--- a/lib/commons/color/incomplete-data.js
+++ b/lib/commons/color/incomplete-data.js
@@ -7,25 +7,23 @@ color.incompleteData = (function() {
 	var data = {};
 	return {
 		/**
-		 * Store incomplete data by key with a data object value
+		 * Store incomplete data by key with a string value
 		 * @param {String} key 						Identifier for missing data point (fgColor, bgColor, etc.)
-		 * @param {Object} dataObj 				Missing data information
-		 * @param {String} dataObj.reason Key for reason we couldn't tell
+		 * @param {String} reason 				Missing data reason to match message template
 		 */
-		set: function(key, dataObj) {
+		set: function(key, reason) {
 			if (typeof key !== 'string') {
 				throw new Error('Incomplete data: key must be a string');
 			}
-			if (dataObj){
-				data[key] = dataObj;
+			if (reason){
+				data[key] = reason;
 			}
 		},
 		/**
 		 * Get incomplete data by key
 		 * @param {String} key 	Identifier for missing data point (fgColor, bgColor, etc.)
-		 * @return {Object} Data object for string key
+		 * @return {String} String for reason we couldn't tell
 		 */
-		 // TODO: do we need to lookup by node to ensure we have the right value?
 		get: function(key) {
 			return data[key];
 		},

--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -8,19 +8,14 @@ function extender(checksData, shouldBeTrue) {
 		delete data.messages;
 		if (check.result === undefined) {
 			if (typeof messages.incomplete === 'object') {
-				var missingData = check.data.missingData;
-				missingData.forEach(function(datum) {
-					var reason;
-					// Catch errors if incompleteData API isn't called, observed in CI
-					try {
-						reason = datum.reason;
-					}
-					catch (e) {
-						reason = 'default';
-					}
+				if (check.data && check.data.missingReason) {
+					var missingReason = check.data.missingReason;
 					// return a function with the appropriate message
-					data.message = function(){ return messages.incomplete[reason]; };
-				});
+					data.message = function() { return messages.incomplete[missingReason]; };
+				}
+				else {
+					data.message = function() { return messages.incomplete.default; };
+				}
 			}
 			else {
 				// fall back to string message

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -143,7 +143,7 @@ describe('color-contrast', function () {
 		assert.isUndefined(checks['color-contrast'].evaluate.call(checkContext, target));
 		assert.isUndefined(checkContext._data.bgColor);
 		assert.equal(checkContext._data.contrastRatio, 0);
-		assert.equal(checkContext._data.missingData[0].reason, 'bgImage');
+		assert.equal(checkContext._data.missingReason, 'bgImage');
 	});
 
 	it('should return undefined for background-gradient elements', function () {
@@ -154,7 +154,7 @@ describe('color-contrast', function () {
 		var target = fixture.querySelector('#target');
 		assert.isUndefined(checks['color-contrast'].evaluate.call(checkContext, target));
 		assert.isUndefined(checkContext._data.bgColor);
-		assert.equal(checkContext._data.missingData[0].reason, 'bgGradient');
+		assert.equal(checkContext._data.missingReason, 'bgGradient');
 		assert.equal(checkContext._data.contrastRatio, 0);
 	});
 });

--- a/test/checks/color/link-in-text-block.js
+++ b/test/checks/color/link-in-text-block.js
@@ -180,7 +180,7 @@ describe('link-in-text-block', function () {
 				backgroundColor: 'white'
 			});
 			assert.isUndefined(checks['link-in-text-block'].evaluate.call(checkContext, linkElm));
-			assert.equal(checkContext._data.missingData[0].reason, 'bgContrast');
+			assert.equal(checkContext._data.missingReason, 'bgContrast');
 		});
 
 		it('returns false if background contrast < 3:0', function() {
@@ -202,7 +202,7 @@ describe('link-in-text-block', function () {
 				color: '#000000'
 			});
 			assert.isUndefined(checks['link-in-text-block'].evaluate.call(checkContext, linkElm));
-			assert.equal(checkContext._data.missingData[0].reason, 'bgImage');
+			assert.equal(checkContext._data.missingReason, 'bgImage');
 		});
 
 	});

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -131,7 +131,7 @@ describe('color.getBackgroundColor', function () {
 		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
 		assert.isNull(actual);
 		assert.deepEqual(bgNodes, [target, parent]);
-		assert.equal(axe.commons.color.incompleteData.get('bgColor').reason, 'bgImage');
+		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
 	});
 
 	it('should return white if transparency goes all the way up to document', function () {
@@ -154,14 +154,14 @@ describe('color.getBackgroundColor', function () {
 		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
 		assert.isNull(actual);
 		assert.deepEqual(bgNodes, [target]);
-		assert.equal(axe.commons.color.incompleteData.get('bgColor').reason, 'bgImage');
+		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
 	});
 
 	it('should return null if something opaque is obscuring it', function () {
 		fixture.innerHTML = '<div style="width:100%; height: 100px; background: #000"></div>' +
 			'<div id="target" style="position: relative; top: -50px; z-index:-1;color:#fff;">Hello</div>';
 		var actual = axe.commons.color.getBackgroundColor(document.getElementById('target'), []);
-		assert.equal(axe.commons.color.incompleteData.get('bgColor').reason, 'bgOverlap');
+		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgOverlap');
 		assert.isNull(actual);
 	});
 
@@ -272,7 +272,7 @@ describe('color.getBackgroundColor', function () {
 		var bgNodes = [];
 		var outcome = axe.commons.color.getBackgroundColor(target, bgNodes, false);
 		assert.isNull(outcome);
-		assert.equal(axe.commons.color.incompleteData.get('bgColor').reason, 'bgImage');
+		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
 	});
 
 	it('should return null when encountering image nodes during visual traversal', function () {
@@ -291,7 +291,7 @@ describe('color.getBackgroundColor', function () {
 		var bgNodes = [];
 		var outcome = axe.commons.color.getBackgroundColor(target, bgNodes, false);
 		assert.isNull(outcome);
-		assert.equal(axe.commons.color.incompleteData.get('bgColor').reason, 'imgNode');
+		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'imgNode');
 	});
 
 	it('does not change the scroll when scroll is disabled', function() {

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -44,7 +44,7 @@ describe('color.getForegroundColor', function () {
 			'</div></div>';
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
-		assert.equal(axe.commons.color.incompleteData.get('fgColor').reason, 'bgImage');
+		assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'bgImage');
 		assert.isNull(actual);
 	});
 

--- a/test/commons/color/incomplete-data.js
+++ b/test/commons/color/incomplete-data.js
@@ -11,38 +11,27 @@ describe('axe.commons.color.incompleteData', function () {
 		assert.isObject(axe.commons.color.incompleteData);
 	});
 
-	it('should store an object with a key for the incomplete check', function () {
+	it('should store a string with a key for the incomplete check', function () {
 		var node = document.createElement('div');
 		fixture.appendChild(node);
-		axe.commons.color.incompleteData.set('fgColor', {
-			node: node,
-			reason: 'bgImage'
-		});
+		axe.commons.color.incompleteData.set('fgColor', 'bgImage');
 
-		assert.equal(axe.commons.color.incompleteData.get('fgColor').node, node);
+		assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'bgImage');
 	});
 
 	it('should throw an error if key is not a string', function () {
 		assert.throws(function () {
-			axe.commons.color.incompleteData.set({
-				node: {}
-			});
+			axe.commons.color.incompleteData.set();
 		}, /key must be a string/);
 	});
 
 	it('should store a reason that matches a list of possibilities', function () {
-		axe.commons.color.incompleteData.set('bgColor', {
-			node: {},
-			reason: 'bgImage'
-		});
-		assert.equal(axe.commons.color.incompleteData.get('bgColor').reason, 'bgImage');
+		axe.commons.color.incompleteData.set('bgColor', 'bgImage');
+		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
 	});
 
 	it('should clear the data object on request', function () {
-		axe.commons.color.incompleteData.set('fgColor', {
-			node: {},
-			reason: 'bgOverlap'
-		});
+		axe.commons.color.incompleteData.set('fgColor', 'bgOverlap');
 		axe.commons.color.incompleteData.clear();
 		assert.isUndefined(axe.commons.color.incompleteData.get('fgColor'), 'bgOverlap');
 	});


### PR DESCRIPTION
If check result doesn't supply a reason, it is difficult to handle fallbacks as written. This change simplifies things now that missingData doesn't include nodes (due to a circular dependency). The one caveat is it now can't handle floating up multiple reasons.

This issue makes our Attest extension not error out if there is no missingData, and it solves an internal issue where color contrast is listed in the extension but comes back with a count of 0. (https://dequesrc.atlassian.net/browse/WWD-726)