### PR TITLE
fix(utils/element-matches.js): Use `node.matches*` in place of `prototype.matches*`

### DIFF
--- a/lib/core/utils/element-matches.js
+++ b/lib/core/utils/element-matches.js
@@ -9,10 +9,9 @@ axe.utils.matchesSelector = (function () {
 
 	var method;
 
-	function getMethod(win) {
+	function getMethod(node) {
 
 		var index, candidate,
-			elProto = win.Element.prototype,
 			candidates = [
 				'matches',
 				'matchesSelector',
@@ -24,7 +23,7 @@ axe.utils.matchesSelector = (function () {
 
 		for (index = 0; index < length; index++) {
 			candidate = candidates[index];
-			if (elProto[candidate]) {
+			if (node[candidate]) {
 				return candidate;
 			}
 		}
@@ -34,7 +33,7 @@ axe.utils.matchesSelector = (function () {
 	return function (node, selector) {
 
 		if (!method || !node[method]) {
-			method = getMethod(node.ownerDocument.defaultView);
+			method = getMethod(node);
 		}
 
 		return node[method](selector);


### PR DESCRIPTION
Closes https://github.com/dequelabs/axe-core/issues/953

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
- [x] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
- [ ] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Description of the changes

- Github issue: https://github.com/dequelabs/axe-core/issues/953

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
I ran `grunt test` under Linux which fired up two instances of Chromium and one of Firefox. I’m guessing it also used PhantomJS. There was one failure reported, but it was present before these changes were applied:
```
>> URL: http://localhost:9876/test/commons/
>> Describe: color.getBackgroundColor
>> it should ignore inline ancestors of non-overlapping elements
>> AssertionError@http://localhost:9876/node_modules/chai/chai.js:9320:13                                                             
>> [3]</module.exports/Assertion.prototype.assert@http://localhost:9876/node_modules/chai/chai.js:239:13                              
>> [6]</module.exports/assert.equal@http://localhost:9876/node_modules/chai/chai.js:4218:5                                            
>> @http://localhost:9876/test/commons/color/get-background-color.js:365:3  
```

I was unable to find information on how to run the automated test suite on IE, Safari and Chrome for Android.