### PR TITLE
feat: allow link text from single-cell layout table

### DIFF
--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -169,8 +169,16 @@ text.accessibleTextVirtual = function accessibleTextVirtual(element, inLabelledB
 		}, '');
 	}
 
+	function getLayoutTableText (element) {
+		// // check if layout table only has one cell
+		if (!axe.commons.table.isDataTable(element.actualNode) && axe.commons.table.getAllCells(element.actualNode).length === 1) {
+			return getInnerText(element, false, false).trim();
+		}
+		return '';
+	}
+
 	function checkNative (element, inLabelledByContext, inControlContext) {
-		// jshint maxstatements:30
+		// jshint maxstatements:30, maxcomplexity: 20
 		let returnText = '';
 		const { actualNode } = element;
 		const nodeName = actualNode.nodeName.toUpperCase();
@@ -197,7 +205,7 @@ text.accessibleTextVirtual = function accessibleTextVirtual(element, inLabelledB
 			}
 
 			returnText = (actualNode.getAttribute('title') ||
-					actualNode.getAttribute('summary') || '');
+					actualNode.getAttribute('summary') || getLayoutTableText(element) || '');
 
 			if (nonEmptyText(returnText)) {
 				return returnText;

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -911,6 +911,22 @@ describe('text.accessibleTextVirtual', function() {
 			var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
 			assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
 		});
+
+		it('should use text from a table with a single cell and role=presentation', function() {
+			fixture.innerHTML = '<a href="example.html">' +
+				'<table role="presentation">' +
+					'<tr>' +
+						'<td>' +
+						'Descriptive Link Text' +
+						'</td>' +
+					'</tr>' +
+				'</table>' +
+			'</a>';
+			axe._tree = axe.utils.getFlattenedTree(fixture);
+
+			var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+			assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Descriptive Link Text');
+		});
 	});
 
 	describe('button', function() {


### PR DESCRIPTION
This one seemed easy enough to fix, so I made a PR for it. Essentially we had a client report back in January that a table with role="presentation" and a single table cell was failing the link text rule. That would work fine from an AT perspective, so we decided it was a false positive. But I drew the line on using a single table cell since concatenation of multiple cells would produce horrible link text.

If you have suggestions on how to reduce the complexity, I'm open to changes!

Closes https://dequesrc.atlassian.net/browse/WWD-547 (internal only)