### PR TITLE
fix offScreen test failing in Chrome

### DIFF
--- a/build/tasks/test-webdriver.js
+++ b/build/tasks/test-webdriver.js
@@ -35,12 +35,12 @@ module.exports = function (grunt) {
 	/**
 	 * Test each URL
 	 */
-	function runTestUrls(driver, urls) {
+	function runTestUrls(driver, urls, errors) {
 		var url = urls.shift();
-		var errors = [];
+		errors = errors || [];
 
 		// Give each page enough time
-		driver.manage().timeouts().setScriptTimeout(600);
+		driver.manage().timeouts().setScriptTimeout(60000);
 
 		return driver.get(url)
 		// Get results
@@ -69,8 +69,9 @@ module.exports = function (grunt) {
 		}).then(function () {
 			// Start the next job, if any
 			if (urls.length > 0) {
-				return runTestUrls(driver, urls);
+				return runTestUrls(driver, urls, errors);
 			} else {
+				driver.quit();
 				return Promise.resolve(errors);
 			}
 		});
@@ -168,10 +169,6 @@ module.exports = function (grunt) {
 		}).catch(function (err) {
 			grunt.log.error(err);
 			done(false);
-
-		// Lastly, always close the browser
-		}).then(function () {
-			return driver.quit();
 		});
 
 	});

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -6,6 +6,7 @@ describe('color.getBackgroundColor', function () {
 	afterEach(function () {
 		document.getElementById('fixture').innerHTML = '';
 		axe.commons.color.incompleteData.clear();
+		document.body.scrollTop = 0;
 	});
 
 	it('should return the blended color if it has no background set', function () {

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -5,6 +5,8 @@ describe('color.getForegroundColor', function () {
 
 	afterEach(function () {
 		document.getElementById('fixture').innerHTML = '';
+		axe.commons.color.incompleteData.clear();
+		document.body.scrollTop = 0;
 	});
 
 	it('should return the blended color if it has alpha set', function () {

--- a/test/integration/full/options/options.js
+++ b/test/integration/full/options/options.js
@@ -3,13 +3,13 @@ describe('Options', function() {
 
 	before(function (done) {
 		var frame = document.getElementById('myframe');
-		if (frame.contentWindow.document.readyState === 'complete') {
-			done();
-		} else {
-			frame.addEventListener('load', function () {
+		var interval = setInterval(function () {
+			var win = frame.contentWindow;
+			axe.utils.respondable(win, 'axe.ping', null, undefined, function() {
+				clearInterval(interval);
 				done();
 			});
-		}
+		}, 100);
 	});
 
 	function $id(id) {
@@ -17,39 +17,19 @@ describe('Options', function() {
 	}
 
 	describe('iframes', function() {
-		it('should include iframes by default', function(done) {
-			var config = {};
-			axe.a11yCheck(document, config, function(results) {
-				try {
-					assert.lengthOf(results.violations, 0, 'violations');
-					assert.lengthOf(results.passes, 1, 'passes');
-					assert.lengthOf(results.passes[0].nodes, 2, 'results from main and iframe');
-					assert.isTrue(results.passes[0].nodes.some(function(node) {
-						if (node.target.length !== 2) {
-							return false;
-						}
-						return node.target[0] === '#myframe';
-					}), 'couldn\'t find iframe result');
-					done();
-				} catch (e) {
-					done(e);
-				}
-			});
-		});
-
 		it('should include iframes if `iframes` is true', function(done) {
 			var config = { iframes: true };
 			axe.a11yCheck(document, config, function(results) {
 				try {
 					assert.lengthOf(results.violations, 0, 'violations');
 					assert.lengthOf(results.passes, 1, 'passes');
-					assert.lengthOf(results.passes[0].nodes, 2, 'results from main and iframe');
 					assert.isTrue(results.passes[0].nodes.some(function(node) {
 						if (node.target.length !== 2) {
 							return false;
 						}
 						return node.target[0] === '#myframe';
 					}), 'couldn\'t find iframe result');
+					assert.lengthOf(results.passes[0].nodes, 2, 'results from main and iframe');
 					done();
 				} catch (e) {
 					done(e);
@@ -63,13 +43,33 @@ describe('Options', function() {
 				try {
 					assert.lengthOf(results.violations, 0, 'violations');
 					assert.lengthOf(results.passes, 1, 'passes');
-					assert.lengthOf(results.passes[0].nodes, 1, 'results from main frame only');
 					assert.isFalse(results.passes[0].nodes.some(function(node) {
 						if (node.target.length !== 2) {
 							return false;
 						}	
 						return node.target[0] === '#myframe';
 					}), 'unexpectedly found iframe result');
+					assert.lengthOf(results.passes[0].nodes, 1, 'results from main frame only');
+					done();
+				} catch (e) {
+					done(e);
+				}
+			});
+		});
+
+		it('should include iframes by default', function(done) {
+			var config = {};
+			axe.a11yCheck(document, config, function(results) {
+				try {
+					assert.lengthOf(results.violations, 0, 'violations');
+					assert.lengthOf(results.passes, 1, 'passes');
+					assert.isTrue(results.passes[0].nodes.some(function(node) {
+						if (node.target.length !== 2) {
+							return false;
+						}
+						return node.target[0] === '#myframe';
+					}), 'couldn\'t find iframe result');
+					assert.lengthOf(results.passes[0].nodes, 2, 'results from main and iframe');
 					done();
 				} catch (e) {
 					done(e);


### PR DESCRIPTION
- Errors got swallowed by the browser testrunner. That’s fixed now
- Chrome was failing one of the tests due to not cleaning up scroll position