### PR TITLE
Color fixes: #607, #556, #596

### DIFF
--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -121,6 +121,9 @@ function elmPartiallyObscured(elm, bgElm, bgColor) {
  * @param {Element} elm
  */
 function includeMissingElements(elmStack, elm) {
+	if (!elmStack.includes(elm)) {
+		elmStack.unshift(elm);
+	}
 	const elementMap = {'TD': ['TR', 'TBODY'], 'TH': ['TR', 'THEAD'], 'INPUT': ['LABEL']};
 	const tagArray = elmStack.map((elm) => {
 		return elm.tagName;

--- a/lib/rules/color-contrast-matches.js
+++ b/lib/rules/color-contrast-matches.js
@@ -35,8 +35,12 @@ if (nodeName === 'FIELDSET' && node.disabled || axe.commons.dom.findUp(node, 'fi
 var nodeParentLabel = axe.commons.dom.findUp(node, 'label');
 if (nodeName === 'LABEL' || nodeParentLabel) {
 	var relevantNode = node;
+	var relevantVirtualNode = virtualNode;
+
 	if (nodeParentLabel) {
 		relevantNode = nodeParentLabel;
+		// we need an input candidate from a parent to account for label children
+		relevantVirtualNode = axe.utils.getNodeFromTree(axe._tree[0], nodeParentLabel);
 	}
 	// explicit label of disabled input
 	let doc = axe.commons.dom.getRootNode(relevantNode);
@@ -45,7 +49,7 @@ if (nodeName === 'LABEL' || nodeParentLabel) {
 		return false;
 	}
 
-	var candidate = axe.utils.querySelectorAll(virtualNode, 'input:not([type="hidden"]):not([type="image"])' +
+	var candidate = axe.utils.querySelectorAll(relevantVirtualNode, 'input:not([type="hidden"]):not([type="image"])' +
 		':not([type="button"]):not([type="submit"]):not([type="reset"]), select, textarea');
 	if (candidate.length && candidate[0].actualNode.disabled) {
 		return false;

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -95,6 +95,21 @@ describe('color-contrast', function () {
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
+	it('should return true for inline elements with sufficient contrast spanning multiple lines', function () {
+		fixture.innerHTML = '<p>Text oh heyyyy <a href="#" id="target">and here\'s <br>a link</a></p>';
+		var target = fixture.querySelector('#target');
+		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.deepEqual(checkContext._relatedNodes, []);
+	});
+
+	it('should return true for inline elements with sufficient contrast', function () {
+		fixture.innerHTML = '<p>Text oh heyyyy <b id="target">and here\'s bold text</b></p>';
+		var target = fixture.querySelector('#target');
+		var result = checks['color-contrast'].evaluate.call(checkContext, target);
+		assert.isTrue(result);
+		assert.deepEqual(checkContext._relatedNodes, []);
+	});
+
 	it('should return false when there is not sufficient contrast', function () {
 		fixture.innerHTML = '<div style="color: yellow; background-color: white;" id="target">' +
 			'My text</div>';

--- a/test/rule-matches/color-contrast-matches.js
+++ b/test/rule-matches/color-contrast-matches.js
@@ -149,7 +149,18 @@ describe('color-contrast-matches', function () {
 		var target = fixture.querySelector('input');
 		var tree = axe._tree = axe.utils.getFlattenedTree(fixture);
 		assert.isFalse(rule.matches(target, axe.utils.getNodeFromTree(tree[0], target)));
+	});
 
+	it('should not match a disabled implicit label child', function () {
+		fixture.innerHTML = '<label>' +
+			'<input type="checkbox" style="position: absolute;display: inline-block;width: 1.5rem;height: 1.5rem;opacity: 0;" disabled checked>' +
+			'<span style="background-color:rgba(0, 0, 0, 0.26);display:inline-block;width: 1.5rem;height: 1.5rem;" aria-hidden="true"></span>' +
+			'<span style="color:rgba(0, 0, 0, 0.38);" id="target">Baseball</span>' +
+			'</label>';
+		var target = fixture.querySelector('#target');
+		var tree = axe._tree = axe.utils.getFlattenedTree(fixture);
+		var result = rule.matches(target, axe.utils.getNodeFromTree(tree[0], target));
+		assert.isFalse(result);
 	});
 
 	it('should not match <textarea disabled>', function () {


### PR DESCRIPTION
I fixed two separate color contrast bugs: 

- The sibling of a disabled input inside of a label should be exempt
- Inline elements spanning multiple lines shouldn't be incomplete

I decided against rewriting the color contrast algorithm entirely at this time, since the fix for #607 was as simple as adding a target to the background stack. 