### PR TITLE
fix(rule): Remove coverage of `svg[role="img"]` for image-alt rule

### DIFF
--- a/lib/rules/image-alt.json
+++ b/lib/rules/image-alt.json
@@ -1,6 +1,6 @@
 {
   "id": "image-alt",
-  "selector": "img, [role='img']",
+  "selector": "img, [role='img']:not(svg)",
   "tags": [
     "cat.text-alternatives",
     "wcag2a",

--- a/test/integration/rules/image-alt/image-alt.html
+++ b/test/integration/rules/image-alt/image-alt.html
@@ -16,3 +16,4 @@
 <img src="img.jpg" id="pass8" aria-labelledby="ninjamonkeys">
 <div role="img" alt="blah" id="violation6"></div>
 <div role="img" aria-label="blah" id="pass9"></div>
+<svg role="img" id="ignore1"><title>SVG Title</title></svg>


### PR DESCRIPTION
We have been advised that best practice is to use the following for inline SVGs:
```
<svg role="img">
  <title>SVG Title</title>
</svg>
```
which is echoed in [this article](https://css-tricks.com/accessible-svgs/#article-header-id-6).

I see that there is conversation in this issue https://github.com/dequelabs/axe-core/issues/20 about how to best go about it, but for now the test for `svg[role="img"]` needs to be removed since it isn't really valid.