### PR TITLE
 feat(rules): add new rule aria-dpub-role-fallback 

### DIFF
--- a/doc/rule-descriptions.md
+++ b/doc/rule-descriptions.md
@@ -3,6 +3,7 @@
 | accesskeys | Ensures every accesskey attribute value is unique | wcag2a, wcag211, cat.keyboard | true |
 | area-alt | Ensures &lt;area&gt; elements of image maps have alternate text | cat.text-alternatives, wcag2a, wcag111, section508, section508.22.a | true |
 | aria-allowed-attr | Ensures ARIA attributes are allowed for an element&apos;s role | cat.aria, wcag2a, wcag411, wcag412 | true |
+| aria-dpub-role-fallback | Ensures unsupported DPUB roles are only used on elements with implicit fallback roles | cat.aria, wcag2a, wcag131 | true |
 | aria-hidden-body | Ensures aria-hidden=&apos;true&apos; is not present on the document body. | cat.aria, wcag2a, wcag412 | true |
 | aria-required-attr | Ensures elements with ARIA roles have all required ARIA attributes | cat.aria, wcag2a, wcag411, wcag412 | true |
 | aria-required-children | Ensures elements with an ARIA role that require child roles contain them | cat.aria, wcag2a, wcag131 | true |

--- a/lib/checks/aria/implicit-role-fallback.js
+++ b/lib/checks/aria/implicit-role-fallback.js
@@ -1,0 +1,6 @@
+var role = node.getAttribute('role');
+if (role === null || !axe.commons.aria.isValidRole(role)) {
+	return true;
+}
+var roleType = axe.commons.aria.getRoleType(role);
+return axe.commons.aria.implicitRole(node) === roleType;

--- a/lib/checks/aria/implicit-role-fallback.json
+++ b/lib/checks/aria/implicit-role-fallback.json
@@ -1,0 +1,11 @@
+{
+  "id": "implicit-role-fallback",
+  "evaluate": "implicit-role-fallback.js",
+  "metadata": {
+    "impact": "moderate",
+    "messages": {
+      "pass": "Element’s implicit ARIA role is an appropriate fallback",
+      "fail": "Element’s implicit ARIA role is not a good fallback for the (unsupported) role"
+    }
+  }
+}

--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -345,6 +345,357 @@ lookupTable.role = {
 		context: null,
 		implicit: ['body']
 	},
