### PR TITLE
Fix the `dlitem` rule for XHTML documents

### DIFF
--- a/lib/checks/lists/dlitem.js
+++ b/lib/checks/lists/dlitem.js
@@ -1,2 +1,2 @@
-return node.parentNode.tagName === 'DL';
+return node.parentNode.tagName.toUpperCase() === 'DL';
 

--- a/test/integration/full/definition-list/dlitem-xhtml.js
+++ b/test/integration/full/definition-list/dlitem-xhtml.js
@@ -1,0 +1,52 @@
+
+describe('dlitem XHTML test', function () {
+  'use strict';
+
+  var results;
+
+  before(function (done) {
+    axe.run({ runOnly: { type: 'rule', values: ['dlitem'] } }, function (err, r) {
+      assert.isNull(err);
+      results = r;
+      done();
+    });
+  });
+
+  describe('violations', function() {
+
+    it('should find 2', function () {
+      assert.lengthOf(results.violations, 1);
+      assert.lengthOf(results.violations[0].nodes, 2);
+    });
+
+    it('should find #uncontained and #also', function () {
+      assert.equal(results.violations[0].nodes[0].any[0].id, 'dlitem');
+      assert.deepEqual(results.violations[0].nodes[0].target, ['#uncontained']);
+    });
+
+    it('should find #alsouncontained', function () {
+      assert.equal(results.violations[0].nodes[1].any[0].id, 'dlitem');
+      assert.deepEqual(results.violations[0].nodes[1].target, ['#alsouncontained']);
+    });
+
+  });
+
+  describe('passes', function() {
+
+    it('should find 2', function () {
+      assert.lengthOf(results.passes, 1);
+      assert.lengthOf(results.passes[0].nodes, 2);
+    });
+
+    it('should find #uncontained and #also', function () {
+      assert.equal(results.passes[0].nodes[0].any[0].id, 'dlitem');
+      assert.deepEqual(results.passes[0].nodes[0].target, ['#contained']);
+    });
+
+    it('should find #alsouncontained', function () {
+      assert.equal(results.passes[0].nodes[1].any[0].id, 'dlitem');
+      assert.deepEqual(results.passes[0].nodes[1].target, ['#alsocontained']);
+    });
+
+  });
+});

--- a/test/integration/full/definition-list/dlitem-xhtml.xhtml
+++ b/test/integration/full/definition-list/dlitem-xhtml.xhtml
@@ -1,0 +1,30 @@
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<title>axe.utils.getSelector test</title>
+	<meta charset="utf-8"/>
+	<link rel="stylesheet" type="text/css" href="/node_modules/mocha/mocha.css" />
+	<script src="/node_modules/mocha/mocha.js"></script>
+	<script src="/node_modules/chai/chai.js"></script>
+	<script src="/axe.js"></script>
+	<script>
+		mocha.setup({
+			timeout: 10000,
+			ui: 'bdd'
+		});
+		var assert = chai.assert;
+	</script>
+</head>
+<body>
+	<div id="fixture">
+		<dd id="uncontained">Should belong to a list.</dd>
+		<dt id="alsouncontained">Should belong to a list.</dt>
+		<dl>
+			<dt id="contained">Does belong to a list.</dt>
+			<dd id="alsocontained">Also belongs to a list.</dd>
+		</dl>
+	</div>
+<div id="mocha"></div>
+<script src="dlitem-xhtml.js"></script>
+<script src="/test/integration/adapter.js"></script>
+</body>
+</html>


### PR DESCRIPTION
In XHTML, `element.tagName` preserves the case.

In the `dlitem` check, the tag name is now upper-cased before
being tested as '`DL`', to make the rules works on XHTML documents.

Fixes #581