### PR TITLE
fix: Properly output error stack

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -165,7 +165,7 @@ Audit.prototype.run = function (context, options, resolve, reject) {
 							result: axe.constants.CANTTELL,
 							description: 'An error occured while running this rule',
 							message: err.message,
-							help: err.stack || err.message,
+							stack: err.stack,
 							error: err
 						});
 						res(errResult);

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -496,6 +496,7 @@ describe('Audit', function () {
 		});
 
 		it('catches errors and passes them as a cantTell result', function (done) {
+			var err = new Error('Launch the super sheep!');
 			a.addRule({
 				id: 'throw1',
 				selector: '*',
@@ -506,7 +507,7 @@ describe('Audit', function () {
 			a.addCheck({
 				id: 'throw1-check1',
 				evaluate: function () {
-					throw new Error('Launch the super sheep!');
+					throw err;
 				}
 			});
 
@@ -518,7 +519,9 @@ describe('Audit', function () {
 			}, function (results) {
 				assert.lengthOf(results,1);
 				assert.equal(results[0].result, 'cantTell');
-				assert.equal(results[0].error.message, 'Launch the super sheep!');
+				assert.equal(results[0].message, err.message);
+				assert.equal(results[0].stack, err.stack);
+				assert.equal(results[0].error, err);
 				done();
 			}, isNotCalled);
 		});


### PR DESCRIPTION
Small fix to ensure the stack is always exposed when a check throws an exception. This should make it much easier for us to track down problems people find in axe using the extensions.