### PR TITLE
fix: don't put offscreen file inputs into review

### DIFF
--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -20,6 +20,17 @@ function isClipped(clip) {
 	return false;
 
 }
+/**
+ * Determines if an element is hidden with opacity and position
+ * @method invisibleInPlace
+ * @memberof axe.commons.dom
+ * @private
+ * @param  {Object}  style Computed style value of node
+ * @return {Boolean}
+ */
+function invisibleInPlace(style) {
+	return style.getPropertyValue('opacity') === '0' && style.getPropertyValue('position') === 'absolute';
+}
 
 /**
  * Determine whether an element is visible
@@ -32,7 +43,7 @@ function isClipped(clip) {
  * @return {Boolean} The element's visibilty status
  */
 dom.isVisible = function (el, screenReader, recursed) {
-	//jshint maxcomplexity: 13
+	//jshint maxcomplexity: 14
 	'use strict';
 	var style, nodeName, parent;
 
@@ -56,6 +67,8 @@ dom.isVisible = function (el, screenReader, recursed) {
 	if (style.getPropertyValue('display') === 'none' ||
 
 		nodeName.toUpperCase() === 'STYLE' || nodeName.toUpperCase() === 'SCRIPT' ||
+
+		(!screenReader && invisibleInPlace(style)) ||
 
 		(!screenReader && (isClipped(style.getPropertyValue('clip')))) ||
 

--- a/lib/rules/color-contrast-matches.js
+++ b/lib/rules/color-contrast-matches.js
@@ -8,6 +8,9 @@ if (node.getAttribute('aria-disabled') === 'true' || axe.commons.dom.findUp(node
 }
 
 if (nodeName === 'INPUT') {
+	if (nodeType === 'file' && !axe.commons.dom.isVisible(node)) {
+		return false;
+	}
 	return ['hidden', 'range', 'color', 'checkbox', 'radio', 'image'].indexOf(nodeType) === -1 && !node.disabled;
 }
 

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -110,6 +110,13 @@ describe('dom.isVisible', function () {
 			assert.isTrue(axe.commons.dom.isVisible(el));
 		});
 
+		it('should return false on absolutely positioned elements with opacity: 0', function () {
+			fixture.innerHTML = '<div id="target" style="position:absolute; opacity:0;">Text</div>';
+
+			var el = document.getElementById('target');
+			assert.isFalse(axe.commons.dom.isVisible(el));
+		});
+
 		it('should detect clip rect hidden text technique', function () {
 			var el,
 				clip = 'clip: rect(1px 1px 1px 1px);' +

--- a/test/rule-matches/color-contrast-matches.js
+++ b/test/rule-matches/color-contrast-matches.js
@@ -116,6 +116,14 @@ describe('color-contrast-matches', function () {
 		}
 	});
 
+	it('should not match <input type="file"> that is visually hidden', function () {
+		fixture.innerHTML = '<input type="file" style="width:0.1px; height:0.1px; opacity:0; overflow:hidden; position:absolute; z-index:-1;">';
+		var target = fixture.querySelector('input');
+		var tree = axe._tree = axe.utils.getFlattenedTree(fixture);
+
+		assert.isFalse(rule.matches(target, axe.utils.getNodeFromTree(tree[0], target)));
+	});
+
 	it('should match <select> with options', function () {
 		fixture.innerHTML = '<select><option>Hello</option></select>';
 		var target = fixture.querySelector('select');


### PR DESCRIPTION
Closes #622.

I used `opacity: 0` and `position: absolute` to determine visibility. In my mind absolute positioning makes it more clearly an offscreen/visibility technique. But perhaps it should simply check opacity, since that's all that really matters for color contrast? I'm open to changes.