### PR TITLE
fix(check): fix bug with async checks

### DIFF
--- a/lib/core/utils/check-helper.js
+++ b/lib/core/utils/check-helper.js
@@ -13,7 +13,7 @@ axe.utils.checkHelper = function checkHelper(checkResult, options, resolve, reje
 			this.isAsync = true;
 			return function (result) {
 				if (result instanceof Error === false) {
-					checkResult.value = result;
+					checkResult.result = result;
 					resolve(checkResult);
 				} else {
 					reject(result);

--- a/test/core/base/check.js
+++ b/test/core/base/check.js
@@ -193,7 +193,7 @@ describe('Check', function () {
 					}
 				}).run(fixture, {}, function (d) {
 					assert.instanceOf(d, CheckResult);
-					assert.deepEqual(d.value, data);
+					assert.deepEqual(d.result, data);
 					done();
 				});
 


### PR DESCRIPTION
	The correct field to set on CheckResult is 'result' not 'value'