### PR TITLE
fix: allow title on button-name

### DIFF
--- a/lib/rules/button-name.json
+++ b/lib/rules/button-name.json
@@ -20,7 +20,8 @@
     "aria-label",
     "aria-labelledby",
     "role-presentation",
-    "role-none"
+    "role-none",
+    "non-empty-title"
   ],
   "none": [
     "focusable-no-name"

--- a/test/integration/rules/button-name/button-name.html
+++ b/test/integration/rules/button-name/button-name.html
@@ -10,3 +10,5 @@
 <div id="labeldiv">Button label</div>
 <div id="emptydiv"></div>
 <button id="combo" aria-label="Aria Name">Name</button>
+<button id="buttonTitle" title="Title"></button>
+<input id="inputTitle" title="Search" type="button">

--- a/test/integration/rules/button-name/button-name.json
+++ b/test/integration/rules/button-name/button-name.json
@@ -2,5 +2,5 @@
 	"description": "button-name test",
 	"rule": "button-name",
 	"violations": [["#empty"], ["#val"], ["#alempty"], ["#albmissing"], ["#albempty"]],
-	"passes": [["#text"], ["#al"], ["#alb"], ["#combo"]]
+	"passes": [["#text"], ["#al"], ["#alb"], ["#combo"], ["#buttonTitle"], ["#inputTitle"]]
 }


### PR DESCRIPTION
This change makes it more clear that `title` is allowed for accessible naming of button elements and button inputs.

Closes https://github.com/dequelabs/axe-core/issues/747
Closes https://github.com/dequelabs/axe-core/issues/765