### PR TITLE
fix: help-same-as-label for shadow DOM

### DIFF
--- a/build/templates.js
+++ b/build/templates.js
@@ -1,8 +1,8 @@
 module.exports = {
-	evaluate: 'function (node, options) {\n<%=source%>\n}',
+	evaluate: 'function (node, options, virtualNode) {\n<%=source%>\n}',
 	after: 'function (results, options) {\n<%=source%>\n}',
 	gather: 'function (context) {\n<%=source%>\n}',
-	matches: 'function (node) {\n<%=source%>\n}',
+	matches: 'function (node, virtualNode) {\n<%=source%>\n}',
 	source: '(function () {\n<%=source%>\n}())',
 	commons: '<%=source%>'
 };

--- a/lib/checks/.jshintrc
+++ b/lib/checks/.jshintrc
@@ -3,6 +3,7 @@
 		"results": true,
 		"node": true,
 		"options": true,
+		"virtualNode": true,
 		"axe": true,
 		"document": true,
 		"window": true

--- a/lib/checks/label/help-same-as-label.js
+++ b/lib/checks/label/help-same-as-label.js
@@ -1,5 +1,5 @@
 
-var labelText = axe.commons.text.label(node),
+var labelText = axe.commons.text.label(virtualNode),
 	check = node.getAttribute('title');
 
 if (!labelText) {

--- a/lib/commons/text/accessible-text.js
+++ b/lib/commons/text/accessible-text.js
@@ -137,6 +137,7 @@ function nonEmptyText(t) {
  * @return {string}
  */
 text.accessibleText = function(element, inLabelledByContext) {
+	//todo: implement shadowDOM
 	var accessibleNameComputation;
 	var encounteredNodes = [];
 

--- a/test/checks/label/help-same-as-label.js
+++ b/test/checks/label/help-same-as-label.js
@@ -5,6 +5,7 @@ describe('help-same-as-label', function () {
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		axe._tree = undefined;
 	});
 
 	it('should return true if an element has a label and a title with the same text', function () {
@@ -14,8 +15,8 @@ describe('help-same-as-label', function () {
 		node.setAttribute('aria-label', 'Duplicate');
 
 		fixture.appendChild(node);
-
-		assert.isTrue(checks['help-same-as-label'].evaluate(node));
+		var tree = axe._tree = axe.utils.getFlattenedTree(fixture);
+		assert.isTrue(checks['help-same-as-label'].evaluate(node, undefined, axe.utils.getNodeFromTree(tree[0], node)));
 	});
 
 	it('should return true if an element has a label and aria-describedby with the same text', function () {
@@ -30,7 +31,8 @@ describe('help-same-as-label', function () {
 		fixture.appendChild(node);
 		fixture.appendChild(dby);
 
-		assert.isTrue(checks['help-same-as-label'].evaluate(node));
+		var tree = axe._tree = axe.utils.getFlattenedTree(fixture);
+		assert.isTrue(checks['help-same-as-label'].evaluate(node, undefined, axe.utils.getNodeFromTree(tree[0], node)));
 	});
 
 
@@ -41,7 +43,8 @@ describe('help-same-as-label', function () {
 
 		fixture.appendChild(node);
 
-		assert.isFalse(checks['help-same-as-label'].evaluate(node));
+		var tree = axe._tree = axe.utils.getFlattenedTree(fixture);
+		assert.isFalse(checks['help-same-as-label'].evaluate(node, undefined, axe.utils.getNodeFromTree(tree[0], node)));
 
 	});
 
@@ -56,7 +59,8 @@ describe('help-same-as-label', function () {
 		fixture.appendChild(node);
 		fixture.appendChild(dby);
 
-		assert.isFalse(checks['help-same-as-label'].evaluate(node));
+		var tree = axe._tree = axe.utils.getFlattenedTree(fixture);
+		assert.isFalse(checks['help-same-as-label'].evaluate(node, undefined, axe.utils.getNodeFromTree(tree[0], node)));
 	});
 
 });


### PR DESCRIPTION
fixes #387 

Also exposes the virtualNode to the check code