### PR TITLE
chore: ensure package is built before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "scripts": {
     "build": "grunt",
     "test": "grunt test",
-    "test-fast": "grunt test-fast"
+    "test-fast": "grunt test-fast",
+    "prepublishOnly": "grunt build"
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.6.5",


### PR DESCRIPTION
I almost forgot to run `grunt build` before `npm publish` again today, so this script makes sure that doesn't happen. `prepublishOnly` will run before the module is published, but not on npm install. We could potentially run it as `prepublish` to get both of those. That might actually simplify other projects, like attest-standards.

More on npm scripts including `prepublishOnly`: https://docs.npmjs.com/misc/scripts