### PR TITLE
feat: updated rule and check for hidden content to omit head, templat…

### DIFF
--- a/lib/checks/visibility/hidden-content.js
+++ b/lib/checks/visibility/hidden-content.js
@@ -1,6 +1,8 @@
 let styles = window.getComputedStyle(node);
+let nodeName = node.nodeName.toUpperCase();
+let skipOver = ['HEAD', 'TEMPLATE', 'SCRIPT'];
 
-if (axe.commons.dom.hasContent(node)) {
+if (skipOver.indexOf(nodeName) < 0 && axe.commons.dom.hasContent(node)) {
   if (styles.getPropertyValue('display') === 'none') {
     return undefined;
   } else if (styles.getPropertyValue('visibility') === 'hidden') {

--- a/lib/rules/hidden-content.json
+++ b/lib/rules/hidden-content.json
@@ -1,6 +1,6 @@
 {
   "id": "hidden-content",
-  "selector": "*",
+  "selector": "body *",
   "excludeHidden": false,
   "tags": [
     "experimental",

--- a/test/checks/visibility/hidden-content.js
+++ b/test/checks/visibility/hidden-content.js
@@ -39,4 +39,16 @@ describe('hidden content', function () {
 		assert.isTrue(checks['hidden-content'].evaluate.call(checkContext, node));
 	});
 
+	it('should return true on <template>', function () {
+		fixture.innerHTML = '<template id="target">Hello, world.</template>';
+		var node = fixture.querySelector('#target');
+		assert.isTrue(checks['hidden-content'].evaluate.call(checkContext, node));
+	});
+
+	it('should return true on <script>', function () {
+		fixture.innerHTML = '<script id="target" src="some.js">var noop = function () { return null; }</script>';
+		var node = fixture.querySelector('#target');
+		assert.isTrue(checks['hidden-content'].evaluate.call(checkContext, node));
+	});
+
 });

--- a/test/integration/rules/hidden-content/hidden-content.html
+++ b/test/integration/rules/hidden-content/hidden-content.html
@@ -1,3 +1,5 @@
 <div id="canttell1" style="display: none"><p id="pass1">Some paragraph text.</p></div>
 <div id="canttell2" style="visibility: hidden"><p id="pass2">Some paragraph text.</p></div>
 <span id="pass3" aria-hidden="true"></span>
+<template id="pass4">Hello, world.</template>
+<script id="pass5" src="some.js">var noop = function () { return null; }</script>

--- a/test/integration/rules/hidden-content/hidden-content.json
+++ b/test/integration/rules/hidden-content/hidden-content.json
@@ -9,6 +9,8 @@
     ["#fixture"],
     ["#pass1"],
     ["#pass2"],
-    ["#pass3"]
+    ["#pass3"],
+    ["#pass4"],
+    ["#pass5"]
   ]
 }


### PR DESCRIPTION
Updates a previously added and merged rule that checks for hidden content, by omitting `head`, `template`, and `script`. Additional tests were added for this update.