### PR TITLE
doc(examples): add simple Puppeteer example

### DIFF
--- a/doc/examples/puppeteer/.eslintrc
+++ b/doc/examples/puppeteer/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 8
+  }
+}

--- a/doc/examples/puppeteer/.npmrc
+++ b/doc/examples/puppeteer/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/doc/examples/puppeteer/README.md
+++ b/doc/examples/puppeteer/README.md
@@ -1,0 +1,10 @@
+# axe-puppeteer-example
+
+This example demonstrates how to use `axe-core` with [Puppeteer](https://github.com/GoogleChrome/puppeteer).
+
+## To run the example
+
+* Ensure Node v8+ is installed and on `PATH`
+* Move to the `doc/examples/puppeteer` directory
+* Run `npm install`
+* Run `node axe-puppeteer.js http://www.deque.com` to run `axe-core` via Puppeteer against http://www.deque.com and output results to the terminal

--- a/doc/examples/puppeteer/README.md
+++ b/doc/examples/puppeteer/README.md
@@ -1,6 +1,8 @@
 # axe-puppeteer-example
 
-This example demonstrates how to use `axe-core` with [Puppeteer](https://github.com/GoogleChrome/puppeteer).
+This (very minimal) example demonstrates how to use `axe-core` with [Puppeteer](https://github.com/GoogleChrome/puppeteer).
+
+The example does not have feature pairty with [`axe-webdriverjs`](https://github.com/dequelabs/axe-webdriverjs), and does not run on `<iframe>`s.
 
 ## To run the example
 

--- a/doc/examples/puppeteer/axe-puppeteer.js
+++ b/doc/examples/puppeteer/axe-puppeteer.js
@@ -1,0 +1,60 @@
+const puppeteer = require('puppeteer');
+const axeCore = require('axe-core');
+const { parse: parseURL } = require('url');
+const assert = require('assert');
+
+// Cheap URL validation
+const isValidURL = input => {
+	const u = parseURL(input);
+	return u.protocol && u.host;
+};
+
+// node axe-puppeteer.js <url>
+const url = process.argv[2];
+assert(isValidURL(url), 'Invalid URL');
+
+const main = async url => {
+	let browser;
+	let results;
+	try {
+		// Setup Puppeteer
+		browser = await puppeteer.launch();
+
+		// Get new page
+		const page = await browser.newPage();
+		await page.goto(url);
+
+		// Inject and run axe-core
+		const handle = await page.evaluateHandle(`
+			// Inject axe source code
+			${axeCore.source}
+			// Run axe
+			axe.run()
+		`);
+
+		// Get the results from `axe.run()`.
+		results = await handle.jsonValue();
+		// Destroy the handle & return axe results.
+		await handle.dispose();
+	} catch (err) {
+		// Ensure we close the puppeteer connection when possible
+		if (browser) {
+			await browser.close();
+		}
+
+		// Re-throw
+		throw err;
+	}
+
+	await browser.close();
+	return results;
+};
+
+main(url)
+	.then(results => {
+		console.log(results);
+	})
+	.catch(err => {
+		console.error('Error running axe-core:', err.message);
+		process.exit(1);
+	});

--- a/doc/examples/puppeteer/package.json
+++ b/doc/examples/puppeteer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "axe-puppeteer",
+  "version": "0.0.0",
+  "private": true,
+  "main": "axe-puppeteer.js",
+  "dependencies": {
+    "axe-core": "^3.0.3",
+    "puppeteer": "^1.6.0"
+  }
+}


### PR DESCRIPTION
As requested, this patch adds an example of using `axe-core` with [Puppeteer](https://github.com/GoogleChrome/puppeteer). The example is very minimal and does not include all of `axe-webdriverjs`'s features.

Related to #1008.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
