### PR TITLE
fix(accessible-name): Allow fallback labels when input has id

### DIFF
--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -25,7 +25,8 @@ function findLabel(virtualNode) {
 		label = dom.findElmsInContext({
 			elm: 'label', attr: 'for', value: virtualNode.actualNode.id, context: virtualNode.actualNode
 		})[0];
-	} else {
+	}
+	if (!label) {
 		label = dom.findUpVirtual(virtualNode, 'label');
 	}
 	return axe.utils.getNodeFromTree(axe._tree[0], label);

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -778,6 +778,18 @@ describe('text.accessibleTextVirtual', function() {
 			});
 		});
 
+		it('should find implicit labels with id that does not match to a label', function () {
+			types.forEach(function(type) {
+				var t = type ? ' type="' + type + '"' : '';
+				fixture.innerHTML = '<label for="t1">Hello World' +
+					'<input' + t + ' id="foo"></label>';
+				axe._tree = axe.utils.getFlattenedTree(fixture);
+
+				var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+				assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello World', type);
+			});
+		})
+
 		// not implemented yet, doesn't work accross ATs
 		it.skip('should find a placeholder attribute', function() {
 			types.forEach(function(type) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
- [x] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
- [ ] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Description of the changes

I was poking around in the accessibleName method when I found/ noticed this little bug. It turns out that if you have an input element with an ID, Axe doesn't bother looking for an implicit label. That should obviously have been based on if there was actually an explicit label, not if the input has an ID.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

