### PR TITLE
Align impact levels with Deque Way

### DIFF
--- a/lib/checks/color/link-in-text-block.json
+++ b/lib/checks/color/link-in-text-block.json
@@ -2,7 +2,7 @@
   "id": "link-in-text-block",
   "evaluate": "link-in-text-block.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "Links can be distinguished from surrounding text in a way that does not rely on color",
       "fail": "Links can not be distinguished from surrounding text in a way that does not rely on color",

--- a/lib/checks/keyboard/accesskeys.json
+++ b/lib/checks/keyboard/accesskeys.json
@@ -3,7 +3,7 @@
   "evaluate": "accesskeys.js",
   "after": "accesskeys-after.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "Accesskey attribute value is unique",
       "fail": "Document has multiple elements with the same accesskey"

--- a/lib/checks/lists/listitem.json
+++ b/lib/checks/lists/listitem.json
@@ -2,7 +2,7 @@
   "id": "listitem",
   "evaluate": "listitem.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "List item has a <ul>, <ol> or role=\"list\" parent element",
       "fail": "List item does not have a <ul>, <ol> or role=\"list\" parent element"

--- a/lib/checks/media/description.json
+++ b/lib/checks/media/description.json
@@ -2,7 +2,7 @@
   "id": "description",
   "evaluate": "description.js",
   "metadata": {
-    "impact": "serious",
+    "impact": "critical",
     "messages": {
       "pass": "The multimedia element has an audio description track",
       "fail": "The multimedia element does not have an audio description track",

--- a/lib/checks/navigation/header-present.json
+++ b/lib/checks/navigation/header-present.json
@@ -2,7 +2,7 @@
   "id": "header-present",
   "evaluate": "header-present.js",
   "metadata": {
-    "impact": "moderate",
+    "impact": "serious",
     "messages": {
       "pass": "Page has a header",
       "fail": "Page does not have a header"

--- a/lib/checks/navigation/heading-order.json
+++ b/lib/checks/navigation/heading-order.json
@@ -3,7 +3,7 @@
   "evaluate": "heading-order.js",
   "after": "heading-order-after.js",
   "metadata": {
-    "impact": "minor",
+    "impact": "moderate",
     "messages": {
       "pass": "Heading order valid",
       "fail": "Heading order invalid"

--- a/lib/checks/navigation/internal-link-present.json
+++ b/lib/checks/navigation/internal-link-present.json
@@ -2,7 +2,7 @@
   "id": "internal-link-present",
   "evaluate": "internal-link-present.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "Valid skip link found",
       "fail": "No valid skip link found"

--- a/lib/checks/navigation/p-as-heading.json
+++ b/lib/checks/navigation/p-as-heading.json
@@ -16,7 +16,7 @@
     }]
   },
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "<p> elements are not styled as headings",
       "fail": "Heading elements should be used instead of styled p elements"

--- a/lib/checks/navigation/skip-link.json
+++ b/lib/checks/navigation/skip-link.json
@@ -3,7 +3,7 @@
   "evaluate": "skip-link.js",
   "after": "skip-link-after.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "moderate",
     "messages": {
       "pass": "Valid skip link found",
       "fail": "No valid skip link found"

--- a/lib/checks/shared/aria-label.json
+++ b/lib/checks/shared/aria-label.json
@@ -2,7 +2,7 @@
   "id": "aria-label",
   "evaluate": "aria-label.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "aria-label attribute exists and is not empty",
       "fail": "aria-label attribute does not exist or is empty"

--- a/lib/checks/shared/aria-labelledby.json
+++ b/lib/checks/shared/aria-labelledby.json
@@ -2,7 +2,7 @@
   "id": "aria-labelledby",
   "evaluate": "aria-labelledby.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "aria-labelledby attribute exists and references elements that are visible to screen readers",
       "fail": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty or not visible"

--- a/lib/checks/shared/doc-has-title.json
+++ b/lib/checks/shared/doc-has-title.json
@@ -2,7 +2,7 @@
   "id": "doc-has-title",
   "evaluate": "doc-has-title.js",
   "metadata": {
-    "impact": "moderate",
+    "impact": "serious",
     "messages": {
       "pass": "Document has a non-empty <title> element",
       "fail": "Document does not have a non-empty <title> element"

--- a/lib/checks/shared/has-visible-text.json
+++ b/lib/checks/shared/has-visible-text.json
@@ -2,7 +2,7 @@
   "id": "has-visible-text",
   "evaluate": "has-visible-text.js",
   "metadata": {
-    "impact": "moderate",
+    "impact": "minor",
     "messages": {
       "pass": "Element has text that is visible to screen readers",
       "fail": "Element does not have text that is visible to screen readers"

--- a/lib/checks/shared/is-on-screen.json
+++ b/lib/checks/shared/is-on-screen.json
@@ -2,7 +2,7 @@
   "id": "is-on-screen",
   "evaluate": "is-on-screen.js",
   "metadata": {
-    "impact": "minor",
+    "impact": "serious",
     "messages": {
       "pass": "Element is not visible",
       "fail": "Element is visible"

--- a/lib/checks/shared/non-empty-title.json
+++ b/lib/checks/shared/non-empty-title.json
@@ -2,7 +2,7 @@
   "id": "non-empty-title",
   "evaluate": "non-empty-title.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "Element has a title attribute",
       "fail": "Element has no title attribute or the title attribute is empty"

--- a/lib/checks/shared/role-none.json
+++ b/lib/checks/shared/role-none.json
@@ -2,7 +2,7 @@
   "id": "role-none",
   "evaluate": "role-none.js",
   "metadata": {
-    "impact": "moderate",
+    "impact": "minor",
     "messages": {
       "pass": "Element's default semantics were overriden with role=\"none\"",
       "fail": "Element's default semantics were not overridden with role=\"none\""

--- a/lib/checks/shared/role-presentation.json
+++ b/lib/checks/shared/role-presentation.json
@@ -2,7 +2,7 @@
   "id": "role-presentation",
   "evaluate": "role-presentation.js",
   "metadata": {
-    "impact": "moderate",
+    "impact": "minor",
     "messages": {
       "pass": "Element's default semantics were overriden with role=\"presentation\"",
       "fail": "Element's default semantics were not overridden with role=\"presentation\""

--- a/lib/checks/tables/caption-faked.json
+++ b/lib/checks/tables/caption-faked.json
@@ -2,7 +2,7 @@
   "id": "caption-faked",
   "evaluate": "caption-faked.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "The first row of a table is not used as a caption",
       "fail": "The first row of the table should be a caption instead of a table cell"

--- a/lib/checks/tables/html5-scope.json
+++ b/lib/checks/tables/html5-scope.json
@@ -2,7 +2,7 @@
   "id": "html5-scope",
   "evaluate": "html5-scope.js",
   "metadata": {
-    "impact": "serious",
+    "impact": "moderate",
     "messages": {
       "pass": "Scope attribute is only used on table header elements (<th>)",
       "fail": "In HTML 5, scope attributes may only be used on table header elements (<th>)"

--- a/lib/checks/tables/same-caption-summary.json
+++ b/lib/checks/tables/same-caption-summary.json
@@ -2,7 +2,7 @@
   "id": "same-caption-summary",
   "evaluate": "same-caption-summary.js",
   "metadata": {
-    "impact": "moderate",
+    "impact": "minor",
     "messages": {
       "pass": "Content of summary attribute and <caption> are not duplicated",
       "fail": "Content of summary attribute and <caption> element are identical"

--- a/lib/checks/tables/th-has-data-cells.json
+++ b/lib/checks/tables/th-has-data-cells.json
@@ -2,7 +2,7 @@
   "id": "th-has-data-cells",
   "evaluate": "th-has-data-cells.js",
   "metadata": {
-    "impact": "critical",
+    "impact": "serious",
     "messages": {
       "pass": "All table header cells refer to data cells",
       "fail": "Not all table header cells refer to data cells",


### PR DESCRIPTION
Thanks to the work of Matt Isner, I had a nice list to work from. I’ve double checked that for each impact I changed, it only changes the impact level of the rules I wanted to change. The changes are as follow:

| Rule			| Impact from		| Impact to
|-----------------------|-----------------------|---------------
| accesskeys		| critical		| serious
| blink			| minor			| serious
| marquee		| minor			| serious
| document-title	| moderate		| serious
| duplicate-id		| critical		| moderate
| heading-order		| minor			| moderate
| link-in-text-b	| critical		| serious
| listitem		| critical		| serious
| p-as-heading		| critical		| serious
| scope-attr-val	| critical, serious	| critical, moderate
| server-side-ima	| minor			| critical
| skip-link		| critical		| moderate
| table-duplicate-name	| moderate		| minor
| table-fake-caption	| critical		| serious
| th-has-data-cells	| critical		| serious
| video-description	| serious		| critical
| bypass		| critical		| serious
| empty-heading		| moderate		| minor
| frame-title		| critical		| serious
| link-name		| critical		| serious
| object-alt		| critical		| serious
