### PR TITLE
chore(types): add resultTypes to typings

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -12,6 +12,8 @@ declare module axe {
 
 	type RunOnlyType = "rule" | "rules" | "tag" | "tags";
 
+	type resultGroups = "inapplicable" | "passes" | "incomplete" | "violations";
+
 	type RunOnlyObject = {
 		include?: string[] | string[][],
 		exclude?: string[] | string[][]
@@ -30,7 +32,8 @@ declare module axe {
 		rules?: Object,
 		iframes?: Boolean,
 		elementRef?: Boolean,
-		selectors?: Boolean
+		selectors?: Boolean,
+		resultTypes?: resultGroups[],
 	}
 	interface AxeResults {
 		url: string,


### PR DESCRIPTION
  add missing resultTypes to RunOptions. Fixes TS compilation on some projects.

    fixes #896

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
- [x] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
- [x] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Description of the changes

- Github issue: #896

## Does this PR introduce a breaking change?
Add missing resultTypes to RunOptions introduced in #568. Fixes TS compilation on some projects.
- [ ] Yes
- [x] No

## Other information
