### PR TITLE
Update remaining checks to support Shadow DOM

### DIFF
--- a/lib/checks/keyboard/focusable-no-name.js
+++ b/lib/checks/keyboard/focusable-no-name.js
@@ -3,4 +3,4 @@ var tabIndex = node.getAttribute('tabindex'),
 if (!inFocusOrder) {
 	return false;
 }
-return !axe.commons.text.accessibleText(node);
+return !axe.commons.text.accessibleTextVirtual(virtualNode);

--- a/lib/checks/label/implicit.js
+++ b/lib/checks/label/implicit.js
@@ -1,6 +1,6 @@
 
 var label = axe.commons.dom.findUpVirtual(virtualNode, 'label');
 if (label) {
-	return !!axe.commons.text.accessibleText(label);
+	return !!axe.commons.text.accessibleTextVirtual(label);
 }
 return false;

--- a/lib/checks/navigation/header-present.js
+++ b/lib/checks/navigation/header-present.js
@@ -1,1 +1,1 @@
-return !!node.querySelector('h1, h2, h3, h4, h5, h6, [role="heading"]');
+return !!axe.utils.querySelectorAll(virtualNode, 'h1, h2, h3, h4, h5, h6, [role="heading"]')[0];

--- a/lib/checks/navigation/internal-link-present.js
+++ b/lib/checks/navigation/internal-link-present.js
@@ -1,1 +1,2 @@
-return !!node.querySelector('a[href^="#"]');
+const links = axe.utils.querySelectorAll(virtualNode, 'a[href]');
+return links.some(vLink => vLink.actualNode.getAttribute('href')[0] === '#');

