### PR TITLE
fix(axe.run): allow returning a Promise in jsdom

### DIFF
--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -105,7 +105,7 @@ axe.run = function (context, options, callback) {
 	let reject = noop;
 	let resolve = noop;
 
-	if (window.Promise && callback === noop) {
+	if (typeof Promise === 'function' && callback === noop) {
 		p = new Promise(function (_resolve, _reject) {
 			reject = _reject;
 			resolve = _resolve;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
- [ ] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
- [ ] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Description of the changes

This patch enables `axe.run()` to return a Promise when `window.Promise` is not defined, but there is a Promise implementation in the global scope.

This, while very edge-casey, enables me to run axe in a node process by only importing [`jsdom-global/register`](https://github.com/rstacruz/jsdom-global).

- Github issue:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
