### PR TITLE
fix: Exclude `any` checks from output if one passed

### DIFF
--- a/lib/core/utils/aggregateChecks.js
+++ b/lib/core/utils/aggregateChecks.js
@@ -33,20 +33,22 @@ axe.utils.aggregateChecks = function (nodeResOriginal) {
 	});
 
 	// Find the result with the highest priority
-	let priorities = anyAllNone(nodeResult, (c) => c.priority);
-	nodeResult.priority = Math.max(
-		priorities.all.reduce((a, b) => Math.max(a,b), 0),
-		priorities.none.reduce((a, b) => Math.max(a,b), 0),
+	const priorities = {
+		all: nodeResult.all.reduce((a, b) => Math.max(a, b.priority), 0),
+		none: nodeResult.none.reduce((a, b) => Math.max(a,b.priority), 0),
 		// get the lowest passing of 'any' defaulting
 		// to 0 by wrapping around 4 to 0 (inapplicable)
-		priorities.any.reduce((a, b) => Math.min(a,b), 4) % 4
-	);
+		any: nodeResult.any.reduce((a, b) => Math.min(a, b.priority), 4) % 4
+	};
+
+	nodeResult.priority = Math.max(priorities.all, priorities.none, priorities.any);
 
 	// Of each type, filter out all results not matching the final priority
 	let impacts = [];
 	checkTypes.forEach((type) => {
 		nodeResult[type] = nodeResult[type].filter((check) => {
-			return check.priority === nodeResult.priority;
+			return (check.priority === nodeResult.priority &&
+				check.priority === priorities[type]);
 		});
 		nodeResult[type].forEach((check) => impacts.push(check.impact));
 	});

--- a/test/core/utils/aggregateChecks.js
+++ b/test/core/utils/aggregateChecks.js
@@ -156,6 +156,26 @@ describe('axe.utils.aggregateChecks', function() {
 			}));
 			assert.equal(checkResult.result, FAIL);
 		});
+
+		it('ignores fail checks on any, if at least one passed', function () {
+			var checkResult = axe.utils.aggregateChecks( createTestCheckResults({
+				any: [false, undefined, true], // cantTell
+				none: [true, false] // fail
+			}));
+
+			assert.lengthOf(checkResult.any, 0);
+			assert.lengthOf(checkResult.none, 1);
+		});
+
+		it('includes cantTell checks from any if there are no fails', function () {
+			var checkResult = axe.utils.aggregateChecks( createTestCheckResults({
+				any: [undefined, undefined, false], // cantTell
+				none: [undefined, false] // cantTell
+			}));
+
+			assert.lengthOf(checkResult.any, 2);
+			assert.lengthOf(checkResult.none, 1);
+		});
 	});
 
 });


### PR DESCRIPTION
This should resolve #446.