### PR TITLE
feat(aria): allow DPUB ARIA roles

### DIFF
--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -345,6 +345,357 @@ lookupTable.role = {
 		context: null,
 		implicit: ['body']
 	},
+	'doc-abstract': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-acknowledgments': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-afterword': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-appendix': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-backlink': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-biblioentry': {
+		type: 'listitem',
+		attributes: {
+			allowed: ['aria-expanded', 'aria-level', 'aria-posinset', 'aria-setsize']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: ['doc-bibliography'],
+	},
+	'doc-bibliography': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-biblioref': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-chapter': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-colophon': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-conclusion': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-cover': {
+		type: 'img',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-credit': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-credits': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-dedication': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-endnote': {
+		type: 'listitem',
+		attributes: {
+			allowed: ['aria-expanded', 'aria-level', 'aria-posinset', 'aria-setsize']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: ['doc-endnotes'],
+	},
+	'doc-endnotes': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: ['doc-endnote'],
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-epigraph': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-epilogue': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-errata': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-example': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-footnote': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-foreword': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-glossary': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: ['term', 'definition'],
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-glossref': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-index': {
+		type: 'navigation',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-introduction': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-noteref': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-notice': {
+		type: 'note',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-pagebreak': {
+		type: 'separator',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-pagelist': {
+		type: 'navigation',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-part': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-preface': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-prologue': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-pullquote': {
+		type: 'none',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-qna': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-subtitle': {
+		type: 'sectionhead',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-tip': {
+		type: 'note',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-toc': {
+		type: 'navigation',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
 	'feed': {
 		type: 'structure',
 		attributes: {

--- a/test/integration/rules/aria-roles/aria-roles.html
+++ b/test/integration/rules/aria-roles/aria-roles.html
@@ -69,6 +69,45 @@
 	<div role="searchbox" id="pass67">ok</div>
 	<div role="text" id="pass68">ok</div>
 	<div role="table" id="pass69">ok</div>
+	<div role="doc-abstract" id="pass70">ok</div>
+	<div role="doc-acknowledgments" id="pass71">ok</div>
+	<div role="doc-afterword" id="pass72">ok</div>
+	<div role="doc-appendix" id="pass73">ok</div>
+	<div role="doc-backlink" id="pass74">ok</div>
+	<div role="doc-biblioentry" id="pass75">ok</div>
+	<div role="doc-bibliography" id="pass76">ok</div>
+	<div role="doc-biblioref" id="pass77">ok</div>
+	<div role="doc-chapter" id="pass78">ok</div>
+	<div role="doc-colophon" id="pass79">ok</div>
+	<div role="doc-conclusion" id="pass80">ok</div>
+	<div role="doc-cover" id="pass81">ok</div>
+	<div role="doc-credit" id="pass82">ok</div>
+	<div role="doc-credits" id="pass83">ok</div>
+	<div role="doc-dedication" id="pass84">ok</div>
+	<div role="doc-endnote" id="pass85">ok</div>
+	<div role="doc-endnotes" id="pass86">ok</div>
+	<div role="doc-epigraph" id="pass87">ok</div>
+	<div role="doc-epilogue" id="pass88">ok</div>
+	<div role="doc-errata" id="pass89">ok</div>
+	<div role="doc-example" id="pass90">ok</div>
+	<div role="doc-footnote" id="pass91">ok</div>
+	<div role="doc-foreword" id="pass92">ok</div>
+	<div role="doc-glossary" id="pass93">ok</div>
+	<div role="doc-glossref" id="pass94">ok</div>
+	<div role="doc-index" id="pass95">ok</div>
+	<div role="doc-introduction" id="pass96">ok</div>
+	<div role="doc-noteref" id="pass97">ok</div>
+	<div role="doc-notice" id="pass98">ok</div>
+	<div role="doc-pagebreak" id="pass99">ok</div>
+	<div role="doc-pagelist" id="pass100">ok</div>
+	<div role="doc-part" id="pass101">ok</div>
+	<div role="doc-preface" id="pass102">ok</div>
+	<div role="doc-prologue" id="pass103">ok</div>
+	<div role="doc-pullquote" id="pass104">ok</div>
+	<div role="doc-qna" id="pass105">ok</div>
+	<div role="doc-subtitle" id="pass106">ok</div>
+	<div role="doc-tip" id="pass107">ok</div>
+	<div role="doc-toc" id="pass108">ok</div>
 </div>
 <div id="violation">
 	<!-- abstract roles -->

--- a/test/integration/rules/aria-roles/aria-roles.json
+++ b/test/integration/rules/aria-roles/aria-roles.json
@@ -15,6 +15,12 @@
 		["#pass43"], ["#pass44"], ["#pass45"], ["#pass46"], ["#pass47"], ["#pass48"], ["#pass49"],
 		["#pass50"], ["#pass51"], ["#pass52"], ["#pass53"], ["#pass54"], ["#pass55"], ["#pass56"],
 		["#pass57"], ["#pass58"], ["#pass59"], ["#pass60"], ["#pass61"], ["#pass62"], ["#pass63"],
-		["#pass64"], ["#pass65"], ["#pass66"], ["#pass67"], ["#pass68"], ["#pass69"]
+		["#pass64"], ["#pass65"], ["#pass66"], ["#pass67"], ["#pass68"], ["#pass69"], ["#pass70"],
+		["#pass71"], ["#pass72"], ["#pass73"], ["#pass74"], ["#pass75"], ["#pass76"], ["#pass77"],
+		["#pass78"], ["#pass79"], ["#pass80"], ["#pass81"], ["#pass82"], ["#pass83"], ["#pass84"],
+		["#pass85"], ["#pass86"], ["#pass87"], ["#pass88"], ["#pass89"], ["#pass90"], ["#pass91"],
+		["#pass92"], ["#pass93"], ["#pass94"], ["#pass95"], ["#pass96"], ["#pass97"], ["#pass98"],
+		["#pass99"], ["#pass100"], ["#pass101"], ["#pass102"], ["#pass103"], ["#pass104"], ["#pass105"],
+		["#pass106"], ["#pass107"], ["#pass108"]
 	]
 }


### PR DESCRIPTION
This PR adds DPUB ARIA roles to the lookup table (+ integration tests).

DPUB ARIA roles can be used in HTML (not restricted to EPUB or XHTML), it's in the final stages of Rec track and mappings are reasonably implemented (see the [implementation report for DPUB AAM](https://w3c.github.io/test-results/dpub-aam/)).

This PR is of course awaiting decision on #580 (I'm in touch with Wilco), but submitted to have a common understanding on the proposed changes.

Closes #580