### PR TITLE
fix documentation of check properties

### DIFF
--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -25,12 +25,12 @@ aXe 3.0 supports open Shadow DOM: see our virtual DOM APIs and test utilities fo
 ### Environment Pre-requisites
 
 1.  You must have NodeJS installed.
-2.  Grunt must be installed globally.  `npm install -g grunt-cli`
-3.  Install npm development dependencies.  `npm install`
+2.  Grunt must be installed globally.  `npm install -g grunt-cli` (You may need to do this as `sudo npm install -g grunt-cli`)
+3.  Install npm development dependencies.  In the root folder of your axe-core repository, run `npm install`
 
 ### Building axe.js
 
-To build axe.js, simply run `grunt build`.  axe.js and axe.min.js are placed into the `dist` folder.
+To build axe.js, simply run `grunt build` in the root folder of the axe-core repository.  axe.js and axe.min.js are placed into the `dist` folder.
 
 ### Running Tests
 

--- a/doc/rule-development.md
+++ b/doc/rule-development.md
@@ -27,8 +27,8 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | matches              | Function to further filter the outcome of the selector
 | excludeHidden        | Should hidden elements be excluded
 | all                  | Checks that must all return true
-| any                  | Checks that must all return false
-| none                 | Checks of which at least one must return true
+| any                  | Checks of which at least one must return true
+| none                 | Checks that must all return false
 | pageLevel            | Should the rule only run on the main window
 | enabled              | Does the rule run by default
 | tags                 | Grouping for the rule, such as wcag2a, best-practice
@@ -40,7 +40,7 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | Prop. Name         | Description
 |--------------------|-----------------
 | id                 | Unique identifier for the check
-| evaluate           | Evaluating function, returning a boolean value
+| evaluate           | Evaluating function, returning a boolean valuet
 | options            | Configurable value for the check
 | after              | Cleanup function, run after check is done
 | metadata impact    | "minor", "serious", "critical"

--- a/doc/rule-development.md
+++ b/doc/rule-development.md
@@ -44,9 +44,9 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | options            | Configurable value for the check
 | after              | Cleanup function, run after check is done
 | metadata impact    | "minor", "serious", "critical"
-| metadata pass      | Describes why the check passed
-| metadata fail      | Describes why the check failed
-| metadata incomplete| Describes why the check didn’t complete
+| metadata.messages.pass      | Describes why the check passed
+| metadata.messages.fail      | Describes why the check failed
+| metadata.messages.incomplete| Describes why the check didn’t complete
 
 Incomplete results occur when axe-core can’t produce a clear pass or fail result,
 giving users the opportunity to review it manually. Incomplete messages can take

--- a/doc/rule-development.md
+++ b/doc/rule-development.md
@@ -40,7 +40,7 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | Prop. Name         | Description
 |--------------------|-----------------
 | id                 | Unique identifier for the check
-| evaluate           | Evaluating function, returning a boolean valuet
+| evaluate           | Evaluating function, returning a boolean value
 | options            | Configurable value for the check
 | after              | Cleanup function, run after check is done
 | metadata impact    | "minor", "serious", "critical"


### PR DESCRIPTION
the `pass`, `fail` and `incomplete` messages in the check's `metadata` object have to be in a `messages` object.