### PR TITLE
fix: Don't require all ARIA IDREFS to exist

### DIFF
--- a/lib/commons/aria/attributes.js
+++ b/lib/commons/aria/attributes.js
@@ -89,11 +89,7 @@ aria.validateAttrValue = function (node, attr) {
 			return true;
 		}
 		list = axe.utils.tokenList(value);
-		// Check if any value isn't in the list of values
-		return list.reduce(function (result, token) {
-			return !!(result && doc.getElementById(token));
-		// Initial state, fail if the list is empty
-		}, list.length !== 0);
+		return list.some((token) => doc.getElementById(token));
 
 	case 'string':
 		// anything goes

--- a/test/commons/aria/attributes.js
+++ b/test/commons/aria/attributes.js
@@ -239,18 +239,23 @@ describe('aria.validateAttrValue', function () {
 			});
 
 			it('should return false when a single referenced node is not found', function () {
-
 				node.setAttribute('cats', 'invalid');
 				// target2 not found
 				assert.isFalse(axe.commons.aria.validateAttrValue(node, 'cats'));
 			});
 
-			it('should return false when a referenced element is not found', function () {
+			it('should return false when at no referenced element is found', function () {
+				fixture.innerHTML = '<div id="target"></div>';
+				node.setAttribute('cats', 'target2 target3');
+				// target2 not found
+				assert.isFalse(axe.commons.aria.validateAttrValue(node, 'cats'));
+			});
 
+			it('should return true when at least one referenced element is found', function () {
 				fixture.innerHTML = '<div id="target"></div>';
 				node.setAttribute('cats', 'target target2');
 				// target2 not found
-				assert.isFalse(axe.commons.aria.validateAttrValue(node, 'cats'));
+				assert.isTrue(axe.commons.aria.validateAttrValue(node, 'cats'));
 			});
 
 			it('should return true when all targets are found', function () {

--- a/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.html
+++ b/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.html
@@ -74,7 +74,7 @@
 	<div aria-controls=" ref ref2 " id="pass22">hi</div>
 
 	<div aria-describedby="ref" id="pass23">hi</div>
-	<div aria-describedby="ref ref2" id="pass24">hi</div>
+	<div aria-describedby="ref ref2 failref" id="pass24">hi</div>
 	<div aria-describedby=" ref ref2 " id="pass25">hi</div>
 
 	<div aria-disabled="true" id="pass26">hi</div>
@@ -117,7 +117,7 @@
 	<div aria-label="stuff" id="pass55">hi</div>
 
 	<div aria-labelledby="ref" id="pass56">hi</div>
-	<div aria-labelledby="ref ref2" id="pass57">hi</div>
+	<div aria-labelledby="ref ref2 failedref" id="pass57">hi</div>
 	<div aria-labelledby=" ref ref2 " id="pass58">hi</div>
 
 	<div aria-level="0" id="pass59">hi</div>
@@ -145,7 +145,7 @@
 	<div aria-orientation="vertical" id="pass76">hi</div>
 
 	<div aria-owns="ref" id="pass77">hi</div>
-	<div aria-owns="ref ref2" id="pass78">hi</div>
+	<div aria-owns="ref ref2 failedref" id="pass78">hi</div>
 	<div aria-owns=" ref ref2 " id="pass79">hi</div>
 
 	<div aria-posinset="0" id="pass80">hi</div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
- [ ] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
- [ ] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Description of the changes

Allow ARIA IDREFS attributes to pass if at least one of the elements exists.

- Github issue: #875

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information
