### PR TITLE
fix: incomplete results should have impact

### DIFF
--- a/lib/core/utils/aggregateChecks.js
+++ b/lib/core/utils/aggregateChecks.js
@@ -1,3 +1,4 @@
+const { CANTTELL_PRIO, FAIL_PRIO } = axe.constants;
 let checkMap = [];
 checkMap[axe.constants.PASS_PRIO] = true;
 checkMap[axe.constants.CANTTELL_PRIO] = null;
@@ -51,9 +52,8 @@ axe.utils.aggregateChecks = function (nodeResOriginal) {
 		nodeResult[type].forEach((check) => impacts.push(check.impact));
 	});
 
-
 	// for failed nodes, define the impact
-	if (nodeResult.priority === axe.constants.FAIL_PRIO) {
+	if ([CANTTELL_PRIO, FAIL_PRIO].includes(nodeResult.priority)) {
 		nodeResult.impact = axe.utils.aggregate(axe.constants.impact, impacts);
 	} else {
 		nodeResult.impact = null;

--- a/lib/core/utils/aggregateRule.js
+++ b/lib/core/utils/aggregateRule.js
@@ -35,11 +35,15 @@ axe.utils.aggregateRule = function (subResults) {
 		ruleResult[groupName].push(subResult);
 	});
 
-	// Take the highest impact of failed rules
-	var failGroup = axe.constants.FAIL_GROUP;
-	if (ruleResult[failGroup].length > 0) {
-		// Get the impact of all violations
-		let impactList = ruleResult[failGroup]
+	// Take the highest impact of failed or canttell rules
+	var impactGroup = axe.constants.FAIL_GROUP;
+	if (ruleResult[impactGroup].length === 0) {
+		impactGroup = axe.constants.CANTTELL_GROUP;
+	}
+
+	if (ruleResult[impactGroup].length > 0) {
+		// Get the impact of all issues
+		let impactList = ruleResult[impactGroup]
 		.map((failure) => failure.impact);
 
 		ruleResult.impact = axe.utils.aggregate(axe.constants.impact, impactList) || null;

--- a/test/core/utils/aggregateChecks.js
+++ b/test/core/utils/aggregateChecks.js
@@ -54,6 +54,24 @@ describe('axe.utils.aggregateChecks', function() {
 		});
 	});
 
+	it('returns impact for fail and canttell', function () {
+		var failCheck = axe.utils.aggregateChecks( createTestCheckResults({
+			any: [{ result: false, impact: 'serious' }]
+		}));
+		var canttellCheck = axe.utils.aggregateChecks( createTestCheckResults({
+			any: [{ result: undefined, impact: 'moderate' }]
+		}));
+
+		assert.equal(failCheck.impact, 'serious');
+		assert.equal(canttellCheck.impact, 'moderate');
+	});
+
+	it('sets impact to null for pass', function () {
+		var passCheck = axe.utils.aggregateChecks( createTestCheckResults({
+			any: [{ result: true, impact: 'serious' }]
+		}));
+		assert.isNull(passCheck.impact);
+	});
 
 	describe('none', function () {
 		it('gives result FAIL when any is true', function() {

--- a/test/core/utils/aggregateRule.js
+++ b/test/core/utils/aggregateRule.js
@@ -107,6 +107,13 @@ describe('axe.utils.aggregateRule', function() {
 		assert.lengthOf(ruleResult.passes, 1);
 	});
 
+	it('should provide impact on incomplete', function () {
+		var ruleResult = axe.utils.aggregateRule( createTestResults({
+			none: { result: undefined, impact: 'serious' }
+		}));
+		assert.equal(ruleResult.impact, 'serious');
+	});
+
 	it('should raise the highest "raisedMetadata" on failing checks', function() {
 		var ruleResult = axe.utils.aggregateRule( createTestResults({
 				none: { result: true, impact: 'moderate' },
@@ -116,12 +123,12 @@ describe('axe.utils.aggregateRule', function() {
 					{ result: false, impact: 'serious'}
 				]
 			},
-			{ none: { result: false, impact: 'critical' }},
+			{ none: { result: undefined, impact: 'critical' }},
 			{ none: { result: false, impact: 'critical' }}
 		));
 		assert.equal(ruleResult.impact, 'serious');
 		assert.equal(ruleResult.violations[0].impact, 'serious');
+		assert.equal(ruleResult.incomplete[0].impact, 'critical');
 		assert.isNull(ruleResult.passes[0].impact);
-		assert.isNull(ruleResult.passes[1].impact);
 	});
 });

--- a/test/playground.html
+++ b/test/playground.html
@@ -2,24 +2,17 @@
 <html lang="en">
 <title>O hai</title>
 
-<div style="
-  height: 50px;
-  width: 50px;
-  border: solid 1px black;
-  overflow: auto;
-">
-  <p>foofoofoofoofoofoo</p>
-  <p>foofoofoofoofoofoo</p>
-  <p>foofoofoofoofoofoo</p>
-  <p>foofoofoofoofoofoo</p>
-  <p>foofoofoofoofoofoo</p>
-</div>
+<video src="https://youtu.be/cgbJo5fuFMo"></video>
+<p style="color: #ccc">Some text</p>
+<p style="background:url(https://bennettfeely.com/gradients/img/gradient_24.png)">
+  Some more text</p>
 
 <script src="/axe.js"></script>
 <script>
 window.addEventListener('load' , function () {
-  axe.a11yCheck(document, { restoreScroll: true }, function (res) {
-    console.log(res);
+  axe.run(document, function (err, res) {
+    console.log(res.violations[0]);
+    res.incomplete.forEach(issue => console.log(issue))
   });
 })
 </script>


### PR DESCRIPTION
This solves a problem we had with the axe-devtools extension, where, if there wasn’t also a violation for that same rule, the impact wouldn’t be available.