### PR TITLE
API compatibility for incompleteData

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -30,7 +30,7 @@ var data = {
 	contrastRatio: cr ? truncatedResult : undefined,
 	fontSize: (fontSize * 72 / 96).toFixed(1) + 'pt',
 	fontWeight: bold ? 'bold' : 'normal',
-	missingReason: missing
+	missingData: missing
 };
 
 this.data(data);

--- a/lib/checks/color/link-in-text-block.js
+++ b/lib/checks/color/link-in-text-block.js
@@ -45,7 +45,7 @@ if (color.elementIsDistinct(node, parentBlock)) {
 	} else if (contrast >= 3.0) {
 		axe.commons.color.incompleteData.set('fgColor', 'bgContrast');
 		this.data({
-			missingReason: axe.commons.color.incompleteData.get('fgColor')
+			missingData: axe.commons.color.incompleteData.get('fgColor')
 		});
 		axe.commons.color.incompleteData.clear();
 		// User needs to check whether there is a hover and a focus style
@@ -66,7 +66,7 @@ if (color.elementIsDistinct(node, parentBlock)) {
 		}
 		axe.commons.color.incompleteData.set('fgColor', reason);
 		this.data({
-			missingReason: axe.commons.color.incompleteData.get('fgColor')
+			missingData: axe.commons.color.incompleteData.get('fgColor')
 		});
 		axe.commons.color.incompleteData.clear();
 		return undefined;

--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -8,21 +8,26 @@ function extender(checksData, shouldBeTrue) {
 		delete data.messages;
 		if (check.result === undefined) {
 			if (typeof messages.incomplete === 'object') {
-				if (check.data && check.data.missingReason) {
-					var missingReason = check.data.missingReason;
+				if (check.data && check.data.missingData) {
+					var missingReason;
+					try {
+						missingReason = check.data.missingData[0].reason;
+					} finally {
+						if (typeof check.data.missingData === 'string')  {
+							missingReason = check.data.missingData;
+						}
+					}
 					// return a function with the appropriate message
 					data.message = function() { return messages.incomplete[missingReason]; };
-				}
-				else {
+				} else {
+					// fall back to the default message if no reason specified
 					data.message = function() { return messages.incomplete.default; };
 				}
-			}
-			else {
+			} else {
 				// fall back to string message
 				data.message = messages.incomplete;
 			}
-		}
-		else {
+		} else {
 			data.message = check.result === shouldBeTrue ? messages.pass : messages.fail;
 		}
 		axe.utils.extendMetaData(check, data);

--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -1,4 +1,35 @@
 
+/**
+ * Construct incomplete message from check.data
+ * @param  {Object} checkData Check result with reason specified
+ * @param  {Object} messages Source data object with message options
+ * @return  {String}
+ * @private
+ */
+function getIncompleteReason(checkData, messages) {
+	if (checkData && checkData.missingData) {
+		var missingReason;
+		try {
+			missingReason = checkData.missingData[0].reason;
+		} finally {
+			if (typeof checkData.missingData === 'string')  {
+				missingReason = checkData.missingData;
+			}
+		}
+		// return a function with the appropriate message
+		return messages.incomplete[missingReason];
+	} else {
+		// fall back to the default message if no reason specified
+		return messages.incomplete.default;
+	}
+}
+/**
+ * Extend checksData with the correct result message
+ * @param  {Object} checksData The check result data
+ * @param  {Boolean} shouldBeTrue Result of pass/fail check run
+ * @return {Function}
+ * @private
+ */
 function extender(checksData, shouldBeTrue) {
 	'use strict';
 	return function (check) {
@@ -8,21 +39,7 @@ function extender(checksData, shouldBeTrue) {
 		delete data.messages;
 		if (check.result === undefined) {
 			if (typeof messages.incomplete === 'object') {
-				if (check.data && check.data.missingData) {
-					var missingReason;
-					try {
-						missingReason = check.data.missingData[0].reason;
-					} finally {
-						if (typeof check.data.missingData === 'string')  {
-							missingReason = check.data.missingData;
-						}
-					}
-					// return a function with the appropriate message
-					data.message = function() { return messages.incomplete[missingReason]; };
-				} else {
-					// fall back to the default message if no reason specified
-					data.message = function() { return messages.incomplete.default; };
-				}
+				data.message = function() { return getIncompleteReason(check.data, messages); };
 			} else {
 				// fall back to string message
 				data.message = messages.incomplete;

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -143,7 +143,7 @@ describe('color-contrast', function () {
 		assert.isUndefined(checks['color-contrast'].evaluate.call(checkContext, target));
 		assert.isUndefined(checkContext._data.bgColor);
 		assert.equal(checkContext._data.contrastRatio, 0);
-		assert.equal(checkContext._data.missingReason, 'bgImage');
+		assert.equal(checkContext._data.missingData, 'bgImage');
 	});
 
 	it('should return undefined for background-gradient elements', function () {
@@ -154,7 +154,7 @@ describe('color-contrast', function () {
 		var target = fixture.querySelector('#target');
 		assert.isUndefined(checks['color-contrast'].evaluate.call(checkContext, target));
 		assert.isUndefined(checkContext._data.bgColor);
-		assert.equal(checkContext._data.missingReason, 'bgGradient');
+		assert.equal(checkContext._data.missingData, 'bgGradient');
 		assert.equal(checkContext._data.contrastRatio, 0);
 	});
 });

--- a/test/checks/color/link-in-text-block.js
+++ b/test/checks/color/link-in-text-block.js
@@ -180,7 +180,7 @@ describe('link-in-text-block', function () {
 				backgroundColor: 'white'
 			});
 			assert.isUndefined(checks['link-in-text-block'].evaluate.call(checkContext, linkElm));
-			assert.equal(checkContext._data.missingReason, 'bgContrast');
+			assert.equal(checkContext._data.missingData, 'bgContrast');
 		});
 
 		it('returns false if background contrast < 3:0', function() {
@@ -202,7 +202,7 @@ describe('link-in-text-block', function () {
 				color: '#000000'
 			});
 			assert.isUndefined(checks['link-in-text-block'].evaluate.call(checkContext, linkElm));
-			assert.equal(checkContext._data.missingReason, 'bgImage');
+			assert.equal(checkContext._data.missingData, 'bgImage');
 		});
 
 	});

--- a/test/core/utils/publish-metadata.js
+++ b/test/core/utils/publish-metadata.js
@@ -184,6 +184,374 @@ describe('axe.utils.publishMetaData', function () {
 
 	});
 
+	it('should handle incomplete objects with no reason specified by the check', function () {
+
+		axe._load({
+			rules: [],
+			data: {
+				rules: {
+					cats: {
+						help: function () {
+							return 'cats-rule';
+						}
+					}
+				},
+				checks: {
+					'cats-NONE': {
+						messages: {
+							fail: function () {
+								return 'fail-NONE';
+							},
+							pass: function () {
+								return 'pass-NONE';
+							},
+							incomplete: {
+								'incomplete-NONE-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-NONE-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					},
+					'cats-ANY': {
+						messages: {
+							fail: function () {
+								return 'fail-ANY';
+							},
+							pass: function () {
+								return 'pass-ANY';
+							},
+							incomplete: {
+								'incomplete-ANY-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-ANY-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					},
+					'cats-ALL': {
+						messages: {
+							fail: function () {
+								return 'fail-ALL';
+							},
+							pass: function () {
+								return 'pass-ALL';
+							},
+							incomplete: {
+								'incomplete-ALL-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-ALL-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					}
+				}
+			}
+		});
+
+		var result = {
+			id: 'cats',
+			nodes: [{
+				any: [{
+					result: undefined,
+					id: 'cats-ANY',
+					data: {}
+				}],
+				none: [{
+					result: undefined,
+					id: 'cats-NONE',
+					data: {}
+				}],
+				all: [{
+					result: undefined,
+					id: 'cats-ALL',
+					data: {}
+				}]
+			}]
+		};
+		axe.utils.publishMetaData(result);
+		assert.deepEqual(result, {
+			id: 'cats',
+			help: 'cats-rule',
+			tags: [],
+			nodes: [{
+				any: [{
+					result: undefined,
+					id: 'cats-ANY',
+					message: 'Fallback message for no reason',
+					data: {}
+				}],
+				none: [{
+					result: undefined,
+					id: 'cats-NONE',
+					message: 'Fallback message for no reason',
+					data: {}
+				}],
+				all: [{
+					result: undefined,
+					id: 'cats-ALL',
+					message: 'Fallback message for no reason',
+					data: {}
+				}]
+			}]
+		});
+
+	});
+
+	it('should handle incomplete reasons', function () {
+
+		axe._load({
+			rules: [],
+			data: {
+				rules: {
+					cats: {
+						help: function () {
+							return 'cats-rule';
+						}
+					}
+				},
+				checks: {
+					'cats-NONE': {
+						messages: {
+							fail: function () {
+								return 'fail-NONE';
+							},
+							pass: function () {
+								return 'pass-NONE';
+							},
+							incomplete: {
+								'incomplete-NONE-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-NONE-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					},
+					'cats-ANY': {
+						messages: {
+							fail: function () {
+								return 'fail-ANY';
+							},
+							pass: function () {
+								return 'pass-ANY';
+							},
+							incomplete: {
+								'incomplete-ANY-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-ANY-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					},
+					'cats-ALL': {
+						messages: {
+							fail: function () {
+								return 'fail-ALL';
+							},
+							pass: function () {
+								return 'pass-ALL';
+							},
+							incomplete: {
+								'incomplete-ALL-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-ALL-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					}
+				}
+			}
+		});
+
+		var result = {
+			id: 'cats',
+			nodes: [{
+				any: [{
+					result: undefined,
+					id: 'cats-ANY',
+					data: {
+						missingData: 'incomplete-ANY-reason1'
+					}
+				}],
+				none: [{
+					result: undefined,
+					id: 'cats-NONE',
+					data: {
+						missingData: 'incomplete-NONE-reason1'
+					}
+				}],
+				all: [{
+					result: undefined,
+					id: 'cats-ALL',
+					data: {
+						missingData: 'incomplete-ALL-reason1'
+					}
+				}]
+			}]
+		};
+		axe.utils.publishMetaData(result);
+		assert.deepEqual(result, {
+			id: 'cats',
+			help: 'cats-rule',
+			tags: [],
+			nodes: [{
+				any: [{
+					result: undefined,
+					id: 'cats-ANY',
+					message: 'We couldn\'t tell because of some reason',
+					data: {
+						missingData: 'incomplete-ANY-reason1'
+					}
+				}],
+				none: [{
+					result: undefined,
+					id: 'cats-NONE',
+					message: 'We couldn\'t tell because of some reason',
+					data: {
+						missingData: 'incomplete-NONE-reason1'
+					}
+				}],
+				all: [{
+					result: undefined,
+					id: 'cats-ALL',
+					message: 'We couldn\'t tell because of some reason',
+					data: {
+						missingData: 'incomplete-ALL-reason1'
+					}
+				}]
+			}]
+		});
+
+	});
+
+	it('should handle incomplete reasons with backwards compatibility', function () {
+
+		axe._load({
+			rules: [],
+			data: {
+				rules: {
+					cats: {
+						help: function () {
+							return 'cats-rule';
+						}
+					}
+				},
+				checks: {
+					'cats-NONE': {
+						messages: {
+							fail: function () {
+								return 'fail-NONE';
+							},
+							pass: function () {
+								return 'pass-NONE';
+							},
+							incomplete: {
+								'incomplete-NONE-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-NONE-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					},
+					'cats-ANY': {
+						messages: {
+							fail: function () {
+								return 'fail-ANY';
+							},
+							pass: function () {
+								return 'pass-ANY';
+							},
+							incomplete: {
+								'incomplete-ANY-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-ANY-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					},
+					'cats-ALL': {
+						messages: {
+							fail: function () {
+								return 'fail-ALL';
+							},
+							pass: function () {
+								return 'pass-ALL';
+							},
+							incomplete: {
+								'incomplete-ALL-reason1': 'We couldn\'t tell because of some reason',
+								'incomplete-ALL-reason2': 'Some other reason',
+								'default': 'Fallback message for no reason'
+							}
+						}
+					}
+				}
+			}
+		});
+
+		var result = {
+			id: 'cats',
+			nodes: [{
+				any: [{
+					result: undefined,
+					id: 'cats-ANY',
+					data: {
+						missingData: [{
+							reason: 'incomplete-ANY-reason1'
+						}]
+					}
+				}],
+				none: [{
+					result: undefined,
+					id: 'cats-NONE',
+					data: {
+						missingData: [{
+							reason: 'incomplete-NONE-reason1'
+						}]
+					}
+				}],
+				all: [{
+					result: undefined,
+					id: 'cats-ALL',
+					data: {
+						missingData: [{
+							reason: 'incomplete-ALL-reason1'
+						}]
+					}
+				}]
+			}]
+		};
+		axe.utils.publishMetaData(result);
+		assert.deepEqual(result, {
+			id: 'cats',
+			help: 'cats-rule',
+			tags: [],
+			nodes: [{
+				any: [{
+					result: undefined,
+					id: 'cats-ANY',
+					message: 'We couldn\'t tell because of some reason',
+					data: {
+						missingData: [{
+							reason: 'incomplete-ANY-reason1'
+						}]
+					}
+				}],
+				none: [{
+					result: undefined,
+					id: 'cats-NONE',
+					message: 'We couldn\'t tell because of some reason',
+					data: {
+						missingData: [{
+							reason: 'incomplete-NONE-reason1'
+						}]
+					}
+				}],
+				all: [{
+					result: undefined,
+					id: 'cats-ALL',
+					message: 'We couldn\'t tell because of some reason',
+					data: {
+						missingData: [{
+							reason: 'incomplete-ALL-reason1'
+						}]
+					}
+				}]
+			}]
+		});
+
+	});
 
 	it('should not modify base configuration', function () {
 		axe._load({


### PR DESCRIPTION
To make axe-core more backwards-compatible, I reverted part of yesterday's change to incomplete check results so they use the same key (`missingData` instead of `missingReason`). I also added some logic and test coverage in case a rule depends on the 2.2.0 version.