### PR TITLE
Use application name in respondable

### DIFF
--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -12,7 +12,7 @@
 	 */
 	function _getSource() {
 		var application = 'axe', version = '', src;
-		if (typeof axe !== 'undefined' && axe._audit && !axe._audit.application) {
+		if (typeof axe !== 'undefined' && axe._audit && axe._audit.application) {
 			application = axe._audit.application;
 		}
 		if (typeof axe !== 'undefined') {

--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -11,7 +11,7 @@
 	 * @private
 	 */
 	function _getSource() {
-		var application = 'axe', version = '', src;
+		var application = 'axeAPI', version = '', src;
 		if (typeof axe !== 'undefined' && axe._audit && axe._audit.application) {
 			application = axe._audit.application;
 		}
@@ -37,8 +37,8 @@
 			return ( // Check the version matches
 				postedMessage._source === messageSource ||
 				// Allow free communication with axe test
-				postedMessage._source === 'axe.x.y.z' ||
-				messageSource === 'axe.x.y.z'
+				postedMessage._source === 'axeAPI.x.y.z' ||
+				messageSource === 'axeAPI.x.y.z'
 			);
 		}
 		return false;

--- a/test/core/utils/respondable.js
+++ b/test/core/utils/respondable.js
@@ -118,7 +118,7 @@ describe('axe.utils.respondable', function () {
 		event.initEvent('message', true, true);
 		event.data = JSON.stringify({
 			_respondable: true,
-			_source: 'axe.2.0.0',
+			_source: 'axeAPI.2.0.0',
 			topic: 'Death star',
 			message: 'Help us Obi-Wan',
 			uuid: mockUUID
@@ -133,14 +133,14 @@ describe('axe.utils.respondable', function () {
 		assert.isTrue(success);
 	});
 
-	it('should allow messages with _source axe.x.y.z', function () {
+	it('should allow messages with _source axeAPI.x.y.z', function () {
 		var success = false;
 		var event = document.createEvent('Event');
 		// Define that the event name is 'build'.
 		event.initEvent('message', true, true);
 		event.data = JSON.stringify({
 			_respondable: true,
-			_source: 'axe.x.y.z',
+			_source: 'axeAPI.x.y.z',
 			topic: 'Death star',
 			message: 'Help us Obi-Wan',
 			uuid: mockUUID
@@ -164,7 +164,7 @@ describe('axe.utils.respondable', function () {
 		event.initEvent('message', true, true);
 		event.data = JSON.stringify({
 			_respondable: true,
-			_source: 'axe.2.0.0',
+			_source: 'axeAPI.2.0.0',
 			topic: 'Death star',
 			message: 'Help us Obi-Wan',
 			uuid: mockUUID
@@ -189,7 +189,7 @@ describe('axe.utils.respondable', function () {
 		event.initEvent('message', true, true);
 		event.data = JSON.stringify({
 			_respondable: true,
-			_source: 'axe.2.0.0',
+			_source: 'axeAPI.2.0.0',
 			topic: 'Death star',
 			message: 'Help us Obi-Wan',
 			uuid: mockUUID
@@ -311,7 +311,7 @@ describe('axe.utils.respondable', function () {
 		event.initEvent('message', true, true);
 		event.data = JSON.stringify({
 			_respondable: true,
-			_source: 'axe.2.0.0',
+			_source: 'axeAPI.2.0.0',
 			topic: 'Death star',
 			error: {
 				name: 'ReferenceError',
@@ -340,7 +340,7 @@ describe('axe.utils.respondable', function () {
 		event.initEvent('message', true, true);
 		event.data = JSON.stringify({
 			_respondable: true,
-			_source: 'axe.2.0.0',
+			_source: 'axeAPI.2.0.0',
 			topic: 'Death star',
 			error: {
 				name: 'evil',


### PR DESCRIPTION
The most important change here is respondable.js [line 15](https://github.com/dequelabs/axe-core/pull/825/files#diff-addc6dbd1628709793c7399662a26bfeR15), in response to https://github.com/dequelabs/axe-core/issues/818. We want the source comparison string to use the application name when it exists.

Since the Audit's `application` property is being hard-coded [here](https://github.com/dequelabs/axe-core/blob/develop/lib/core/base/audit.js#L42) as "axeAPI", this also changes the fallback to match so we're using the same application name everywhere. In practice, even though we had set `application` to "axeAPI", almost all message responses were identified as coming from "axe" because the fallback was being applied.