### PR TITLE
ci: Speed up builds by caching node_modules

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,12 @@ jobs:
       - image: circleci/node:6.12.3-browsers
     steps:
       - checkout
-      - run:
-          name: install-npm
-          command: npm install
-      - run:
-          name: test
-          command: npm test
+      - restore_cache:
+          keys:
+            - npm-deps-{{ checksum "package-lock.json" }}
+      - run: npm install
+      - save_cache:
+          key: npm-deps-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
+      - run: npm test

--- a/circle.yml
+++ b/circle.yml
@@ -8,10 +8,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - npm-deps-{{ checksum "package-lock.json" }}
+            - npm-deps-{{ checksum "package.json" }}
       - run: npm install
       - save_cache:
-          key: npm-deps-{{ checksum "package-lock.json" }}
+          key: npm-deps-{{ checksum "package.json" }}
           paths:
             - node_modules
       - run: npm test

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:6.12.3-browsers
+    working_directory: ~/axe-core
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
This patch reduces the CircleCI build time by about ~2 minutes since do not have to `npm install` in most builds/scenarios.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu
