### PR TITLE
fix(checks/aria/required-children): add exception for native input combobox missing textbox

### DIFF
--- a/lib/checks/aria/required-children.js
+++ b/lib/checks/aria/required-children.js
@@ -46,6 +46,15 @@ function missingRequiredChildren(node, childRoles, all) {
 		}
 	}
 
+	// combobox > textbox exception:
+	// remove textbox from missing roles if node is a native input
+	if (node.tagName === 'INPUT' && node.type === 'text') {
+		var textboxIndex = missing.indexOf('textbox');
+		if (textboxIndex >= 0) {
+			missing.splice(textboxIndex, 1);
+		}
+	}
+
 	if (missing.length) { return missing; }
 	if (!all && childRoles.length) { return childRoles; }
 	return null;

--- a/test/checks/aria/required-children.js
+++ b/test/checks/aria/required-children.js
@@ -49,6 +49,12 @@ describe('aria-required-children', function () {
 		assert.isTrue(checks['aria-required-children'].evaluate.call(checkContext, node));
 	});
 
+	it('should pass a native input with role comboxbox when missing child is role textbox', function () {
+		fixture.innerHTML = '<input type="text" role="combobox" aria-owns="listbox" id="target"></div><p role="listbox" id="listbox">Nothing here.</p>';
+		var node = fixture.querySelector('#target');
+		assert.isTrue(checks['aria-required-children'].evaluate.call(checkContext, node));
+	});
+
 	it('should pass one indirectly aria-owned child when one required', function () {
 		fixture.innerHTML = '<div role="grid" id="target" aria-owns="r"></div><div id="r"><div role="row">Nothing here.</div></div>';
 		var node = fixture.querySelector('#target');


### PR DESCRIPTION
Remove textbox from the list of missing roles when checking a combobox node that is a native input element

https://github.com/dequelabs/axe-core/issues/160