### PR TITLE
fix: Tag video-caption only as SC 1.2.2

### DIFF
--- a/doc/rule-descriptions.md
+++ b/doc/rule-descriptions.md
@@ -65,5 +65,5 @@
 | td-headers-attr | Ensure that each cell in a table using the headers refers to another cell in that table | cat.tables, wcag2a, wcag131, section508, section508.22.g | true |
 | th-has-data-cells | Ensure that each table header in a data table refers to data cells | cat.tables, wcag2a, wcag131, section508, section508.22.g | true |
 | valid-lang | Ensures lang attributes have valid values | cat.language, wcag2aa, wcag312 | true |
-| video-caption | Ensures &lt;video&gt; elements have captions | cat.text-alternatives, wcag2a, wcag122, wcag123, section508, section508.22.a | true |
+| video-caption | Ensures &lt;video&gt; elements have captions | cat.text-alternatives, wcag2a, wcag122, section508, section508.22.a | true |
 | video-description | Ensures &lt;video&gt; elements have audio descriptions | cat.text-alternatives, wcag2aa, wcag125, section508, section508.22.b | true |

--- a/lib/rules/video-caption.json
+++ b/lib/rules/video-caption.json
@@ -6,7 +6,6 @@
     "cat.text-alternatives",
     "wcag2a",
     "wcag122",
-    "wcag123",
     "section508",
     "section508.22.a"
   ],


### PR DESCRIPTION
Small fix for an issue that got reported through Slack.