### PR TITLE
feat: Add sri-history file and update process

### DIFF
--- a/build/sri-update.js
+++ b/build/sri-update.js
@@ -1,0 +1,47 @@
+var path = require('path');
+var fs = require('fs');
+var sriToolbox = require("sri-toolbox");
+
+// Check if we should be validating or updating 
+var validate = process.argv.some(function (arg) {
+	return arg === '--validate';
+});
+ 
+var root = path.join(__dirname, '..')
+var axeVersion = require('../package.json').version;
+var axeHistory = require('../sri-history.json');
+
+if (typeof axeHistory[axeVersion] !== 'object') {
+	axeHistory[axeVersion] = {}
+}
+var versionSRIs = axeHistory[axeVersion];
+
+// List all axe files (including minified and localized axe files)
+var axeFiles = fs.readdirSync(root).filter(function (file) {
+	return file.match(/^axe(\.[a-z.-]+)?\.js$/);
+});
+
+axeFiles.forEach(function (axeFile) {
+	var axeSource = fs.readFileSync(path.join(root, axeFile), 'utf-8');
+	var axeIntegrity = sriToolbox.generate({ algorithms: ["sha256"] }, axeSource);
+
+	if (!validate) {
+		// Update SRI
+		versionSRIs[axeFile] = axeIntegrity;
+
+	// Test if the SRI shouldn't be changed
+	} else if (versionSRIs[axeFile] && versionSRIs[axeFile] !== axeIntegrity) {
+		console.log(axeFile, 'did not match the SRI in sri-history.json')
+		process.exitCode = 1;
+	}
+});
+
+if (!validate) {
+	fs.writeFileSync(path.join(root, './sri-history.json'),
+		JSON.stringify(axeHistory, null, '\t'), 'utf-8');
+	console.log("Updated sri-history.json ")
+
+} else if (process.exitCode === 1) {
+	console.log('\nMake sure the package version and sri-history.json is updated ' +
+		'before publishing to NPM.\n');
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "build": "grunt",
     "test": "grunt test",
     "test-fast": "grunt test-fast",
-    "prepublishOnly": "grunt build"
+    "version": "node build/sri-update",
+    "prepublishOnly": "grunt build && node build/sri-update --validate"
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
@@ -79,6 +80,8 @@
     "mocha": "^3.2.0",
     "promise": "~7.1.1",
     "revalidator": "~0.3.1",
-    "selenium-webdriver": "~3.4.0"
-  }
+    "selenium-webdriver": "~3.4.0",
+    "sri-toolbox": "^0.2.0"
+  },
+  "dependencies": {}
 }

--- a/sri-history.json
+++ b/sri-history.json
@@ -1,0 +1,54 @@
+{
+	"1.0.1": {
+		"axe.js": "sha256-F14wfpbaL6+ZafS2ufmz74/R6CD1L777gCOJVuLn5Ao=",
+		"axe.min.js": "sha256-GfbQgd6aKJKQT21HaQfVUuGEbMUfSKhi7RsWrrih7SM="
+	},
+	"1.1.0": {
+		"axe.js": "sha256-nG9+LLksY/HS6yG4x0iS08U7RAmTucy50uXQS5ndQnM=",
+		"axe.min.js": "sha256-5Lfk3/s+ieHttrDTOCVuepGjDgH2D1neTDDtXnJdIT0="
+	},
+	"1.1.1": {
+		"axe.js": "sha256-K0MLUClls79s14CT01F82LPc+ZubTBwt6fZDdN5iyFw=",
+		"axe.min.js": "sha256-UWXq259l36QypXwd2e4K2V1Lli2qHeSPmKfDXy+7uIM="
+	},
+	"2.0.5": {
+		"axe.js": "sha256-KVA5sj4tNmFLneuHPPbg4iEp3MBzsHvn3+s9CxfMrmc=",
+		"axe.min.js": "sha256-lt5eNq/L7IBUaoSUSAbQ7MEO02DThMGdVm/oxeA88gk="
+	},
+	"2.0.6": {
+		"axe.js": "sha256-cLV1ABoE5NjfwLaRAJYIstAJCmciDXZ55/TrQS5rR/M=",
+		"axe.min.js": "sha256-fnbwW70tA7/ya+5q5Oimc8wCRsdiv3WrU0MElp/euvY="
+	},
+	"2.0.7": {
+		"axe.js": "sha256-HjHe1xKQqP6i3eGpDlARb5HkFsZxvAslvr1JJhUlp60=",
+		"axe.min.js": "sha256-vo7Qs4YxFxzFEW5DG9u05JdAUCsFxx7dBIoBP5rzmKA="
+	},
+	"2.1.7": {
+		"axe.js": "sha256-kXUowSb3HQy6AChF4LYR4cvNxKEHCWqCcuiSxvY6E1s=",
+		"axe.min.js": "sha256-xJPQwkKDFmgwYDLqrt/esIHlc2HLUB2ogf9c1uS1BXA="
+	},
+	"2.2.0": {
+		"axe.js": "sha256-0iX4Q9QT3uHAo+oxS5NWsrU4DNZKB30JRf7m+jjZcX0=",
+		"axe.min.js": "sha256-3UsQJdfWbhtVd0QzcYi2VAJEfs8DMzxrRvr3h9WbMiE="
+	},
+	"2.2.1": {
+		"axe.js": "sha256-1kuZOWtoYszbvrtG7TYfl/FuO48uwZeFpN4aNnebABk=",
+		"axe.min.js": "sha256-WSHVQ1/IJaG9ZOydoFg+QXHLjOq8x/mhYkRAyN1yAdI="
+	},
+	"2.2.2": {
+		"axe.js": "sha256-jTirRblNTKinTlmCK3FqDG6POtZVbP/bJNdrXZhCuqk=",
+		"axe.min.js": "sha256-zpmYSLTgHx09UyYIvYrS5K6uj4VuBbspk54kHk5hPqo="
+	},
+	"2.2.3": {
+		"axe.js": "sha256-dV8RkE0hyyzj7qgValVkoP7Rtu8789BmbyeHZmidvqA=",
+		"axe.min.js": "sha256-BrNWjOcDL265Me8eKQosGWerJ6ju2g+G9+RvMWiBGOA="
+	},
+	"2.3.0": {
+		"axe.js": "sha256-rkyHB2lHjs+tissQLBUxuxIvWlzRbS4f4cdaH+TjQvo=",
+		"axe.min.js": "sha256-MGWkallV18uw6bSq6w8cjbGsf9v4rJtXP+NDtMEbO14="
+	},
+	"2.3.1": {
+		"axe.js": "sha256-63oq1xHBiOhX9jlvn5sJmoL8TwJ8JaLYIB91gyb74RI=",
+		"axe.min.js": "sha256-BGAllCBTUJjJXw3yOPMVai2Bj+1PVaEhK2na699nI/o="
+	}
+}


### PR DESCRIPTION
Since axe-core is injected into many many web pages, it is very important that we’re able to check the integrity of the file we’re injecting. Keeping the SRI of all previously published versions around makes this much easier.

https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity