### PR TITLE
refactor(checks/keyboard): change var names to distinguish being in focus order from being focusable

### DIFF
--- a/doc/rule-proposal.md
+++ b/doc/rule-proposal.md
@@ -59,7 +59,7 @@ In short sentences, using plain language, describe what conditions will lead to 
 
 `###` keyboard/focusable-no-name (none)
 
-1. If the element is not focusable, return false
+1. If the element is not in the focus order, return false
 2. If the element has an accessible name, return false
 3. Otherwise return true
 

--- a/lib/checks/keyboard/focusable-no-name.js
+++ b/lib/checks/keyboard/focusable-no-name.js
@@ -1,6 +1,6 @@
 var tabIndex = node.getAttribute('tabindex'),
-	isFocusable = axe.commons.dom.isFocusable(node) && tabIndex > -1;
-if (!isFocusable) {
+	inFocusOrder = axe.commons.dom.isFocusable(node) && tabIndex > -1;
+if (!inFocusOrder) {
 	return false;
 }
 return !axe.commons.text.accessibleText(node);


### PR DESCRIPTION
The existing variable name isFocusable is confusing because it's really asking whether the element is in the focus order. To clarify the difference: elements with tabindex -1 are focusable, elements with tabindex > -1 are in the focus order (and focusable).

Ideally, we can change the incorrect name of the "focusable-no-name" rule to the correct "focus-order-no-name" -- but @marcysutton has [mentioned there may be backwards compatibility issues](https://github.com/dequelabs/axe-core/pull/638#issuecomment-351219583)