+	'doc-abstract': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-acknowledgments': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-afterword': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-appendix': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-backlink': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-biblioentry': {
+		type: 'listitem',
+		attributes: {
+			allowed: ['aria-expanded', 'aria-level', 'aria-posinset', 'aria-setsize']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: ['doc-bibliography'],
+	},
+	'doc-bibliography': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author'],
+		context: null,
+	},
+	'doc-biblioref': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		nameFrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-chapter': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-colophon': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-conclusion': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-cover': {
+		type: 'img',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-credit': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-credits': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-dedication': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-endnote': {
+		type: 'listitem',
+		attributes: {
+			allowed: ['aria-expanded', 'aria-level', 'aria-posinset', 'aria-setsize']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: ['doc-endnotes'],
+	},
+	'doc-endnotes': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: ['doc-endnote'],
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-epigraph': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-epilogue': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-errata': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-example': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-footnote': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-foreword': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-glossary': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: ['term', 'definition'],
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-glossref': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-index': {
+		type: 'navigation',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-introduction': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-noteref': {
+		type: 'link',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author', 'contents'],
+		context: null,
+	},
+	'doc-notice': {
+		type: 'note',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-pagebreak': {
+		type: 'separator',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-pagelist': {
+		type: 'navigation',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-part': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-preface': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-prologue': {
+		type: 'landmark',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-pullquote': {
+		type: 'none',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-qna': {
+		type: 'section',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-subtitle': {
+		type: 'sectionhead',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-tip': {
+		type: 'note',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
+	'doc-toc': {
+		type: 'navigation',
+		attributes: {
+			allowed: ['aria-expanded']
+		},
+		owned: null,
+		namefrom: ['author'],
+		context: null,
+	},
 	'feed': {
 		type: 'structure',
 		attributes: {

--- a/lib/rules/aria-dpub-role-fallback-matches.js
+++ b/lib/rules/aria-dpub-role-fallback-matches.js
@@ -1,0 +1,10 @@
+var role = node.getAttribute('role');
+return [
+	'doc-backlink',
+	'doc-biblioentry',
+	'doc-biblioref',
+	'doc-cover',
+	'doc-endnote',
+	'doc-glossref',
+	'doc-noteref'
+].includes(role);

--- a/lib/rules/aria-dpub-role-fallback.json
+++ b/lib/rules/aria-dpub-role-fallback.json
@@ -1,0 +1,19 @@
+{
+  "id": "aria-dpub-role-fallback",
+  "selector": "[role]",
+  "matches": "aria-dpub-role-fallback-matches.js",
+  "tags": [
+    "cat.aria",
+    "wcag2a",
+    "wcag131"
+  ],
+  "metadata": {
+    "description": "Ensures unsupported DPUB roles are only used on elements with implicit fallback roles",
+    "help": "Unsupported DPUB ARIA roles should be used on elements with implicit fallback roles"
+  },
+  "all": [
+    "implicit-role-fallback"
+  ],
+  "any": [],
+  "none": []
+}

--- a/test/checks/aria/implicit-role-fallback.js
+++ b/test/checks/aria/implicit-role-fallback.js
@@ -1,0 +1,76 @@
+describe('implicit-role-fallback', function () {
+	'use strict';
+
+	var fixture = document.getElementById('fixture');
+	var node;
+	var checkContext = axe.testUtils.MockCheckContext();
+
+
+	afterEach(function () {
+		node.innerHTML = '';
+		checkContext._data = null;
+	});
+
+	it('should return true for elements with no role', function() {
+		node = document.createElement('div');
+		fixture.appendChild(node);
+		assert.isTrue(checks['implicit-role-fallback'].evaluate.call(checkContext, node));
+	});
+
+	it('should return true for elements with nonsensical roles', function() {
+		fixture.innerHTML = '<a role="awesomelink" id="target" href="#">text</a>';
+		var target = fixture.children[0];
+		assert.isTrue(checks['implicit-role-fallback'].evaluate.call(checkContext, target));
+	});
+
+	it('should return true if the provided role’s parent is the element’s implicit role', function () {
+
+		axe.commons.aria.lookupTable.role.awesomelink = {
+			type: 'link',
+			attributes: {
+				allowed: ['aria-expanded']
+			},
+			owned: null,
+			namefrom: ['author', 'contents'],
+			context: null,
+		};
+		fixture.innerHTML = '<a role="awesomelink" id="target" href="#">text</a>';
+		var target = fixture.children[0];
+		assert.isTrue(checks['implicit-role-fallback'].evaluate.call(checkContext, target));
+		delete axe.commons.aria.lookupTable.role.awesomelink;
+	});
+
+	it('should return false if the provided role’s type is not the element’s implicit role', function () {
+
+		axe.commons.aria.lookupTable.role.awesomelink = {
+			type: 'link',
+			attributes: {
+				allowed: ['aria-expanded']
+			},
+			owned: null,
+			namefrom: ['author', 'contents'],
+			context: null,
+		};
+		fixture.innerHTML = '<article role="awesomelink" id="target"></article>';
+		var target = fixture.children[0];
+		assert.isFalse(checks['implicit-role-fallback'].evaluate.call(checkContext, target));
+		delete axe.commons.aria.lookupTable.role.awesomelink;
+	});
+
+	it('should return false if the element has no implicit role', function () {
+
+		axe.commons.aria.lookupTable.role.awesomelink = {
+			type: 'link',
+			attributes: {
+				allowed: ['aria-expanded']
+			},
+			owned: null,
+			namefrom: ['author', 'contents'],
+			context: null,
+		};
+		fixture.innerHTML = '<div role="awesomelink" id="target"></div>';
+		var target = fixture.children[0];
+		assert.isFalse(checks['implicit-role-fallback'].evaluate.call(checkContext, target));
+		delete axe.commons.aria.lookupTable.role.awesomelink;
+	});
+});

--- a/test/integration/rules/aria-dpub-role-fallback/aria-dpub-role-fallback.html
+++ b/test/integration/rules/aria-dpub-role-fallback/aria-dpub-role-fallback.html
@@ -1,0 +1,25 @@
+
+<div id="ok">
+	<!-- links -->
+	<a id="pass1" role="doc-backlink" href="#">ok</a>
+	<a id="pass2" role="doc-biblioref" href="#">ok</a>
+	<a id="pass3" role="doc-glossref" href="#">ok</a>
+	<a id="pass4" role="doc-noteref" href="#">ok</a>
+	<!-- images -->
+	<img id="pass5" role="doc-cover"/>
+	<!-- listitems -->
+	<ul><li id="pass6" role="doc-biblioentry">ok</li></ul>
+	<ul><li id="pass7" role="doc-endnote">ok</li></ul>
+</div>
+<div id="violation">
+	<!-- links -->
+	<div id="fail1" role="doc-backlink">ok</div>
+	<div id="fail2" role="doc-biblioref">ok</div>
+	<div id="fail3" role="doc-glossref">ok</div>
+	<div id="fail4" role="doc-noteref">ok</div>
+	<!-- images -->
+	<div id="fail5" role="doc-cover">ok</div>
+	<!-- listitems -->
+	<div id="fail6" role="doc-biblioentry">ok</div>
+	<div id="fail7" role="doc-endnote">ok</div>
+</div>

--- a/test/integration/rules/aria-dpub-role-fallback/aria-dpub-role-fallback.json
+++ b/test/integration/rules/aria-dpub-role-fallback/aria-dpub-role-fallback.json
@@ -1,0 +1,10 @@
+{
+	"description": "aria-dpub-role-fallback tests",
+	"rule": "aria-dpub-role-fallback",
+	"violations": [
+		["#fail1"], ["#fail2"], ["#fail3"], ["#fail4"], ["#fail5"], ["#fail6"], ["#fail7"]
+	],
+	"passes": [
+		["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"], ["#pass6"], ["#pass7"]
+	]
+}

--- a/test/integration/rules/aria-roles/aria-roles.html
+++ b/test/integration/rules/aria-roles/aria-roles.html
@@ -69,6 +69,45 @@
 	<div role="searchbox" id="pass67">ok</div>
 	<div role="text" id="pass68">ok</div>
 	<div role="table" id="pass69">ok</div>
+	<div role="doc-abstract" id="pass70">ok</div>
+	<div role="doc-acknowledgments" id="pass71">ok</div>
+	<div role="doc-afterword" id="pass72">ok</div>
+	<div role="doc-appendix" id="pass73">ok</div>
+	<div role="doc-backlink" id="pass74">ok</div>
+	<div role="doc-biblioentry" id="pass75">ok</div>
+	<div role="doc-bibliography" id="pass76">ok</div>
+	<div role="doc-biblioref" id="pass77">ok</div>
+	<div role="doc-chapter" id="pass78">ok</div>
+	<div role="doc-colophon" id="pass79">ok</div>
+	<div role="doc-conclusion" id="pass80">ok</div>
+	<div role="doc-cover" id="pass81">ok</div>
+	<div role="doc-credit" id="pass82">ok</div>
+	<div role="doc-credits" id="pass83">ok</div>
+	<div role="doc-dedication" id="pass84">ok</div>
+	<div role="doc-endnote" id="pass85">ok</div>
+	<div role="doc-endnotes" id="pass86">ok</div>
+	<div role="doc-epigraph" id="pass87">ok</div>
+	<div role="doc-epilogue" id="pass88">ok</div>
+	<div role="doc-errata" id="pass89">ok</div>
+	<div role="doc-example" id="pass90">ok</div>
+	<div role="doc-footnote" id="pass91">ok</div>
+	<div role="doc-foreword" id="pass92">ok</div>
+	<div role="doc-glossary" id="pass93">ok</div>
+	<div role="doc-glossref" id="pass94">ok</div>
+	<div role="doc-index" id="pass95">ok</div>
+	<div role="doc-introduction" id="pass96">ok</div>
+	<div role="doc-noteref" id="pass97">ok</div>
+	<div role="doc-notice" id="pass98">ok</div>
+	<div role="doc-pagebreak" id="pass99">ok</div>
+	<div role="doc-pagelist" id="pass100">ok</div>
+	<div role="doc-part" id="pass101">ok</div>
+	<div role="doc-preface" id="pass102">ok</div>
+	<div role="doc-prologue" id="pass103">ok</div>
+	<div role="doc-pullquote" id="pass104">ok</div>
+	<div role="doc-qna" id="pass105">ok</div>
+	<div role="doc-subtitle" id="pass106">ok</div>
+	<div role="doc-tip" id="pass107">ok</div>
+	<div role="doc-toc" id="pass108">ok</div>
 </div>
 <div id="violation">
 	<!-- abstract roles -->

--- a/test/integration/rules/aria-roles/aria-roles.json
+++ b/test/integration/rules/aria-roles/aria-roles.json
@@ -15,6 +15,12 @@
 		["#pass43"], ["#pass44"], ["#pass45"], ["#pass46"], ["#pass47"], ["#pass48"], ["#pass49"],
 		["#pass50"], ["#pass51"], ["#pass52"], ["#pass53"], ["#pass54"], ["#pass55"], ["#pass56"],
 		["#pass57"], ["#pass58"], ["#pass59"], ["#pass60"], ["#pass61"], ["#pass62"], ["#pass63"],
-		["#pass64"], ["#pass65"], ["#pass66"], ["#pass67"], ["#pass68"], ["#pass69"]
+		["#pass64"], ["#pass65"], ["#pass66"], ["#pass67"], ["#pass68"], ["#pass69"], ["#pass70"],
+		["#pass71"], ["#pass72"], ["#pass73"], ["#pass74"], ["#pass75"], ["#pass76"], ["#pass77"],
+		["#pass78"], ["#pass79"], ["#pass80"], ["#pass81"], ["#pass82"], ["#pass83"], ["#pass84"],
+		["#pass85"], ["#pass86"], ["#pass87"], ["#pass88"], ["#pass89"], ["#pass90"], ["#pass91"],
+		["#pass92"], ["#pass93"], ["#pass94"], ["#pass95"], ["#pass96"], ["#pass97"], ["#pass98"],
+		["#pass99"], ["#pass100"], ["#pass101"], ["#pass102"], ["#pass103"], ["#pass104"], ["#pass105"],
+		["#pass106"], ["#pass107"], ["#pass108"]
 	]
 }

--- a/test/rule-matches/aria-dpub-role-fallback-matches.js
+++ b/test/rule-matches/aria-dpub-role-fallback-matches.js
@@ -1,0 +1,55 @@
+describe('aria-dpub-role-fallback-matches', function () {
+	'use strict';
+
+	var fixture = document.getElementById('fixture');
+	var rule;
+
+	beforeEach(function () {
+		rule = axe._audit.rules.find(function (rule) {
+			return rule.id === 'aria-dpub-role-fallback';
+		});
+	});
+
+	afterEach(function () {
+		fixture.innerHTML = '';
+	});
+
+	it('is a function', function () {
+		assert.isFunction(rule.matches);
+	});
+
+	it('should not match elements with no role', function () {
+		fixture.innerHTML = '<div></div>';
+		var target = fixture.children[0];
+
+		assert.isFalse(rule.matches(target));
+	});
+
+	it('should not match elements with a nonsensical role', function () {
+		fixture.innerHTML = '<div role="yay"></div>';
+		var target = fixture.children[0];
+
+		assert.isFalse(rule.matches(target));
+	});
+
+	it('should not match elements with a non-DPUB role', function () {
+		fixture.innerHTML = '<div role="main"></div>';
+		var target = fixture.children[0];
+
+		assert.isFalse(rule.matches(target));
+	});
+
+	it('should not match elements with a "harmless" DPUB role', function () {
+		fixture.innerHTML = '<div role="doc-bibliography"></div>';
+		var target = fixture.children[0];
+
+		assert.isFalse(rule.matches(target));
+	});
+
+	it('should match elements with one of the targeted DPUB roles"', function () {
+		fixture.innerHTML = '<div role="doc-backlink"></div>';
+		var target = fixture.children[0];
+
+		assert.isTrue(rule.matches(target));
+	});
+});


### PR DESCRIPTION
# aria-dpub-role-fallback

Ensures that DPUB ARIA roles that are unsupported and may have a negative
impact are only used on elements which have a compatible implicit ARIA
role fallback.

**Tags**: cat.aria, wcag2a, wcag131

## Selector

CSS selector `[role]`
+ JS matcher that matches the elements with the following roles: 'doc-backlink', 'doc-biblioentry', 'doc-biblioref', 'doc-cover', 'doc-endnote', 'doc-glossref', 'doc-noteref'

## Checks

###  implicit-role-fallback (all)

1. gets the element’s role
2. if there’s no role, or the role is invalid, ignore (return `true`)
3. return `true` if and only if the role’s type is equal to the element’s implicit role (i.e. if the implicit role is a compatible fallback for the explicit role).

This PR implements the rule to complement #584 
