### PR TITLE
fix: Update axe.source to work with Firefox webdriver

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -11,7 +11,7 @@ if (typeof define === 'function' && define.amd) {
 	});
 }
 if (typeof module === 'object' && module.exports && typeof axeFunction.toString === 'function') {
-    axe.source = '(' + axeFunction.toString() + ')(this, this.document);';
+    axe.source = '(' + axeFunction.toString() + ')(typeof window === "object" ? window : this);';
     module.exports = axe;
 }
 if (typeof window.getComputedStyle === 'function') {


### PR DESCRIPTION
axe-webdriverjs wasn’t running properly because axe.source wasn’t getting the window object passed in correctly.