### PR TITLE
docs: document help text and incomplete messages

### DIFF
--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -78,7 +78,7 @@ Similar to Rules, Checks are defined by JSON files in the [lib/checks directory]
 	* `messages` - `Object` These messages are displayed when the Check passes or fails
 		* `pass` - `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check passes
 		* `fail` - `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check fails
-		* `incomplete` – `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check is incomplete OR `Object` consisting of missingData for why it returned incomplete. Refer to [rules.md](./rules.md).
+		* `incomplete` – `String|Object` – [doT.js](http://olado.github.io/doT/) template string displayed when the Check is incomplete OR an object with `missingData` on why it returned incomplete. Refer to [rules.md](./rules.md).
 
 #### Check `evaluate`
 
@@ -119,6 +119,17 @@ return results.filter(function (r) {
 #### Pass and Fail Templates
 
 Occasionally, you may want to add additional information about why a Check passed or failed into its message.  For example, the [aria-valid-attr](../lib/checks/aria/valid-attr.json) will add information about any invalid ARIA attributes to its fail message.  The message uses the [doT.js](http://olado.github.io/doT/) and is compiled to a JavaScript function at build-time.  In the Check message, you have access to the `CheckResult` as `it`.
+
+```javascript
+// aria-valid-attr check
+"messages": {
+  "pass": "ARIA attributes are used correctly for the defined role",
+  "fail": "ARIA attribute{{=it.data && it.data.length > 1 ? 's are' : ' is'}} not allowed:{{~it.data:value}} {{=value}}{{~}}"
+}
+```
+
+See [rules.md](./rules.md) for more information on writing rules and checks,
+including incomplete results.
 
 #### CheckResult
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -78,6 +78,7 @@ Similar to Rules, Checks are defined by JSON files in the [lib/checks directory]
 	* `messages` - `Object` These messages are displayed when the Check passes or fails
 		* `pass` - `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check passes
 		* `fail` - `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check fails
+		* `incomplete` – `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check is incomplete OR `Object` consisting of missingData for why it returned incomplete. Refer to [rules.md](./rules.md).
 
 #### Check `evaluate`
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -31,16 +31,62 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | enabled              | Does the rule run by default
 | tags                 | Grouping for the rule, such as wcag2a, best-practice
 | metadata.description | Description of what a rule does
-| metadata.help        | Description of how to resolve an issue
+| metadata.help        | Short description of a violation, used in the aXe extension sidebar
 
 ## Check Properties
 
-| Prop. Name      | Description
-|-----------------|-----------------
-| id              | Unique identifier for the check
-| evaluate        | Evaluating function, returning a boolean value
-| options         | Configurable value for the check
-| after           | Cleanup function, run after check is done
-| metadata impact | "minor", "serious", "critical"
-| metadata pass   | Describes why the check passed
-| metadata fail   | Describes why the check failed
+| Prop. Name         | Description
+|--------------------|-----------------
+| id                 | Unique identifier for the check
+| evaluate           | Evaluating function, returning a boolean value
+| options            | Configurable value for the check
+| after              | Cleanup function, run after check is done
+| metadata impact    | "minor", "serious", "critical"
+| metadata pass      | Describes why the check passed
+| metadata fail      | Describes why the check failed
+| metadata incomplete| Describes why the check returned undefined
+
+Incomplete results occur when axe-core can’t produce a clear pass or fail result,
+giving users the opportunity to review it manually. Incomplete messages can take
+the form of a string, or an object with arbitrary keys matching the data returned
+from the check.
+
+Incomplete is optional for checks, while pass and fail are required.
+
+### Incomplete message string
+
+As one example, the audio and video caption checks return an incomplete string:
+```
+messages: {
+	pass: 'Why the check passed',
+	fail: 'Why the check failed',
+	incomplete: 'Why the check returned undefined'
+}
+```
+
+### Incomplete message object with missingData
+
+As another example, the color-contrast check returns missingData to aid in
+remediation. Here’s the message format:
+
+```
+messages: {
+	pass: 'Why the check passed',
+	fail: 'Why the check failed',
+	incomplete: {
+		bgImage: 'The background color could not be determined due to a background image',
+		default: 'fallback string'
+	}
+}
+```
+
+To wire up an incomplete message with a specific reason it returned undefined,
+the check needs matching data. Otherwise, it will fall back to the `default` message.
+Reasons are arbitrary for the check (such as 'bgImage') but they must match the
+data returned:
+
+```
+this.data({
+	missingData: 'bgImage'
+});
+```

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -44,14 +44,14 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | metadata impact    | "minor", "serious", "critical"
 | metadata pass      | Describes why the check passed
 | metadata fail      | Describes why the check failed
-| metadata incomplete| Describes why the check returned undefined
+| metadata incomplete| Describes why the check didn’t complete
 
 Incomplete results occur when axe-core can’t produce a clear pass or fail result,
 giving users the opportunity to review it manually. Incomplete messages can take
 the form of a string, or an object with arbitrary keys matching the data returned
 from the check.
 
-Incomplete is optional for checks, while pass and fail are required.
+A pass message is required, while fail and incomplete are dependent on the check result.
 
 ### Incomplete message string
 


### PR DESCRIPTION
Now that people are submitting rules, I thought we could use more documentation about how help text is used and how to create incomplete messages.