### PR TITLE
doc: explain category mappings

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -77,12 +77,30 @@ Returns a list of all rules with their ID and description
 
 The current set of tags supported are listed in the following table:
 
-| Tag Name           | Accessibility Standard                |
-|--------------------|:-------------------------------------:|
-| `wcag2a`           | WCAG 2.0 Level A                      |
-| `wcag2aa`          | WCAG 2.0 Level AA                     |
-| `section508`       | Section 508                           |
-| `best-practice`    | Best practices endorsed by Deque      |
+| Tag Name           | Accessibility Standard/Purpose              |
+|--------------------|:-------------------------------------------:|
+| `wcag2a`           | WCAG 2.0 Level A                            |
+| `wcag2aa`          | WCAG 2.0 Level AA                           |
+| `section508`       | Section 508                                 |
+| `best-practice`    | Best practices endorsed by Deque            |
+| `experimental`     | Cutting-edge techniques                     |
+| `cat`              | Category mappings used by Deque (see below) |
+
+| Category name                 |
+|-------------------------------|
+| `cat.aria`                    |
+| `cat.color`                   |
+| `cat.forms`                   |
+| `cat.keyboard`                |
+| `cat.language`                |
+| `cat.name-role-value`         |
+| `cat.parsing`                 |
+| `cat.semantics`               |
+| `cat.sensory-and-visual-cues` |
+| `cat.structure`               |
+| `cat.tables`                  |
+| `cat.text-alternatives`       |
+| `cat.time-and-media`          |
 
 
 #### Example 1


### PR DESCRIPTION
We've gotten questions about the new category mappings added in https://github.com/dequelabs/axe-core/commit/fe829e2b47c067d67dd8f0e33875ab05885d2b63, so I listed them out in API.md.

I considered listing which rules these apply to, but we'd have to maintain it...and since these are only used by Deque internally it didn't seem worth it. Let me know if this needs more detail.

Closes https://dequesrc.atlassian.net/browse/WWD-698