### PR TITLE
fix: Don't crash with slot elements without shadowDOM

### DIFF
--- a/lib/core/utils/flattened-tree.js
+++ b/lib/core/utils/flattened-tree.js
@@ -89,7 +89,7 @@ axe.utils.getFlattenedTree = function (node, shadowId) {
 		if (nodeName === 'content') {
 			realArray = Array.from(node.getDistributedNodes());
 			return realArray.reduce(reduceShadowDOM, []);
-		} else if (nodeName === 'slot') {
+		} else if (nodeName === 'slot' && typeof node.assignedNodes === 'function') {
 			realArray = Array.from(node.assignedNodes());
 			if (!realArray.length) {
 				// fallback content

--- a/test/core/utils/flattened-tree.js
+++ b/test/core/utils/flattened-tree.js
@@ -231,6 +231,13 @@ describe('axe.utils.getFlattenedTree', function() {
 				assert.equal(virtualDOM[0].actualNode, vNode.actualNode);
 			});
 		});
+	} else {
+		it('does not throw when slot elements are used', function () {
+			fixture.innerHTML = '<button><slot></slot></button>';
+			assert.doesNotThrow(function () {
+				axe.utils.getFlattenedTree(fixture);
+			});
+		});
 	}
 
 	if (shadowSupport.undefined) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message(s) follow our guidelines: https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md#git-commits
- [ ] Changes to rules and checks appropriately support [Shadow DOM](https://github.com/dequelabs/axe-core/blob/develop/doc/developer-guide.md)
- [ ] Changes have been tested in [major browsers and Assistive Technologies](https://github.com/dequelabs/axe-core/blob/develop/doc/accessibility-supported.md#accessibility-supported)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Description of the changes

- Github issue: closes #965

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information
