### PR TITLE
Provide default arguments to axe.cleanup()

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -617,7 +617,18 @@ Register a plugin with the aXe plugin system. See [implementing a plugin](plugin
 
 ### API Name: axe.cleanup
 
-Call the plugin system's cleanup function. See [implementing a plugin](plugins.md).
+Call each plugin's cleanup function. See [implementing a plugin](plugins.md).
+
+The signature is:
+
+```
+    axe.cleanup(resolve, reject)
+```
+
+`resolve` and `reject` are functions that will be invoked on success or failure respectively.
+
+`resolve` takes no arguments and `reject` takes a single argument that must be a string or have a toString() method in its prototype.
+
 
 ### API Name: axe.a11yCheck
 

--- a/lib/core/public/cleanup-plugins.js
+++ b/lib/core/public/cleanup-plugins.js
@@ -1,6 +1,9 @@
 
 function cleanupPlugins(resolve, reject) {
   'use strict';
+  resolve = resolve || function() {};
+  reject = reject || axe.log;
+
   if (!axe._audit) {
     throw new Error('No audit configured');
   }

--- a/test/core/public/cleanup-plugins.js
+++ b/test/core/public/cleanup-plugins.js
@@ -59,6 +59,30 @@ describe('cleanupPlugins', function () {
   });
 
 
+  it('should not throw exception if no arguments are provided', function(done) {
+    var cleaned = false;
+    axe._load({
+      rules: []
+    });
+    axe.registerPlugin({
+      id: 'p',
+      run: function () {},
+      add: function (impl) {
+        this._registry[impl.id] = impl;
+      },
+      commands: []
+    });
+    axe.plugins.p.cleanup = function (res) {
+      cleaned = true;
+      res();
+    };
+    assert.doesNotThrow(function () {
+      cleanupPlugins();
+      done();
+    });
+  });
+
+
   it('should send command to frames to cleanup', function (done) {
     createFrames(function () {
       axe._load({});


### PR DESCRIPTION
axe.cleanup() requires two functional arguments, 'resolve' and 'reject' that are not mentioned in the documentation (I will create a separate pull-request for that).  

This change will define default arguments with reasonable behavior:  default resolve() does nothing and default reject() logs an error message to the console.

This is related to Issue #705 .