### PR TITLE
feat(core): expand rule configs for single run

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -92,7 +92,8 @@ Rule.prototype.gather = function (context, options) {
 	'use strict';
 	var ruleOptions = ((options || {}).rules || {})[this.id];
 	var selector = ruleOptions && ruleOptions.selector ? ruleOptions.selector : this.selector;
-	var excludeHidden = ruleOptions && typeof ruleOptions.excludeHidden === 'boolean' ? ruleOptions.excludeHidden : this.excludeHidden;
+	var excludeHidden = ruleOptions && typeof ruleOptions.excludeHidden ===
+		'boolean' ? ruleOptions.excludeHidden : this.excludeHidden;
 	var elements = axe.utils.select(selector, context);
 	if (excludeHidden) {
 		return elements.filter(function (element) {

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -85,12 +85,16 @@ Rule.prototype.matches = function () {
 /**
  * Selects `HTMLElement`s based on configured selector
  * @param  {Context} context The resolved Context object
+ * @param  {Mixed}   options (optional) Options specific to this rule
  * @return {Array}           All matching `HTMLElement`s
  */
-Rule.prototype.gather = function (context) {
+Rule.prototype.gather = function (context, options) {
 	'use strict';
-	var elements = axe.utils.select(this.selector, context);
-	if (this.excludeHidden) {
+	var ruleOptions = ((options || {}).rules || {})[this.id];
+	var selector = ruleOptions && ruleOptions.selector ? ruleOptions.selector : this.selector;
+	var excludeHidden = ruleOptions && typeof ruleOptions.excludeHidden === 'boolean' ? ruleOptions.excludeHidden : this.excludeHidden;
+	var elements = axe.utils.select(selector, context);
+	if (excludeHidden) {
 		return elements.filter(function (element) {
 			return !axe.utils.isHidden(element.actualNode);
 		});
@@ -102,14 +106,20 @@ Rule.prototype.runChecks = function (type, node, options, resolve, reject) {
 	'use strict';
 
 	var self = this;
+	var ruleOptions = (options.rules || {})[this.id];
 	var checkQueue = axe.utils.queue();
-	this[type].forEach(function (c) {
+	var checkFn = function (c) {
 		var check = self._audit.checks[c.id || c];
 		var option = axe.utils.getCheckOption(check, self.id, options);
 		checkQueue.defer(function (res, rej) {
 			check.run(node, option, res, rej);
 		});
-	});
+	};
+	if (ruleOptions && ruleOptions[type]) {
+		ruleOptions[type].forEach(checkFn);
+	} else {
+		this[type].forEach(checkFn);
+	}
 
 	checkQueue.then(function (results) {
 		results = results.filter(function (check) {
@@ -129,12 +139,14 @@ Rule.prototype.runChecks = function (type, node, options, resolve, reject) {
 Rule.prototype.run = function (context, options, resolve, reject) {
 	const q = axe.utils.queue();
 	const ruleResult = new RuleResult(this);
+	var ruleOptions = (options.rules || {})[this.id];
+	var matchesFn = ruleOptions && ruleOptions.matches ? createExecutionContext(ruleOptions.matches) : this.matches;
 	let nodes;
 
 	try {
 		// Matches throws an error when it lacks support for document methods
-		nodes = this.gather(context)
-					.filter(node => this.matches(node.actualNode, node));
+		nodes = this.gather(context, options)
+					.filter(node => matchesFn(node.actualNode, node));
 	} catch (error) {
 		// Exit the rule execution if matches fails
 		reject(new SupportError({cause: error, ruleId: this.id}));
@@ -325,10 +337,6 @@ Rule.prototype.configure = function (spec) {
 	}
 
 	if (spec.hasOwnProperty('matches')) {
-		if (typeof spec.matches === 'string') {
-			this.matches = new Function('return ' + spec.matches + ';')();
-		} else {
-			this.matches = spec.matches;
-		}
+		this.matches = createExecutionContext(spec.matches);
 	}
 };

--- a/lib/core/utils/rule-should-run.js
+++ b/lib/core/utils/rule-should-run.js
@@ -3,13 +3,15 @@
  * @private
  * @param  {object} rule
  * @param  {object}	runOnly Value of runOnly with type=tags
+ * @param  {Array}  optionTags (optional) Override tags specified by options
  * @return {bool}
  */
-function matchTags(rule, runOnly) {
+function matchTags(rule, runOnly, optionTags) {
 	// jshint maxcomplexity: 11
 	'use strict';
 	var include, exclude, matching;
 	var defaultExclude = (axe._audit && axe._audit.tagExclude) ? axe._audit.tagExclude : [];
+	var tags = optionTags || rule.tags;
 
 	// normalize include/exclude
 	if (runOnly.include || runOnly.exclude) {
@@ -34,11 +36,11 @@ function matchTags(rule, runOnly) {
 	}
 
 	matching = include.some(function (tag) {
-		return rule.tags.indexOf(tag) !== -1;
+		return tags.indexOf(tag) !== -1;
 	});
 	if (matching || (include.length === 0 && rule.enabled !== false)) {
 		return exclude.every(function (tag) {
-			return rule.tags.indexOf(tag) === -1;
+			return tags.indexOf(tag) === -1;
 		});
 	} else {
 		return false;
@@ -57,9 +59,12 @@ axe.utils.ruleShouldRun = function (rule, context, options) {
 	'use strict';
 	var runOnly = options.runOnly || {};
 	var ruleOptions = (options.rules || {})[rule.id];
+	// Check for override tags specified by options
+	var tags = (ruleOptions || {}).tags;
 
 	// Never run page level rules if the context is not on the page
-	if (rule.pageLevel && !context.page) {
+	// Can be overridden by options.rules[rule].pageLevel
+	if ((ruleOptions && ruleOptions.pageLevel === true) || rule.pageLevel && !context.page) {
 		return false;
 
 	// First, runOnly type rule overrides anything else
@@ -72,11 +77,11 @@ axe.utils.ruleShouldRun = function (rule, context, options) {
 
 	// Third, if tags are set, look at those
 	} else if(runOnly.type === 'tag' && runOnly.values) {
-		return matchTags(rule, runOnly.values);
+		return matchTags(rule, runOnly.values, tags);
 
 	// If nothing is set, only check for default excludes
 	} else {
-		return matchTags(rule, []);
+		return matchTags(rule, [], tags);
 	}
 
 };

--- a/lib/core/utils/rule-should-run.js
+++ b/lib/core/utils/rule-should-run.js
@@ -7,7 +7,7 @@
  * @return {bool}
  */
 function matchTags(rule, runOnly, optionTags) {
-	// jshint maxcomplexity: 11
+	// jshint maxcomplexity: 12
 	'use strict';
 	var include, exclude, matching;
 	var defaultExclude = (axe._audit && axe._audit.tagExclude) ? axe._audit.tagExclude : [];

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -516,8 +516,8 @@ describe('Audit', function () {
 			}, isNotCalled);
 		});
 		it('should use excludeHidden attribute specified by options', function (done) {
-			fixture.innerHTML = '<blink style="visibility: hidden;" id="monkeys">BAD '
-					+ 'BLINKY ELEMENT</blink>';
+			fixture.innerHTML = '<blink style="visibility: hidden;" id="monkeys">' +
+					'BAD BLINKY ELEMENT</blink>';
 
 			a.run({ include: [axe.utils.getFlattenedTree(fixture)[0]] }, {
 				rules: {

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -501,6 +501,84 @@ describe('Audit', function () {
 				done();
 			}, isNotCalled);
 		});
+		it('should use selectors for rules specified by the options', function (done) {
+			fixture.innerHTML = '<blink>BAD BLINKY ELEMENT</blink>';
+
+			a.run({ include: [axe.utils.getFlattenedTree(fixture)[0]] }, {
+				rules: {
+					'positive3': {
+						selector: '#FAKE-ID'
+					}
+				}
+			}, function (results) {
+				assert.equal(results[3].nodes.length, 0);
+				done();
+			}, isNotCalled);
+		});
+		it('should use excludeHidden attribute specified by options', function (done) {
+			fixture.innerHTML = '<blink style="visibility: hidden;" id="monkeys">BAD '
+					+ 'BLINKY ELEMENT</blink>';
+
+			a.run({ include: [axe.utils.getFlattenedTree(fixture)[0]] }, {
+				rules: {
+					'positive3': {
+						excludeHidden: false
+					}
+				}
+			}, function (results) {
+				assert.equal(results[1].nodes.length, 0);
+				assert.equal(results[3].nodes.length, 1);
+				done();
+			}, isNotCalled);
+		});
+		it('should use matches function specified by options', function (done) {
+			fixture.innerHTML = '<blink>BAD BLINKY ELEMENT</blink>';
+
+			a.run({ include: [axe.utils.getFlattenedTree(fixture)[0]] }, {
+				rules: {
+					'positive3': {
+						matches: 'function (node) { return false; }'
+					}
+				}
+			}, function (results) {
+				assert.equal(results[3].nodes.length, 0);
+				done();
+			}, isNotCalled);
+		});
+		it('should use any and none attributes specified by options', function (done) {
+			fixture.innerHTML = '<blink>BAD BLINKY ELEMENT</blink>';
+
+			a.run({ include: [axe.utils.getFlattenedTree(fixture)[0]] }, {
+				rules: {
+					'positive3': {
+						any: [],
+						none: ['positive3-check1']
+					}
+				}
+			}, function (results) {
+				assert.equal(results[3].nodes[0].any.length, 0);
+				assert.equal(results[3].nodes[0].none.length, 1);
+				done();
+			}, isNotCalled);
+		});
+		it('should use tags attribute specified by options', function (done) {
+			fixture.innerHTML = '<blink>BAD BLINKY ELEMENT</blink>';
+
+			a.run({ include: [axe.utils.getFlattenedTree(fixture)[0]] }, {
+				runOnly: {
+					type: 'tag',
+					values: ['custom']
+				},
+				rules: {
+					'positive3': {
+						tags: ['custom']
+					}
+				}
+			}, function (results) {
+				assert.equal(results.length, 1);
+				done();
+			}, isNotCalled);
+		});
 		it('should call the rule\'s run function', function (done) {
 			var targetRule = mockRules[mockRules.length - 1],
 				rule = axe.utils.findBy(a.rules, 'id', targetRule.id),


### PR DESCRIPTION
Bring rule property customization in axe.run to parity with axe.configure

Closes #484