### PR TITLE
chore: add grunt build step to npm run release

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
   ],
   "main": "axe.js",
   "typings": "axe.d.ts",
+  "standard-version": {
+    "scripts": {
+      "postbump": "npm run sri-update"
+    }
+  },
   "scripts": {
     "build": "grunt",
     "test": "grunt test",
@@ -56,7 +61,8 @@
     "version": "echo \"use 'npm run release' to bump axe-core version\" && exit 1",
     "prepublishOnly": "grunt build",
     "postinstall": "node build/utils/postinstall.js",
-    "release": "standard-version && node build/sri-update"
+    "release": "standard-version -a",
+    "sri-update": "grunt build && node build/sri-update && git add sri-history.json"
   },
   "devDependencies": {
     "angular-precommit": "^1.0.3",


### PR DESCRIPTION
This should hopefully get axe-core into the proper state before creating a new entry for sri-history. My best guess as to why sri-history was changing was because it had been updated without running `grunt build` first, so the source was actually different. This makes it an automatic build step instead of relying on the publisher to remember it. 