### PR TITLE
docs: Add activity and usage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # axe-core
 
-[![Join the chat at https://gitter.im/dequelabs/axe-core](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dequelabs/axe-core?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Version](https://img.shields.io/npm/v/axe-core.svg)](https://www.npmjs.com/package/axe-core)
-[![Bower](https://img.shields.io/bower/v/axe-core.svg)](http://bower.io/search)
 [![License](https://img.shields.io/npm/l/axe-core.svg)](LICENSE)
-[![CircleCI Build](https://circleci.com/gh/dequelabs/axe-core/tree/develop.svg?style=svg)](https://circleci.com/gh/dequelabs/axe-core/tree/develop)
-[![Dependency Status](https://gemnasium.com/dequelabs/axe-core.svg)](https://gemnasium.com/dequelabs/axe-core)
+[![Version](https://img.shields.io/npm/v/axe-core.svg)](https://www.npmjs.com/package/axe-core)
+[![Total npm downloads](https://img.shields.io/npm/dt/axe-core.svg)](https://www.npmjs.com/package/axe-core)
+[![Commits](https://img.shields.io/github/commit-activity/y/dequelabs/axe-core.svg)](https://github.com/dequelabs/axe-core/commits/develop)
+[![GitHub contributors](https://img.shields.io/github/contributors/dequelabs/axe-core.svg)](https://github.com/dequelabs/axe-core/graphs/contributors)
+[![Join the chat at https://gitter.im/dequelabs/axe-core](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dequelabs/axe-core?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Package Quality](http://npm.packagequality.com/shield/axe-core.svg)](http://packagequality.com/#?package=axe-core)
 
 The Accessibility Engine for automated testing of HTML-based user interfaces. Drop the aXe on your accessibility defects!


### PR DESCRIPTION
Also removed some badges that do not add a lot of value - probably most controversial is the CircleCI build status badge. Reason I don't think this adds value is that we never merge a change that does not pass CircleCI, so the most important build statuses are the build status of the individual pull requests.