### PR TITLE
fix: update copy in href-no-hash best practice rule

### DIFF
--- a/lib/checks/navigation/href-no-hash.json
+++ b/lib/checks/navigation/href-no-hash.json
@@ -4,8 +4,8 @@
   "metadata": {
     "impact": "moderate",
     "messages": {
-      "pass": "Anchor does not have a href quals #",
-      "fail": "Anchor has a href quals #"
+      "pass": "Anchor does not have an href value of #",
+      "fail": "Anchor has an href value of #"
     }
   }
 }

--- a/lib/rules/href-no-hash.json
+++ b/lib/rules/href-no-hash.json
@@ -8,7 +8,7 @@
   ],
   "metadata": {
     "description": "Ensures that href values are valid link references to promote only using anchors as links",
-    "help": "Anchors must only be used as links and must therefore have an href value that is a valid reference. Otherwise you should probably usa a button"
+    "help": "Anchors must only be used as links with valid URLs or URL fragments"
   },
   "all": [],
   "any": [


### PR DESCRIPTION
I noticed the copy in this rule when I was testing extensions with best practice rules turned on. Because help text is used in the sidebar of our new extensions, it read poorly compared to the help text in other rules.

Here's the commit where the text originated: https://github.com/dequelabs/axe-core/commit/e0ebdea70fcc1e1c6b7abb82c1467d3031630474