### PR TITLE
test: upgrade to CircleCI 2.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,13 @@
-machine:
-  node:
-    version: v6.1.0
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6.12.3-browsers
+    steps:
+      - checkout
+      - run:
+          name: install-npm
+          command: npm install
+      - run:
+          name: test
+          command: npm test


### PR DESCRIPTION
 It's time to upgrade Circle, as "end of 1.0 is on the horizon." Documentation is no longer being updated for 1.0 which makes debugging more difficult. The new system is more containerized with Docker and gives you finer granularity over all the steps. 

Geckodriver didn't work for some reason, but Chromedriver did with the `6.12.3-browsers` node image. It fixed the `chrome:mobile` test failures I saw in #711. https://hub.docker.com/r/circleci/node/tags/ 

Closes https://github.com/dequelabs/axe-core/issues/717