### PR TITLE
feat: localize incomplete fallback message

### DIFF
--- a/build/configure.js
+++ b/build/configure.js
@@ -54,10 +54,23 @@ function buildRules(grunt, options, commons, callback) {
 		function createFailureSummaryObject(summaries) {
 			var result = {};
 			summaries.forEach(function (summary) {
-				result[summary.type] = parseMetaData(summary, 'failureSummaries');
+				if (summary.type) {
+					result[summary.type] = parseMetaData(summary, 'failureSummaries');
+				}
 			});
 			return result;
 		}
+
+		function getIncompleteMsg(summaries) {
+			var result = {};
+			summaries.forEach(function(summary) {
+				if (summary.incompleteFallbackMessage) {
+					result = dot.template(summary.incompleteFallbackMessage).toString();
+				}
+			})
+			return result;
+		}
+
 
 		function replaceFunctions(string) {
 			return string.replace(/"(evaluate|after|gather|matches|source|commons)":\s*("[^"]+?")/g, function (m, p1, p2) {
@@ -154,6 +167,7 @@ function buildRules(grunt, options, commons, callback) {
 
 		// Translate failureSummaries
 		metadata.failureSummaries = createFailureSummaryObject(result.misc);
+		metadata.incompleteFallbackMessage = getIncompleteMsg(result.misc);
 
 		callback({
 			auto: replaceFunctions(JSON.stringify({

--- a/build/tasks/add-locale.js
+++ b/build/tasks/add-locale.js
@@ -34,6 +34,10 @@ module.exports = function (grunt) {
           failureSummaries: result.misc.reduce(function (out, misc) {
             out[misc.type] = misc.metadata;
             return out;
+          }, {}),
+          incompleteFallbackMessage: result.misc.reduce(function (out, misc) {
+            out[misc.incompleteFallbackMessage] = misc.metadata;
+            return out;
           }, {})
         };
 

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -66,6 +66,7 @@ Audit.prototype._init = function () {
 	this.data.checks = (audit.data && audit.data.checks) || {};
 	this.data.rules = (audit.data && audit.data.rules) || {};
 	this.data.failureSummaries = (audit.data && audit.data.failureSummaries) || {};
+	this.data.incompleteFallbackMessage = (audit.data && audit.data.incompleteFallbackMessage || '');
 
 	this._constructHelpUrls(); // create default helpUrls
 };

--- a/lib/core/reporters/helpers/incomplete-fallback-msg.js
+++ b/lib/core/reporters/helpers/incomplete-fallback-msg.js
@@ -1,0 +1,11 @@
+/*global helpers */
+
+/**
+ * Provides a fallback message in case incomplete checks don't provide one
+ * This mechanism allows the string to be localized.
+ * @return {String}
+ */
+helpers.incompleteFallbackMessage = function incompleteFallbackMessage() {
+	'use strict';
+	return axe._audit.data.incompleteFallbackMessage();
+};

--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -1,4 +1,4 @@
-
+/*global helpers */
 /**
  * Construct incomplete message from check.data
  * @param  {Object} checkData Check result with reason specified
@@ -12,8 +12,7 @@ function getIncompleteReason(checkData, messages) {
 			// fall back to the default message if no reason specified
 			return messages.incomplete.default;
 		} else {
-			// TODO: localize it
-			return 'aXe couldn\'t tell the reason. Time to break out the element inspector!';
+			return helpers.incompleteFallbackMessage();
 		}
 	}
 	if (checkData && checkData.missingData) {

--- a/lib/misc/incomplete-fallback.json
+++ b/lib/misc/incomplete-fallback.json
@@ -1,0 +1,3 @@
+{
+	"incompleteFallbackMessage": "aXe couldn't tell the reason. Time to break out the element inspector!"
+}

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -31,5 +31,6 @@
     "any": {
       "failureMessage": "Gebruik een van de volgende oplossingen:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
     }
-  }
+  },
+  "incompleteFallbackMessage": "aXe kon de reden niet vertellen. Tijd om de element inspecteur uit te breken!"
 }

--- a/test/core/reporters/helpers/incomplete-fallback-msg.js
+++ b/test/core/reporters/helpers/incomplete-fallback-msg.js
@@ -1,0 +1,21 @@
+
+describe('helpers.incompleteFallbackMessage', function() {
+	'use strict';
+	before(function() {
+		axe._load({
+			messages: {},
+			rules: [],
+			data: {
+				incompleteFallbackMessage: function anonymous() {
+					return 'Dogs are the best';
+				}
+			}
+		});
+	});
+
+	it('should return a string', function() {
+		var summary = helpers.incompleteFallbackMessage();
+		assert.equal(summary, 'Dogs are the best');
+	});
+
+});

--- a/test/core/utils/publish-metadata.js
+++ b/test/core/utils/publish-metadata.js
@@ -300,6 +300,9 @@ describe('axe.utils.publishMetaData', function () {
 		axe._load({
 			rules: [],
 			data: {
+				incompleteFallbackMessage: function() {
+					return 'Dogs are the best';
+				},
 				rules: {
 					cats: {
 						help: function () {
@@ -374,19 +377,19 @@ describe('axe.utils.publishMetaData', function () {
 				any: [{
 					result: undefined,
 					id: 'cats-ANY',
-					message: 'aXe couldn\'t tell the reason. Time to break out the element inspector!',
+					message: 'Dogs are the best',
 					data: {}
 				}],
 				none: [{
 					result: undefined,
 					id: 'cats-NONE',
-					message: 'aXe couldn\'t tell the reason. Time to break out the element inspector!',
+					message: 'Dogs are the best',
 					data: {}
 				}],
 				all: [{
 					result: undefined,
 					id: 'cats-ALL',
-					message: 'aXe couldn\'t tell the reason. Time to break out the element inspector!',
+					message: 'Dogs are the best',
 					data: {}
 				}]
 			}]


### PR DESCRIPTION
I added the ability to localize the fallback message. This makes it so that if a check doesn't supply a default incomplete message or reasons, aXe will still return _something_ in the appropriate language.