### PR TITLE
docs: Correct function documentation

### DIFF
--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -135,16 +135,16 @@
 	/**
 	 * Publishes the "respondable" message to the appropriate subscriber
 	 * @private
-	 * @param  {Event} event The event object of the postMessage
-	 * @param  {Object} data  The data sent with the message
-	 * @param  {Boolean}  keepalive Whether to allow multiple responses - default is false
+	 * @param  {Window}  source    The window from which the message originated
+	 * @param  {Object}  data      The data sent with the message
+	 * @param  {Boolean} keepalive Whether to allow multiple responses - default is false
 	 */
-	function publish(target, data, keepalive) {
+	function publish(source, data, keepalive) {
 		var topic = data.topic;
 		var subscriber = subscribers[topic];
 
 		if (subscriber) {
-			var responder = createResponder(target, null, data.uuid);
+			var responder = createResponder(source, null, data.uuid);
 			subscriber(data.message, keepalive, responder);
 		}
 	}


### PR DESCRIPTION
I noticed that the documentation for the `publish` method was inaccurate, referring to a non-existent `event` parameter. I reused the language found in the docs for the `createResponder` method a few lines above.