### PR TITLE
Region: allow forms with non-empty title, plain div[role=form]

### DIFF
--- a/lib/checks/navigation/region.js
+++ b/lib/checks/navigation/region.js
@@ -30,16 +30,14 @@ function isLandmark(virtualNode) {
 	var explictRole = (node.getAttribute('role') || '').trim().toLowerCase();
 
 	if (explictRole) {
-		if (explictRole === 'form') {
-			return !!aria.labelVirtual(virtualNode);
-		}
 		return landmarkRoles.includes(explictRole);
 	} else {
 		// Check if the node matches any of the CSS selectors of implicit landmarks
 		return implicitLandmarks.some(implicitSelector => {
 			let matches = axe.utils.matchesSelector(node, implicitSelector);
 			if (node.tagName.toLowerCase() === 'form') {
-				return matches && !!aria.labelVirtual(virtualNode);
+				let title = node.getAttribute('title') || '';
+				return matches && (!!aria.labelVirtual(virtualNode) || !!axe.commons.text.sanitize(title) );
 			}
 			return matches;
 		});

--- a/lib/checks/navigation/region.js
+++ b/lib/checks/navigation/region.js
@@ -36,8 +36,12 @@ function isLandmark(virtualNode) {
 		return implicitLandmarks.some(implicitSelector => {
 			let matches = axe.utils.matchesSelector(node, implicitSelector);
 			if (node.tagName.toLowerCase() === 'form') {
-				let title = node.getAttribute('title') || '';
-				return matches && (!!aria.labelVirtual(virtualNode) || !!axe.commons.text.sanitize(title) );
+				let titleAttr = node.getAttribute('title');
+				let title =
+					titleAttr && titleAttr.trim() !== ''
+						? axe.commons.text.sanitize(titleAttr)
+						: null;
+				return matches && (!!aria.labelVirtual(virtualNode) || !!title);
 			}
 			return matches;
 		});

--- a/test/checks/navigation/region.js
+++ b/test/checks/navigation/region.js
@@ -160,7 +160,7 @@ describe('region', function() {
 
 	it('treats role=forms with aria label as landmarks', function() {
 		var checkArgs = checkSetup(
-			'<div role="form" id="target" aria-label="foo"><p>This is random content.</p></form>'
+			'<div role="form" id="target" aria-label="foo"><p>This is random content.</p></div>'
 		);
 		assert.isTrue(checks.region.evaluate.apply(checkContext, checkArgs));
 	});

--- a/test/checks/navigation/region.js
+++ b/test/checks/navigation/region.js
@@ -185,14 +185,30 @@ describe('region', function() {
 		assert.deepEqual(checkContext._relatedNodes, [fixture.querySelector('p')]);
 	});
 
-	it('treats forms with an empty aria label as not a landmarks', function() {
+	it('treats forms with non empty titles as landmarks', function() {
 		var checkArgs = checkSetup(
-			'<div role="form" id="target"><p>This is random content.</p></form>'
+			'<form id="target" title="Thing"><p>This is random content.</p></form>'
+		);
+
+		assert.isTrue(checks.region.evaluate.apply(checkContext, checkArgs));
+	});
+
+	it('treats forms with empty titles not as landmarks', function() {
+		var checkArgs = checkSetup(
+			'<form id="target" title=""><p>This is random content.</p></form>'
 		);
 
 		assert.isFalse(checks.region.evaluate.apply(checkContext, checkArgs));
 		assert.lengthOf(checkContext._relatedNodes, 1);
 		assert.deepEqual(checkContext._relatedNodes, [fixture.querySelector('p')]);
+	});
+
+	it('treats ARIA forms with no label or title as landmarks', function() {
+		var checkArgs = checkSetup(
+			'<div role="form" id="target"><p>This is random content.</p></div>'
+		);
+
+		assert.isTrue(checks.region.evaluate.apply(checkContext, checkArgs));
 	});
 
 	(shadowSupport.v1 ? it : xit)('should test Shadow tree content', function() {


### PR DESCRIPTION
Form elements with a title attribute are now counted as landmarks, whereas forms without a label or title are not. ARIA forms are counted as landmarks regardless of label or title.

Closes  #962 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
