### PR TITLE
chore: ignore node_modules when linting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -329,7 +329,8 @@ module.exports = function (grunt) {
 				},
 				src: [
 					'lib/**/*.js', 'test/**/*.js', 'build/tasks/**/*.js',
-					'doc/**/*.js', '!doc/examples/jest+react/*.js', 'Gruntfile.js'
+					'doc/**/*.js', '!doc/examples/jest+react/*.js', 'Gruntfile.js',
+					'!**/node_modules/**/*.js'
 				]
 			}
 		}


### PR DESCRIPTION
If you've `npm install`ed any of the example projects in examples/, the grunt "jshint" task gets bogged down trying to lint the node_modules/ directory within the example.