### PR TITLE
build(eslint): enable usage of the "spread" operator

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": ["prettier"],
+  "parserOptions":{
+    "ecmaVersion": 9
+  },
   "env": {
     "node": true
   },

--- a/doc/examples/chrome-debugging-protocol/.eslintrc
+++ b/doc/examples/chrome-debugging-protocol/.eslintrc
@@ -3,6 +3,6 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 8
+    "ecmaVersion": 9
   }
 }

--- a/doc/examples/puppeteer/.eslintrc
+++ b/doc/examples/puppeteer/.eslintrc
@@ -3,6 +3,6 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 8
+    "ecmaVersion": 9
   }
 }

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -16,14 +16,7 @@ function getDefaultConfiguration(audit) {
 	config.reporter = config.reporter || null;
 	config.rules = config.rules || [];
 	config.checks = config.checks || [];
-	config.data = Object.assign(
-		{
-			checks: {},
-			rules: {}
-		},
-		config.data
-	);
-
+	config.data = { checks: {}, rules: {}, ...config.data };
 	return config;
 }
 


### PR DESCRIPTION
The patch updates our ESLint configs and instructs ESLint to enable ECMA v9 features (including the spread `...` operator).

Additionally, a random usage of `Object.assign()` has been replaced by the spread operator to ensure this is working as expected.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: << Name here >>
