### PR TITLE
Shadow support for color contrast

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,13 @@
-machine:
-  node:
-    version: v6.1.0
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6.12.3-browsers
+    steps:
+      - checkout
+      - run:
+          name: install-npm
+          command: npm install
+      - run:
+          name: test
+          command: npm test

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -57,8 +57,7 @@ function contentOverlapping(targetElement, bgNode) {
 	// get content box of target element
 	// check to see if the current bgNode is overlapping
 	var targetRect = targetElement.getClientRects()[0];
-	var doc = axe.commons.dom.getRootNode(targetElement);
-	var obscuringElements = doc.elementsFromPoint(targetRect.left, targetRect.top);
+	var obscuringElements = dom.shadowElementsFromPoint(targetRect.left, targetRect.top);
 	if (obscuringElements) {
 		for(var i = 0; i < obscuringElements.length; i++) {
 			if (obscuringElements[i] !== targetElement && obscuringElements[i] === bgNode) {
@@ -205,32 +204,6 @@ color.getCoords = function(rect) {
 	return {x, y};
 };
 /**
- * Get elements from point across shadow dom boundaries
- * @method getElementsFromPoint
- * @memberof axe.commons.color
- * @instance
- * @param {Object} nodeCoords X and Y coordinates of point
- * @param {Object} [root] Shadow root or document root
- * @return {Array}
- */
-color.getElementsFromPoint = function(nodeCoords, root = document) {
-  return root.elementsFromPoint(nodeCoords.x, nodeCoords.y)
-    .reduce((stack, elm) => {
-      if (axe.utils.isShadowRoot(elm)) {
-        const shadowStack = color.getElementsFromPoint(nodeCoords, elm.shadowRoot);
-        stack = stack.concat(shadowStack);
-        // filter host nodes which get included regardless of overlap
-        // TODO: refactor multiline overlap checking inside shadow dom
-        if (stack.length && axe.commons.dom.visuallyContains(stack[0], elm)) {
-        	stack.push(elm);
-        }
-      } else {
-      	stack.push(elm);
-      }
-      return stack;
-    }, []);
-};
-/**
  * Get relevant stacks of block and inline elements, excluding line breaks
  * @method getRectStack
  * @memberof axe.commons.color
@@ -241,7 +214,7 @@ color.getElementsFromPoint = function(nodeCoords, root = document) {
 color.getRectStack = function(elm) {
 	let boundingCoords = color.getCoords(elm.getBoundingClientRect());
 	if (boundingCoords) {
-		let boundingStack = color.getElementsFromPoint(boundingCoords);
+		let boundingStack = dom.shadowElementsFromPoint(boundingCoords.x, boundingCoords.y);
 		// allows inline elements spanning multiple lines to be evaluated
 		let rects = Array.from(elm.getClientRects());
 		if (rects && rects.length > 1) {
@@ -252,7 +225,7 @@ color.getRectStack = function(elm) {
 			.map((rect) => {
 				let coords = color.getCoords(rect);
 				if (coords) {
-					return color.getElementsFromPoint(coords);
+					return dom.shadowElementsFromPoint(coords.x, coords.y);
 				}
 			});
 			// add bounding client rect stack for comparison later

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -57,7 +57,8 @@ function contentOverlapping(targetElement, bgNode) {
 	// get content box of target element
 	// check to see if the current bgNode is overlapping
 	var targetRect = targetElement.getClientRects()[0];
-	var obscuringElements = document.elementsFromPoint(targetRect.left, targetRect.top);
+	var doc = axe.commons.dom.getRootNode(targetElement);
+	var obscuringElements = doc.elementsFromPoint(targetRect.left, targetRect.top);
 	if (obscuringElements) {
 		for(var i = 0; i < obscuringElements.length; i++) {
 			if (obscuringElements[i] !== targetElement && obscuringElements[i] === bgNode) {
@@ -204,7 +205,33 @@ color.getCoords = function(rect) {
 	return {x, y};
 };
 /**
- * Get elements from point for block and inline elements, excluding line breaks
+ * Get elements from point across shadow dom boundaries
+ * @method getElementsFromPoint
+ * @memberof axe.commons.color
+ * @instance
+ * @param {Object} nodeCoords X and Y coordinates of point
+ * @param {Object} [root] Shadow root or document root
+ * @return {Array}
+ */
+color.getElementsFromPoint = function(nodeCoords, root = document) {
+  return root.elementsFromPoint(nodeCoords.x, nodeCoords.y)
+    .reduce((stack, elm) => {
+      if (axe.utils.isShadowRoot(elm)) {
+        const shadowStack = color.getElementsFromPoint(nodeCoords, elm.shadowRoot);
+        stack = stack.concat(shadowStack);
+        // filter host nodes which get included regardless of overlap
+        // TODO: refactor multiline overlap checking inside shadow dom
+        if (stack.length && axe.commons.dom.visuallyContains(stack[0], elm)) {
+        	stack.push(elm);
+        }
+      } else {
+      	stack.push(elm);
+      }
+      return stack;
+    }, []);
+};
+/**
+ * Get relevant stacks of block and inline elements, excluding line breaks
  * @method getRectStack
  * @memberof axe.commons.color
  * @instance
@@ -214,9 +241,9 @@ color.getCoords = function(rect) {
 color.getRectStack = function(elm) {
 	let boundingCoords = color.getCoords(elm.getBoundingClientRect());
 	if (boundingCoords) {
+		let boundingStack = color.getElementsFromPoint(boundingCoords);
 		// allows inline elements spanning multiple lines to be evaluated
 		let rects = Array.from(elm.getClientRects());
-		let boundingStack = Array.from(document.elementsFromPoint(boundingCoords.x, boundingCoords.y));
 		if (rects && rects.length > 1) {
 	 		let filteredArr = rects.filter((rect) => {
 				// exclude manual line breaks in Chrome/Safari
@@ -225,7 +252,7 @@ color.getRectStack = function(elm) {
 			.map((rect) => {
 				let coords = color.getCoords(rect);
 				if (coords) {
-					return Array.from(document.elementsFromPoint(coords.x, coords.y));
+					return color.getElementsFromPoint(coords);
 				}
 			});
 			// add bounding client rect stack for comparison later

--- a/lib/commons/dom/shadow-elements-from-point.js
+++ b/lib/commons/dom/shadow-elements-from-point.js
@@ -1,0 +1,28 @@
+/* global axe, dom */
+/**
+ * Get elements from point across shadow dom boundaries
+ * @method shadowElementsFromPoint
+ * @memberof axe.commons.dom
+ * @instance
+ * @param {Number} nodeX X coordinates of point
+ * @param {Number} nodeY Y coordinates of point
+ * @param {Object} [root] Shadow root or document root
+ * @return {Array}
+ */
+dom.shadowElementsFromPoint = function(nodeX, nodeY, root = document) {
+  return root.elementsFromPoint(nodeX, nodeY)
+    .reduce((stack, elm) => {
+      if (axe.utils.isShadowRoot(elm)) {
+        const shadowStack = dom.shadowElementsFromPoint(nodeX, nodeY, elm.shadowRoot);
+        stack = stack.concat(shadowStack);
+        // filter host nodes which get included regardless of overlap
+        // TODO: refactor multiline overlap checking inside shadow dom
+        if (stack.length && axe.commons.dom.visuallyContains(stack[0], elm)) {
+        	stack.push(elm);
+        }
+      } else {
+      	stack.push(elm);
+      }
+      return stack;
+    }, []);
+};

--- a/lib/core/utils/flattened-tree.js
+++ b/lib/core/utils/flattened-tree.js
@@ -51,20 +51,6 @@ function getSlotChildren(node) {
 	return retVal;
 }
 
-const possibleShadowRoots = ['article', 'aside', 'blockquote', 
-		'body', 'div', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 
-		'header', 'main', 'nav', 'p', 'section', 'span'];
-axe.utils.isShadowRoot = function isShadowRoot (node) {
-	const nodeName = node.nodeName.toLowerCase();
-	if (node.shadowRoot) {
-		if (/^[a-z][a-z0-9_.-]*-[a-z0-9_.-]*$/.test(nodeName) ||
-				possibleShadowRoots.includes(nodeName)) {
-			return true;
-		}
-	}
-	return false;
-};
-
 /**
  * Recursvely returns an array of the virtual DOM nodes at this level
  * excluding comment nodes and the shadow DOM nodes <content> and <slot>

--- a/lib/core/utils/is-shadow-root.js
+++ b/lib/core/utils/is-shadow-root.js
@@ -1,0 +1,21 @@
+/* global axe */
+
+const possibleShadowRoots = ['article', 'aside', 'blockquote', 
+		'body', 'div', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 
+		'header', 'main', 'nav', 'p', 'section', 'span'];
+/**
+ * Test a node to see if it has a spec-conforming shadow root
+ *
+ * @param {Node}   node  The HTML DOM node
+ * @return {Boolean}
+ */
+axe.utils.isShadowRoot = function isShadowRoot (node) {
+	const nodeName = node.nodeName.toLowerCase();
+	if (node.shadowRoot) {
+		if (/^[a-z][a-z0-9_.-]*-[a-z0-9_.-]*$/.test(nodeName) ||
+				possibleShadowRoots.includes(nodeName)) {
+			return true;
+		}
+	}
+	return false;
+};

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -3,6 +3,8 @@ describe('color-contrast', function () {
 
 	var fixture = document.getElementById('fixture');
 	var fixtureSetup = axe.testUtils.fixtureSetup;
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 
 	var checkContext = {
 		_relatedNodes: [],
@@ -288,5 +290,17 @@ describe('color-contrast', function () {
 			checkContext._relatedNodes[0],
 			document.querySelector('#background')
 		);
+	});
+
+	(shadowSupported ? it : xit)
+	('returns colors across Shadow DOM boundaries', function () {
+		var params = shadowCheckSetup(
+			'<div id="container" style="background-color:black;"></div>',
+			'<p style="color: #333;" id="target">Text</p>'
+		);
+		var container = fixture.querySelector('#container');
+		var result = checks['color-contrast'].evaluate.apply(checkContext, params);
+		assert.isFalse(result);
+		assert.deepEqual(checkContext._relatedNodes, [container]);
 	});
 });

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -337,14 +337,14 @@ describe('color.getBackgroundColor', function () {
 	});
 
 	it('should count an implicit label as a background element', function () {
-		fixture.innerHTML = '<label id="target" style="background-color: #fff;">My label' +
+		fixture.innerHTML = '<label id="target" style="background-color: #000;">My label' +
 		'<input type="text">' +
 			'</label>';
 		var target = fixture.querySelector('#target');
 		var bgNodes = [];
 		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 		var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
-		var expected = new axe.commons.color.Color(255, 255, 255, 1);
+		var expected = new axe.commons.color.Color(0, 0, 0, 1);
 		assert.equal(actual.red, expected.red);
 		assert.equal(actual.green, expected.green);
 		assert.equal(actual.blue, expected.blue);
@@ -534,7 +534,7 @@ describe('color.getBackgroundColor', function () {
 	});
 
 	it('returns elements with negative z-index', function () {
-		fixture.innerHTML = '<div id="sibling" ' + 
+		fixture.innerHTML = '<div id="sibling" ' +
 			'style="z-index:-1; position:absolute; width:100%; height:2em; background: #000"></div>' +
 			'<div id="target">Some text</div>';
 
@@ -550,7 +550,7 @@ describe('color.getBackgroundColor', function () {
 	});
 
 	it('returns negative z-index elements when body has a background', function () {
-		fixture.innerHTML = '<div id="sibling" ' + 
+		fixture.innerHTML = '<div id="sibling" ' +
 			'style="z-index:-1; position:absolute; width:100%; height:2em; background: #000"></div>' +
 			'<div id="target">Some text</div>';
 
@@ -613,7 +613,6 @@ describe('color.getBackgroundColor', function () {
 		var expected = new axe.commons.color.Color(0, 255, 0, 1);
 		document.documentElement.style.background = orig;
 
-
 		assert.closeTo(actual.red, expected.red, 0.5);
 		assert.closeTo(actual.green, expected.green, 0.5);
 		assert.closeTo(actual.blue, expected.blue, 0.5);
@@ -652,8 +651,10 @@ describe('color.getBackgroundColor', function () {
 		fixture.innerHTML = '<div style="height: 20px; width: 30px; background-color: red;">' +
 			'<div id="target" style="height:20px; top: 25px; width: 45px; position:absolute;">Text' +
 			'</div></div>';
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getBackgroundColor(target, []);
+
 		assert.closeTo(actual.red, 255, 0);
 		assert.closeTo(actual.green, 255, 0);
 		assert.closeTo(actual.blue, 255, 0);
@@ -668,6 +669,7 @@ describe('color.getBackgroundColor', function () {
 		shadow.innerHTML = '<div style="background-color: black;">' +
 			'<span id="shadowTarget" style="color: #ccc;">Text</span>' +
 		'</div>';
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 
 		var target = shadow.querySelector('#shadowTarget');
 		var actual = axe.commons.color.getBackgroundColor(target, []);
@@ -684,14 +686,15 @@ describe('color.getBackgroundColor', function () {
 		var container = fixture.querySelector('#container');
 		var shadow = container.attachShadow({ mode: 'open' });
 		shadow.innerHTML = '<span id="shadowTarget" style="color:#ccc;">Text</span>';
-
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
+		
 		var target = shadow.querySelector('#shadowTarget');
 		var actual = axe.commons.color.getBackgroundColor(target, [], false);
 
-		assert.closeTo(actual.red, 0, 0);
-		assert.closeTo(actual.green, 0, 0);
-		assert.closeTo(actual.blue, 0, 0);
-		assert.closeTo(actual.alpha, 1, 0);
+		assert.equal(actual.red, 0);
+		assert.equal(actual.green, 0);
+		assert.equal(actual.blue, 0);
+		assert.equal(actual.alpha, 1);
 	});
 
 	(shadowSupported ? it : xit)
@@ -699,10 +702,13 @@ describe('color.getBackgroundColor', function () {
 		fixture.innerHTML = '<div id="container"></div>';
 		var container = fixture.querySelector('#container');
 		var shadow = container.attachShadow({ mode: 'open' });
-		shadow.innerHTML = '<label id="target">Text<input type="text"></label>';
+		shadow.innerHTML = '<div><label id="target" style="background-color:#000;">Text<input type="text"></label></div>';
+		
 		var target = shadow.querySelector('#target');
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 		var actual = axe.commons.color.getBackgroundColor(target, []);
-		var expected = new axe.commons.color.Color(255, 255, 255, 1);
+		var expected = new axe.commons.color.Color(0, 0, 0, 1);
+
 		assert.equal(actual.red, expected.red);
 		assert.equal(actual.green, expected.green);
 		assert.equal(actual.blue, expected.blue);
@@ -715,13 +721,15 @@ describe('color.getBackgroundColor', function () {
 		var container = fixture.querySelector('#container');
 		var shadow = container.attachShadow({ mode: 'open' });
 		shadow.innerHTML = '<div id="shadowTarget" style="color:#333; height:20px; position:absolute; top:20px;">Text</div>';
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 
 		var target = shadow.querySelector('#shadowTarget');
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 		var actual = axe.commons.color.getBackgroundColor(target, []);
-		assert.closeTo(actual.red, 255, 0);
-		assert.closeTo(actual.green, 255, 0);
-		assert.closeTo(actual.blue, 255, 0);
-		assert.closeTo(actual.alpha, 1, 0);
+		assert.equal(actual.red, 255);
+		assert.equal(actual.green, 255);
+		assert.equal(actual.blue, 255);
+		assert.equal(actual.alpha, 1);
 	});
 
 	(shadowSupported ? it : xit)
@@ -729,15 +737,16 @@ describe('color.getBackgroundColor', function () {
 		fixture.innerHTML = '<div id="elm1" style="width:10em; height:0; position:absolute;"></div>' +
 			'<div id="elm2" style="color:green; position:absolute;">Text</div>';
 
-	  var elm1 = document.querySelector('#elm1');
-	  var shadow1 = elm1.attachShadow({ mode: 'open' });
-	  shadow1.innerHTML = '<div style="background:rgba(0,0,0,1); height:10em;"></div>';
-	  var elm2 = document.querySelector('#elm2');
-	  var actual = axe.commons.color.getBackgroundColor(elm2, []);
-	  assert.closeTo(actual.red, 0, 0);
-	  assert.closeTo(actual.blue, 0, 0);
-	  assert.closeTo(actual.green, 0, 0);
-	  assert.closeTo(actual.alpha, 1, 0);
+		var elm1 = document.querySelector('#elm1');
+		var shadow1 = elm1.attachShadow({ mode: 'open' });
+		shadow1.innerHTML = '<div style="background:rgba(0,0,0,1); height:10em;"></div>';
+		var elm2 = document.querySelector('#elm2');
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
+		var actual = axe.commons.color.getBackgroundColor(elm2, []);
+		assert.equal(actual.red, 0);
+		assert.equal(actual.blue, 0);
+		assert.equal(actual.green, 0);
+		assert.equal(actual.alpha, 1);
 	});
 
 	(shadowSupported ? it : xit)
@@ -745,23 +754,23 @@ describe('color.getBackgroundColor', function () {
 		fixture.innerHTML = '<div style="position:relative;"><div id="elm1" style="width:10em;"></div>' +
 			'<div id="elm2"></div></div>';
 
-	  var elm1 = document.querySelector('#elm1');
-	  var shadow1 = elm1.attachShadow({ mode: 'open' });
-	  shadow1.innerHTML = '<div style="background:rgba(0,0,0,1); height:10em;"></div>';
-	  var elm2 = document.querySelector('#elm2');
-	  var shadow2 = elm2.attachShadow({ mode: 'open' });
-	  shadow2.innerHTML = ''+
-	  '<div id="elm3" style="background:rgba(255,255,255,0.5);color:green;height:10em;top:0;position:absolute;">' +
-	  	'Text' +
-  	'</div>';
+		var elm1 = document.querySelector('#elm1');
+		var shadow1 = elm1.attachShadow({ mode: 'open' });
+		shadow1.innerHTML = '<div style="background:rgba(0,0,0,1); height:10em;"></div>';
+		var elm2 = document.querySelector('#elm2');
+		var shadow2 = elm2.attachShadow({ mode: 'open' });
+		shadow2.innerHTML = ''+
+		'<div id="elm3" style="background:rgba(255,255,255,0.5);color:green;height:10em;top:0;position:absolute;">' +
+			'Text' +
+		'</div>';
 
-	  var elm3 = shadow2.querySelector('#elm3');
-
-	  var actual = axe.commons.color.getBackgroundColor(elm3, []);
-	  assert.closeTo(actual.red, 128, 2);
-	  assert.closeTo(actual.blue, 128, 2);
-	  assert.closeTo(actual.green, 128, 2);
-	  assert.closeTo(actual.alpha, 1, 0);
+		var elm3 = shadow2.querySelector('#elm3');
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
+		var actual = axe.commons.color.getBackgroundColor(elm3, []);
+		assert.closeTo(actual.red, 128, 2);
+		assert.closeTo(actual.blue, 128, 2);
+		assert.closeTo(actual.green, 128, 2);
+		assert.closeTo(actual.alpha, 1, 0);
 	});
 
 	(shadowSupported ? it : xit)
@@ -770,13 +779,13 @@ describe('color.getBackgroundColor', function () {
 		var container = fixture.querySelector('#container');
 		var shadow = container.attachShadow({ mode: 'open' });
 		shadow.innerHTML = '<div id="shadowTarget" style="color:#333;">Text<br>More text</div>';
-
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 		var target = shadow.querySelector('#shadowTarget');
 		var actual = axe.commons.color.getBackgroundColor(target, []);
-		assert.closeTo(actual.red, 0, 0);
-		assert.closeTo(actual.green, 0, 0);
-		assert.closeTo(actual.blue, 0, 0);
-		assert.closeTo(actual.alpha, 1, 0);
+		assert.equal(actual.red, 0);
+		assert.equal(actual.green, 0);
+		assert.equal(actual.blue, 0);
+		assert.equal(actual.alpha, 1);
 	});
 
 	(shadowSupported ? xit : xit)
@@ -785,9 +794,25 @@ describe('color.getBackgroundColor', function () {
 		var container = fixture.querySelector('#container');
 		var shadow = container.attachShadow({ mode: 'open' });
 		shadow.innerHTML = '<div id="shadowTarget" style="color:#333;">Text<br>More text</div>';
-
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
 		var target = shadow.querySelector('#shadowTarget');
 		var actual = axe.commons.color.getBackgroundColor(target, []);
 		assert.isNull(actual);
+	});
+
+	(shadowSupported ? it : xit)
+	('returns a color for slotted content', function () {
+		fixture.innerHTML = '<div id="container"></div>';
+		var div = fixture.querySelector('#container');
+		div.innerHTML = '<a href="">Link</a>';
+		var shadow = div.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<p style="background-color: #000;"><slot></slot></p>';
+		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
+		var linkElm = div.querySelector('a');
+		var actual = axe.commons.color.getBackgroundColor(linkElm, []);
+		assert.equal(actual.red, 0);
+		assert.equal(actual.green, 0);
+		assert.equal(actual.blue, 0);
+		assert.equal(actual.alpha, 1);
 	});
 });

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -3,6 +3,8 @@ describe('color.getBackgroundColor', function () {
 
 	var fixture = document.getElementById('fixture');
 
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+
 	afterEach(function () {
 		document.getElementById('fixture').innerHTML = '';
 		axe.commons.color.incompleteData.clear();
@@ -231,6 +233,26 @@ describe('color.getBackgroundColor', function () {
 		var actual = axe.commons.color.getBackgroundColor(document.getElementById('target'), []);
 		assert.isNull(actual);
 		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'elmPartiallyObscuring');
+	});
+
+	it('should return an actual if an absolutely positioned element does not cover background', function () {
+		fixture.innerHTML = '<div style="background-color:black; height:20px; position:relative;">' +
+			'<div style="color:#333; position:absolute; top:21px;" id="target">Text</div>' +
+		'</div>';
+		var actual = axe.commons.color.getBackgroundColor(document.getElementById('target'), []);
+		assert.equal(Math.round(actual.blue), 255);
+		assert.equal(Math.round(actual.red), 255);
+		assert.equal(Math.round(actual.green), 255);
+	});
+
+	it('should return null if an absolutely positioned element partially obsures background', function () {
+		fixture.innerHTML = '<div style="height:40px; position:relative;">' +
+			'<div style="background-color:black; height:20px;"></div>' +
+			'<div style="color:#333; position:absolute; margin-top:-11px;" id="target">Text</div>' +
+		'</div>';
+		var actual = axe.commons.color.getBackgroundColor(document.getElementById('target'), []);
+		assert.isNull(actual);
+		assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'elmPartiallyObscured');
 	});
 
 	it('should count a TR as a background element for TD', function () {
@@ -626,4 +648,146 @@ describe('color.getBackgroundColor', function () {
 		assert.closeTo(actual.alpha, 1, 0.1);
 	});
 
+	it('should return the body bgColor when content does not overlap', function () {
+		fixture.innerHTML = '<div style="height: 20px; width: 30px; background-color: red;">' +
+			'<div id="target" style="height:20px; top: 25px; width: 45px; position:absolute;">Text' +
+			'</div></div>';
+		var target = fixture.querySelector('#target');
+		var actual = axe.commons.color.getBackgroundColor(target, []);
+		assert.closeTo(actual.red, 255, 0);
+		assert.closeTo(actual.green, 255, 0);
+		assert.closeTo(actual.blue, 255, 0);
+		assert.closeTo(actual.alpha, 1, 0);
+	});
+
+	(shadowSupported ? it : xit)
+	('finds colors in shadow boundaries', function () {
+		fixture.innerHTML = '<div id="container"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div style="background-color: black;">' +
+			'<span id="shadowTarget" style="color: #ccc;">Text</span>' +
+		'</div>';
+
+		var target = shadow.querySelector('#shadowTarget');
+		var actual = axe.commons.color.getBackgroundColor(target, []);
+
+		assert.closeTo(actual.red, 0, 0);
+		assert.closeTo(actual.green, 0, 0);
+		assert.closeTo(actual.blue, 0, 0);
+		assert.closeTo(actual.alpha, 1, 0);
+	});
+
+	(shadowSupported ? it : xit)
+	('finds colors across shadow boundaries', function () {
+		fixture.innerHTML = '<div id="container" style="background-color:black;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<span id="shadowTarget" style="color:#ccc;">Text</span>';
+
+		var target = shadow.querySelector('#shadowTarget');
+		var actual = axe.commons.color.getBackgroundColor(target, [], false);
+
+		assert.closeTo(actual.red, 0, 0);
+		assert.closeTo(actual.green, 0, 0);
+		assert.closeTo(actual.blue, 0, 0);
+		assert.closeTo(actual.alpha, 1, 0);
+	});
+
+	(shadowSupported ? it : xit)
+	('should count an implicit label as a background element inside shadow dom', function () {
+		fixture.innerHTML = '<div id="container"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<label id="target">Text<input type="text"></label>';
+		var target = shadow.querySelector('#target');
+		var actual = axe.commons.color.getBackgroundColor(target, []);
+		var expected = new axe.commons.color.Color(255, 255, 255, 1);
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+	});
+
+	(shadowSupported ? it : xit)
+	('finds colors for absolutely positioned elements across shadow boundaries', function () {
+		fixture.innerHTML = '<div id="container" style="background-color:black; height:20px; position:relative;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div id="shadowTarget" style="color:#333; height:20px; position:absolute; top:20px;">Text</div>';
+
+		var target = shadow.querySelector('#shadowTarget');
+		var actual = axe.commons.color.getBackgroundColor(target, []);
+		assert.closeTo(actual.red, 255, 0);
+		assert.closeTo(actual.green, 255, 0);
+		assert.closeTo(actual.blue, 255, 0);
+		assert.closeTo(actual.alpha, 1, 0);
+	});
+
+	(shadowSupported ? it : xit)
+	('finds a color for absolutely positioned content when background is in shadow dom', function () {
+		fixture.innerHTML = '<div id="elm1" style="width:10em; height:0; position:absolute;"></div>' +
+			'<div id="elm2" style="color:green; position:absolute;">Text</div>';
+
+	  var elm1 = document.querySelector('#elm1');
+	  var shadow1 = elm1.attachShadow({ mode: 'open' });
+	  shadow1.innerHTML = '<div style="background:rgba(0,0,0,1); height:10em;"></div>';
+	  var elm2 = document.querySelector('#elm2');
+	  var actual = axe.commons.color.getBackgroundColor(elm2, []);
+	  assert.closeTo(actual.red, 0, 0);
+	  assert.closeTo(actual.blue, 0, 0);
+	  assert.closeTo(actual.green, 0, 0);
+	  assert.closeTo(actual.alpha, 1, 0);
+	});
+
+	(shadowSupported ? it : xit)
+	('finds colors for content rendered across multiple shadow boundaries', function () {
+		fixture.innerHTML = '<div style="position:relative;"><div id="elm1" style="width:10em;"></div>' +
+			'<div id="elm2"></div></div>';
+
+	  var elm1 = document.querySelector('#elm1');
+	  var shadow1 = elm1.attachShadow({ mode: 'open' });
+	  shadow1.innerHTML = '<div style="background:rgba(0,0,0,1); height:10em;"></div>';
+	  var elm2 = document.querySelector('#elm2');
+	  var shadow2 = elm2.attachShadow({ mode: 'open' });
+	  shadow2.innerHTML = ''+
+	  '<div id="elm3" style="background:rgba(255,255,255,0.5);color:green;height:10em;top:0;position:absolute;">' +
+	  	'Text' +
+  	'</div>';
+
+	  var elm3 = shadow2.querySelector('#elm3');
+
+	  var actual = axe.commons.color.getBackgroundColor(elm3, []);
+	  assert.closeTo(actual.red, 128, 2);
+	  assert.closeTo(actual.blue, 128, 2);
+	  assert.closeTo(actual.green, 128, 2);
+	  assert.closeTo(actual.alpha, 1, 0);
+	});
+
+	(shadowSupported ? it : xit)
+	('finds colors for multiline elements across shadow boundaries', function () {
+		fixture.innerHTML = '<div id="container" style="background-color:black; height:40px;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div id="shadowTarget" style="color:#333;">Text<br>More text</div>';
+
+		var target = shadow.querySelector('#shadowTarget');
+		var actual = axe.commons.color.getBackgroundColor(target, []);
+		assert.closeTo(actual.red, 0, 0);
+		assert.closeTo(actual.green, 0, 0);
+		assert.closeTo(actual.blue, 0, 0);
+		assert.closeTo(actual.alpha, 1, 0);
+	});
+
+	(shadowSupported ? xit : xit)
+	('returns null for multiline elements not fully covering parents across shadow boundaries', function () {
+		fixture.innerHTML = '<div id="container" style="background-color:black; height:20px;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div id="shadowTarget" style="color:#333;">Text<br>More text</div>';
+
+		var target = shadow.querySelector('#shadowTarget');
+		var actual = axe.commons.color.getBackgroundColor(target, []);
+		assert.isNull(actual);
+	});
 });

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -2,6 +2,7 @@ describe('color.getForegroundColor', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
 
 	afterEach(function () {
 		document.getElementById('fixture').innerHTML = '';
@@ -63,4 +64,21 @@ describe('color.getForegroundColor', function () {
 		assert.equal(actual.alpha, expected.alpha);
 	});
 
+	(shadowSupported ? it : xit)
+	('should return the fgcolor from inside of Shadow DOM', function () {
+		fixture.innerHTML = '<div id="container" style="height: 40px; width: 30px; background-color: red;">' +
+			'</div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div id="target" style="height:20px;width:15px;color:#000080;background-color:green;"></div>';
+		
+		var target = shadow.querySelector('#target');
+		var actual = axe.commons.color.getForegroundColor(target);
+		var expected = new axe.commons.color.Color(0, 0, 128, 1);
+		
+		assert.equal(actual.red, expected.red);
+		assert.equal(actual.green, expected.green);
+		assert.equal(actual.blue, expected.blue);
+		assert.equal(actual.alpha, expected.alpha);
+	});
 });

--- a/test/commons/dom/shadow-elements-from-point.js
+++ b/test/commons/dom/shadow-elements-from-point.js
@@ -8,7 +8,7 @@ describe('dom.shadowElementsFromPoint', function () {
 		document.getElementById('fixture').innerHTML = '';
 	});
 
-	(shadowSupported ? xit : xit)
+	(shadowSupported ? it : xit)
 	('should return an array from inside and outside of shadow dom', function () {
 		fixture.innerHTML = '<div id="container" style="background-color:#000;position:relative;"></div>';
 		var container = fixture.querySelector('#container');

--- a/test/commons/dom/shadow-elements-from-point.js
+++ b/test/commons/dom/shadow-elements-from-point.js
@@ -1,0 +1,36 @@
+describe('dom.shadowElementsFromPoint', function () {
+	'use strict';
+
+	var fixture = document.getElementById('fixture');
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+
+	afterEach(function () {
+		document.getElementById('fixture').innerHTML = '';
+	});
+
+	(shadowSupported ? xit : xit)
+	('should return an array from inside and outside of shadow dom', function () {
+		fixture.innerHTML = '<div id="container" style="background-color:#000;position:relative;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow1 = container.attachShadow({ mode: 'open' });
+		shadow1.innerHTML = '<p style="background-color:red;">Text</p>' +
+			'<div id="shadowHost2" style="position:absolute;"></div>';
+		var paragraph = shadow1.querySelector('p');
+		var container2 = shadow1.querySelector('#shadowHost2');
+		var shadow2 = container2.attachShadow({ mode: 'open' });
+		shadow2.innerHTML = '<span>Text</span>';
+		var shadowSpan = shadow2.querySelector('span');
+
+		container.scrollIntoView();
+
+		var spanCoords = shadowSpan.getBoundingClientRect();
+		var result = axe.commons.dom.shadowElementsFromPoint(spanCoords.x, spanCoords.y);
+		var pCoords = paragraph.getBoundingClientRect();
+		var result2 = axe.commons.dom.shadowElementsFromPoint(pCoords.x, pCoords.y);
+
+		assert.includeMembers(result, [shadowSpan, container2]);
+		assert.notInclude(result, paragraph);
+		assert.includeMembers(result2, [paragraph, container]);
+		assert.notInclude(result2, shadowSpan);
+	});
+});

--- a/test/commons/dom/visually-contains.js
+++ b/test/commons/dom/visually-contains.js
@@ -3,6 +3,8 @@ describe('dom.visuallyContains', function () {
 
 	var fixture = document.getElementById('fixture');
 
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+
 	afterEach(function () {
 		document.getElementById('fixture').innerHTML = '';
 	});
@@ -16,11 +18,21 @@ describe('dom.visuallyContains', function () {
 	});
 
 	it('should return false when overflow is hidden', function () {
-		fixture.innerHTML = '<div style="height: 40px; width: 30px; background-color: red; overflow: hidden;">' +
-			'<div id="target" style="height: 20px; width: 45px; background-color: green;">' +
+		fixture.innerHTML = '<div style="height: 20px; width: 30px; background-color: red; overflow: hidden;">' +
+			'<div id="target" style="height:20px; top: 25px; width: 45px; background-color: green; position:absolute;">' +
 			'</div></div>';
 		var target = fixture.querySelector('#target');
-		assert.isTrue(axe.commons.dom.visuallyContains(target, target.parentNode));
+		var result = axe.commons.dom.visuallyContains(target, target.parentNode);
+		assert.isFalse(result);
+	});
+
+	it('should return false when absolutely positioned content does not overlap', function () {
+		fixture.innerHTML = '<div style="height:20px; width:30px; background-color:red;">' +
+			'<div id="target" style="height:20px; top:25px; width:45px; background-color:green; position:absolute;">Text' +
+			'</div></div>';
+		var target = fixture.querySelector('#target');
+		var result = axe.commons.dom.visuallyContains(target, target.parentNode);
+		assert.isFalse(result);
 	});
 
 	it('should return false when element is outside of margin', function () {
@@ -54,5 +66,59 @@ describe('dom.visuallyContains', function () {
 			'</label>';
 		var target = fixture.querySelector('#target');
 		assert.isTrue(axe.commons.dom.visuallyContains(target, target.parentNode));
+	});
+
+	it('should return false when element is partially contained', function () {
+		fixture.innerHTML = '<div style="background-color:red; height:20px;">' +
+			'<p id="target" style="margin:0; position:absolute;">Text<br>more text</p></div>';
+		var target = fixture.querySelector('#target');
+		var result = axe.commons.dom.visuallyContains(target, target.parentNode);
+		assert.isFalse(result);
+	});
+
+	(shadowSupported ? it : xit)
+	('should return true when element is visually contained across shadow boundary', function () {
+		fixture.innerHTML = '<div style="height:40px; background-color:red;" id="container"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML ='<div id="target" style="height: 20px; width: 45px; background-color: green;"></div>';
+		var target = shadow.querySelector('#target');
+		var result = axe.commons.dom.visuallyContains(target, container);
+		assert.isTrue(result);
+	});
+
+	(shadowSupported ? it : xit)
+	('should return false when element is not visually contained across shadow boundary', function () {
+		fixture.innerHTML = '<div id="container" style="height:20px;background-color:red;overflow:hidden;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div id="target" style="top:20px;height:20px;background-color:green;position:absolute;"><div>';
+		var target = shadow.querySelector('#target');
+		var result = axe.commons.dom.visuallyContains(target, container);
+		assert.isFalse(result);
+	});
+
+	(shadowSupported ? it : xit)
+	('should return false when element is absolutely positioned off of background across shadow boundary', function () {
+		fixture.innerHTML = '<div id="container" style="background-color:black; height:20px;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div id="shadowTarget" style="color:#333; height:20px; position:absolute; top:20px;">Text</div>';
+
+		var target = shadow.querySelector('#shadowTarget');
+		var result = axe.commons.dom.visuallyContains(target, container);
+		assert.isFalse(result);
+	});
+
+	(shadowSupported ? it : xit)
+	('should return false when element is partially positioned off of background across shadow boundary', function () {
+		fixture.innerHTML = '<div id="container" style="background-color:black; height:20px; position:relative;"></div>';
+		var container = fixture.querySelector('#container');
+		var shadow = container.attachShadow({ mode: 'open' });
+		shadow.innerHTML = '<div id="shadowTarget" style="color:#333; height:20px; position:absolute; top:10px;">Text</div>';
+
+		var target = shadow.querySelector('#shadowTarget');
+		var result = axe.commons.dom.visuallyContains(target, container);
+		assert.isFalse(result);
 	});
 });

--- a/test/core/utils/flattened-tree.js
+++ b/test/core/utils/flattened-tree.js
@@ -1,294 +1,241 @@
 var fixture = document.getElementById('fixture');
 var shadowSupport = axe.testUtils.shadowSupport;
 
-function createStyle (box) {
+describe('axe.utils.getFlattenedTree', function() {
 	'use strict';
 
-	var style = document.createElement('style');
-	style.textContent = 'div.breaking { color: Red;font-size: 20px; border: 1px dashed Purple; }' +
-		(box ? 'slot { display: block; }' : '') +
-		'div.other { padding: 2px 0 0 0; border: 1px solid Cyan; }';
-	return style;
-}
+	function createStyle (box) {
+		var style = document.createElement('style');
+		style.textContent = 'div.breaking { color: Red;font-size: 20px; border: 1px dashed Purple; }' +
+			(box ? 'slot { display: block; }' : '') +
+			'div.other { padding: 2px 0 0 0; border: 1px solid Cyan; }';
+		return style;
+	}
 
-function flattenedTreeAssertions () {
-	'use strict';
+	function flattenedTreeAssertions () {
+		var virtualDOM = axe.utils.getFlattenedTree(fixture.firstChild);
+		assert.equal(virtualDOM.length, 1); // host
+		assert.equal(virtualDOM[0].actualNode.nodeName, 'DIV');
 
-	var virtualDOM = axe.utils.getFlattenedTree(fixture.firstChild);
-	assert.equal(virtualDOM.length, 1); // host
-	assert.equal(virtualDOM[0].actualNode.nodeName, 'DIV');
+		virtualDOM = virtualDOM[0].children;
+		assert.equal(virtualDOM.length, 3);
+		assert.equal(virtualDOM[0].actualNode.nodeName, 'STYLE');
 
-	virtualDOM = virtualDOM[0].children;
-	assert.equal(virtualDOM.length, 3);
-	assert.equal(virtualDOM[0].actualNode.nodeName, 'STYLE');
+		// breaking news stories
+		assert.equal(virtualDOM[1].actualNode.nodeName, 'DIV');
+		assert.equal(virtualDOM[1].actualNode.className, 'breaking');
 
-	// breaking news stories
-	assert.equal(virtualDOM[1].actualNode.nodeName, 'DIV');
-	assert.equal(virtualDOM[1].actualNode.className, 'breaking');
+		// other news stories
+		assert.equal(virtualDOM[2].actualNode.nodeName, 'DIV');
+		assert.equal(virtualDOM[2].actualNode.className, 'other');
 
-	// other news stories
-	assert.equal(virtualDOM[2].actualNode.nodeName, 'DIV');
-	assert.equal(virtualDOM[2].actualNode.className, 'other');
+		// breaking
+		assert.equal(virtualDOM[1].children.length, 1);
+		assert.equal(virtualDOM[1].children[0].actualNode.nodeName, 'UL');
+		virtualDOM[1].children[0].children.forEach(function (child, index) {
+			assert.equal(child.actualNode.nodeName, 'LI');
+			assert.isTrue(child.actualNode.textContent === 3*(index + 1) + '');
+		});
+		assert.equal(virtualDOM[1].children[0].children.length, 2);
 
-	// breaking
-	assert.equal(virtualDOM[1].children.length, 1);
-	assert.equal(virtualDOM[1].children[0].actualNode.nodeName, 'UL');
-	virtualDOM[1].children[0].children.forEach(function (child, index) {
-		assert.equal(child.actualNode.nodeName, 'LI');
-		assert.isTrue(child.actualNode.textContent === 3*(index + 1) + '');
-	});
-	assert.equal(virtualDOM[1].children[0].children.length, 2);
+		// other
+		assert.equal(virtualDOM[2].children.length, 1);
+		assert.equal(virtualDOM[2].children[0].actualNode.nodeName, 'UL');
+		assert.equal(virtualDOM[2].children[0].children.length, 4);
+	}
 
-	// other
-	assert.equal(virtualDOM[2].children.length, 1);
-	assert.equal(virtualDOM[2].children[0].actualNode.nodeName, 'UL');
-	assert.equal(virtualDOM[2].children[0].children.length, 4);
-}
+	function shadowIdAssertions () {
+		var virtualDOM = axe.utils.getFlattenedTree(fixture);
+		assert.isUndefined(virtualDOM[0].shadowId); //fixture
+		assert.isUndefined(virtualDOM[0].children[0].shadowId); //host
+		assert.isDefined(virtualDOM[0].children[0].children[0].shadowId);
+		assert.isDefined(virtualDOM[0].children[0].children[1].shadowId);
+		assert.isDefined(virtualDOM[0].children[1].children[0].shadowId);
+		// shadow IDs in the same shadowRoot must be the same
+		assert.equal(virtualDOM[0].children[0].children[0].shadowId,
+			virtualDOM[0].children[0].children[1].shadowId);
+		// should cascade
+		assert.equal(virtualDOM[0].children[0].children[1].shadowId,
+			virtualDOM[0].children[0].children[1].children[0].shadowId);
+		// shadow IDs in different shadowRoots must be different
+		assert.notEqual(virtualDOM[0].children[0].children[0].shadowId,
+			virtualDOM[0].children[1].children[0].shadowId);
 
-function shadowIdAssertions () {
-	'use strict';
+	}
 
-	var virtualDOM = axe.utils.getFlattenedTree(fixture);
-	assert.isUndefined(virtualDOM[0].shadowId); //fixture
-	assert.isUndefined(virtualDOM[0].children[0].shadowId); //host
-	assert.isDefined(virtualDOM[0].children[0].children[0].shadowId);
-	assert.isDefined(virtualDOM[0].children[0].children[1].shadowId);
-	assert.isDefined(virtualDOM[0].children[1].children[0].shadowId);
-	// shadow IDs in the same shadowRoot must be the same
-	assert.equal(virtualDOM[0].children[0].children[0].shadowId,
-		virtualDOM[0].children[0].children[1].shadowId);
-	// should cascade
-	assert.equal(virtualDOM[0].children[0].children[1].shadowId,
-		virtualDOM[0].children[0].children[1].children[0].shadowId);
-	// shadow IDs in different shadowRoots must be different
-	assert.notEqual(virtualDOM[0].children[0].children[0].shadowId,
-		virtualDOM[0].children[1].children[0].shadowId);
+	if (shadowSupport.v0) {
+		describe('shadow DOM v0', function () {
+			afterEach(function () {
+				fixture.innerHTML = '';
+			});
+			beforeEach(function () {
+				function createStoryGroup (className, contentSelector) {
+					var group = document.createElement('div');
+					group.className = className;
+					group.innerHTML = '<ul><content select="' + contentSelector + '"></content></ul>';
+					return group;
+				}
 
-}
+				function makeShadowTree (storyList) {
+					var root = storyList.createShadowRoot();
+					root.appendChild(createStyle());
+					root.appendChild(createStoryGroup('breaking', '.breaking'));
+					root.appendChild(createStoryGroup('other', ''));
+				}
+				var str = '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking">6</li></div>';
+				str += '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking">6</li></div>';
+				fixture.innerHTML = str;
 
-describe('isShadowRoot', function () {
-	'use strict';
-	var isShadowRoot = axe.utils.isShadowRoot;
+				fixture.querySelectorAll('.stories').forEach(makeShadowTree);
+			});
+			it('it should support shadow DOM v0', function () {
+				assert.isDefined(fixture.firstChild.shadowRoot);
+			});
+			it('getFlattenedTree should return an array of stuff', function () {
+				assert.isTrue(Array.isArray(axe.utils.getFlattenedTree(fixture.firstChild)));
+			});
+			it('getFlattenedTree\'s virtual DOM should represent the flattened tree', flattenedTreeAssertions);
+			it('getFlattenedTree\'s virtual DOM should give an ID to the shadow DOM', shadowIdAssertions);
+		});
+	}
 
-	it('returns false if the node has no shadowRoot', function () {
-		assert.isFalse(isShadowRoot({ nodeName: 'DIV', shadowRoot: undefined }));
-	});
-	it('returns true if the native element allows shadow DOM', function () {
-		assert.isTrue(isShadowRoot({ nodeName: 'DIV', shadowRoot: {} }));
-		assert.isTrue(isShadowRoot({ nodeName: 'H1', shadowRoot: {} }));
-		assert.isTrue(isShadowRoot({ nodeName: 'ASIDE', shadowRoot: {} }));
-	});
-	it('returns true if a custom element with shadowRoot', function () {
-		assert.isTrue(isShadowRoot({ nodeName: 'X-BUTTON', shadowRoot: {} }));
-		assert.isTrue(isShadowRoot({ nodeName: 'T1000-SCHWARZENEGGER', shadowRoot: {} }));
-	});
-	it('returns true if an invalid custom element with shadowRoot', function () {
-		assert.isFalse(isShadowRoot({ nodeName: '0-BUZZ', shadowRoot: {} }));
-		assert.isFalse(isShadowRoot({ nodeName: '--ELM--', shadowRoot: {} }));
-	});
-	it('returns false if the native element does not allow shadow DOM', function () {
-		assert.isFalse(isShadowRoot({ nodeName: 'IFRAME', shadowRoot: {} }));
-		assert.isFalse(isShadowRoot({ nodeName: 'STRONG', shadowRoot: {} }));
-	});
+	if (shadowSupport.v1) {
+		describe('shadow DOM v1', function () {
+			afterEach(function () {
+				fixture.innerHTML = '';
+			});
+			beforeEach(function () {
+				function createStoryGroup (className, slotName) {
+					var group = document.createElement('div');
+					group.className = className;
+					// Empty string in slot name attribute or absence thereof work the same, so no need for special handling.
+					group.innerHTML = '<ul><slot name="' + slotName + '">fallback content<li>one</li></slot></ul>';
+					return group;
+				}
+
+				function makeShadowTree (storyList) {
+					var root = storyList.attachShadow({mode: 'open'});
+					root.appendChild(createStyle());
+					root.appendChild(createStoryGroup('breaking', 'breaking'));
+					root.appendChild(createStoryGroup('other', ''));
+				}
+				var str = '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"></div>';
+				fixture.innerHTML = str;
+
+				fixture.querySelectorAll('.stories').forEach(makeShadowTree);
+			});
+			it('should support shadow DOM v1', function () {
+				assert.isDefined(fixture.firstChild.shadowRoot);
+			});
+			it('getFlattenedTree should return an array of stuff', function () {
+				assert.isTrue(Array.isArray(axe.utils.getFlattenedTree(fixture.firstChild)));
+			});
+			it('getFlattenedTree\'s virtual DOM should represent the flattened tree', flattenedTreeAssertions);
+			it('getFlattenedTree\'s virtual DOM should give an ID to the shadow DOM', shadowIdAssertions);
+			it('getFlattenedTree\'s virtual DOM should have the fallback content', function () {
+				var virtualDOM = axe.utils.getFlattenedTree(fixture);
+				assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children.length === 2);
+				assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children[0].actualNode.nodeType === 3);
+				assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children[0].actualNode.textContent === 'fallback content');
+				assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children[1].actualNode.nodeName === 'LI');
+			});
+		});
+		describe('shadow DOM v1: boxed slots', function () {
+			afterEach(function () {
+				fixture.innerHTML = '';
+			});
+			beforeEach(function () {
+				function createStoryGroup (className, slotName) {
+					var group = document.createElement('div');
+					group.className = className;
+					// Empty string in slot name attribute or absence thereof work the same, so no need for special handling.
+					group.innerHTML = '<ul><slot name="' + slotName + '">fallback content<li>one</li></slot></ul>';
+					return group;
+				}
+
+				function makeShadowTree (storyList) {
+					var root = storyList.attachShadow({mode: 'open'});
+					root.appendChild(createStyle(true));
+					root.appendChild(createStoryGroup('breaking', 'breaking'));
+					root.appendChild(createStoryGroup('other', ''));
+				}
+				var str = '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"></div>';
+				fixture.innerHTML = str;
+
+				fixture.querySelectorAll('.stories').forEach(makeShadowTree);
+			});
+			it('getFlattenedTree\'s virtual DOM should have the <slot> elements', function () {
+				return; // Chrome's implementation of slot is broken
+				// var virtualDOM = axe.utils.getFlattenedTree(fixture);
+				// assert.isTrue(virtualDOM[0].children[1].children[0].children[0].actualNode.nodeName === 'SLOT');
+			});
+		});
+		describe('getNodeFromTree', function () {
+			afterEach(function () {
+				fixture.innerHTML = '';
+			});
+			beforeEach(function () {
+				function createStoryGroup (className, slotName) {
+					var group = document.createElement('div');
+					group.className = className;
+					// Empty string in slot name attribute or absence thereof work the same, so no need for special handling.
+					group.innerHTML = '<ul><slot name="' + slotName + '">fallback content<li>one</li></slot></ul>';
+					return group;
+				}
+
+				function makeShadowTree (storyList) {
+					var root = storyList.attachShadow({mode: 'open'});
+					root.appendChild(createStyle());
+					root.appendChild(createStoryGroup('breaking', 'breaking'));
+					root.appendChild(createStoryGroup('other', ''));
+				}
+				var str = '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"></div>';
+				fixture.innerHTML = str;
+
+				fixture.querySelectorAll('.stories').forEach(makeShadowTree);
+			});
+			it('should find the virtual node that matches the real node passed in', function () {
+				var virtualDOM = axe.utils.getFlattenedTree(fixture);
+				var node = document.querySelector('.stories li');
+				var vNode = axe.utils.getNodeFromTree(virtualDOM[0], node);
+				assert.isDefined(vNode);
+				assert.equal(node, vNode.actualNode);
+				assert.equal(vNode.actualNode.textContent, '1');
+			});
+			it('should find the virtual node if it is the very top of the tree', function () {
+				var virtualDOM = axe.utils.getFlattenedTree(fixture);
+				var vNode = axe.utils.getNodeFromTree(virtualDOM[0], virtualDOM[0].actualNode);
+				assert.isDefined(vNode);
+				assert.equal(virtualDOM[0].actualNode, vNode.actualNode);
+			});
+		});
+	}
+
+	if (shadowSupport.undefined) {
+		describe('shadow dom undefined', function () {
+			it('SHADOW DOM TESTS DEFERRED, NO SUPPORT');
+		});
+	}
 });
-
-if (shadowSupport.v0) {
-	describe('flattened-tree shadow DOM v0', function () {
-		'use strict';
-		afterEach(function () {
-			fixture.innerHTML = '';
-		});
-		beforeEach(function () {
-			function createStoryGroup (className, contentSelector) {
-				var group = document.createElement('div');
-				group.className = className;
-				group.innerHTML = '<ul><content select="' + contentSelector + '"></content></ul>';
-				return group;
-			}
-
-			function makeShadowTree (storyList) {
-				var root = storyList.createShadowRoot();
-				root.appendChild(createStyle());
-				root.appendChild(createStoryGroup('breaking', '.breaking'));
-				root.appendChild(createStoryGroup('other', ''));
-			}
-			var str = '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking">6</li></div>';
-			str += '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking">6</li></div>';
-			fixture.innerHTML = str;
-
-			fixture.querySelectorAll('.stories').forEach(makeShadowTree);
-		});
-		it('it should support shadow DOM v0', function () {
-			assert.isDefined(fixture.firstChild.shadowRoot);
-		});
-		it('getFlattenedTree should return an array of stuff', function () {
-			assert.isTrue(Array.isArray(axe.utils.getFlattenedTree(fixture.firstChild)));
-		});
-		it('getFlattenedTree\'s virtual DOM should represent the flattened tree', flattenedTreeAssertions);
-		it('getFlattenedTree\'s virtual DOM should give an ID to the shadow DOM', shadowIdAssertions);
-	});
-}
-
-if (shadowSupport.v1) {
-	describe('flattened-tree shadow DOM v1', function () {
-		'use strict';
-		afterEach(function () {
-			fixture.innerHTML = '';
-		});
-		beforeEach(function () {
-			function createStoryGroup (className, slotName) {
-				var group = document.createElement('div');
-				group.className = className;
-				// Empty string in slot name attribute or absence thereof work the same, so no need for special handling.
-				group.innerHTML = '<ul><slot name="' + slotName + '">fallback content<li>one</li></slot></ul>';
-				return group;
-			}
-
-			function makeShadowTree (storyList) {
-				var root = storyList.attachShadow({mode: 'open'});
-				root.appendChild(createStyle());
-				root.appendChild(createStoryGroup('breaking', 'breaking'));
-				root.appendChild(createStoryGroup('other', ''));
-			}
-			var str = '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
-			str += '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
-			str += '<div class="stories"></div>';
-			fixture.innerHTML = str;
-
-			fixture.querySelectorAll('.stories').forEach(makeShadowTree);
-		});
-		it('should support shadow DOM v1', function () {
-			assert.isDefined(fixture.firstChild.shadowRoot);
-		});
-		it('getFlattenedTree should return an array of stuff', function () {
-			assert.isTrue(Array.isArray(axe.utils.getFlattenedTree(fixture.firstChild)));
-		});
-		it('getFlattenedTree\'s virtual DOM should represent the flattened tree', flattenedTreeAssertions);
-		it('getFlattenedTree\'s virtual DOM should give an ID to the shadow DOM', shadowIdAssertions);
-		it('getFlattenedTree\'s virtual DOM should have the fallback content', function () {
-			var virtualDOM = axe.utils.getFlattenedTree(fixture);
-			assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children.length === 2);
-			assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children[0].actualNode.nodeType === 3);
-			assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children[0].actualNode.textContent === 'fallback content');
-			assert.isTrue(virtualDOM[0].children[2].children[1].children[0].children[1].actualNode.nodeName === 'LI');
-		});
-		it('calls isShadowRoot to identify a shadow root', function () {
-			var isShadowRoot = axe.utils.isShadowRoot;
-			fixture.innerHTML = '<div></div>';
-			var div = fixture.querySelector('div');
-			var shadowRoot = div.attachShadow({ mode: 'open' });
-			shadowRoot.innerHTML = '<h1>Just a man in the back</h1>';
-
-			// Test without isShqdowRoot overwritten
-			assert.equal(axe.utils.getFlattenedTree(div)[0].children.length, 1);
-
-			var called = false;
-			axe.utils.isShadowRoot = function () {
-				called = true;
-				return false;
-			};
-			// Test with isShadowRoot overwritten
-			assert.equal(axe.utils.getFlattenedTree(div)[0].children.length, 0);
-			assert.isTrue(called);
-			axe.utils.isShadowRoot = isShadowRoot;
-		});
-	});
-	describe('flattened-tree shadow DOM v1: boxed slots', function () {
-		'use strict';
-		afterEach(function () {
-			fixture.innerHTML = '';
-		});
-		beforeEach(function () {
-			function createStoryGroup (className, slotName) {
-				var group = document.createElement('div');
-				group.className = className;
-				// Empty string in slot name attribute or absence thereof work the same, so no need for special handling.
-				group.innerHTML = '<ul><slot name="' + slotName + '">fallback content<li>one</li></slot></ul>';
-				return group;
-			}
-
-			function makeShadowTree (storyList) {
-				var root = storyList.attachShadow({mode: 'open'});
-				root.appendChild(createStyle(true));
-				root.appendChild(createStoryGroup('breaking', 'breaking'));
-				root.appendChild(createStoryGroup('other', ''));
-			}
-			var str = '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
-			str += '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
-			str += '<div class="stories"></div>';
-			fixture.innerHTML = str;
-
-			fixture.querySelectorAll('.stories').forEach(makeShadowTree);
-		});
-		it('getFlattenedTree\'s virtual DOM should have the <slot> elements', function () {
-			return; // Chrome's implementation of slot is broken
-			// var virtualDOM = axe.utils.getFlattenedTree(fixture);
-			// assert.isTrue(virtualDOM[0].children[1].children[0].children[0].actualNode.nodeName === 'SLOT');
-		});
-	});
-	describe('getNodeFromTree', function () {
-		'use strict';
-		afterEach(function () {
-			fixture.innerHTML = '';
-		});
-		beforeEach(function () {
-			function createStoryGroup (className, slotName) {
-				var group = document.createElement('div');
-				group.className = className;
-				// Empty string in slot name attribute or absence thereof work the same, so no need for special handling.
-				group.innerHTML = '<ul><slot name="' + slotName + '">fallback content<li>one</li></slot></ul>';
-				return group;
-			}
-
-			function makeShadowTree (storyList) {
-				var root = storyList.attachShadow({mode: 'open'});
-				root.appendChild(createStyle());
-				root.appendChild(createStoryGroup('breaking', 'breaking'));
-				root.appendChild(createStoryGroup('other', ''));
-			}
-			var str = '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
-			str += '<div class="stories"><li>1</li>' +
-			'<li>2</li><li class="breaking" slot="breaking">3</li>' +
-			'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
-			str += '<div class="stories"></div>';
-			fixture.innerHTML = str;
-
-			fixture.querySelectorAll('.stories').forEach(makeShadowTree);
-		});
-		it('should find the virtual node that matches the real node passed in', function () {
-			var virtualDOM = axe.utils.getFlattenedTree(fixture);
-			var node = document.querySelector('.stories li');
-			var vNode = axe.utils.getNodeFromTree(virtualDOM[0], node);
-			assert.isDefined(vNode);
-			assert.equal(node, vNode.actualNode);
-			assert.equal(vNode.actualNode.textContent, '1');
-		});
-		it('should find the virtual node if it is the very top of the tree', function () {
-			var virtualDOM = axe.utils.getFlattenedTree(fixture);
-			var vNode = axe.utils.getNodeFromTree(virtualDOM[0], virtualDOM[0].actualNode);
-			assert.isDefined(vNode);
-			assert.equal(virtualDOM[0].actualNode, vNode.actualNode);
-		});
-	});
-}
-
-if (shadowSupport.undefined) {
-	describe('flattened-tree', function () {
-		'use strict';
-		it('SHADOW DOM TESTS DEFERRED, NO SUPPORT');
-	});
-}

--- a/test/core/utils/is-shadow-root.js
+++ b/test/core/utils/is-shadow-root.js
@@ -1,0 +1,94 @@
+var fixture = document.getElementById('fixture');
+var shadowSupport = axe.testUtils.shadowSupport;
+
+describe('axe.utils.isShadowRoot', function() {
+	'use strict';
+
+	function createStyle (box) {
+		var style = document.createElement('style');
+		style.textContent = 'div.breaking { color: Red;font-size: 20px; border: 1px dashed Purple; }' +
+			(box ? 'slot { display: block; }' : '') +
+			'div.other { padding: 2px 0 0 0; border: 1px solid Cyan; }';
+		return style;
+	}
+
+	var isShadowRoot = axe.utils.isShadowRoot;
+
+	it('returns false if the node has no shadowRoot', function () {
+		assert.isFalse(isShadowRoot({ nodeName: 'DIV', shadowRoot: undefined }));
+	});
+	it('returns true if the native element allows shadow DOM', function () {
+		assert.isTrue(isShadowRoot({ nodeName: 'DIV', shadowRoot: {} }));
+		assert.isTrue(isShadowRoot({ nodeName: 'H1', shadowRoot: {} }));
+		assert.isTrue(isShadowRoot({ nodeName: 'ASIDE', shadowRoot: {} }));
+	});
+	it('returns true if a custom element with shadowRoot', function () {
+		assert.isTrue(isShadowRoot({ nodeName: 'X-BUTTON', shadowRoot: {} }));
+		assert.isTrue(isShadowRoot({ nodeName: 'T1000-SCHWARZENEGGER', shadowRoot: {} }));
+	});
+	it('returns true if an invalid custom element with shadowRoot', function () {
+		assert.isFalse(isShadowRoot({ nodeName: '0-BUZZ', shadowRoot: {} }));
+		assert.isFalse(isShadowRoot({ nodeName: '--ELM--', shadowRoot: {} }));
+	});
+	it('returns false if the native element does not allow shadow DOM', function () {
+		assert.isFalse(isShadowRoot({ nodeName: 'IFRAME', shadowRoot: {} }));
+		assert.isFalse(isShadowRoot({ nodeName: 'STRONG', shadowRoot: {} }));
+	});
+
+	if (shadowSupport.v1) {
+		describe('shadow DOM v1', function () {
+			afterEach(function () {
+				fixture.innerHTML = '';
+			});
+			beforeEach(function () {
+				function createStoryGroup (className, slotName) {
+					var group = document.createElement('div');
+					group.className = className;
+					// Empty string in slot name attribute or absence thereof work the same, so no need for special handling.
+					group.innerHTML = '<ul><slot name="' + slotName + '">fallback content<li>one</li></slot></ul>';
+					return group;
+				}
+
+				function makeShadowTree (storyList) {
+					var root = storyList.attachShadow({mode: 'open'});
+					root.appendChild(createStyle());
+					root.appendChild(createStoryGroup('breaking', 'breaking'));
+					root.appendChild(createStoryGroup('other', ''));
+				}
+				var str = '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"><li>1</li>' +
+				'<li>2</li><li class="breaking" slot="breaking">3</li>' +
+				'<li>4</li><li>5</li><li class="breaking" slot="breaking">6</li></div>';
+				str += '<div class="stories"></div>';
+				fixture.innerHTML = str;
+
+				fixture.querySelectorAll('.stories').forEach(makeShadowTree);
+			});
+			it('should support shadow DOM v1', function () {
+				assert.isDefined(fixture.firstChild.shadowRoot);
+			});
+			it('calls isShadowRoot to identify a shadow root', function () {
+				var isShadowRoot = axe.utils.isShadowRoot;
+				fixture.innerHTML = '<div></div>';
+				var div = fixture.querySelector('div');
+				var shadowRoot = div.attachShadow({ mode: 'open' });
+				shadowRoot.innerHTML = '<h1>Just a man in the back</h1>';
+
+				// Test without isShadowRoot overwritten
+				assert.equal(axe.utils.getFlattenedTree(div)[0].children.length, 1);
+
+				var called = false;
+				axe.utils.isShadowRoot = function () {
+					called = true;
+					return false;
+				};
+				// Test with isShadowRoot overwritten
+				assert.equal(axe.utils.getFlattenedTree(div)[0].children.length, 0);
+				assert.isTrue(called);
+				axe.utils.isShadowRoot = isShadowRoot;
+			});
+		});
+	}
+});

--- a/test/integration/full/contrast/shadow-dom.html
+++ b/test/integration/full/contrast/shadow-dom.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Test Page</title>
+	<link rel="stylesheet" type="text/css" href="/node_modules/mocha/mocha.css" />
+	<script src="/node_modules/mocha/mocha.js"></script>
+	<script src="/node_modules/chai/chai.js"></script>
+	<script src="/axe.js"></script>
+	<script>
+		mocha.setup({
+			timeout: 10000,
+			ui: 'bdd'
+		});
+		var assert = chai.assert;
+	</script>
+	<script src="/test/integration/no-ui-reporter.js"></script>
+  <style>
+    
+  </style>
+</head>
+<body>
+	<div style="background-color: darkred;" id="redHerring">Text</div>
+  <div id="fixture" style="background-color: black;"></div>
+  <script src="/test/testutils.js"></script>
+  <script src="shadow-dom.js"></script>
+  <script src="/test/integration/adapter.js"></script>
+</body>
+</html>

--- a/test/integration/full/contrast/shadow-dom.js
+++ b/test/integration/full/contrast/shadow-dom.js
@@ -1,0 +1,32 @@
+describe('color-contrast shadow dom test', function () {
+	'use strict';
+
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+
+	before(function() {
+		var  fixture = document.querySelector('#fixture');
+		if (shadowSupported) {
+			var  shadow = fixture.attachShadow({mode: 'open'});
+			shadow.innerHTML = '<button style="background-color:red;color:white;">Go!</button>' +
+			'<span style="color:#ccc;">Text</span>' +
+			'<div><label style="color:#ccc;">Text<input type="text"></label></div>' +
+			'<div style="background-color:black; height:20px;">' +
+				'<div style="color:#666; position:absolute;">Text</div>' +
+			'</div>';
+		}
+	});
+
+	describe('violations', function () {
+		(shadowSupported ? it : xit)('should find issues in shadow tree', function (done) {
+			axe.run('#fixture', { runOnly: { type: 'rule', values: ['color-contrast'] } }, function (err, results) {
+				assert.isNull(err);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.violations[0].nodes, 2);
+				assert.equal(results.violations[0].nodes[1].any[0].data.bgColor, '#000000');
+				assert.lengthOf(results.incomplete, 0);
+				done();
+			});
+		});
+	});
+
+});


### PR DESCRIPTION
This PR adds color contrast support for pages with nested Shadow DOM. 

One TODO I still have is to support multiline elements inside of shadow boundaries (inline elements with line breaks, originally added in https://github.com/dequelabs/axe-core/pull/610). The actual background color for those is wrong in this PR because the tree walking across multiple roots doesn't really factor in client rects that partially overlap. I've struggled with it for the past week and decided to punt on it.

Part of the complication is that a shadow host is always returned from `document.elementsFromPoint` regardless of whether its content overlaps (i.e. absolute positioning, etc.). For block elements that don't visually overlap their host element, we have to filter out the host element from the stack or it ends up in Needs Review for `elmPartiallyObscured`. But then we're in a conundrum when multiline elements only partially overlap: our utilities for overlap checking only look at the boundingClientRect, and it would take some refactoring to check individual rects against a shadow host. 

I sorta wonder if the `contentOverlapping` method in `axe.commons.color.getBackgroundColor` should just go away....it seems like we're checking the same thing more than once, and it's way more complicated now (checking overlap of individual rects against multiple bgNodes, across multiple roots). Some of the work has been moved to the stack gathering steps, where we did more evaluation after the fact before. There's probably some redundancy that could get cleaned up as a next step.

Closes https://github.com/dequelabs/axe-core/issues/687