### PR TITLE
Rebuild getSelector

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -300,6 +300,19 @@ The options parameter is flexible way to configure how `axe.run` operates. The d
 * Run all rules defined in the system, except for the list of rules specified
 * Run a specific set of rules provided as a list of rule ids
 
+Additionally, there are a number or properties that allow configuration of different options:
+
+| Property        | Default | Description                |
+|-----------------|:-------:|:----------------------------:|
+| `runOnly`       | n/a     | Limit which rules are executed, based on names or tags
+| `rules`         | n/a     | Allow customizing a rule's properties (including { enable: false })
+| `reporter`      | `v1`    | Which reporter to use (see [Configutration](#api-name-axeconfigure))
+| `xpath`         | `false` | Return xpath selectors for elements
+| `absolutePaths` | `false` | Use absolute paths when creating element selectors
+| `iframes`       | `true`  | Tell axe to run inside iframes
+| `elementRef`    | `false` | Return element references in addition to the target
+
+
 ###### Options Parameter Examples
 
 1. Run only Rules for an accessibility standard

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -66,7 +66,7 @@ Check.prototype.run = function (node, options, resolve, reject) {
 
 	if (enabled) {
 		var checkResult = new CheckResult(this);
-		var checkHelper = axe.utils.checkHelper(checkResult, resolve, reject);
+		var checkHelper = axe.utils.checkHelper(checkResult, options, resolve, reject);
 		var result;
 
 		try {

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -171,7 +171,7 @@ Rule.prototype.run = function (context, options, resolve, reject) {
 						}
 					});
 					if (hasResults) {
-						result.node = new axe.utils.DqElement(node);
+						result.node = new axe.utils.DqElement(node, options);
 						ruleResult.nodes.push(result);
 					}
 				}

--- a/lib/core/utils/check-helper.js
+++ b/lib/core/utils/check-helper.js
@@ -4,7 +4,7 @@
  * @param  {Function} callback    The callback to expose when `this.async()` is called
  * @return {Object}               Bound to `this` for a check's fn
  */
-axe.utils.checkHelper = function checkHelper(checkResult, resolve, reject) {
+axe.utils.checkHelper = function checkHelper(checkResult, options, resolve, reject) {
 	'use strict';
 
 	return {
@@ -26,7 +26,7 @@ axe.utils.checkHelper = function checkHelper(checkResult, resolve, reject) {
 		relatedNodes: function (nodes) {
 			nodes = nodes instanceof Node ? [nodes] : axe.utils.toArray(nodes);
 			checkResult.relatedNodes = nodes.map(function (element) {
-				return new axe.utils.DqElement(element);
+				return new axe.utils.DqElement(element, options);
 			});
 		}
 	};

--- a/lib/core/utils/collect-results-from-frames.js
+++ b/lib/core/utils/collect-results-from-frames.js
@@ -104,7 +104,7 @@ function collectResultsFromFrames(context, options, command, parameter, resolve,
 
 	// Combine results from all frames and give it back
 	q.then(function(data) {
-		resolve(axe.utils.mergeResults(data));
+		resolve(axe.utils.mergeResults(data, options));
 	}).catch(reject);
 }
 

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -1,8 +1,6 @@
 /*exported DqElement */
 
 function truncate(str, maxLength) {
-	'use strict';
-
 	maxLength = maxLength || 300;
 
 	if (str.length > maxLength) {
@@ -14,8 +12,6 @@ function truncate(str, maxLength) {
 }
 
 function getSource (element) {
-	'use strict';
-
 	var source = element.outerHTML;
 	if (!source && typeof XMLSerializer === 'function') {
 		source = new XMLSerializer().serializeToString(element);
@@ -29,12 +25,13 @@ function getSource (element) {
  * @param {HTMLElement} element The element to serialize
  * @param {Object} spec Properties to use in place of the element when instantiated on Elements from other frames
  */
-function DqElement(element, spec) {
-	'use strict';
-	
+function DqElement(element, options, spec) {
 	this._fromFrame = !!spec;
 
 	this.spec = spec || {};
+	if (options && options.absolutePaths) {
+		this._options = { toRoot: true };
+	}
 
 	/**
 	 * The generated HTML source code of the element
@@ -56,7 +53,9 @@ DqElement.prototype = {
 	 * @return {String}
 	 */
 	get selector() {
-		return this.spec.selector || [axe.utils.getSelector(this.element)];
+		return this.spec.selector || [
+			axe.utils.getSelector(this.element, this._options)
+		];
 	},
 
 	/**
@@ -64,7 +63,9 @@ DqElement.prototype = {
 	 * @return {String}
 	 */
 	get xpath() {
-		return this.spec.xpath || [axe.utils.getXpath(this.element)];
+		return this.spec.xpath || [
+			axe.utils.getXpath(this.element)
+		];
 	},
 	
 	/**	
@@ -88,10 +89,10 @@ DqElement.prototype = {
 	}
 };
 
-DqElement.fromFrame = function (node, frame) {
+DqElement.fromFrame = function (node, options, frame) {
     node.selector.unshift(frame.selector);
     node.xpath.unshift(frame.xpath);
-    return new axe.utils.DqElement(frame.element, node);
+    return new axe.utils.DqElement(frame.element, options, node);
 };
 
 axe.utils.DqElement = DqElement;

--- a/lib/core/utils/get-check-option.js
+++ b/lib/core/utils/get-check-option.js
@@ -7,7 +7,6 @@
  * @return {Object}         The resolved object with `options` and `enabled` keys
  */
 axe.utils.getCheckOption = function (check, ruleID, options) {
-	'use strict';
 	var ruleCheckOption = ((options.rules && options.rules[ruleID] || {}).checks || {})[check.id];
 	var checkOption = (options.checks || {})[check.id];
 
@@ -35,6 +34,7 @@ axe.utils.getCheckOption = function (check, ruleID, options) {
 
 	return {
 		enabled: enabled,
-		options: opts
+		options: opts,
+		absolutePaths: options.absolutePaths
 	};
 };

--- a/lib/core/utils/get-friendly-uri-end.js
+++ b/lib/core/utils/get-friendly-uri-end.js
@@ -1,0 +1,125 @@
+/**
+ * Check if a string contains mostly numbers
+ */
+function isMostlyNumbers (str = '') {
+  return (
+    str.length !== 0 &&
+    (str.match(/[0-9]/g) || '').length >= str.length / 2
+  );
+}
+
+/**
+ * Spit a string into an array with two pieces, at a given index
+ * @param String  string to split
+ * @param Number  index at which to split
+ * @return Array
+ */
+function splitString (str, splitIndex) {
+  return [str.substring(0, splitIndex), str.substring(splitIndex)];
+}
+
+/**
+ * Take a relative or absolute URL and pull it into it's indivisual pieces
+ *
+ * @param url (string)
+ * @return urlPieces
+ *   .protocol  The protocol used, e.g. 'https://'
+ *   .domain    Domain name including sub domains and TLD, e.g. 'docs.deque.com'
+ *   .port      The port number, e.g. ':8080'
+ *   .path      Path after the domain, e.g. '/home.html'
+ *   .query     Query string, e.g. '?user=admin&password=pass'
+ *   .hash      Hash / internal reference, e.g. '#footer'
+ */
+function uriParser (url) {
+  // jshint maxstatements:19
+  let original = url;
+  let protocol = '', domain = '', port = '', path = '', query = '', hash = '';
+  if (url.includes('#')) {
+    [url, hash] = splitString(url, url.indexOf('#'));
+  }
+
+  if (url.includes('?')) {
+    [url, query] = splitString(url, url.indexOf('?'));
+  }
+
+  if (url.includes('://')) {
+    [protocol, url] = url.split('://');
+    [domain, url] = splitString(url, url.indexOf('/'));
+  } else if (url.substr(0,2) === '//') {
+    url = url.substr(2);
+    [domain, url] = splitString(url, url.indexOf('/'));
+  }
+
+  if (domain.substr(0,4) === 'www.') {
+    domain = domain.substr(4);
+  }
+
+  if (domain && domain.includes(':')) {
+    [domain, port] = splitString(domain, domain.indexOf(':'));
+  }
+
+  path = url; // Whatever is left, must be the path
+  return { original, protocol, domain, port, path, query, hash };
+}
+
+/**
+ * Try to, at the end of the URI, find a string that a user can identify the URI by
+ *
+ * @param uri       The URI to use
+ * @param options
+ *   .currentDomain  The current domain name (optional)
+ *   .maxLength      Max length of the returned string (default: 25)
+ * @return string   A portion at the end of the uri, no longer than maxLength
+ */
+axe.utils.getFriendlyUriEnd = function getFriendlyUriEnd (uri = '', options = {}) {
+  // jshint maxstatements: 16, maxcomplexity: 13, scripturl: true
+  if (// Skip certain URIs:
+    uri.length <= 1 || // very short
+    uri.substr(0, 5) === 'data:' || // data URIs are unreadable
+    uri.substr(0, 11) === 'javascript:' || // JS isn't a URL
+    uri.includes('?') // query strings aren't very readable either
+  ) {
+    return;
+  }
+
+  const { currentDomain, maxLength = 25 } = options;
+  const { path, domain, hash } = uriParser(uri);
+  // Split the path at the last / that has text after it
+  const pathEnd = path.substr(
+    path.substr(0, path.length-2).lastIndexOf('/') + 1
+  );
+
+  if (hash) {
+    if (pathEnd && (pathEnd + hash).length <= maxLength) {
+      return pathEnd + hash;
+    } else if (pathEnd.length < 2 && hash.length > 2 && hash.length <= maxLength) {
+      return hash;
+    } else {
+      return;
+    }
+  } else if (domain && domain.length < maxLength && path.length <= 1) {// '' or '/'
+    return domain + path;
+  }
+
+  // See if the domain should be returned
+  if (path === '/' + pathEnd &&
+    domain && currentDomain &&
+    domain !== currentDomain &&
+    (domain + path).length <= maxLength
+  ) {
+    return domain + path;
+  }
+  
+  const lastDotIndex = pathEnd.lastIndexOf('.');
+  if (// Exclude very short or very long string
+    (lastDotIndex === -1 || lastDotIndex > 1) &&
+    (lastDotIndex !== -1 || pathEnd.length > 2) &&
+    pathEnd.length <= maxLength &&
+    // Exclude index files
+    !pathEnd.match(/index(\.[a-zA-Z]{2-4})?/) &&
+    // Exclude files that are likely to be database IDs
+    !isMostlyNumbers(pathEnd)
+  ) {
+    return pathEnd;
+  }
+};

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -5,7 +5,7 @@ function isUncommonClassName (className) {
     'focus', 'hover',
     'hidden', 'visible',
     'dirty', 'touched', 'valid', 'disable',
-    'disable', 'enable', 'active', 'col-'
+    'enable', 'active', 'col-'
   ].find(str => className.includes(str));
 }
 

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -14,9 +14,8 @@ function getDistinctClassList (elm) {
     return [];
   }
 
-  return Array.from(
-    elm.parentNode && elm.parentNode.children || []
-  ).reduce((classList, childElm) => {
+  const siblings = elm.parentNode && Array.from(elm.parentNode.children || '') || [];
+  return siblings.reduce((classList, childElm) => {
     if (elm === childElm) {
       return classList;
     } else {
@@ -34,12 +33,14 @@ const commonNodes = [
 ];
 
 function getNthChildString (elm, selector) {
+	const siblings = elm.parentNode && Array.from(elm.parentNode.children || '') || [];
   // TODO: Use the current polyfill
-  const hasMatchingSiblings = Array.from(elm.parentNode.children).find(
-    sibling => sibling !== elm && sibling.matches(selector)
-  );
+  const hasMatchingSiblings = siblings.find(sibling => (
+  	sibling !== elm &&
+    axe.utils.matchesSelector(sibling, selector)
+  ));
   if (hasMatchingSiblings) {
-    const nthChild = 1 + Array.from(elm.parentNode.children).indexOf(elm);
+    const nthChild = 1 + siblings.indexOf(elm);
     return ':nth-child(' + nthChild + ')';
   } else {
     return '';
@@ -48,9 +49,18 @@ function getNthChildString (elm, selector) {
 
 const createSelector = {
   // Get ID properties
-  getElmId (elm) { 
-    if (elm.id && !elm.id.match(/player_uid_/)) {
-      return '#' + escapeSelector(elm.id);
+  getElmId (elm) {
+  	if (!elm.id) {
+  		return;
+  	}
+  	const id = '#' + escapeSelector(elm.id || '');
+    if (
+    	// Don't include youtube's uid values, they change  on reload
+    	!id.match(/player_uid_/) &&
+    	// Don't include IDs that occur more then once on the page
+    	document.querySelectorAll(id).length === 1
+    ) {
+      return id;
     }
   },
   // Get custom element name
@@ -69,6 +79,7 @@ const createSelector = {
   // Get uncommon node names
   getUncommonElm (elm, { isCommonElm, isCustomElm, nodeName })  {
     if (!isCommonElm && !isCustomElm) {
+    	nodeName = escapeSelector(nodeName);
       // Add [type] if nodeName is an input element
       if (nodeName === 'input' && elm.hasAttribute('type')) {
         nodeName += '[type=' + elm.type + ']';
@@ -113,15 +124,6 @@ const createSelector = {
     if (isCommonElm) {
       return nodeName;
     }
-  },
-  // Get common classes
-  getCommonClass (elm, { isCommonElm, classList, distinctClassList }) {
-    if (
-      isCommonElm && classList.length > 0 &&
-      (distinctClassList.length === 0 || distinctClassList.length >= 3)
-    ) {
-      return '.' + classList.map(escapeSelector).join('.');
-    }
   }
 };
 
@@ -146,14 +148,12 @@ function getElmFeatures (elm, featureCount) {
 
   return [
     // go through feature selectors in order of priority
-    createSelector.getElmId,
     createSelector.getCustomElm,
     createSelector.getElmRoleProp,
     createSelector.getUncommonElm,
     createSelector.getElmNameProp,
     createSelector.getDistinctClass,
-    createSelector.getCommonName,
-    createSelector.getCommonClass
+    createSelector.getCommonName
   ].reduce((features, func) => {
     // As long as we haven't met our count, keep looking for features
     if (features.length === featureCount) {
@@ -178,6 +178,7 @@ function getElmFeatures (elm, featureCount) {
  * @return {String}      Unique CSS selector for the node
  */
 axe.utils.getSelector = function createUniqueSelector (elm, options = {}) {
+	//jshint maxstatements: 17
   if (!elm) {
     return '';
   }
@@ -188,11 +189,21 @@ axe.utils.getSelector = function createUniqueSelector (elm, options = {}) {
 	  childSelectors = []
 	} = options;
 
+  const idSelector = createSelector.getElmId(elm);
+  if (idSelector) {
+  	return [idSelector, ...childSelectors].join(' > ');
+  }
+
   const elmFeatures = getElmFeatures(elm, featureCount);
-  const selector = elmFeatures.join('');
+  let selector = elmFeatures.join('');
   const nthChildPath = getNthChildString(elm, selector);
 
   const isUnique = options.isUnique || document.querySelectorAll(selector).length === 1;
+  // For the odd case that document doesn't have a unique selector
+  if (!isUnique && elm === document.documentElement) {
+  	selector += ':root';
+  }
+
   const addParent = (toRoot || minDepth > 0 || !isUnique);
   const selectorParts = [selector + nthChildPath, ...childSelectors];
 

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -82,7 +82,7 @@ const createSelector = {
     	nodeName = escapeSelector(nodeName);
       // Add [type] if nodeName is an input element
       if (nodeName === 'input' && elm.hasAttribute('type')) {
-        nodeName += '[type=' + elm.type + ']';
+        nodeName += '[type="' + elm.type + '"]';
       }
       return nodeName;
     }

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -1,104 +1,209 @@
-/**
- * Gets the index of element siblings that have the same nodeName
- * Intended for use with the CSS psuedo-class `:nth-of-type()` and xpath node index
- * @param  {HTMLElement} element The element to test
- * @return {Number}         The number of preceeding siblings with the same nodeName
- * @private
- */
-function nthOfType(element) {
-	'use strict';
+const escapeSelector = axe.utils.escapeSelector;
 
-	var index = 1,
-		type = element.nodeName.toUpperCase();
-
-	/*jshint boss:true */
-	element = element.previousElementSibling;
-	while (element) {
-		if (element.nodeName.toUpperCase() === type) {
-			index++;
-		}
-		element = element.previousElementSibling;
-	}
-
-	return index;
+function isUncommonClassName (className) {
+  return ![
+    'focus', 'hover',
+    'hidden', 'visible',
+    'dirty', 'touched', 'valid', 'disable',
+    'disable', 'enable', 'active', 'col-'
+  ].find(str => className.includes(str));
 }
 
-/**
- * Checks if an element has siblings with the same selector
- * @param  {HTMLElement} node     The element to test
- * @param  {String} selector The CSS selector to test
- * @return {Boolean}          Whether any of element's siblings matches selector
- * @private
- */
-function siblingsHaveSameSelector(node, selector) {
-	'use strict';
+function getDistinctClassList (elm) {
+  if (!elm.classList || elm.classList.length === 0) {
+    return [];
+  }
 
-	var index, sibling,
-		siblings = node.parentNode.children;
-
-	if (!siblings) {
-		return false;
-	}
-
-	var length = siblings.length;
-
-	for (index = 0; index < length; index++) {
-		sibling = siblings[index];
-		if (sibling !== node && axe.utils.matchesSelector(sibling, selector)) {
-			return true;
-		}
-	}
-	return false;
+  return Array.from(
+    elm.parentNode && elm.parentNode.children || []
+  ).reduce((classList, childElm) => {
+    if (elm === childElm) {
+      return classList;
+    } else {
+      return classList.filter(classItem => {
+        return !childElm.classList.contains(classItem);
+      });
+    }
+  }, Array.from(elm.classList).filter(isUncommonClassName));
 }
 
+const commonNodes = [
+  'div', 'span', 'p', 
+  'b', 'i', 'u', 'strong', 'em',
+  'h2', 'h3'
+];
+
+function getNthChildString (elm, selector) {
+  // TODO: Use the current polyfill
+  const hasMatchingSiblings = Array.from(elm.parentNode.children).find(
+    sibling => sibling !== elm && sibling.matches(selector)
+  );
+  if (hasMatchingSiblings) {
+    const nthChild = 1 + Array.from(elm.parentNode.children).indexOf(elm);
+    return ':nth-child(' + nthChild + ')';
+  } else {
+    return '';
+  }
+}
+
+const createSelector = {
+  // Get ID properties
+  getElmId (elm) { 
+    if (elm.id && !elm.id.match(/player_uid_/)) {
+      return '#' + escapeSelector(elm.id);
+    }
+  },
+  // Get custom element name
+  getCustomElm (elm, { isCustomElm, nodeName }) {
+    if (isCustomElm) {
+      return nodeName;
+    }
+  },
+
+  // Get ARIA role
+  getElmRoleProp (elm) {
+    if (elm.hasAttribute('role')) {
+      return '[role="' + escapeSelector(elm.getAttribute('role')) +'"]';
+    }
+  },
+  // Get uncommon node names
+  getUncommonElm (elm, { isCommonElm, isCustomElm, nodeName })  {
+    if (!isCommonElm && !isCustomElm) {
+      // Add [type] if nodeName is an input element
+      if (nodeName === 'input' && elm.hasAttribute('type')) {
+        nodeName += '[type=' + elm.type + ']';
+      }
+      return nodeName;
+    }
+  },
+  // Has a name property, but no ID (Think input fields)
+  getElmNameProp (elm) {
+    if (!elm.id && elm.name) {
+      return '[name="' + escapeSelector(elm.name) + '"]';
+    }
+  },
+  // Get any distinct classes (as long as there aren't more then 3 of them)
+  getDistinctClass (elm, { distinctClassList }) {
+    if (distinctClassList.length > 0 && distinctClassList.length < 3) {
+      return '.' + distinctClassList.map(escapeSelector).join('.');
+    }
+  },
+  // Get a selector that uses src/href props
+  getFileRefProp (elm) {
+    if (elm.id) {
+      return;
+    }
+    // TODO: find a better way to either show a brief name, or exit empty
+    let attr;
+    if (elm.hasAttribute('href')) {
+      attr = 'href';
+    } else if (elm.hasAttribute('src')) {
+      attr = 'src';
+    }
+
+    if (attr) {
+      const filePath = elm.getAttribute(attr).replace(/\/$/, '').split(/\//g);
+      if (filePath) {
+        return '[' + attr + '$="' + encodeURI(filePath.pop()) + '"]';
+      }
+    }
+  },
+  // Get common node names
+  getCommonName (elm, { nodeName, isCommonElm }) {
+    if (isCommonElm) {
+      return nodeName;
+    }
+  },
+  // Get common classes
+  getCommonClass (elm, { isCommonElm, classList, distinctClassList }) {
+    if (
+      isCommonElm && classList.length > 0 &&
+      (distinctClassList.length === 0 || distinctClassList.length >= 3)
+    ) {
+      return '.' + classList.map(escapeSelector).join('.');
+    }
+  }
+};
+
+/**
+ * Get an array of features (as CSS selectors) that describe an element
+ *
+ * By going down the list of most to least prominent element features,
+ * we attempt to find those features that a dev is most likely to
+ * recognize the element by (IDs, aria roles, custom element names, etc.)
+ */
+function getElmFeatures (elm, featureCount) {
+  const nodeName = elm.nodeName.toLowerCase();
+  const classList = Array.from(elm.classList) || [];
+  // Collect some props we need to build the selector
+  const props = {
+    nodeName,
+    classList,
+    isCustomElm: nodeName.includes('-'),
+    isCommonElm: commonNodes.includes(nodeName),
+    distinctClassList: getDistinctClassList(elm)
+  };
+
+  return [
+    // go through feature selectors in order of priority
+    createSelector.getElmId,
+    createSelector.getCustomElm,
+    createSelector.getElmRoleProp,
+    createSelector.getUncommonElm,
+    createSelector.getElmNameProp,
+    createSelector.getDistinctClass,
+    createSelector.getCommonName,
+    createSelector.getCommonClass
+  ].reduce((features, func) => {
+    // As long as we haven't met our count, keep looking for features
+    if (features.length === featureCount) {
+      return features;
+    }
+
+    const feature = func(elm, props);
+    if (feature) {
+      if (!feature[0].match(/[a-z]/)) {
+        features.push(feature);
+      } else {
+        features.unshift(feature);
+      }
+    }
+    return features;
+  }, []);
+}
 
 /**
  * Gets a unique CSS selector
  * @param  {HTMLElement} node The element to get the selector for
  * @return {String}      Unique CSS selector for the node
  */
-axe.utils.getSelector = function getSelector(node) {
-	//jshint maxstatements: 21
-	'use strict';
+axe.utils.getSelector = function createUniqueSelector (elm, options = {}) {
+  if (!elm) {
+    return '';
+  }
+  const {
+	  featureCount = 2, 
+	  minDepth = 1,
+	  toRoot = false,
+	  childSelectors = []
+	} = options;
 
-	function escape(p) {
-		return axe.utils.escapeSelector(p);
-	}
+  const elmFeatures = getElmFeatures(elm, featureCount);
+  const selector = elmFeatures.join('');
+  const nthChildPath = getNthChildString(elm, selector);
 
-	var parts = [], part;
+  const isUnique = options.isUnique || document.querySelectorAll(selector).length === 1;
+  const addParent = (toRoot || minDepth > 0 || !isUnique);
+  const selectorParts = [selector + nthChildPath, ...childSelectors];
 
-	while (node.parentNode) {
-		part = '';
-
-		if (node.id && document.querySelectorAll('#' + axe.utils.escapeSelector(node.id)).length === 1) {
-			parts.unshift('#' + axe.utils.escapeSelector(node.id));
-			break;
-		}
-
-		if (node.className && typeof node.className === 'string') {
-			part = '.' + node.className.trim().split(/\s+/).map(escape).join('.');
-			if (part === '.' || siblingsHaveSameSelector(node, part)) {
-				part = '';
-			}
-		}
-
-		if (!part) {
-			part = axe.utils.escapeSelector(node.nodeName).toLowerCase();
-			if (part === 'html' || part === 'body') {
-				parts.unshift(part);
-				break;
-			}
-			if (siblingsHaveSameSelector(node, part)) {
-				part += ':nth-of-type(' + nthOfType(node) + ')';
-			}
-
-		}
-
-		parts.unshift(part);
-
-		node = node.parentNode;
-	}
-
-	return parts.join(' > ');
-
+  if (elm.parentElement && addParent) {
+    return createUniqueSelector(elm.parentNode, {
+      toRoot, isUnique,
+      childSelectors: selectorParts,
+      featureCount: 1,
+      minDepth: minDepth -1
+    });
+  } else {
+    return selectorParts.join(' > ');
+  }
 };

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -100,22 +100,17 @@ const createSelector = {
   },
   // Get a selector that uses src/href props
   getFileRefProp (elm) {
-    if (elm.id) {
-      return;
-    }
-    // TODO: find a better way to either show a brief name, or exit empty
     let attr;
     if (elm.hasAttribute('href')) {
       attr = 'href';
     } else if (elm.hasAttribute('src')) {
       attr = 'src';
+    } else {
+      return;
     }
-
-    if (attr) {
-      const filePath = elm.getAttribute(attr).replace(/\/$/, '').split(/\//g);
-      if (filePath) {
-        return '[' + attr + '$="' + encodeURI(filePath.pop()) + '"]';
-      }
+    const friendlyUriEnd = axe.utils.getFriendlyUriEnd(elm.getAttribute(attr));
+    if (friendlyUriEnd) {
+      return '[' + attr + '$="' + encodeURI(friendlyUriEnd) + '"]';
     }
   },
   // Get common node names
@@ -152,6 +147,7 @@ function getElmFeatures (elm, featureCount) {
     createSelector.getUncommonElm,
     createSelector.getElmNameProp,
     createSelector.getDistinctClass,
+    createSelector.getFileRefProp,
     createSelector.getCommonName
   ].reduce((features, func) => {
     // As long as we haven't met our count, keep looking for features

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -34,7 +34,6 @@ const commonNodes = [
 
 function getNthChildString (elm, selector) {
 	const siblings = elm.parentNode && Array.from(elm.parentNode.children || '') || [];
-  // TODO: Use the current polyfill
   const hasMatchingSiblings = siblings.find(sibling => (
   	sibling !== elm &&
     axe.utils.matchesSelector(sibling, selector)
@@ -178,36 +177,39 @@ function getElmFeatures (elm, featureCount) {
  * @return {String}      Unique CSS selector for the node
  */
 axe.utils.getSelector = function createUniqueSelector (elm, options = {}) {
-	//jshint maxstatements: 17
+  //jshint maxstatements: 19
   if (!elm) {
     return '';
   }
-  const {
-	  featureCount = 2, 
-	  minDepth = 1,
-	  toRoot = false,
-	  childSelectors = []
-	} = options;
-
+  let selector, addParent;
+  let { isUnique = false } = options;
   const idSelector = createSelector.getElmId(elm);
+  const {
+    featureCount = 2, 
+    minDepth = 1,
+    toRoot = false,
+    childSelectors = []
+  } = options;
+
   if (idSelector) {
-  	return [idSelector, ...childSelectors].join(' > ');
+    selector = idSelector;
+    isUnique = true;
+
+  } else {
+    selector = getElmFeatures(elm, featureCount).join('');
+    selector += getNthChildString(elm, selector);
+    isUnique = options.isUnique || document.querySelectorAll(selector).length === 1;
+
+    // For the odd case that document doesn't have a unique selector
+    if (!isUnique && elm === document.documentElement) {
+    	selector += ':root';
+    }
+    addParent = (minDepth !== 0 || !isUnique);
   }
 
-  const elmFeatures = getElmFeatures(elm, featureCount);
-  let selector = elmFeatures.join('');
-  const nthChildPath = getNthChildString(elm, selector);
+  const selectorParts = [selector, ...childSelectors];
 
-  const isUnique = options.isUnique || document.querySelectorAll(selector).length === 1;
-  // For the odd case that document doesn't have a unique selector
-  if (!isUnique && elm === document.documentElement) {
-  	selector += ':root';
-  }
-
-  const addParent = (toRoot || minDepth > 0 || !isUnique);
-  const selectorParts = [selector + nthChildPath, ...childSelectors];
-
-  if (elm.parentElement && addParent) {
+  if (elm.parentElement && (toRoot || addParent)) {
     return createUniqueSelector(elm.parentNode, {
       toRoot, isUnique,
       childSelectors: selectorParts,

--- a/lib/core/utils/merge-results.js
+++ b/lib/core/utils/merge-results.js
@@ -6,7 +6,7 @@
 * @param  {HTMLElement} frameElement  The frame element
 * @param  {String} frameSelector     Unique CSS selector for the frame
 */
-function pushFrame(resultSet, frameElement, frameSelector) {
+function pushFrame(resultSet, options, frameElement, frameSelector) {
   'use strict';
   var frameXpath = axe.utils.getXpath(frameElement);
   var frameSpec = {
@@ -16,13 +16,13 @@ function pushFrame(resultSet, frameElement, frameSelector) {
   };
 
   resultSet.forEach(function (res) {
-    res.node = axe.utils.DqElement.fromFrame(res.node, frameSpec);
+    res.node = axe.utils.DqElement.fromFrame(res.node,  options, frameSpec);
 
     var checks = axe.utils.getAllChecks(res);
     if (checks.length) {
       checks.forEach(function (check) {
         check.relatedNodes = check.relatedNodes.map(
-          (node) => axe.utils.DqElement.fromFrame(node, frameSpec)
+          (node) => axe.utils.DqElement.fromFrame(node, options, frameSpec)
         );
       });
     }
@@ -78,7 +78,7 @@ function normalizeResult(result) {
 * @param  {Array} frameResults  Array of objects including the RuleResults as `results` and frame as `frame`
 * @return {Array}              The merged RuleResults; should only have one result per rule
 */
-axe.utils.mergeResults = function mergeResults(frameResults) {
+axe.utils.mergeResults = function mergeResults(frameResults, options) {
   'use strict';
   var result = [];
   frameResults.forEach(function (frameResult) {
@@ -89,7 +89,7 @@ axe.utils.mergeResults = function mergeResults(frameResults) {
 
     results.forEach(function (ruleResult) {
       if (ruleResult.nodes && frameResult.frame) {
-        pushFrame(ruleResult.nodes, frameResult.frameElement, frameResult.frame);
+        pushFrame(ruleResult.nodes, options, frameResult.frameElement, frameResult.frame);
       }
 
       var res = axe.utils.findBy(result, 'id', ruleResult.id);

--- a/lib/core/utils/pollyfills.js
+++ b/lib/core/utils/pollyfills.js
@@ -242,3 +242,16 @@ if (!Array.from) {
     };
   }());
 }
+
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    if (typeof start !== 'number') {
+      start = 0;
+    }
+    if (start + search.length > this.length) {
+      return false;
+    } else {
+      return this.indexOf(search, start) !== -1;
+    }
+  };
+}

--- a/test/core/base/check.js
+++ b/test/core/base/check.js
@@ -164,7 +164,7 @@ describe('Check', function () {
 					cb = function () { return true; },
 					result = { monkeys: 'bananas' };
 
-				axe.utils.checkHelper = function (checkResult, callback) {
+				axe.utils.checkHelper = function (checkResult, options, callback) {
 					assert.instanceOf(checkResult, window.CheckResult);
 					assert.equal(callback, cb);
 

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -542,7 +542,11 @@ describe('Rule', function() {
 							id: 'cats',
 							enabled: true,
 							after: function(results, options) {
-								assert.deepEqual(options, { enabled: true, options: { dogs: true }});
+								assert.deepEqual(options, {
+									enabled: true,
+									options: { dogs: true },
+									absolutePaths: undefined
+								});
 								success = true;
 								return results;
 							}

--- a/test/core/public/run.js
+++ b/test/core/public/run.js
@@ -276,6 +276,45 @@ describe('axe.run', function () {
 			});
 		});
 	});
+
+	describe('option absolutePaths', function () {
+
+		it('returns relative paths when falsy', function (done) {
+			axe.run('#fixture', {
+				absolutePaths: 0
+			}, function (err, result) {
+				assert.deepEqual(
+					result.violations[0].nodes[0].target,
+					['#fixture']
+				);
+				done();
+			});
+		});
+
+		it('returns absolute paths when truthy', function (done) {
+			axe.run('#fixture', {
+				absolutePaths: 'yes please'
+			}, function (err, result) {
+				assert.deepEqual(
+					result.violations[0].nodes[0].target,
+					['html > body > #fixture']
+				);
+				done();
+			});
+		});
+
+		it('returns absolute paths on related nodes', function (done) {
+			axe.run('#fixture', {
+				absolutePaths: true
+			}, function (err, result) {
+				assert.deepEqual(
+					result.violations[0].nodes[0].none[0].relatedNodes[0].target,
+					['html > body > #fixture']
+				);
+				done();
+			});
+		});
+	});
 });
 
 describe('axe.run iframes', function () {

--- a/test/core/utils/check-helper.js
+++ b/test/core/utils/check-helper.js
@@ -8,8 +8,8 @@ describe('axe.utils.checkHelper', function () {
 		assert.isFunction(axe.utils.checkHelper);
 	});
 
-	it('should accept 3 named parameters', function () {
-		assert.lengthOf(axe.utils.checkHelper, 3);
+	it('should accept 4 named parameters', function () {
+		assert.lengthOf(axe.utils.checkHelper, 4);
 	});
 
 	it('should return an object', function () {
@@ -25,10 +25,10 @@ describe('axe.utils.checkHelper', function () {
 				helper.async();
 				assert.isTrue(helper.isAsync);
 			});
-			it('should call the second parameter of `axe.utils.checkHelper` when invoked', function () {
+			it('should call the third parameter of `axe.utils.checkHelper` when invoked', function () {
 				function fn() { success = true; }
 				var success = false,
-					helper = axe.utils.checkHelper({}, fn);
+					helper = axe.utils.checkHelper({}, {}, fn);
 
 				var done = helper.async();
 				done();
@@ -36,14 +36,14 @@ describe('axe.utils.checkHelper', function () {
 				assert.isTrue(success);
 			});
 
-			it('should call the third parameter of `axe.utils.checkHelper` when returning an error', function () {
+			it('should call the fourth parameter of `axe.utils.checkHelper` when returning an error', function () {
 				var success = false;
 				function reject(e) {
 					success = true;
 					assert.equal(e.message, 'Concrete donkey!');
 				}
 
-				var helper = axe.utils.checkHelper({}, noop, reject);
+				var helper = axe.utils.checkHelper({}, {}, noop, reject);
 				var done = helper.async();
 				done( new Error('Concrete donkey!'));
 

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -72,7 +72,7 @@ describe('DqElement', function () {
 
 		it('should use spec object over passed element', function () {
 			fixture.innerHTML = '<div id="foo" class="bar">Hello!</div>';
-			var result = new DqElement(fixture.firstChild, {
+			var result = new DqElement(fixture.firstChild, {}, {
 				source: 'woot'
 			});
 			assert.equal(result.source, 'woot');
@@ -100,7 +100,7 @@ describe('DqElement', function () {
 
 		it('should prefer selector from spec object', function () {
 			fixture.innerHTML = '<div id="foo" class="bar">Hello!</div>';
-			var result = new DqElement(fixture.firstChild, {
+			var result = new DqElement(fixture.firstChild, {}, {
 				selector: 'woot'
 			});
 			assert.equal(result.selector, 'woot');
@@ -126,12 +126,24 @@ describe('DqElement', function () {
 
 		it('should prefer selector from spec object', function () {
 			fixture.innerHTML = '<div id="foo" class="bar">Hello!</div>';
-			var result = new DqElement(fixture.firstChild, {
+			var result = new DqElement(fixture.firstChild, {}, {
 				xpath: 'woot'
 			});
 			assert.equal(result.xpath, 'woot');
 		});
 
+	});
+
+	describe('absolutePaths', function () {
+		it('creates a path all the way to root', function () {
+			fixture.innerHTML = '<div id="foo" class="bar">Hello!</div>';
+			var result = new DqElement(fixture.firstChild, {
+				absolutePaths: true
+			});
+			assert.include(result.selector[0], 'html > ');
+			assert.include(result.selector[0], '#fixture > ');
+			assert.include(result.selector[0], '#foo');
+		});
 	});
 
 	describe('toJSON', function () {
@@ -141,7 +153,7 @@ describe('DqElement', function () {
 				source: '<joe aria-required="true">',
 				xpath: '/foo/bar/joe'
 			};
-			var result = new DqElement('joe', expected);
+			var result = new DqElement('joe', {}, expected);
 
 			assert.deepEqual(JSON.stringify(result), JSON.stringify(expected));
 		});

--- a/test/core/utils/get-check-option.js
+++ b/test/core/utils/get-check-option.js
@@ -26,7 +26,8 @@ describe('axe.utils.getCheckOption', function () {
 				}
 			}), {
 				enabled: 'yes',
-				options: 'please'
+				options: 'please',
+				absolutePaths: undefined
 			});
 	});
 	it('should fallback to global check options if not defined on the rule', function () {
@@ -52,7 +53,8 @@ describe('axe.utils.getCheckOption', function () {
 				}
 			}), {
 				enabled: 'yes',
-				options: 'please'
+				options: 'please',
+				absolutePaths: undefined
 			});
 	});
 
@@ -70,7 +72,8 @@ describe('axe.utils.getCheckOption', function () {
 				}
 			}), {
 				enabled: 'yes',
-				options: 'please'
+				options: 'please',
+				absolutePaths: undefined
 			});
 	});
 
@@ -81,8 +84,23 @@ describe('axe.utils.getCheckOption', function () {
 				options: 'please'
 			}, 'monkeys', {}), {
 				enabled: 'yes',
-				options: 'please'
+				options: 'please',
+				absolutePaths: undefined
 			});
+	});
+
+	it('passes absolutePaths option along', function () {
+		assert.deepEqual(axe.utils.getCheckOption({
+			id: 'bananas',
+			enabled: 'on',
+			options: 'many'
+		}, 'monkeys', {
+			absolutePaths: 'yep'
+		}), {
+			enabled: 'on',
+			options: 'many',
+			absolutePaths: 'yep'
+		});
 	});
 
 });

--- a/test/core/utils/get-friendly-uri-end.js
+++ b/test/core/utils/get-friendly-uri-end.js
@@ -1,0 +1,52 @@
+describe('axe.utils.getFriendlyUriEnd', function () {
+  'use strict';
+  var getFriendlyUriEnd = axe.utils.getFriendlyUriEnd;
+
+  it('returns a domain name', function () {
+    assert.equal('deque.com', getFriendlyUriEnd('http://deque.com'));
+    assert.equal('deque.com/', getFriendlyUriEnd('https://www.deque.com/'));
+    assert.equal('docs.deque.com/', getFriendlyUriEnd('//docs.deque.com/'));
+  });
+
+  it('returns a filename', function () {
+    assert.equal('contact/', getFriendlyUriEnd('../../contact/'));
+    assert.equal('contact/', getFriendlyUriEnd('http://deque.com/contact/'));
+    assert.equal('contact', getFriendlyUriEnd('/contact'));
+    assert.equal('contact.html', getFriendlyUriEnd('/contact.html'));
+  });
+
+  it('returns a hash URI', function () {
+    assert.equal('#footer', getFriendlyUriEnd('#footer'));
+    assert.equal('contact.html#footer', getFriendlyUriEnd('/contact.html#footer'));
+  });
+
+  it('returns undef when there is a query', function () {
+    assert.isUndefined(getFriendlyUriEnd('/contact?'));
+    assert.isUndefined(getFriendlyUriEnd('/contact?foo=bar'));
+  });
+
+  it('returns undef for index files', function () {
+    assert.isUndefined(getFriendlyUriEnd('/index.cfs'));
+    assert.isUndefined(getFriendlyUriEnd('/index'));
+  });
+
+  it('returns undef when the result is too short', function () {
+    assert.isUndefined(getFriendlyUriEnd('/i.html'));
+    assert.isUndefined(getFriendlyUriEnd('/dq'));
+  });
+
+  it('returns undef when the result is too long', function () {
+    assert.isDefined(getFriendlyUriEnd('/abcd.html', { maxLength: 50 }));
+    assert.isDefined(getFriendlyUriEnd('#foo-bar-baz', { maxLength: 50 }));
+    assert.isDefined(getFriendlyUriEnd('//deque.com', { maxLength: 50 }));
+
+    assert.isUndefined(getFriendlyUriEnd('/abcd.html', { maxLength: 5 }));
+    assert.isUndefined(getFriendlyUriEnd('#foo-bar-baz', { maxLength: 5 }));
+    assert.isUndefined(getFriendlyUriEnd('//deque.com', { maxLength: 5 }));
+  });
+
+  it('returns undef when the result has too many numbers', function () {
+    assert.isUndefined(getFriendlyUriEnd('123456.html'));
+  });
+
+});

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -99,12 +99,11 @@ describe('axe.utils.getSelector', function () {
 
 		var sel = axe.utils.getSelector(node);
 
-		assert.equal(sel, '#fixture > div:nth-of-type(2)');
+		assert.equal(sel, '#fixture > div:nth-child(2)');
 
 		var result = document.querySelectorAll(sel);
 		assert.lengthOf(result, 1);
 		assert.equal(result[0], node);
-
 	});
 
 	it('should use classes if available and unique', function () {
@@ -118,7 +117,7 @@ describe('axe.utils.getSelector', function () {
 
 		var sel = axe.utils.getSelector(node);
 
-		assert.equal(sel, '#fixture > .dogs.cats');
+		assert.equal(sel, '#fixture > div.dogs.cats');
 
 		var result = document.querySelectorAll(sel);
 		assert.lengthOf(result, 1);
@@ -137,44 +136,11 @@ describe('axe.utils.getSelector', function () {
 
 		var sel = axe.utils.getSelector(node);
 
-		assert.equal(sel, '#fixture > div:nth-of-type(2)');
+		assert.equal(sel, '#fixture > div:nth-child(2)');
 
 		var result = document.querySelectorAll(sel);
 		assert.lengthOf(result, 1);
 		assert.equal(result[0], node);
-
-	});
-
-	it('should properly calculate nth-of-type when siblings are of different type', function () {
-		var node, target;
-		node = document.createElement('span');
-		fixture.appendChild(node);
-
-		node = document.createElement('span');
-		fixture.appendChild(node);
-
-		node = document.createElement('div');
-		fixture.appendChild(node);
-
-		node = document.createElement('div');
-		target = node;
-		fixture.appendChild(node);
-
-		node = document.createElement('div');
-		fixture.appendChild(node);
-
-		node = document.createElement('span');
-		fixture.appendChild(node);
-
-
-
-		var sel = axe.utils.getSelector(target);
-
-		assert.equal(sel, '#fixture > div:nth-of-type(2)');
-
-		var result = document.querySelectorAll(sel);
-		assert.lengthOf(result, 1);
-		assert.equal(result[0], target);
 
 	});
 
@@ -214,8 +180,12 @@ describe('axe.utils.getSelector', function () {
 	it('shouldn\'t fail if the node\'s parentNode doesnt have children, somehow (Firefox bug)', function () {
 		var sel = axe.utils.getSelector({
 			nodeName: 'a',
+			classList: [],
+			hasAttribute: function () { return false; },
 			parentNode: {
-				nodeName: 'b'
+				nodeName: 'b',
+				hasAttribute: function () { return false; },
+				classList: []
 			}
 		});
 		assert.equal(sel, 'a');

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -202,6 +202,25 @@ describe('axe.utils.getSelector', function () {
 		);
 	});
 
+	it('should use href and src attributes', function () {
+		var link = document.createElement('a');
+		link.setAttribute('href', '//deque.com/about/');
+		fixture.appendChild(link);
+
+		var img = document.createElement('img');
+		img.setAttribute('src', '//deque.com/logo.png');
+		fixture.appendChild(img);
+
+		assert.equal(
+			axe.utils.getSelector(link),
+			'#fixture > a[href$="about/"]'
+		);
+		assert.equal(
+			axe.utils.getSelector(img),
+			'#fixture > img[src$="logo.png"]'
+		);
+	});
+
 	it('should give use two features on the first element', function () {
 		var node = document.createElement('div');
 		node.setAttribute('role', 'menuitem');

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -190,4 +190,81 @@ describe('axe.utils.getSelector', function () {
 		});
 		assert.equal(sel, 'a');
 	});
+
+	it('should use role attributes', function () {
+		var node = document.createElement('div');
+		node.setAttribute('role', 'menuitem');
+		fixture.appendChild(node);
+
+		assert.equal(
+			axe.utils.getSelector(node),
+			'#fixture > div[role="menuitem"]'
+		);
+	});
+
+	it('should give use two features on the first element', function () {
+		var node = document.createElement('div');
+		node.setAttribute('role', 'menuitem');
+		fixture.appendChild(node);
+
+		assert.equal(
+			axe.utils.getSelector(node),
+			'#fixture > div[role="menuitem"]'
+		);
+		
+		node.className = 'dqpl-btn-primary';
+		assert.equal(
+			axe.utils.getSelector(node),
+			'#fixture > [role="menuitem"].dqpl-btn-primary'
+		);
+	});
+
+	it('should give use one features on the subsequent elements', function () {
+		var span = document.createElement('span');
+		var node = document.createElement('div');
+		node.setAttribute('role', 'menuitem');
+		span.className = 'expand-icon';
+		node.appendChild(span);
+		fixture.appendChild(node);
+
+		assert.equal(
+			axe.utils.getSelector(span),
+			'[role="menuitem"] > span.expand-icon'
+		);
+	});
+
+	it('should prioritize uncommon tagNames', function () {
+		var node = document.createElement('button');
+		node.setAttribute('role', 'menuitem');
+		node.className = 'dqpl-btn-primary';
+		fixture.appendChild(node);
+		assert.equal(
+			axe.utils.getSelector(node),
+			'#fixture > button[role="menuitem"]'
+		);
+	});
+
+	it('should add [type] to input elements', function () {
+		var node = document.createElement('input');
+		node.type = 'password';
+		node.className = 'dqpl-textfield';
+		fixture.appendChild(node);
+		assert.equal(
+			axe.utils.getSelector(node),
+			'#fixture > input[type="password"].dqpl-textfield'
+		);
+	});
+
+	it('should use the name property', function () {
+		var node = document.createElement('input');
+		node.type = 'text';
+		node.name = 'username';
+		node.className = 'dqpl-textfield';
+		fixture.appendChild(node);
+		assert.equal(
+			axe.utils.getSelector(node),
+			'#fixture > input[type="text"][name="username"]'
+		);
+	});
+
 });

--- a/test/integration/rules/duplicate-id/duplicate-id.json
+++ b/test/integration/rules/duplicate-id/duplicate-id.json
@@ -1,6 +1,6 @@
 {
 	"description": "duplicate-id test",
 	"rule": "duplicate-id",
-	"violations": [["#fixture > p:nth-of-type(1)"]],
+	"violations": [["#fixture > p:nth-child(1)"]],
 	"passes": [["#fixture"], ["#single"]]
 }


### PR DESCRIPTION
Rebuild the getSelector method, to return selectors that are more readable, shorter and more durable. In addition, the absolutePaths option was added which will return full paths to elements, rather then the shortest possible selectors we could find.