### PR TITLE
perf(perf-timer): add instrumentation for Rule.runChecks

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -127,8 +127,11 @@ Rule.prototype.runChecks = function (type, node, options, resolve, reject) {
  * @param  {Function} callback Function to call when evaluate is complete; receives a RuleResult instance
  */
 Rule.prototype.run = function (context, options, resolve, reject) {
+	//jshint maxstatements: 17
 	const q = axe.utils.queue();
 	const ruleResult = new RuleResult(this);
+	const markStart = 'mark_runchecks_start_' + this.id;
+	const markEnd = 'mark_runchecks_end_' + this.id;
 	let nodes;
 
 	try {
@@ -143,6 +146,7 @@ Rule.prototype.run = function (context, options, resolve, reject) {
 
 	if (options.performanceTimer) {
 		axe.log('gather (', nodes.length, '):', axe.utils.performanceTimer.timeElapsed()+'ms');
+		axe.utils.performanceTimer.mark(markStart);
 	}
 
 	nodes.forEach(node => {
@@ -179,6 +183,11 @@ Rule.prototype.run = function (context, options, resolve, reject) {
 			}).catch(err => rejectNode(err));
 		});
 	});
+
+	if (options.performanceTimer) {
+		axe.utils.performanceTimer.mark(markEnd);
+		axe.utils.performanceTimer.measure('runchecks_' + this.id, markStart, markEnd);
+	}
 
 	q.then(() => resolve(ruleResult))
 	.catch(error => reject(error));


### PR DESCRIPTION
When running things with perfTimer, I noticed sometimes there was significant cost within the runChecks methods, however that wasn't always obvious from the existing performanceTimer measures.

This adds instrumentation around the `runChecks` methods.  

One note is that the intrumentation is synchronous, however checks finish asynchronously. But in my experience, it appears the majority of the cost happens in the first bit of synchronous runChecks work.  So this seems OK.

Screenshot including the nontrivial cost of `runchecks-duplicate-id`:

![image](https://user-images.githubusercontent.com/39191/35527819-d417e406-04e0-11e8-8b26-4b463d1b8b8e.png)

~[This patch doesn't pass JSHint.](https://user-images.githubusercontent.com/39191/35527867-f7fd761a-04e0-11e8-82ce-54a5b4935d24.png) I'm interested in your suggestions on handling that.~

