### PR TITLE
fix(perf): improve select performance fixes #702

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -145,6 +145,7 @@ Audit.prototype.run = function (context, options, resolve, reject) {
 	this.validateOptions(options);
 
 	axe._tree = axe.utils.getFlattenedTree(document.documentElement); //cache the flattened tree
+	axe._selectCache = [];
 	var q = axe.utils.queue();
 	this.rules.forEach(function (rule) {
 		if (axe.utils.ruleShouldRun(rule, context, options)) {
@@ -180,6 +181,7 @@ Audit.prototype.run = function (context, options, resolve, reject) {
 	});
 	q.then(function (results) {
 		axe._tree = undefined; // empty the tree
+		axe._selectCache = undefined; // remove the cache
 		resolve(results.filter(function (result) { return !!result; }));
 	}).catch(reject);
 };

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -200,6 +200,7 @@ function validateContext(context) {
  * @param {Object} spec Configuration or "specification" object
  */
 function Context(spec) {
+	//jshint maxstatements:18
 	'use strict';
 	var self = this;
 
@@ -229,4 +230,8 @@ function Context(spec) {
 	if (err instanceof Error) {
 		throw err;
 	}
+	if (!Array.isArray(this.include)) {
+		this.include = Array.from(this.include);
+	}
+	this.include.sort(axe.utils.nodeSorter); // ensure that the order of the include nodes is document order
 }

--- a/lib/core/utils/qsa.js
+++ b/lib/core/utils/qsa.js
@@ -29,7 +29,7 @@ function matchesPseudos (target, exp) {
 
 	if (!exp.pseudos || exp.pseudos.reduce((result, pseudo) => {
 		if (pseudo.name === 'not') {
-			return result && !matchExpressions([target], pseudo.expressions, false, target.shadowId).length;
+			return result && !matchExpressions([target], pseudo.expressions, false).length;
 		}
 		throw new Error('the pseudo selector ' + pseudo.name + ' has not yet been implemented');
 	}, true)) {
@@ -193,12 +193,12 @@ function matchesSelector (node, exp) {
 		);
 }
 
-matchExpressions = function  (domTree, expressions, recurse, parentShadowId, filter) {
+matchExpressions = function  (domTree, expressions, recurse, filter) {
 	//jshint maxstatements:34
 	//jshint maxcomplexity:15
 	let stack = [];
 	let nodes = Array.isArray(domTree) ? domTree : [domTree];
-	let currentLevel = createLocalVariables(nodes, expressions, [], parentShadowId);
+	let currentLevel = createLocalVariables(nodes, expressions, [], domTree[0].shadowId);
 	let result = [];
 
 	while (currentLevel.nodes.length) {
@@ -266,13 +266,13 @@ axe.utils.querySelectorAll = function (domTree, selector) {
  * querySelectorAllFilter implements querySelectorAll on the virtual DOM with
  * ability to filter the returned nodes using an optional supplied filter function
  *
- * @method querySelectorAll
+ * @method querySelectorAllFilter
  * @memberof axe.utils
  * @instance
  * @param  {NodeList} domTree flattened tree collection to search
  * @param  {String} selector String containing one or more CSS selectors separated by commas
  * @param  {Function} filter function (optional)
- * @return {NodeList} Elements matched by any of the selectors and filtered by the filter function
+ * @return {Array} Elements matched by any of the selectors and filtered by the filter function
  */
 
 axe.utils.querySelectorAllFilter = function (domTree, selector, filter) {
@@ -280,5 +280,5 @@ axe.utils.querySelectorAllFilter = function (domTree, selector, filter) {
 	var expressions = axe.utils.cssParser.parse(selector);
 	expressions = expressions.selectors ? expressions.selectors : [expressions];
 	expressions = convertExpressions(expressions);
-	return matchExpressions(domTree, expressions, true, domTree[0].shadowId, filter);
+	return matchExpressions(domTree, expressions, true, filter);
 };

--- a/lib/core/utils/qsa.js
+++ b/lib/core/utils/qsa.js
@@ -29,34 +29,13 @@ function matchesPseudos (target, exp) {
 
 	if (!exp.pseudos || exp.pseudos.reduce((result, pseudo) => {
 		if (pseudo.name === 'not') {
-			return result && !matchExpressions([target], pseudo.expressions, false).length;
+			return result && !matchExpressions([target], pseudo.expressions, false, target.shadowId).length;
 		}
 		throw new Error('the pseudo selector ' + pseudo.name + ' has not yet been implemented');
 	}, true)) {
 		return true;
 	}
 	return false;
-}
-
-function matchSelector (targets, exp, recurse) {
-	var result = [];
-
-	targets = Array.isArray(targets) ? targets : [targets];
-	targets.forEach((target) => {
-		if (matchesTag(target.actualNode, exp) &&
-				matchesClasses(target.actualNode, exp) &&
-				matchesAttributes(target.actualNode, exp) &&
-				matchesId(target.actualNode, exp) &&
-				matchesPseudos(target, exp)) {
-			result.push(target);
-		}
-		if (recurse) {
-			result = result.concat(matchSelector(target.children.filter((child) => {
-				return !exp.id || child.shadowId === target.shadowId;
-			}), exp, recurse));
-		}
-	});
-	return result;
 }
 
 var escapeRegExp = (function(){
@@ -194,27 +173,80 @@ convertExpressions = function (expressions) {
 	});
 };
 
-matchExpressions = function  (domTree, expressions, recurse) {
-	return expressions.reduce((collected, exprArr) => {
-		var candidates = domTree;
-		exprArr.forEach((exp, index) => {
-			recurse = exp.combinator === '>' ? false : recurse;
-			if ([' ', '>'].includes(exp.combinator) === false) {
-				throw new Error('axe.utils.querySelectorAll does not support the combinator: ' + exp.combinator);
-			}
-			candidates = candidates.reduce((result, node) => {
-				return result.concat(matchSelector(index ? node.children : node, exp, recurse));
-			}, []);
-		});
+function createLocalVariables (nodes, anyLevel, thisLevel, parentShadowId) {
+	let retVal = {
+		nodes: nodes.slice(),
+		anyLevel: anyLevel,
+		thisLevel: thisLevel,
+		parentShadowId: parentShadowId
+	};
+	retVal.nodes.reverse();
+	return retVal;
+}
 
-		// Ensure elements aren't added multiple times
-		return candidates.reduce((collected, candidate) => {
-			if (collected.includes(candidate) === false) {
-				collected.push(candidate);
+function matchesSelector (node, exp) {
+	return (matchesTag(node.actualNode, exp[0]) &&
+			matchesClasses(node.actualNode, exp[0]) &&
+			matchesAttributes(node.actualNode, exp[0]) &&
+			matchesId(node.actualNode, exp[0]) &&
+			matchesPseudos(node, exp[0])
+		);
+}
+
+matchExpressions = function  (domTree, expressions, recurse, parentShadowId, filter) {
+	//jshint maxstatements:34
+	//jshint maxcomplexity:15
+	let stack = [];
+	let nodes = Array.isArray(domTree) ? domTree : [domTree];
+	let currentLevel = createLocalVariables(nodes, expressions, [], parentShadowId);
+	let result = [];
+
+	while (currentLevel.nodes.length) {
+		let node = currentLevel.nodes.pop();
+		let childOnly = []; // we will add hierarchical '>' selectors here
+		let childAny = [];
+		let combined = currentLevel.anyLevel.slice().concat(currentLevel.thisLevel);
+		let added = false;
+		// see if node matches
+		for ( let i = 0; i < combined.length; i++) {
+			let exp = combined[i];
+			if (matchesSelector(node, exp) &&
+				(!exp[0].id || node.shadowId === currentLevel.parentShadowId)) {
+				if (exp.length === 1) {
+					if (!added && (!filter || filter(node))) {
+						result.push(node);
+						added = true;
+					}
+				} else {
+					let rest = exp.slice(1);
+					if ([' ', '>'].includes(rest[0].combinator) === false) {
+						throw new Error('axe.utils.querySelectorAll does not support the combinator: ' + exp[1].combinator);
+					}
+					if (rest[0].combinator === '>') {
+						// add the rest to the childOnly array
+						childOnly.push(rest);
+					} else {
+						// add the rest to the childAny array
+						childAny.push(rest);
+					}
+				}
 			}
-			return collected;
-		}, collected);
-	}, []);
+			if (currentLevel.anyLevel.includes(exp) &&
+				(!exp[0].id || node.shadowId === currentLevel.parentShadowId)) {
+				childAny.push(exp);
+			}
+		}
+		// "recurse"
+		if (node.children && node.children.length && recurse) {
+			stack.push(currentLevel);
+			currentLevel = createLocalVariables(node.children, childAny, childOnly, node.shadowId);
+		}
+		// check for "return"
+		while (!currentLevel.nodes.length && stack.length) {
+			currentLevel = stack.pop();
+		}
+	}
+	return result;
 };
 
 /**
@@ -227,9 +259,26 @@ matchExpressions = function  (domTree, expressions, recurse) {
  * @return {NodeList} Elements matched by any of the selectors
  */
 axe.utils.querySelectorAll = function (domTree, selector) {
+	return axe.utils.querySelectorAllFilter(domTree, selector);
+};
+
+/**
+ * querySelectorAllFilter implements querySelectorAll on the virtual DOM with
+ * ability to filter the returned nodes using an optional supplied filter function
+ *
+ * @method querySelectorAll
+ * @memberof axe.utils
+ * @instance
+ * @param  {NodeList} domTree flattened tree collection to search
+ * @param  {String} selector String containing one or more CSS selectors separated by commas
+ * @param  {Function} filter function (optional)
+ * @return {NodeList} Elements matched by any of the selectors and filtered by the filter function
+ */
+
+axe.utils.querySelectorAllFilter = function (domTree, selector, filter) {
 	domTree = Array.isArray(domTree) ? domTree : [domTree];
 	var expressions = axe.utils.cssParser.parse(selector);
 	expressions = expressions.selectors ? expressions.selectors : [expressions];
 	expressions = convertExpressions(expressions);
-	return matchExpressions(domTree, expressions, true);
+	return matchExpressions(domTree, expressions, true, domTree[0].shadowId, filter);
 };

--- a/lib/core/utils/select.js
+++ b/lib/core/utils/select.js
@@ -45,16 +45,10 @@ function isNodeInContext(node, context) {
  * @param  {Array} nodes   The list of nodes to push
  * @param  {Object} context The "resolved" context object, @see resolveContext
  */
-function pushNode(result, nodes, context) {
+function pushNode(result, nodes) {
 	'use strict';
 
 	var temp;
-	var curried = (function (context) {
-		return function (node) {
-			return isNodeInContext(node, context);
-		};
-	})(context);
-	nodes = nodes.filter(curried);
 
 	if (result.length === 0) {
 		return nodes;
@@ -96,6 +90,7 @@ function hasOverlappingIncludes(includes) {
  * @return {Array}            Matching virtual DOM nodes sorted by DOM order
  */
 axe.utils.select = function select(selector, context) {
+	//jshint maxstatements:20
 	'use strict';
 
 	var result = [], candidate;
@@ -103,16 +98,37 @@ axe.utils.select = function select(selector, context) {
 		context.include = Array.from(context.include);
 	}
 	context.include.sort(axe.utils.nodeSorter); // ensure that the order of the include nodes is document order
-	for (var i = 0, l = context.include.length; i < l; i++) {
+	if (axe._selectCache) { // if used outside of run, it will still work
+		for (var j = 0, l = axe._selectCache.length; j < l; j++) {
+			// First see whether the item exists in the cache
+			let item = axe._selectCache[j];
+			if (item.selector === selector) {
+				return item.result;
+			}
+		}	
+	}
+	var curried = (function (context) {
+		return function (node) {
+			return isNodeInContext(node, context);
+		};
+	})(context);
+	for (var i = 0; i < context.include.length; i++) {
 		candidate = context.include[i];
 		if (candidate.actualNode.nodeType === candidate.actualNode.ELEMENT_NODE &&
-			axe.utils.matchesSelector(candidate.actualNode, selector)) {
-			result = pushNode(result, [candidate], context);
+			axe.utils.matchesSelector(candidate.actualNode, selector) &&
+			curried(candidate)) {
+			result = pushNode(result, [candidate]);
 		}
-		result = pushNode(result, axe.utils.querySelectorAll(candidate, selector), context);
+		result = pushNode(result, axe.utils.querySelectorAllFilter(candidate, selector, curried));
 	}
 	if (context.include.length > 1 && hasOverlappingIncludes(context.include)) {
 		result.sort(axe.utils.nodeSorter);
+	}
+	if (axe._selectCache) {
+		axe._selectCache.push({
+			selector: selector,
+			result: result
+		});
 	}
 	return result;
 };

--- a/lib/core/utils/select.js
+++ b/lib/core/utils/select.js
@@ -74,6 +74,22 @@ function pushNode(result, nodes, context) {
 }
 
 /**
+ * returns true if any of the nodes in the list is a parent of another node in the list
+ * @param {Array} the array of include nodes
+ * @return {Boolean}
+ */
+function hasOverlappingIncludes(includes) {
+	let list = includes.slice();
+	while (list.length > 1) {
+		let last = list.pop();
+		if (list[list.length - 1].actualNode.contains(last.actualNode)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Selects elements which match `selector` that are included and excluded via the `Context` object
  * @param  {String} selector  CSS selector of the HTMLElements to select
  * @param  {Context} context  The "resolved" context object, @see Context
@@ -83,6 +99,10 @@ axe.utils.select = function select(selector, context) {
 	'use strict';
 
 	var result = [], candidate;
+	if (!Array.isArray(context.include)) {
+		context.include = Array.from(context.include);
+	}
+	context.include.sort(axe.utils.nodeSorter); // ensure that the order of the include nodes is document order
 	for (var i = 0, l = context.include.length; i < l; i++) {
 		candidate = context.include[i];
 		if (candidate.actualNode.nodeType === candidate.actualNode.ELEMENT_NODE &&
@@ -91,6 +111,8 @@ axe.utils.select = function select(selector, context) {
 		}
 		result = pushNode(result, axe.utils.querySelectorAll(candidate, selector), context);
 	}
-
-	return result.sort(axe.utils.nodeSorter);
+	if (context.include.length > 1 && hasOverlappingIncludes(context.include)) {
+		result.sort(axe.utils.nodeSorter);
+	}
+	return result;
 };

--- a/lib/core/utils/select.js
+++ b/lib/core/utils/select.js
@@ -68,19 +68,17 @@ function pushNode(result, nodes) {
 }
 
 /**
- * returns true if any of the nodes in the list is a parent of another node in the list
+ * reduces the includes list to only the outermost includes
  * @param {Array} the array of include nodes
- * @return {Boolean}
+ * @return {Array} the modified array of nodes
  */
-function hasOverlappingIncludes(includes) {
-	let list = includes.slice();
-	while (list.length > 1) {
-		let last = list.pop();
-		if (list[list.length - 1].actualNode.contains(last.actualNode)) {
-			return true;
+function reduceIncludes(includes) {
+	return includes.reduce((res, el) => {
+		if (!res.length || !res[res.length - 1].actualNode.contains(el.actualNode)) {
+			res.push(el);
 		}
-	}
-	return false;
+		return res;
+	}, []);
 }
 
 /**
@@ -94,10 +92,6 @@ axe.utils.select = function select(selector, context) {
 	'use strict';
 
 	var result = [], candidate;
-	if (!Array.isArray(context.include)) {
-		context.include = Array.from(context.include);
-	}
-	context.include.sort(axe.utils.nodeSorter); // ensure that the order of the include nodes is document order
 	if (axe._selectCache) { // if used outside of run, it will still work
 		for (var j = 0, l = axe._selectCache.length; j < l; j++) {
 			// First see whether the item exists in the cache
@@ -112,17 +106,15 @@ axe.utils.select = function select(selector, context) {
 			return isNodeInContext(node, context);
 		};
 	})(context);
-	for (var i = 0; i < context.include.length; i++) {
-		candidate = context.include[i];
+	var reducedIncludes = reduceIncludes(context.include);
+	for (var i = 0; i < reducedIncludes.length; i++) {
+		candidate = reducedIncludes[i];
 		if (candidate.actualNode.nodeType === candidate.actualNode.ELEMENT_NODE &&
 			axe.utils.matchesSelector(candidate.actualNode, selector) &&
 			curried(candidate)) {
 			result = pushNode(result, [candidate]);
 		}
 		result = pushNode(result, axe.utils.querySelectorAllFilter(candidate, selector, curried));
-	}
-	if (context.include.length > 1 && hasOverlappingIncludes(context.include)) {
-		result.sort(axe.utils.nodeSorter);
 	}
 	if (axe._selectCache) {
 		axe._selectCache.push({

--- a/lib/rules/heading-order.json
+++ b/lib/rules/heading-order.json
@@ -1,6 +1,6 @@
 {
   "id": "heading-order",
-  "selector": "h1,h2,h3,h4,h5,h6,[role=heading]",
+  "selector": "h1, h2, h3, h4, h5, h6, [role=heading]",
   "tags": [
     "cat.semantics",
     "best-practice"

--- a/lib/rules/landmark-main-is-top-level.json
+++ b/lib/rules/landmark-main-is-top-level.json
@@ -1,6 +1,6 @@
 {
   "id": "landmark-main-is-top-level",
-  "selector": "main,[role=main]",
+  "selector": "main, [role=main]",
   "tags": [
 	"best-practice"
   ],

--- a/lib/rules/link-in-text-block.json
+++ b/lib/rules/link-in-text-block.json
@@ -1,6 +1,6 @@
 {
   "id": "link-in-text-block",
-  "selector": "a[href], *[role=link]",
+  "selector": "a[href], [role=link]",
   "matches": "link-in-text-block-matches.js",
   "excludeHidden": false,
   "tags": [

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -64,6 +64,7 @@ describe('Audit', function () {
 	afterEach(function () {
 		fixture.innerHTML = '';
 		axe._tree = undefined;
+		axe._selectCache = undefined;
 		axe.utils.getFlattenedTree = getFlattenedTree;
 	});
 
@@ -479,6 +480,54 @@ describe('Audit', function () {
 				rules: {}
 			}, function () {
 				assert.isTrue(called);
+				axe.utils.getFlattenedTree = getFlattenedTree;
+				done();
+			}, isNotCalled);
+		});
+		it('should assign the result of getFlattenedTree to axe._tree', function (done) {
+			var thing = 'honey badger';
+			var saved = axe.utils.ruleShouldRun;
+			axe.utils.ruleShouldRun = function () {
+				assert.equal(axe._tree, thing);
+				return false;
+			};
+			axe.utils.getFlattenedTree = function () {
+				return thing;
+			};
+			a.run({ include: [document] }, {}, function () {
+				axe.utils.ruleShouldRun = saved;
+				done();
+			}, isNotCalled);
+		});
+		it('should clear axe._tree', function (done) {
+			var thing = 'honey badger';
+			axe.utils.getFlattenedTree = function () {
+				return thing;
+			};
+			a.run({ include: [document] }, {
+				rules: {}
+			}, function () {
+				assert.isTrue(typeof axe._tree === 'undefined');
+				axe.utils.getFlattenedTree = getFlattenedTree;
+				done();
+			}, isNotCalled);
+		});
+		it('should assign an empty array to axe._selectCache', function (done) {
+			var saved = axe.utils.ruleShouldRun;
+			axe.utils.ruleShouldRun = function () {
+				assert.equal(axe._selectCache.length, 0);
+				return false;
+			};
+			a.run({ include: [document] }, {}, function () {
+				axe.utils.ruleShouldRun = saved;
+				done();
+			}, isNotCalled);
+		});
+		it('should clear axe._selectCache', function (done) {
+			a.run({ include: [document] }, {
+				rules: {}
+			}, function () {
+				assert.isTrue(typeof axe._selectCache === 'undefined');
 				done();
 			}, isNotCalled);
 		});

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -98,6 +98,19 @@ describe('Context', function() {
 				[$id('foo'), $id('bar')]);
 		});
 
+		it('should sort the include nodes in document order', function() {
+			fixture.innerHTML = '<div id="foo"><div id="bar"></div></div><div id="baz"></div>';
+
+			var result = new Context([
+				['#foo'],
+				['#baz'],
+				['#bar']
+			]);
+
+			assert.deepEqual(result.include.map(function (n) { return n.actualNode; }),
+				[$id('foo'), $id('bar'), $id('baz')]);
+		});
+
 		it('should remove any null reference', function() {
 			fixture.innerHTML = '<div id="foo"><div id="bar"></div></div>';
 

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -521,9 +521,18 @@ describe('Rule', function() {
 							evaluate: function() {},
 							id: 'cats'
 						}]
+					}, {
+						checks: {
+							cats: {
+								run: function (node, options, resolve) {
+									success = true;
+									resolve(true);
+								}
+							}
+						}
 					});
 					rule.run({
-						include: axe.utils.getFlattenedTree(document)[0]
+						include: [axe.utils.getFlattenedTree(document)[0]]
 					}, {}, noop, isNotCalled);
 					assert.isTrue(success);
 
@@ -538,9 +547,18 @@ describe('Rule', function() {
 							evaluate: function() {},
 							id: 'cats'
 						}]
+					}, {
+						checks: {
+							cats: {
+								run: function (node, options, resolve) {
+									success = true;
+									resolve(true);
+								}
+							}
+						}
 					});
 					rule.run({
-						include: axe.utils.getFlattenedTree(document)[0]
+						include: [axe.utils.getFlattenedTree(document)[0]]
 					}, {}, function() {
 						success = true;
 					}, isNotCalled);

--- a/test/core/utils/qsa.js
+++ b/test/core/utils/qsa.js
@@ -109,6 +109,10 @@ describe('axe.utils.querySelectorAll', function () {
 		var result = axe.utils.querySelectorAll(dom, '#one');
 		assert.equal(result.length, 1);
 	});
+	it('should find nodes using id, but not in shadow DOM', function () {
+		var result = axe.utils.querySelectorAll(dom[0].children[0], '#one');
+		assert.equal(result.length, 1);
+	});
 	it('should find nodes using id, within a shadow DOM', function () {
 		var result = axe.utils.querySelectorAll(dom[0].children[0].children[2], '#one');
 		assert.equal(result.length, 1);
@@ -181,5 +185,11 @@ describe('axe.utils.querySelectorAll', function () {
 
 		assert.isBelow(divOnes.length, divs.length + ones.length,
 			'Elements matching both parts of a selector should not be included twice');
+	});
+	it('should return nodes sorted by document position', function () {
+		var result = axe.utils.querySelectorAll(dom, 'ul, #one');
+		assert.equal(result[0].actualNode.nodeName, 'UL');
+		assert.equal(result[1].actualNode.nodeName, 'DIV');
+		assert.equal(result[2].actualNode.nodeName, 'UL');
 	});
 });

--- a/test/core/utils/qsa.js
+++ b/test/core/utils/qsa.js
@@ -15,13 +15,9 @@ Vnode.prototype.getAttribute = function (att) {
 	return attribute ? attribute.value : null;
 };
 
-describe('axe.utils.querySelectorAll', function () {
+function getTestDom() {
 	'use strict';
-	var dom;
-	afterEach(function () {
-	});
-	beforeEach(function () {
-		dom = [{
+	return [{
 			actualNode: new Vnode('html'),
 			children: [{
 				actualNode: new Vnode('body'),
@@ -72,124 +68,153 @@ describe('axe.utils.querySelectorAll', function () {
 				}]
 			}]
 		}];
+}
+
+describe('axe.utils.querySelectorAllFilter', function () {
+	'use strict';
+	var dom;
+	afterEach(function () {
+	});
+	beforeEach(function () {
+		dom = getTestDom();
 	});
 	it('should find nodes using just the tag', function () {
-		var result = axe.utils.querySelectorAll(dom, 'li');
+		var result = axe.utils.querySelectorAllFilter(dom, 'li');
 		assert.equal(result.length, 4);
 	});
 	it('should find nodes using parent selector', function () {
-		var result = axe.utils.querySelectorAll(dom, 'ul > li');
+		var result = axe.utils.querySelectorAllFilter(dom, 'ul > li');
 		assert.equal(result.length, 4);
 	});
 	it('should NOT find nodes using parent selector', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div > li');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div > li');
 		assert.equal(result.length, 0);
 	});
 	it('should find nodes using hierarchical selector', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div li');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div li');
 		assert.equal(result.length, 4);
 	});
 	it('should find nodes using class selector', function () {
-		var result = axe.utils.querySelectorAll(dom, '.breaking');
+		var result = axe.utils.querySelectorAllFilter(dom, '.breaking');
 		assert.equal(result.length, 2);
 	});
 	it('should find nodes using hierarchical class selector', function () {
-		var result = axe.utils.querySelectorAll(dom, '.first .breaking');
+		var result = axe.utils.querySelectorAllFilter(dom, '.first .breaking');
 		assert.equal(result.length, 2);
 	});
 	it('should NOT find nodes using hierarchical class selector', function () {
-		var result = axe.utils.querySelectorAll(dom, '.second .breaking');
+		var result = axe.utils.querySelectorAllFilter(dom, '.second .breaking');
 		assert.equal(result.length, 0);
 	});
 	it('should find nodes using multiple class selector', function () {
-		var result = axe.utils.querySelectorAll(dom, '.second.third');
+		var result = axe.utils.querySelectorAllFilter(dom, '.second.third');
 		assert.equal(result.length, 1);
 	});
 	it('should find nodes using id', function () {
-		var result = axe.utils.querySelectorAll(dom, '#one');
+		var result = axe.utils.querySelectorAllFilter(dom, '#one');
 		assert.equal(result.length, 1);
 	});
 	it('should find nodes using id, but not in shadow DOM', function () {
-		var result = axe.utils.querySelectorAll(dom[0].children[0], '#one');
+		var result = axe.utils.querySelectorAllFilter(dom[0].children[0], '#one');
 		assert.equal(result.length, 1);
 	});
 	it('should find nodes using id, within a shadow DOM', function () {
-		var result = axe.utils.querySelectorAll(dom[0].children[0].children[2], '#one');
+		var result = axe.utils.querySelectorAllFilter(dom[0].children[0].children[2], '#one');
 		assert.equal(result.length, 1);
 	});
 	it('should find nodes using attribute', function () {
-		var result = axe.utils.querySelectorAll(dom, '[role]');
+		var result = axe.utils.querySelectorAllFilter(dom, '[role]');
 		assert.equal(result.length, 2);
 	});
 	it('should find nodes using attribute with value', function () {
-		var result = axe.utils.querySelectorAll(dom, '[role=tab]');
+		var result = axe.utils.querySelectorAllFilter(dom, '[role=tab]');
 		assert.equal(result.length, 1);
 	});
 	it('should find nodes using attribute with value', function () {
-		var result = axe.utils.querySelectorAll(dom, '[role="button"]');
+		var result = axe.utils.querySelectorAllFilter(dom, '[role="button"]');
 		assert.equal(result.length, 1);
 	});
 	it('should find nodes using parent attribute with value', function () {
-		var result = axe.utils.querySelectorAll(dom, '[data-a11yhero="faulkner"] > ul');
+		var result = axe.utils.querySelectorAllFilter(dom, '[data-a11yhero="faulkner"] > ul');
 		assert.equal(result.length, 1);
 	});
 	it('should find nodes using hierarchical attribute with value', function () {
-		var result = axe.utils.querySelectorAll(dom, '[data-a11yhero="faulkner"] li');
+		var result = axe.utils.querySelectorAllFilter(dom, '[data-a11yhero="faulkner"] li');
 		assert.equal(result.length, 2);
 	});
 	it('should find nodes using :not selector with class', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not(.first)');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not(.first)');
 		assert.equal(result.length, 2);
 	});
 	it('should find nodes using :not selector with matching id', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not(#one)');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not(#one)');
 		assert.equal(result.length, 2);
 	});
 	it('should find nodes using :not selector with matching attribute selector', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not([data-a11yhero])');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not([data-a11yhero])');
 		assert.equal(result.length, 2);
 	});
 	it('should find nodes using :not selector with matching attribute selector with value', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not([data-a11yhero=faulkner])');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not([data-a11yhero=faulkner])');
 		assert.equal(result.length, 2);
 	});
 	it('should find nodes using :not selector with bogus attribute selector with value', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not([data-a11yhero=wilco])');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not([data-a11yhero=wilco])');
 		assert.equal(result.length, 3);
 	});
 	it('should find nodes using :not selector with bogus id', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not(#thangy)');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not(#thangy)');
 		assert.equal(result.length, 3);
 	});
 	it('should find nodes hierarchically using :not selector', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not(.first) li');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not(.first) li');
 		assert.equal(result.length, 2);
 	});
 	it('should find same nodes hierarchically using more :not selector', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not(.first) li:not(.breaking)');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not(.first) li:not(.breaking)');
 		assert.equal(result.length, 2);
 	});
 	it('should NOT find nodes hierarchically using :not selector', function () {
-		var result = axe.utils.querySelectorAll(dom, 'div:not(.second) li:not(.breaking)');
+		var result = axe.utils.querySelectorAllFilter(dom, 'div:not(.second) li:not(.breaking)');
 		assert.equal(result.length, 0);
 	});
 	it('should put it all together', function () {
-		var result = axe.utils.querySelectorAll(dom,
+		var result = axe.utils.querySelectorAllFilter(dom,
 			'.first[data-a11yhero="faulkner"] > ul li.breaking');
 		assert.equal(result.length, 2);
 	});
 	it('should find an element only once', function () {
-		var divs = axe.utils.querySelectorAll(dom, 'div');
-		var ones = axe.utils.querySelectorAll(dom, '#one');
-		var divOnes = axe.utils.querySelectorAll(dom, 'div, #one');
+		var divs = axe.utils.querySelectorAllFilter(dom, 'div');
+		var ones = axe.utils.querySelectorAllFilter(dom, '#one');
+		var divOnes = axe.utils.querySelectorAllFilter(dom, 'div, #one');
 
 		assert.isBelow(divOnes.length, divs.length + ones.length,
 			'Elements matching both parts of a selector should not be included twice');
 	});
 	it('should return nodes sorted by document position', function () {
-		var result = axe.utils.querySelectorAll(dom, 'ul, #one');
+		var result = axe.utils.querySelectorAllFilter(dom, 'ul, #one');
 		assert.equal(result[0].actualNode.nodeName, 'UL');
 		assert.equal(result[1].actualNode.nodeName, 'DIV');
 		assert.equal(result[2].actualNode.nodeName, 'UL');
+	});
+	it('should filter the returned nodes when passed a filter function', function () {
+		var result = axe.utils.querySelectorAllFilter(dom, 'ul, #one', function (node) {
+			return node.actualNode.nodeName !== 'UL';
+		});
+		assert.equal(result[0].actualNode.nodeName, 'DIV');
+		assert.equal(result.length, 1);
+	});
+});
+describe('axe.utils.querySelectorAll', function () {
+	'use strict';
+	it('should call axe.utils.querySelectorAllFilter', function () {
+		var saved = axe.utils.querySelectorAllFilter;
+		var called = false;
+		axe.utils.querySelectorAllFilter = function () {
+			called = true;
+		};
+		axe.utils.querySelectorAll();
+		assert.isTrue(called);
+		axe.utils.querySelectorAllFilter = saved;
 	});
 });

--- a/test/core/utils/select.js
+++ b/test/core/utils/select.js
@@ -10,6 +10,7 @@ describe('axe.utils.select', function () {
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		axe._selectCache = undefined;
 	});
 
 
@@ -148,6 +149,17 @@ describe('axe.utils.select', function () {
 		assert.equal(result.length, 3);
 
 	});
+	it ('should return the cached result if one exists', function () {
+		fixture.innerHTML = '<div id="zero"><div id="one"><div id="target1" class="bananas"></div></div>' +
+			'<div id="two"><div id="target2" class="bananas"></div></div></div>';
 
+		axe._selectCache = [{
+			selector: '.bananas',
+			result: 'fruit bat'
+		}];
+		var result = axe.utils.select('.bananas', { include: [axe.utils.getFlattenedTree($id('zero'))[0]] });
+		assert.equal(result, 'fruit bat');
+
+	});
 
 });

--- a/test/core/utils/select.js
+++ b/test/core/utils/select.js
@@ -125,30 +125,19 @@ describe('axe.utils.select', function () {
 
 	});
 
-	it('should sort by DOM order', function () {
-		fixture.innerHTML = '<div id="one"><div id="target1" class="bananas"></div></div>' +
-			'<div id="two"><div id="target2" class="bananas"></div></div>';
-
-		var result = axe.utils.select('.bananas', { include: [axe.utils.getFlattenedTree($id('two'))[0],
-			axe.utils.getFlattenedTree($id('one'))[0]] });
-
-		assert.deepEqual(result.map(function (n) { return n.actualNode; }),
-			[$id('target1'), $id('target2')]);
-
-	});
-
-	it('should sort by DOM order on overlapping elements', function () {
+	it('should not return duplicates on overlapping includes', function () {
 		fixture.innerHTML = '<div id="zero"><div id="one"><div id="target1" class="bananas"></div></div>' +
 			'<div id="two"><div id="target2" class="bananas"></div></div></div>';
 
-		var result = axe.utils.select('.bananas', { include: [axe.utils.getFlattenedTree($id('one'))[0],
-			axe.utils.getFlattenedTree($id('zero'))[0]] });
+		var result = axe.utils.select('.bananas', { include: [axe.utils.getFlattenedTree($id('zero'))[0],
+				axe.utils.getFlattenedTree($id('one'))[0]] });
 
 		assert.deepEqual(result.map(function (n) { return n.actualNode; }),
-			[$id('target1'), $id('target1'), $id('target2')]);
-		assert.equal(result.length, 3);
+			[$id('target1'), $id('target2')]);
+		assert.equal(result.length, 2);
 
 	});
+
 	it ('should return the cached result if one exists', function () {
 		fixture.innerHTML = '<div id="zero"><div id="one"><div id="target1" class="bananas"></div></div>' +
 			'<div id="two"><div id="target2" class="bananas"></div></div></div>';

--- a/test/core/utils/select.js
+++ b/test/core/utils/select.js
@@ -136,6 +136,18 @@ describe('axe.utils.select', function () {
 
 	});
 
+	it('should sort by DOM order on overlapping elements', function () {
+		fixture.innerHTML = '<div id="zero"><div id="one"><div id="target1" class="bananas"></div></div>' +
+			'<div id="two"><div id="target2" class="bananas"></div></div></div>';
+
+		var result = axe.utils.select('.bananas', { include: [axe.utils.getFlattenedTree($id('one'))[0],
+			axe.utils.getFlattenedTree($id('zero'))[0]] });
+
+		assert.deepEqual(result.map(function (n) { return n.actualNode; }),
+			[$id('target1'), $id('target1'), $id('target2')]);
+		assert.equal(result.length, 3);
+
+	});
 
 
 });


### PR DESCRIPTION
Improve the performance of `axe.utils.select`

This gets rid of the need for a sort in all instances except when there is an overlapping include context
Memoizes select so that subsequent calls to `axe.utils.select` from within `Audit.run` will return the cached results