### PR TITLE
chore: add sshpk to retireignore

### DIFF
--- a/.retireignore.json
+++ b/.retireignore.json
@@ -12,6 +12,10 @@
 		"justification" : "Used only for testing"
 	},
 	{
+		"path": "node_modules/sshpk",
+		"justification" : "A dependency of retirejs/request"
+	},
+	{
 		"path": "node_modules/grunt-mocha",
 		"justification" : "Used only for testing"
 	},


### PR DESCRIPTION
Grunt-Retire was failing on a dependency of itself (retire -> request -> http-signature -> sshpk). I went down the rabbit-hole of dependencies trying to figure out how to update sshpk, but unfortunately it's 5 dependencies deep. Since we already ignore Retire and Grunt Retire in retireignore.json, it made more sense to add sshpk to the manifest. Hopefully we can upgrade it later on. 

https://hackerone.com/reports/319593
