### PR TITLE
fix(commons/dom): change isFocusable to use unfocusableBecauseHidden

### DIFF
--- a/lib/commons/dom/is-focusable.js
+++ b/lib/commons/dom/is-focusable.js
@@ -1,5 +1,19 @@
 /* global dom */
 /* jshint maxcomplexity: 20 */
+
+/**
+ * Determines if an element is hidden in such a way that makes it unfocusable
+ * @private
+ * @param {Element} el
+ * @return {Boolean} Whether the element is unfocusable due to being hidden
+ */
+function unfocusableBecauseHidden (el) {
+	var style = window.getComputedStyle(el);
+	return (
+		style === null || style.getPropertyValue('visibility') === 'hidden' ||
+		style.getPropertyValue('display') === 'none');
+}
+
 /**
  * Determines if an element is focusable
  * @method isFocusable
@@ -38,7 +52,7 @@ dom.isNativelyFocusable = function(el) {
 
 	if (!el ||
 		el.disabled ||
-		(!dom.isVisible(el) && el.nodeName.toUpperCase() !== 'AREA')) {
+		(unfocusableBecauseHidden(el) && el.nodeName.toUpperCase() !== 'AREA')) {
 		return false;
 	}
 

--- a/test/commons/dom/is-natively-focusable.js
+++ b/test/commons/dom/is-natively-focusable.js
@@ -3,6 +3,23 @@ describe('dom.isNativelyFocusable', function () {
 
 	var fixture = document.getElementById('fixture');
 
+	function hideByClipping (el) {
+		el.style.cssText = 'position: absolute !important;' +
+			' clip: rect(0px 0px 0px 0px); /* IE6, IE7 */' +
+			' clip: rect(0px, 0px, 0px, 0px);';
+		return el;
+	}
+
+	function hideByMovingOffScreen (el) {
+		el.style.cssText = 'position:absolute;' +
+			' left:-10000px;' +
+			' top:auto;' +
+			' width:1px;' +
+			' height:1px;' +
+			' overflow:hidden;';
+		return el;
+	}
+
 	afterEach(function () {
 		document.getElementById('fixture').innerHTML = '';
 	});
@@ -72,11 +89,37 @@ describe('dom.isNativelyFocusable', function () {
 
 	});
 
-	it('should return false for non-visible elements', function () {
-		fixture.innerHTML = '<input type="text" id="target" style="display: none">';
+	it('should return false for elements hidden with display:none', function () {
+		fixture.innerHTML = '<button id="target" style="display: none">button</button>';
 		var el = document.getElementById('target');
 
 		assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
+
+	});
+
+	it('should return false for elements hidden with visibility:hidden', function () {
+		fixture.innerHTML = '<button id="target" style="visibility: hidden">button</button>';
+		var el = document.getElementById('target');
+
+		assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
+
+	});
+
+	it('should return true for clipped elements', function () {
+		fixture.innerHTML = '<button id="target">button</button>';
+		var el = document.getElementById('target');
+		el = hideByClipping(el);
+
+		assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
+
+	});
+
+	it('should return true for elements positioned off screen', function () {
+		fixture.innerHTML = '<button id="target">button</button>';
+		var el = document.getElementById('target');
+		el = hideByMovingOffScreen(el);
+
+		assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
 
 	});
 


### PR DESCRIPTION
change isFocusable to use unfocusableBecauseHidden function instead of isVisible

Adds functionality for detecting when hidden elements are still
focusable or in focus order.

fixes #647

Demo showing that off-screen and clipped elements remain in the focus order, where display:none and visibility:hidden elements do not (they are totally unfocusable)