### PR TITLE
chore: restore comments in axe.js file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -217,7 +217,9 @@ module.exports = function (grunt) {
 						braces: true,
 						quote_style: 1
 					},
-					preserveComments: /^!/
+					output: {
+						comments: /^!/
+					}
 				}
 			},
 			minify: {


### PR DESCRIPTION
When we updated grunt-contrib-uglify through Greenkeeper, it didn't throw an error on the deprecated `preserveComments` option. It needed to be updated to `output.comments` instead.

Closes https://github.com/dequelabs/axe-core/issues/950
