### PR TITLE
fix: consistent landmark rule/check descriptions

### DIFF
--- a/lib/checks/keyboard/page-has-main.json
+++ b/lib/checks/keyboard/page-has-main.json
@@ -9,7 +9,7 @@
     "impact": "moderate",
     "messages": {
       "pass": "Page has at least one main landmark",
-      "fail": "Page must have a main landmark"
+      "fail": "Page does not have a main landmark"
     }
   }
 }

--- a/lib/checks/keyboard/page-no-duplicate-contentinfo.json
+++ b/lib/checks/keyboard/page-no-duplicate-contentinfo.json
@@ -8,8 +8,8 @@
 	"metadata": {
 		"impact": "moderate",
 		"messages": {
-		"pass": "Document has no more than one contentinfo landmark",
-		"fail": "Document has more than one contentinfo landmark"
+		"pass": "Page does not have more than one contentinfo landmark",
+		"fail": "Page has more than one contentinfo landmark"
 		}
 	}
 }

--- a/lib/checks/keyboard/page-no-duplicate-main.json
+++ b/lib/checks/keyboard/page-no-duplicate-main.json
@@ -7,8 +7,8 @@
 	"metadata": {
 		"impact": "moderate",
 		"messages": {
-		"pass": "Document has no more than one main landmark",
-		"fail": "Document has more than one main landmark"
+		"pass": "Page does not have more than one main landmark",
+		"fail": "Page has more than one main landmark"
 		}
 	}
 }

--- a/lib/checks/navigation/region.json
+++ b/lib/checks/navigation/region.json
@@ -5,8 +5,8 @@
   "metadata": {
     "impact": "moderate",
     "messages": {
-      "pass": "Content contained by ARIA landmark",
-      "fail": "Content not contained by an ARIA landmark"
+      "pass": "All page content is contained by landmarks",
+      "fail": "Some page content is not contained by landmarks"
     }
   }
 }

--- a/lib/rules/landmark-banner-is-top-level.json
+++ b/lib/rules/landmark-banner-is-top-level.json
@@ -7,8 +7,8 @@
     "best-practice"
   ],
   "metadata": {
-    "description": "The banner landmark should not be contained in another landmark",
-    "help": "Banner landmark must be at top level"
+    "description": "Ensures the banner landmark is at top level",
+    "help": "Banner landmark must not be contained in another landmark"
   },
   "all": [],
   "any": [

--- a/lib/rules/landmark-contentinfo-is-top-level.json
+++ b/lib/rules/landmark-contentinfo-is-top-level.json
@@ -7,8 +7,8 @@
     "best-practice"
   ],
   "metadata": {
-    "description": "The contentinfo landmark should not be contained in another landmark",
-    "help": "Contentinfo landmark must be at top level"
+    "description": "Ensures the contentinfo landmark is at top level",
+    "help": "Contentinfo landmark must not be contained in another landmark"
   },
   "all": [],
   "any": [

--- a/lib/rules/landmark-main-is-top-level.json
+++ b/lib/rules/landmark-main-is-top-level.json
@@ -6,8 +6,8 @@
     "best-practice"
   ],
   "metadata": {
-    "description": "The main landmark should not be contained in another landmark",
-    "help": "Main landmark is not at top level"
+    "description": "Ensures the main landmark is at top level",
+    "help": "Main landmark must not be contained in another landmark"
   },
   "all": [],
   "any": [

--- a/lib/rules/landmark-no-duplicate-banner.json
+++ b/lib/rules/landmark-no-duplicate-banner.json
@@ -6,8 +6,8 @@
     "best-practice"
   ],
   "metadata": {
-    "description": "Ensures the document has no more than one banner landmark",
-    "help": "Document contain at most one banner landmark"
+    "description": "Ensures the page has at most one banner landmark",
+    "help": "Page must not have more than one banner landmark"
   },
   "all": [],
   "any": [

--- a/lib/rules/landmark-no-duplicate-contentinfo.json
+++ b/lib/rules/landmark-no-duplicate-contentinfo.json
@@ -6,8 +6,8 @@
     "best-practice"
   ],
   "metadata": {
-    "description": "Ensures the document has no more than one contentinfo landmark",
-    "help": "Document contain at most one contentinfo landmark"
+    "description": "Ensures the page has at most one contentinfo landmark",
+    "help": "Page must not have more than one contentinfo landmark"
   },
   "all": [],
   "any": [

--- a/lib/rules/landmark-one-main.json
+++ b/lib/rules/landmark-one-main.json
@@ -6,8 +6,8 @@
 		"best-practice"
 	],
 	"metadata": {
-		"description": "Ensures a navigation point to the primary content of the page. If the page contains iframes, each iframe should contain either no main landmarks or just one",
-		"help": "Page must contain one main landmark"
+		"description": "Ensures the page has only one main landmark and each iframe in the page has at most one main landmark",
+		"help": "Page must have one main landmark"
 	},
 	"all": [
 		"page-has-main",

--- a/lib/rules/region.json
+++ b/lib/rules/region.json
@@ -7,8 +7,8 @@
     "best-practice"
   ],
   "metadata": {
-    "description": "Ensures all content is contained within a landmark region",
-    "help": "Content should be contained in a landmark region"
+    "description": "Ensures all page content is contained by landmarks",
+    "help": "All page content must be contained by landmarks"
   },
   "all": [],
   "any": [


### PR DESCRIPTION
Some of the help and description text entries for landmark rules didn't read very well, and weren't consistent with each other. Thanks very much to @iamrafan for the suggestions!

Closes https://github.com/dequelabs/axe-core/issues/983

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
