### PR TITLE
chore: add help text for testconfig Grunt task

### DIFF
--- a/build/tasks/testconfig.js
+++ b/build/tasks/testconfig.js
@@ -2,7 +2,9 @@
 'use strict';
 
 module.exports = function (grunt) {
-	grunt.registerMultiTask('testconfig', function () {
+	grunt.registerMultiTask('testconfig',
+	'This task creates a file with all the source test config and HTML fixutres in a single JS object "test"',
+	function () {
 
 		var result = {
 			tests: {},


### PR DESCRIPTION
A message will be printed out explaining the task purpose when running
`grunt --help`

Related #364 

____
Using the `[description]` parameter from https://gruntjs.com/creating-tasks#basic-tasks
Before:
```console
     test-webdriver  Custom multi task. *
     testconfig  Custom multi task. *
     update-help  Custom multi task. *
```

After:
```console
     test-webdriver  Custom multi task. *
     testconfig  This task creates a file with all the source test config and
                 HTML fixutres in a single JS object "test" *
     update-help  Custom multi task. *
```