### PR TITLE
Precommit hook to prevent bad commit messages

### DIFF
--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -d ".git" ]; then
+if [ -d ".git/hooks" ]; then
 	if [ ! -f ".git/hooks/commit-msg" ]; then
 		echo "Installing pre-commit hook"
 		cd .git/hooks/ && cp ../../node_modules/angular-precommit/index.js commit-msg && cd ../../

--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -d ".git" ]; then
+	if [ ! -f ".git/hooks/commit-msg" ]; then
+		echo "Installing pre-commit hook"
+		cd .git/hooks/ && cp ../../node_modules/angular-precommit/index.js commit-msg && cd ../../
+	fi
+fi

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test-fast": "grunt test-fast",
     "version": "node build/sri-update",
     "prepublishOnly": "grunt build && node build/sri-update --validate",
-    "postinstall": "cd .git/hooks/ && cp ../../node_modules/angular-precommit/index.js commit-msg && cd ../../"
+    "postinstall": "./bin/postinstall.sh"
   },
   "devDependencies": {
     "angular-precommit": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -51,9 +51,11 @@
     "test": "grunt test",
     "test-fast": "grunt test-fast",
     "version": "node build/sri-update",
-    "prepublishOnly": "grunt build && node build/sri-update --validate"
+    "prepublishOnly": "grunt build && node build/sri-update --validate",
+    "postinstall": "ln -s -f node_modules/angular-precommit/index.js .git/hooks/commit-msg"
   },
   "devDependencies": {
+    "angular-precommit": "^1.0.3",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test-fast": "grunt test-fast",
     "version": "node build/sri-update",
     "prepublishOnly": "grunt build && node build/sri-update --validate",
-    "postinstall": "ln -s -f node_modules/angular-precommit/index.js .git/hooks/commit-msg"
+    "postinstall": "cd .git/hooks/ && cp ../../node_modules/angular-precommit/index.js commit-msg && cd ../../"
   },
   "devDependencies": {
     "angular-precommit": "^1.0.3",


### PR DESCRIPTION
This hook works on the command line only–for some reason GitX throws an error (a known issue according to the [angular-precommit source code](https://github.com/ajoslin/angular-precommit/blob/master/index.js#L25)). 

I've asked the axe-core team to respond with preferred methods of writing commits so I can test different applications. But this will install the hook automatically, preventing commits which don't adhere to our [commit policy](https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits) (which follows the Angular style).

We can use this in our other projects, too, since it doesn't depend on any specific linter.