--- a/lib/checks/shared/button-has-visible-text.js
+++ b/lib/checks/shared/button-has-visible-text.js
@@ -3,7 +3,7 @@ let role = node.getAttribute('role');
 let label;
 
 if (nodeName === 'BUTTON' || (role === 'button' && nodeName !== 'INPUT')) {
-	label = axe.commons.text.accessibleText(node);
+	label = axe.commons.text.accessibleTextVirtual(virtualNode);
 	this.data(label);
 
 	return !!label;

--- a/lib/checks/shared/has-visible-text.js
+++ b/lib/checks/shared/has-visible-text.js
@@ -1,1 +1,1 @@
-return axe.commons.text.accessibleText(node).length > 0;
+return axe.commons.text.accessibleTextVirtual(virtualNode).length > 0;

--- a/lib/checks/tables/same-caption-summary.js
+++ b/lib/checks/tables/same-caption-summary.js
@@ -1,1 +1,2 @@
+// passing node.caption to accessibleText instead of using the logic in accessibleTextVirtual on virtualNode
 return !!(node.summary && node.caption) && node.summary === axe.commons.text.accessibleText(node.caption);

--- a/test/checks/aria/allowed-attr.js
+++ b/test/checks/aria/allowed-attr.js
@@ -19,8 +19,6 @@ describe('aria-allowed-attr', function () {
 
 		assert.isFalse(checks['aria-allowed-attr'].evaluate.call(checkContext, node));
 		assert.deepEqual(checkContext._data, ['aria-selected="true"']);
-
-
 	});
 
 	it('should not report on required attributes', function () {
@@ -32,8 +30,6 @@ describe('aria-allowed-attr', function () {
 		fixture.appendChild(node);
 
 		assert.isTrue(checks['aria-allowed-attr'].evaluate.call(checkContext, node));
-
-
 	});
 
 	it('should detect incorrectly used attributes - implicit role', function () {
@@ -46,8 +42,6 @@ describe('aria-allowed-attr', function () {
 
 		assert.isFalse(checks['aria-allowed-attr'].evaluate.call(checkContext, node));
 		assert.deepEqual(checkContext._data, ['aria-selected="true"']);
-
-
 	});
 
 	it('should return true if there is no role', function () {
@@ -60,8 +54,6 @@ describe('aria-allowed-attr', function () {
 
 		assert.isTrue(checks['aria-allowed-attr'].evaluate.call(checkContext, node));
 		assert.isNull(checkContext._data);
-
-
 	});
 
 	it('should determine attribute validity by calling axe.commons.aria.allowedAttr', function () {
@@ -97,8 +89,6 @@ describe('aria-allowed-attr', function () {
 
 		assert.isTrue(checks['aria-allowed-attr'].evaluate.call(checkContext, node));
 		assert.isNull(checkContext._data);
-
-
 	});
 
 	it('should not report on allowed attributes', function () {

--- a/test/checks/aria/allowed-attr.js
+++ b/test/checks/aria/allowed-attr.js
@@ -2,17 +2,11 @@ describe('aria-allowed-attr', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should detect incorrectly used attributes', function () {

--- a/test/checks/aria/aria-hidden-body.js
+++ b/test/checks/aria/aria-hidden-body.js
@@ -2,16 +2,10 @@ describe('aria-hidden', function () {
 	'use strict';
 
 	var node = document.getElementsByTagName('body')[0];
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
-		checkContext._data = null;
+		checkContext.reset();
 		node.removeAttribute('aria-hidden');
 	});
 

--- a/test/checks/aria/errormessage.js
+++ b/test/checks/aria/errormessage.js
@@ -2,7 +2,8 @@ describe('aria-errormessage', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
@@ -45,5 +46,24 @@ describe('aria-errormessage', function () {
 		target.setAttribute('aria-errormessage', 'plain');
 		target.setAttribute('aria-describedby', 'plain');
 		assert.isTrue(checks['aria-errormessage'].evaluate.call(checkContext, target));
+	});
+
+	(shadowSupported ? it : xit)
+	('should return false if aria-errormessage value crosses shadow boundary', function () {
+		var params = shadowCheckSetup(
+			'<div id="target" aria-errormessage="live"></div>',
+			'<div id="live" aria-live="assertive"></div>'
+		);
+		assert.isFalse(checks['aria-errormessage'].evaluate.apply(checkContext, params));
+	});
+
+	(shadowSupported ? it : xit)
+	('should return true if aria-errormessage and value are inside shadow dom', function () {
+		var params = shadowCheckSetup(
+			'<div></div>',
+			'<div id="target" aria-errormessage="live"</div>' +
+			'<div id="live" aria-live="assertive"></div>'
+		);
+		assert.isTrue(checks['aria-errormessage'].evaluate.apply(checkContext, params));
 	});
 });

--- a/test/checks/aria/errormessage.js
+++ b/test/checks/aria/errormessage.js
@@ -7,7 +7,7 @@ describe('aria-errormessage', function () {
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return false if aria-errormessage value is invalid', function () {

--- a/test/checks/aria/required-attr.js
+++ b/test/checks/aria/required-attr.js
@@ -2,17 +2,11 @@ describe('aria-required-attr', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should detect missing attributes', function () {

--- a/test/checks/aria/required-children.js
+++ b/test/checks/aria/required-children.js
@@ -3,20 +3,13 @@ describe('aria-required-children', function () {
 
 	var fixture = document.getElementById('fixture');
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
-
+	var checkContext = axe.testUtils.MockCheckContext();
 	var checkSetup = axe.testUtils.checkSetup;
 
 	afterEach(function () {
 		fixture.innerHTML = '';
 		axe._tree = undefined;
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should detect missing sole required child', function () {

--- a/test/checks/aria/required-parent.js
+++ b/test/checks/aria/required-parent.js
@@ -3,19 +3,12 @@ describe('aria-required-parent', function () {
 
 	var fixture = document.getElementById('fixture');
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
-
+	var checkContext = axe.testUtils.MockCheckContext();
 	var checkSetup = axe.testUtils.checkSetup;
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 		axe._tree = undefined;
 	});
 

--- a/test/checks/aria/valid-attr-value.js
+++ b/test/checks/aria/valid-attr-value.js
@@ -2,17 +2,11 @@ describe('aria-valid-attr-value', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should not check the validity of attribute names', function () {

--- a/test/checks/aria/valid-attr.js
+++ b/test/checks/aria/valid-attr.js
@@ -2,17 +2,11 @@ describe('aria-valid-attr', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return false if any invalid ARIA attributes are found', function () {

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -5,22 +5,11 @@ describe('color-contrast', function () {
 	var fixtureSetup = axe.testUtils.fixtureSetup;
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
-
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 		axe._tree = undefined;
 	});
 

--- a/test/checks/color/link-in-text-block.js
+++ b/test/checks/color/link-in-text-block.js
@@ -5,16 +5,7 @@ describe('link-in-text-block', function () {
 	var shadowSupport = axe.testUtils.shadowSupport;
 	var styleElm;
 
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	before(function () {
 		styleElm = document.createElement('style');
@@ -33,8 +24,7 @@ describe('link-in-text-block', function () {
 	afterEach(function () {
 		fixture.innerHTML = '';
 		styleElm.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	after(function () {

--- a/test/checks/forms/fieldset.js
+++ b/test/checks/forms/fieldset.js
@@ -4,19 +4,11 @@ describe('fieldset', function () {
 	var shadowSupport = axe.testUtils.shadowSupport.v1;
 	var fixtureSetup = axe.testUtils.fixtureSetup;
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (nodes) {
-			this._relatedNodes = Array.isArray(nodes) ? nodes : [nodes];
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	function tests(type) {

--- a/test/checks/forms/group-labelledby.js
+++ b/test/checks/forms/group-labelledby.js
@@ -5,12 +5,7 @@ describe('group-labelledby', function () {
 	var fixtureSetup = axe.testUtils.fixtureSetup;
 	var shadowSupport = axe.testUtils.shadowSupport.v1;
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	beforeEach(function () {
 		axe._tree = undefined;
@@ -18,7 +13,7 @@ describe('group-labelledby', function () {
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	function tests(type) {

--- a/test/checks/keyboard/accesskeys.js
+++ b/test/checks/keyboard/accesskeys.js
@@ -3,22 +3,11 @@ describe('accesskeys', function () {
 
 	var fixture = document.getElementById('fixture');
 
-
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return true and record accesskey', function () {

--- a/test/checks/keyboard/focusable-no-name.js
+++ b/test/checks/keyboard/focusable-no-name.js
@@ -2,52 +2,51 @@ describe('focusable-no-name', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-	var fixtureSetup = axe.testUtils.fixtureSetup;
+	var checkSetup = axe.testUtils.checkSetup;
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 	var shadowSupport = axe.testUtils.shadowSupport;
+
+	var checkContext = {
+		_data: null,
+		data: function (d) {
+			this._data = d;
+		}
+	};
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		axe._tree = undefined;
 	});
 
 	it('should pass if tabindex < 0', function () {
-		fixtureSetup('<a href="#" tabindex="-1"></a>');
-		var node = fixture.querySelector('a');
-		assert.isFalse(checks['focusable-no-name'].evaluate(node));
+		var params = checkSetup('<a href="#" tabindex="-1" id="target"></a>');
+		assert.isFalse(checks['focusable-no-name'].evaluate.apply(checkContext, params));
 	});
 
 	it('should pass element is not natively focusable', function () {
-		fixtureSetup('<span role="link" href="#"></span>');
-		var node = fixture.querySelector('span');
-		assert.isFalse(checks['focusable-no-name'].evaluate(node));
+		var params = checkSetup('<span role="link" href="#" id="target"></span>');
+		assert.isFalse(checks['focusable-no-name'].evaluate.apply(checkContext, params));
 	});
 
 	it('should fail if element is tabbable with no name - native', function () {
-		fixtureSetup('<a href="#"></a>');
-		var node = fixture.querySelector('a');
-		assert.isTrue(checks['focusable-no-name'].evaluate(node));
+		var params = checkSetup('<a href="#" id="target"></a>');
+		assert.isTrue(checks['focusable-no-name'].evaluate.apply(checkContext, params));
 	});
 
-	it('should fail if element is tabable with no name - ARIA', function () {
-		fixtureSetup('<span tabindex="0" role="link" href="#"></spam>');
-		var node = fixture.querySelector('span');
-		assert.isTrue(checks['focusable-no-name'].evaluate(node));
+	it('should fail if element is tabbable with no name - ARIA', function () {
+		var params = checkSetup('<span tabindex="0" role="link" id="target" href="#"></spam>');
+		assert.isTrue(checks['focusable-no-name'].evaluate.apply(checkContext, params));
 	});
 
-	it('should pass if the element is tabable but has an accessible name', function () {
-		fixtureSetup('<a href="#" title="Hello"></a>');
-		var node = fixture.querySelector('a');
-		assert.isFalse(checks['focusable-no-name'].evaluate(node));
+	it('should pass if the element is tabbable but has an accessible name', function () {
+		var params = checkSetup('<a href="#" title="Hello" id="target"></a>');
+		assert.isFalse(checks['focusable-no-name'].evaluate.apply(checkContext, params));
 	});
 
 	(shadowSupport.v1 ? it : xit)('should pass if the content is passed in with shadow DOM', function () {
-		var node = document.createElement('div');
-		node.innerText = 'Content!';
-		var shadow = node.attachShadow({ mode: 'open' });
-		shadow.innerHTML = '<a href="#"><slot></slot></a>';
-		fixtureSetup(node);
+		var params = shadowCheckSetup('<div>Content!</div>', '<a href="#" id="target"><slot></slot></a>');
 
-		var link = shadow.querySelector('a');
-		assert.isFalse(checks['focusable-no-name'].evaluate(link));
+		assert.isFalse(checks['focusable-no-name'].evaluate.apply(checkContext, params));
 	});
 
 });

--- a/test/checks/keyboard/focusable-no-name.js
+++ b/test/checks/keyboard/focusable-no-name.js
@@ -5,17 +5,13 @@ describe('focusable-no-name', function () {
 	var checkSetup = axe.testUtils.checkSetup;
 	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 	var shadowSupport = axe.testUtils.shadowSupport;
-
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
 		axe._tree = undefined;
+		checkContext.reset();
 	});
 
 	it('should pass if tabindex < 0', function () {

--- a/test/checks/keyboard/has-at-least-one-main.js
+++ b/test/checks/keyboard/has-at-least-one-main.js
@@ -39,7 +39,11 @@ describe('has-at-least-one-main', function () {
 	});
 	
 	it('should return true if one div has role equal to main', function() {
-		var params = checkSetup('<div id = "target" role = "main">Div with role main</div>');
+		var params = checkSetup('<div id="target" role = "main">Div with role main</div>');
+		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
+		assert.isTrue(mainIsFound);
+		assert.equal(checkContext._data, mainIsFound);
+	});
 		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
 		assert.isTrue(mainIsFound);
 		assert.equal(checkContext._data, mainIsFound);

--- a/test/checks/keyboard/has-at-least-one-main.js
+++ b/test/checks/keyboard/has-at-least-one-main.js
@@ -4,10 +4,13 @@ describe('has-at-least-one-main', function () {
 	var fixture = document.getElementById('fixture');
 	var checkContext = new axe.testUtils.MockCheckContext();
 	var checkSetup = axe.testUtils.checkSetup;
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 
 	afterEach(function () {
 		fixture.innerHTML = '';
 		checkContext.reset();
+		axe._tree = undefined;
 	});
 
 	it('should return false if no div has role property', function() {
@@ -44,6 +47,10 @@ describe('has-at-least-one-main', function () {
 		assert.isTrue(mainIsFound);
 		assert.equal(checkContext._data, mainIsFound);
 	});
+
+	(shadowSupported ? it : xit)
+	('should return true if main is inside of shadow dom', function() {
+		var params = shadowCheckSetup('<div id="target"></div>', '<main>main landmark</main>');
 		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
 		assert.isTrue(mainIsFound);
 		assert.equal(checkContext._data, mainIsFound);

--- a/test/checks/keyboard/has-at-least-one-main.js
+++ b/test/checks/keyboard/has-at-least-one-main.js
@@ -11,35 +11,35 @@ describe('has-at-least-one-main', function () {
 	});
 
 	it('should return false if no div has role property', function() {
-		var params = checkSetup('<div id = "target">No role</div>');
+		var params = checkSetup('<div id="target">No role</div>');
 		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
 		assert.isFalse(mainIsFound);
 		assert.deepEqual(checkContext._data, mainIsFound);
 	});
 	
 	it('should return false if div has empty role', function() {
-		var params = checkSetup('<div id = "target" role = "">Empty role</div>');
+		var params = checkSetup('<div id="target" role="">Empty role</div>');
 		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
 		assert.isFalse(mainIsFound);
 		assert.equal(checkContext._data, mainIsFound);
 	});
 	
 	it('should return false if div has role not equal to main', function() {
-		var params = checkSetup('<div id = "target" role = "bananas">Wrong role</div>');
+		var params = checkSetup('<div id="target" role="bananas">Wrong role</div>');
 		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
 		assert.isFalse(mainIsFound);
 		assert.equal(checkContext._data, mainIsFound);
 	});
 	
 	it('should return true if main landmark exists', function(){
-		var params = checkSetup('<main id = "target">main landmark</main>');
+		var params = checkSetup('<main id="target">main landmark</main>');
 		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
 		assert.isTrue(mainIsFound);
 		assert.equal(checkContext._data, mainIsFound);
 	});
 	
 	it('should return true if one div has role equal to main', function() {
-		var params = checkSetup('<div id="target" role = "main">Div with role main</div>');
+		var params = checkSetup('<div id="target" role="main">Div with role main</div>');
 		var mainIsFound = checks['has-at-least-one-main'].evaluate.apply(checkContext, params);
 		assert.isTrue(mainIsFound);
 		assert.equal(checkContext._data, mainIsFound);
@@ -58,5 +58,4 @@ describe('has-at-least-one-main', function () {
 		var results = [{data: false, result: false}, {data: false, result: false}];
 		assert.isFalse(checks['has-at-least-one-main'].after(results)[0].result && checks['has-at-least-one-main'].after(results)[1].result);
 	});
-
 });

--- a/test/checks/keyboard/tabindex.js
+++ b/test/checks/keyboard/tabindex.js
@@ -13,17 +13,14 @@ describe('tabindex', function () {
 		fixture.appendChild(node);
 
 		assert.isFalse(checks.tabindex.evaluate(node));
-
-
 	});
+
 	it('should pass if the tabindex is <= 0', function () {
 		var node = document.createElement('div');
 		node.setAttribute('tabindex', '0');
 		fixture.appendChild(node);
 
 		assert.isTrue(checks.tabindex.evaluate(node));
-
-
 	});
 
 });

--- a/test/checks/label/multiple-label.js
+++ b/test/checks/label/multiple-label.js
@@ -3,21 +3,11 @@ describe('multiple-label', function () {
 
 	var fixture = document.getElementById('fixture');
 
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return true if there are multiple implicit labels', function () {

--- a/test/checks/language/valid-lang.js
+++ b/test/checks/language/valid-lang.js
@@ -3,16 +3,11 @@ describe('valid-lang', function () {
 
 	var fixture = document.getElementById('fixture');
 
-	var checkContext = {
-		_data: null,
-		data: function (data) {
-			this._data = data;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	describe('lang', function () {

--- a/test/checks/lists/only-dlitems.js
+++ b/test/checks/lists/only-dlitems.js
@@ -5,16 +5,11 @@ describe('only-dlitems', function () {
 	var checkSetup = axe.testUtils.checkSetup;
 	var shadowSupport = axe.testUtils.shadowSupport;
 
-	var checkContext = {
-		_relatedNodes: [],
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
+		checkContext.reset();
 	});
 
 	it('should return false if the list has no contents', function () {

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -5,16 +5,11 @@ describe('only-listitems', function () {
 	var checkSetup = axe.testUtils.checkSetup;
 	var shadowSupport = axe.testUtils.shadowSupport;
 
-	var checkContext = {
-		_relatedNodes: [],
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
+		checkContext.reset();
 	});
 
 	it('should return false if the list has no contents', function () {

--- a/test/checks/navigation/header-present.js
+++ b/test/checks/navigation/header-present.js
@@ -2,41 +2,43 @@ describe('header-present', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var checkSetup = axe.testUtils.checkSetup;
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		axe._tree = undefined;
+		checkContext.reset();
 	});
 
 	it('should return true if h1-h6 is found', function () {
-		fixture.innerHTML = '<h1>Hi</h1>';
-		assert.isTrue(checks['header-present'].evaluate(fixture));
+		var params = checkSetup('<h1 id="target">Hi</h1>');
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
 
-		fixture.innerHTML = '<h2>Hi</h2>';
-		assert.isTrue(checks['header-present'].evaluate(fixture));
+		params = checkSetup('<h2 id="target">Hi</h2>');
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
 
-		fixture.innerHTML = '<h3>Hi</h3>';
-		assert.isTrue(checks['header-present'].evaluate(fixture));
+		params = checkSetup('<h3 id="target">Hi</h3>');
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
 
-		fixture.innerHTML = '<h4>Hi</h4>';
-		assert.isTrue(checks['header-present'].evaluate(fixture));
+		params = checkSetup('<h4 id="target">Hi</h4>');
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
 
-		fixture.innerHTML = '<h5>Hi</h5>';
-		assert.isTrue(checks['header-present'].evaluate(fixture));
+		params = checkSetup('<h5 id="target">Hi</h5>');
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
 
-		fixture.innerHTML = '<h6>Hi</h6>';
-		assert.isTrue(checks['header-present'].evaluate(fixture));
+		params = checkSetup('<h6 id="target">Hi</h6>');
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
 	});
 
 	it('should return true if role=heading is found', function () {
-
-		fixture.innerHTML = '<div role="heading">Hi</div>';
-		assert.isTrue(checks['header-present'].evaluate(fixture));
-
+		var params = checkSetup('<div role="heading" id="target">Hi</div>');
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
 	});
 
 	it('should otherwise return false', function () {
-		fixture.innerHTML = '<p>Some stuff and stuff</p>';
-		assert.isFalse(checks['header-present'].evaluate(fixture));
+		var params = checkSetup('<p id="target">Some stuff and stuff</p>');
+		assert.isFalse(checks['header-present'].evaluate.apply(checkContext, params));
 	});
 
 });

--- a/test/checks/navigation/header-present.js
+++ b/test/checks/navigation/header-present.js
@@ -3,7 +3,9 @@ describe('header-present', function () {
 
 	var fixture = document.getElementById('fixture');
 	var checkSetup = axe.testUtils.checkSetup;
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var checkContext = axe.testUtils.MockCheckContext();
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 
 	afterEach(function () {
 		fixture.innerHTML = '';
@@ -41,4 +43,12 @@ describe('header-present', function () {
 		assert.isFalse(checks['header-present'].evaluate.apply(checkContext, params));
 	});
 
+	(shadowSupported ? it : xit)
+	('should return true if heading is in shadow dom', function () {
+		var params = shadowCheckSetup(
+			'<div id="target"><div>',
+			'<h1></h1>'
+		);
+		assert.isTrue(checks['header-present'].evaluate.apply(checkContext, params));
+	});
 });

--- a/test/checks/navigation/heading-order.js
+++ b/test/checks/navigation/heading-order.js
@@ -2,16 +2,12 @@ describe('heading-order', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should store the correct header level for aria-level and return true', function () {

--- a/test/checks/navigation/internal-link-present.js
+++ b/test/checks/navigation/internal-link-present.js
@@ -2,19 +2,23 @@ describe('internal-link-present', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var checkContext = axe.testUtils.MockCheckContext();
+	var checkSetup = axe.testUtils.checkSetup;
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		axe._tree = undefined;
+		checkContext.reset();
 	});
 
 	it('should return true when an internal link is found', function () {
-		fixture.innerHTML = '<a href="#haha">hi</a>';
-		assert.isTrue(checks['internal-link-present'].evaluate(fixture));
+		var params = checkSetup('<div id="target"><a href="#haha">hi</a></div>');
+		assert.isTrue(checks['internal-link-present'].evaluate.apply(checkContext, params));
 	});
 
 	it('should otherwise return false', function () {
-		fixture.innerHTML = '<a href="http://www.deque.com/#haha">hi</a>';
-		assert.isFalse(checks['internal-link-present'].evaluate(fixture));
+		var params = checkSetup('<div id="target"><a href="http://www.deque.com/#haha">hi</a></div>');
+		assert.isFalse(checks['internal-link-present'].evaluate.apply(checkContext, params));
 	});
 
 });

--- a/test/checks/navigation/internal-link-present.js
+++ b/test/checks/navigation/internal-link-present.js
@@ -2,8 +2,10 @@ describe('internal-link-present', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var checkContext = axe.testUtils.MockCheckContext();
 	var checkSetup = axe.testUtils.checkSetup;
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 
 	afterEach(function () {
 		fixture.innerHTML = '';
@@ -21,4 +23,12 @@ describe('internal-link-present', function () {
 		assert.isFalse(checks['internal-link-present'].evaluate.apply(checkContext, params));
 	});
 
+	(shadowSupported ? it : xit)
+	('should return true when internal link is found in shadow dom', function () {
+		var params = shadowCheckSetup(
+			'<div id="target"></div>',
+			'<a href="#haha">hi</a>'
+		);
+		assert.isTrue(checks['internal-link-present'].evaluate.apply(checkContext, params));
+	});
 });

--- a/test/checks/navigation/p-as-heading.js
+++ b/test/checks/navigation/p-as-heading.js
@@ -1,14 +1,11 @@
 describe('p-as-heading', function () {
 	'use strict';
 	var fixture = document.getElementById('fixture');
-	var fixtureSetup = axe.testUtils.fixtureSetup;
+	var checkSetup = axe.testUtils.checkSetup;
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 
 	var testOptions = {
 		margins: [
@@ -20,99 +17,82 @@ describe('p-as-heading', function () {
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 		axe._tree = undefined;
 	});
 
 	it('returns true if the styles are identical', function () {
-		fixtureSetup('<p>elm 1</p> <p>elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<p id="target">elm 1</p> <p>elm 2</p>', testOptions);
+		assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns true if there is no p element following it', function () {
-		fixtureSetup('<p>lone elm</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<p id="target">lone elm</p>', testOptions);
+		assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns false if the font-weight is heavier', function () {
-		fixtureSetup('<p style="font-weight:bold">elm 1</p> <p>elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isFalse(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup(
+			'<p id="target" style="font-weight:bold">elm 1</p>' +
+			'<p>elm 2</p>',
+			testOptions
+		);
+		assert.isFalse(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns false if the font-size is bigger', function () {
-		fixtureSetup('<p style="font-size:150%">elm 1</p> <p>elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isFalse(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<p id="target" style="font-size:150%">elm 1</p> <p>elm 2</p>', testOptions);
+		assert.isFalse(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns false if the fake heading is italic and the text is not', function () {
-		fixtureSetup('<p style="font-style:italic">elm 1</p> <p>elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isFalse(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<p id="target" style="font-style:italic">elm 1</p> <p>elm 2</p>', testOptions);
+		assert.isFalse(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns true if both texts are bold, italic and larger', function () {
-		fixtureSetup('<p style="font-weight:bold; font-size:120%; font-style:italic">elm 1</p>' +
-			'<p style="font: italic bold 120% bold">elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup(
+			'<p id="target" style="font-weight:bold; font-size:120%; font-style:italic">elm 1</p>' +
+			'<p style="font: italic bold 120% bold">elm 2</p>',
+			testOptions
+		);
+		assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('considers styles of elements inside the paragraph', function () {
-		fixtureSetup('<p><b>elm 1</b></p> <p>elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isFalse(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<p id="target"><b>elm 1</b></p> <p>elm 2</p>', testOptions);
+		assert.isFalse(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('ignores empty child element for style', function () {
-		fixtureSetup('<p><span> </span><b>elm 1</b></p> <p>elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isFalse(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<p id="target"><span> </span><b>elm 1</b></p> <p>elm 2</p>', testOptions);
+		assert.isFalse(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('considers styles of elements that do not contain all the text', function () {
-		fixtureSetup('<p><b>elm</b> 1</p> <p>elm 2</p>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<p id="target"><b>elm</b> 1</p> <p>elm 2</p>', testOptions);
+		assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns undefined instead of false if the element is inside a blockquote', function () {
-		fixtureSetup('<blockquote>' +
-			'<p style="font-weight:bold">elm 1</p> <p>elm 2</p>' +
-		'</blockquote>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isUndefined(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<blockquote>' +
+			'<p style="font-weight:bold" id="target">elm 1</p> <p>elm 2</p>' +
+		'</blockquote>', testOptions);
+		assert.isUndefined(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns true over undefined from within a blockquote', function () {
-		fixtureSetup('<blockquote>' +
-			'<p>elm 1</p> <p>elm 2</p>' +
-		'</blockquote>');
-		var node = fixture.querySelector('p');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		var params = checkSetup('<blockquote>' +
+			'<p id="target">elm 1</p> <p>elm 2</p>' +
+		'</blockquote>', testOptions);
+		assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	it('returns undefined if a previous sibling has a similar font-weight', function () {
-		fixtureSetup('<p><b>elm 1</b></p>'+
+		var params = checkSetup('<p><b>elm 1</b></p>'+
 		'<p id="target"><b>elm 2</b></p>'+
-		'<p>elm 3</p>');
-		var node = fixture.querySelector('#target');
-		var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-		assert.isUndefined(checks['p-as-heading'].evaluate.call(checkContext, node, testOptions, virtualNode));
+		'<p>elm 3</p>', testOptions);
+		assert.isUndefined(checks['p-as-heading'].evaluate.apply(checkContext, params));
 	});
 
 	describe('option.margin', function () {
@@ -120,10 +100,8 @@ describe('p-as-heading', function () {
 		it('passes if no margins are set', function () {
 			var options = {};
 
-			fixtureSetup('<p><b>elm 1</b></p> <p>elm 2</p>');
-			var node = fixture.querySelector('p');
-			var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-			assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, options, virtualNode));
+			var params = checkSetup('<p id="target"><b>elm 1</b></p> <p>elm 2</p>', options);
+			assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 		});
 
 		it('takes an array of margins', function () {
@@ -131,10 +109,8 @@ describe('p-as-heading', function () {
 				margins: [{ size: 1.2 }]
 			};
 
-			fixtureSetup('<p><b>elm 1</b></p> <p>elm 2</p>');
-			var node = fixture.querySelector('p');
-			var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-			assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, options, virtualNode));
+			var params = checkSetup('<p id="target"><b>elm 1</b></p> <p>elm 2</p>', options);
+			assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 		});
 
 		it('returns false if all values in the margin are passed', function () {
@@ -142,10 +118,12 @@ describe('p-as-heading', function () {
 				margins: [{ size: 1.2, weight: 100 }]
 			};
 
-			fixtureSetup('<p style="font-size:1.5em; font-weight:bold">elm 1</p> <p>elm 2</p>');
-			var node = fixture.querySelector('p');
-			var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-			assert.isFalse(checks['p-as-heading'].evaluate.call(checkContext, node, options, virtualNode));
+			var params = checkSetup(
+				'<p id="target" style="font-size:1.5em; font-weight:bold">elm 1</p>' +
+				'<p>elm 2</p>',
+				options
+			);
+			assert.isFalse(checks['p-as-heading'].evaluate.apply(checkContext, params));
 		});
 
 		it('returns true if any of the values is not passed', function () {
@@ -153,10 +131,12 @@ describe('p-as-heading', function () {
 				margins: [{ size: 1.2, weight: 100 }]
 			};
 
-			fixtureSetup('<p style="font-weight:bold">elm 1</p> <p>elm 2</p>');
-			var node = fixture.querySelector('p');
-			var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-			assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, options, virtualNode));
+			var params = checkSetup(
+				'<p id="target" style="font-weight:bold">elm 1</p>' +
+				'<p>elm 2</p>',
+				options
+			);
+			assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 		});
 
 		it('returns false if any of the margins is passed', function () {
@@ -168,10 +148,12 @@ describe('p-as-heading', function () {
 				],
 			};
 
-			fixtureSetup('<p style="font-style:italic">elm 1</p> <p>elm 2</p>');
-			var node = fixture.querySelector('p');
-			var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-			assert.isFalse(checks['p-as-heading'].evaluate.call(checkContext, node, options, virtualNode));
+			var params = checkSetup(
+				'<p id="target" style="font-style:italic">elm 1</p>' +
+				'<p>elm 2</p>',
+				options
+			);
+			assert.isFalse(checks['p-as-heading'].evaluate.apply(checkContext, params));
 		});
 
 		it('returns true if none of the set margins is passed', function () {
@@ -183,11 +165,11 @@ describe('p-as-heading', function () {
 				]
 			};
 
-			fixtureSetup('<p style="font-size:1.5em">elm 1</p> <p>elm 2</p>');
-			var node = fixture.querySelector('p');
-			var virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-			assert.isTrue(checks['p-as-heading'].evaluate.call(checkContext, node, options, virtualNode));
+			var params = checkSetup('<p id="target" style="font-size:1.5em">elm 1</p>' +
+				'<p>elm 2</p>',
+				options
+			);
+			assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 		});
 	});
-
 });

--- a/test/checks/navigation/p-as-heading.js
+++ b/test/checks/navigation/p-as-heading.js
@@ -172,4 +172,20 @@ describe('p-as-heading', function () {
 			assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
 		});
 	});
+
+	(shadowSupported ? it : xit)
+	('returns undefined instead of false if the element is inside a blockquote in light dom', function () {
+		var params = shadowCheckSetup('<blockquote></blockquote>',
+			'<p style="font-weight:bold" id="target">elm 1</p> <p>elm 2</p>',
+			testOptions);
+		assert.isUndefined(checks['p-as-heading'].evaluate.apply(checkContext, params));
+	});
+
+	(shadowSupported ? it : xit)
+	('returns true over undefined from within a blockquote in light dom', function () {
+		var params = shadowCheckSetup('<blockquote></blockquote>',
+			'<p id="target">elm 1</p> <p>elm 2</p>',
+			testOptions);
+		assert.isTrue(checks['p-as-heading'].evaluate.apply(checkContext, params));
+	});
 });

--- a/test/checks/navigation/unique-frame-title-after.js
+++ b/test/checks/navigation/unique-frame-title-after.js
@@ -1,15 +1,10 @@
 describe('unique-frame-title-after', function () {
 	'use strict';
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 

--- a/test/checks/navigation/unique-frame-title.js
+++ b/test/checks/navigation/unique-frame-title.js
@@ -1,15 +1,10 @@
 describe('unique-frame-title', function () {
 	'use strict';
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 

--- a/test/checks/shared/button-has-visible-text.js
+++ b/test/checks/shared/button-has-visible-text.js
@@ -3,16 +3,11 @@ describe('button-has-visible-text', function () {
 
 	var fixture = document.getElementById('fixture');
 	var checkSetup = axe.testUtils.checkSetup;
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return false if button element is empty', function () {

--- a/test/checks/shared/button-has-visible-text.js
+++ b/test/checks/shared/button-has-visible-text.js
@@ -29,14 +29,14 @@ describe('button-has-visible-text', function () {
 	});
 
 	it('should return true if ARIA button has text', function () {
-		var checkArgs = checkSetup('<div role="button">Text</div>>', '[role=button]');
+		var checkArgs = checkSetup('<div role="button">Text</div>', '[role=button]');
 
 		assert.isTrue(checks['button-has-visible-text'].evaluate.apply(checkContext, checkArgs));
 		assert.deepEqual(checkContext._data, 'Text');
 	});
 
 	it('should return false if ARIA button has no text', function () {
-		var checkArgs = checkSetup('<div role="button"></div>>', '[role=button]');
+		var checkArgs = checkSetup('<div role="button"></div>', '[role=button]');
 
 		assert.isFalse(checks['button-has-visible-text'].evaluate.apply(checkContext, checkArgs));
 	});

--- a/test/checks/shared/duplicate-id.js
+++ b/test/checks/shared/duplicate-id.js
@@ -4,21 +4,11 @@ describe('duplicate-id', function () {
 	var fixture = document.getElementById('fixture');
 	var shadowSupport = axe.testUtils.shadowSupport;
 
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return true if there is only one element with an ID', function () {

--- a/test/checks/shared/has-visible-text.js
+++ b/test/checks/shared/has-visible-text.js
@@ -2,28 +2,34 @@ describe('has-visible-text', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-	var fixtureSetup = axe.testUtils.fixtureSetup;
+	var checkSetup = axe.testUtils.checkSetup;
+
+	var checkContext = {
+		_data: null,
+		data: function (d) {
+			this._data = d;
+		}
+	};
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		axe._tree = undefined;
+		checkContext._data = null;
 	});
 
 	it('should return false if there is no visible text', function () {
-		fixtureSetup('<object></object>');
-		var node = document.querySelector('object');
-		assert.isFalse(checks['has-visible-text'].evaluate(node));
+		var params = checkSetup('<object id="target"></object>');
+		assert.isFalse(checks['has-visible-text'].evaluate.apply(checkContext, params));
 	});
 
 	it('should return false if there is text, but its hidden', function () {
-		fixtureSetup('<object><span style="display:none">hello!</span></object>');
-		var node = document.querySelector('object');
-		assert.isFalse(checks['has-visible-text'].evaluate(node));
+		var params = checkSetup('<object id="target"><span style="display:none">hello!</span></object>');
+		assert.isFalse(checks['has-visible-text'].evaluate.apply(checkContext, params));
 	});
 
 	it('should return true if there is visible text', function () {
-		fixtureSetup('<object>hello!</object>');
-		var node = document.querySelector('object');
-		assert.isTrue(checks['has-visible-text'].evaluate(node));
+		var params = checkSetup('<object id="target">hello!</object>');
+		assert.isTrue(checks['has-visible-text'].evaluate.apply(checkContext, params));
 	});
 
 });

--- a/test/checks/shared/has-visible-text.js
+++ b/test/checks/shared/has-visible-text.js
@@ -4,17 +4,12 @@ describe('has-visible-text', function () {
 	var fixture = document.getElementById('fixture');
 	var checkSetup = axe.testUtils.checkSetup;
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
 		axe._tree = undefined;
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return false if there is no visible text', function () {

--- a/test/checks/shared/non-empty-if-present.js
+++ b/test/checks/shared/non-empty-if-present.js
@@ -8,16 +8,11 @@ describe('non-empty-if-present', function () {
 	input.type = 'submit';
 	var isEdgeOrIe = typeof input.getAttribute('value') === 'string';
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return false if a value is present', function () {

--- a/test/checks/tables/has-th.js
+++ b/test/checks/tables/has-th.js
@@ -2,21 +2,11 @@ describe('has-th', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return false when the table has no th', function () {

--- a/test/checks/tables/same-caption-summary.js
+++ b/test/checks/tables/same-caption-summary.js
@@ -6,16 +6,12 @@ describe('same-caption-summary', function () {
 	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 	var shadowSupport = axe.testUtils.shadowSupport;
 
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		checkContext.reset();
 		axe._tree = undefined;
 	});
 

--- a/test/checks/tables/same-caption-summary.js
+++ b/test/checks/tables/same-caption-summary.js
@@ -2,59 +2,64 @@ describe('same-caption-summary', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-	var fixtureSetup = axe.testUtils.fixtureSetup;
+	var checkSetup = axe.testUtils.checkSetup;
+	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 	var shadowSupport = axe.testUtils.shadowSupport;
+
+	var checkContext = {
+		_data: null,
+		data: function (d) {
+			this._data = d;
+		}
+	};
+
 
 	afterEach(function () {
 		fixture.innerHTML = '';
+		axe._tree = undefined;
 	});
 
 	it('should return false there is no caption', function () {
-		fixtureSetup('<table summary="hi"><tr><td></td></tr></table>');
-		var node = fixture.querySelector('table');
+		var params = checkSetup('<table summary="hi" id="target"><tr><td></td></tr></table>');
 
-		assert.isFalse(checks['same-caption-summary'].evaluate(node));
+		assert.isFalse(checks['same-caption-summary'].evaluate.apply(checkContext, params));
 
 	});
 
 	it('should return false there is no summary', function () {
-		fixtureSetup('<table><caption>Hi</caption><tr><td></td></tr></table>');
-		var node = fixture.querySelector('table');
+		var params = checkSetup('<table id="target"><caption>Hi</caption><tr><td></td></tr></table>');
 
-		assert.isFalse(checks['same-caption-summary'].evaluate(node));
+		assert.isFalse(checks['same-caption-summary'].evaluate.apply(checkContext, params));
 
 	});
 
 	it('should return false if summary and caption are different', function () {
-		fixtureSetup('<table summary="bye"><caption>Hi</caption><tr><td></td></tr></table>');
-		var node = fixture.querySelector('table');
+		var params = checkSetup('<table summary="bye" id="target"><caption>Hi</caption><tr><td></td></tr></table>');
 
-		assert.isFalse(checks['same-caption-summary'].evaluate(node));
+		assert.isFalse(checks['same-caption-summary'].evaluate.apply(checkContext, params));
 
 	});
 
 	it('should return true if summary and caption are the same', function () {
-		fixtureSetup('<table summary="Hi"><caption>Hi</caption><tr><td></td></tr></table>');
-		var node = fixture.querySelector('table');
+		var params = checkSetup('<table summary="Hi" id="target"><caption>Hi</caption><tr><td></td></tr></table>');
 
-		assert.isTrue(checks['same-caption-summary'].evaluate(node));
+		assert.isTrue(checks['same-caption-summary'].evaluate.apply(checkContext, params));
 	});
 
 	(shadowSupport.v1 ? it : xit)('should match slotted caption elements', function () {
-		var node = document.createElement('div');
-		node.innerHTML = '<span slot="caption">Caption</span>' +
-			'<span slot="one">Data element 1</span>' +
-			'<span slot="two">Data element 2</span>';
+		var params = shadowCheckSetup(
+			'<div>' +
+				'<span slot="caption">Caption</span>' +
+				'<span slot="one">Data element 1</span>' +
+				'<span slot="two">Data element 2</span>' +
+			'</div>',
+			'<table summary="Caption" id="target">' +
+				'<caption><slot name="caption"></slot></caption>' +
+				'<tr><td><slot name="one"></slot></td><td><slot name="two"></slot></td></tr>' +
+			'</table>'
+		);
 
-		var root = node.attachShadow({ mode: 'open' });
-		var table = document.createElement('table');
-		table.innerHTML = '<caption><slot name="caption"></slot></caption>' +
-				'<tr><td><slot name="one"></slot></td><td><slot name="two"></slot></td></tr>';
-		table.setAttribute('summary', 'Caption');
-		root.appendChild(table);
-		fixtureSetup(node);
-
-		assert.isTrue(checks['same-caption-summary'].evaluate(table));
+		assert.isTrue(checks['same-caption-summary'].evaluate.apply(checkContext, params));
 	});
 
 });

--- a/test/checks/tables/td-has-header.js
+++ b/test/checks/tables/td-has-header.js
@@ -3,21 +3,11 @@ describe('td-has-header', function () {
 
 	var fixture = document.getElementById('fixture');
 	var shadowSupport = axe.testUtils.shadowSupport.v1;
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 		axe._tree = null;
 	});
 

--- a/test/checks/tables/td-headers-attr.js
+++ b/test/checks/tables/td-headers-attr.js
@@ -2,21 +2,11 @@ describe('td-headers-attr', function () {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('returns true no headers attribute is present', function () {

--- a/test/checks/tables/th-has-data-cells.js
+++ b/test/checks/tables/th-has-data-cells.js
@@ -3,21 +3,11 @@ describe('th-has-data-cells', function () {
 
 	var fixture = document.getElementById('fixture');
 	var shadowSupport = axe.testUtils.shadowSupport.v1;
-	var checkContext = {
-		_relatedNodes: [],
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._relatedNodes = [];
-		checkContext._data = null;
+		checkContext.reset();
 	});
 
 	it('should return true each row header has a non-empty cell', function (){

--- a/test/checks/visibility/hidden-content.js
+++ b/test/checks/visibility/hidden-content.js
@@ -5,16 +5,11 @@ describe('hidden content', function () {
 	var fixture = document.getElementById('fixture');
 	var shadowSupport = axe.testUtils.shadowSupport.v1;
 	var checkSetup = axe.testUtils.checkSetup;
-	var checkContext = {
-		_data: null,
-		data: function (d) {
-			this._data = d;
-		}
-	};
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function () {
 		fixture.innerHTML = '';
-		checkContext._data = null;
+		checkContext.reset();
 		axe._tree = undefined;
 	});
 

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -102,25 +102,32 @@ testUtils.checkSetup = function (content, options, target) {
  *
  * @param Node|String 	Stuff to go into the fixture (html string or DOM Node)
  * @param Node|String 	Stuff to go into the shadow boundary (html or node)
- * @param String  			Target selector for the check, can be inside or outside of Shadow DOM (default: '#target')
  * @param Object  			Options argument for the check (optional, default: {})
+ * @param String  			Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
  * @return Array
  */
-testUtils.shadowCheckSetup = function (content, shadowContent, targetSelector, options) {
+testUtils.shadowCheckSetup = function (content, shadowContent, options, targetSelector) {
 	'use strict';
 
-	// Normalize the params
+	// Normalize target, allow it to be the provided string or use '#target' to query composed tree
+	if (typeof targetSelector !== 'string') {
+		targetSelector = '#target';
+	}
+
+	// Normalize the object params
 	if (typeof options !== 'object') {
 		options = {};
 	}
-	// Normalize target, allow it to be the provided string or use '#target' to query composed tree
-	targetSelector = targetSelector || '#target';
 
 	var fixture = testUtils.fixtureSetup(content);
 	var targetCandidate = fixture.querySelector(targetSelector);
 	var container = targetCandidate;
 	if (!targetCandidate) {
-		container = fixture.firstChild;
+		// check if content specifies a shadow container
+		container = fixture.querySelector('#shadow');
+		if (!container) {
+			container = fixture.firstChild;
+		}
 	}
 	// attach a shadowRoot with the content provided
 	var shadowRoot = container.attachShadow({ mode: 'open' });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -13,8 +13,8 @@ testUtils.MockCheckContext = function () {
 		data: function (d) {
 			this._data = d;
 		},
-		relatedNodes: function (rn) {
-			this._relatedNodes = rn;
+		relatedNodes: function (nodes) {
+			this._relatedNodes = Array.isArray(nodes) ? nodes : [nodes];
 		},
 		reset: function () {
 			this._data = null;
@@ -100,7 +100,7 @@ testUtils.checkSetup = function (content, options, target) {
  * Create check arguments with Shadow DOM. Target can be inside or outside of Shadow DOM, queried by
  * adding `id="target"` to a fragment. Or specify a custom selector as the `targetSelector` argument.
  *
- * @param Node|String 	Stuff to go into the fixture (html or node)
+ * @param Node|String 	Stuff to go into the fixture (html string or DOM Node)
  * @param Node|String 	Stuff to go into the shadow boundary (html or node)
  * @param String  			Target selector for the check, can be inside or outside of Shadow DOM (default: '#target')
  * @param Object  			Options argument for the check (optional, default: {})


### PR DESCRIPTION
I went through each of the checks to see if there was Shadow DOM coverage, and there were a couple that needed updating:

- header-present
- internal-link-present

There were a few others where I simply added unit tests:
- aria-errormessage
- p-as-heading

And a few I updated to use accessibleTextVirtual:
- focusable-no-name
- implicit
- button-has-visible-text
- has-visible-text

I also did a bunch of test cleanup and fixed up the shadowCheckSetup utility to support a wider range of scenarios.

Closes https://github.com/dequelabs/axe-core/issues/690