### PR TITLE
fix(core): Explicitly name the axe module 'axe-core'

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -6,7 +6,8 @@ var axe = axe || {};
 axe.version = '<%= pkg.version %>';
 
 if (typeof define === 'function' && define.amd) {
-	define([], function () {
+	// Explicitly naming the module to avoid mismatched anonymous define() modules when injected in a page
+	define('axe-core', [], function () {
 		'use strict';
 		return axe;
 	});

--- a/test/integration/full/umd/umd-define.js
+++ b/test/integration/full/umd/umd-define.js
@@ -6,8 +6,8 @@ describe('UMD define', function () {
 		assert.equal(defineCalls.length, 1);
 
 		var call = defineCalls[0];
-		assert.isFunction(call[1]);
-		assert.strictEqual(call[1](), axe);
+		assert.isFunction(call[2]);
+		assert.strictEqual(call[2](), axe);
 	});
 
 });


### PR DESCRIPTION
Avoid the "Mismatched anonymous define() modules" error when the axe script is injected in a page that uses requireJS

Closes #849

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
- [ ] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
- [ ] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Description of the changes
- Github issue: 849


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
