### PR TITLE
fix(docs): add minor spelling fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Contributor License Agreement
 
-In order to contribute, you must accept the [contributor licence agreement](https://cla-assistant.io/dequelabs/axe-core) (CLA). Acceptance of this agreement will be checked automatically and pull requests without a CLA cannot be merged.
+In order to contribute, you must accept the [contributor license agreement](https://cla-assistant.io/dequelabs/axe-core) (CLA). Acceptance of this agreement will be checked automatically and pull requests without a CLA cannot be merged.
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
correct misspelling in CONTRIBUTING doc

I don't think I've ever spelled license correctly the first time 😊 