### PR TITLE
Add github templates for issues and PRs

### DIFF
--- a/doc/.github/ISSUE_TEMPLATE.md
+++ b/doc/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Thanks for reporting an issue to axe-core. Please provide all necessary info to reproduce the issue. Without adequate details, your issue may be closed without investigation. -->
+
+## Issue Description
+<!-- Basic description of the problem. Is it a false positive? Feature request? -->
+
+### Current Behavior
+<!-- Describe how the issue manifests. -->
+
+### Expected Behavior
+<!-- Describe what the desired behavior would be. -->
+
+### Steps to reproduce the behavior
+<!--
+Please provide the *STEPS TO REPRODUCE* and if possible, a *MINIMAL DEMO* of the problem via Codepen, jsbin, Plunkr or similar.
+-->
+
+<pre><code>
+axe-core version: X.Y.Z
+axe-webdriver, extension or other integration version: X.Y.Z
+
+Browser and Assistive Technology versions
+
+For Tooling issues:
+- Node version: XX  <!-- run `node --version` -->
+- Platform:  <!-- Mac, Linux, Windows -->
+</code></pre>

--- a/doc/.github/ISSUE_TEMPLATE.md
+++ b/doc/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
 <!-- Describe how the issue manifests. -->
 
 ### Expected Behavior
-<!-- Describe what the desired behavior would be. -->
+<!-- Describe what the desired behavior would be, and how it applies to "Accessibility Supported" https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md -->
 
 ### Steps to reproduce the behavior
 <!--

--- a/doc/.github/ISSUE_TEMPLATE.md
+++ b/doc/.github/ISSUE_TEMPLATE.md
@@ -1,18 +1,11 @@
-<!-- Thanks for reporting an issue to axe-core. Please provide all necessary info to reproduce the issue. Without adequate details, your issue may be closed without investigation. -->
+<!-- Thanks for reporting an issue to axe-core. Please provide all necessary info to reproduce the issue. Without adequate details, your issue may be closed without investigation. 
 
-## Issue Description
-<!-- Basic description of the problem. Is it a false positive? Feature request? -->
+If you’re reporting a bug, include a description of the issue and a page or code snippet where it can be reproduced. Please make sure you have tested this with the latest version of axe-core. When proposing a new rule, please use our rule template: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-proposal.md
 
-### Current Behavior
-<!-- Describe how the issue manifests. -->
-
-### Expected Behavior
-<!-- Describe what the desired behavior would be, and how it applies to "Accessibility Supported" https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md -->
-
-### Steps to reproduce the behavior
-<!--
-Please provide the *STEPS TO REPRODUCE* and if possible, a *MINIMAL DEMO* of the problem via Codepen, jsbin, Plunkr or similar.
+Describe what the desired behavior would be, and how it applies to axe-core's  "Accessibility Supported" policy: https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md
 -->
+
+- Link to live demo:
 
 <pre><code>
 axe-core version: X.Y.Z

--- a/doc/.github/PULL_REQUEST_TEMPLATE.md
+++ b/doc/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,24 +2,10 @@
 Please check if your PR fulfills the following requirements:
 
 - [ ] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
+- [ ] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-
-## PR Type
-What kind of change does this PR introduce?
-
-<!-- Please check the one that applies to this PR using "x". -->
-```
-[ ] Bugfix
-[ ] Feature
-[ ] Code style update (formatting, local variables)
-[ ] Refactoring (no functional changes, no api changes)
-[ ] Build/infrastructure related changes
-[ ] CI related changes
-[ ] Documentation content changes
-[ ] Other... Please describe:
-```
 
 ## What is the current behavior?
 <!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

--- a/doc/.github/PULL_REQUEST_TEMPLATE.md
+++ b/doc/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,17 +3,12 @@ Please check if your PR fulfills the following requirements:
 
 - [ ] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
 - [ ] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
+- [ ] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-
-## What is the current behavior?
-<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
-
-Issue Number: N/A
-
-
-## What is the new behavior?
+## Description of the changes
+- Github issue:
 
 
 ## Does this PR introduce a breaking change?

--- a/doc/.github/PULL_REQUEST_TEMPLATE.md
+++ b/doc/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## PR Checklist
+Please check if your PR fulfills the following requirements:
+
+- [ ] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+## PR Type
+What kind of change does this PR introduce?
+
+<!-- Please check the one that applies to this PR using "x". -->
+```
+[ ] Bugfix
+[ ] Feature
+[ ] Code style update (formatting, local variables)
+[ ] Refactoring (no functional changes, no api changes)
+[ ] Build/infrastructure related changes
+[ ] CI related changes
+[ ] Documentation content changes
+[ ] Other... Please describe:
+```
+
+## What is the current behavior?
+<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
+
+Issue Number: N/A
+
+
+## What is the new behavior?
+
+
+## Does this PR introduce a breaking change?
+```
+[ ] Yes
+[ ] No
+```
+
+
+## Other information


### PR DESCRIPTION
We have to repeat ourselves a lot in issues and PRs, so it makes sense to add Github templates that point out common things (commit policy, accessibility supported, axe-core/integration versions, etc.). I started with the Angular templates so we may want to make additional changes. I'm open to suggestions!