### PR TITLE
test: throw a helpful error when running alongside the extension

### DIFF
--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,3 +1,10 @@
+// Let the user know they need to disable their axe/attest extension before running the tests.
+if (window.__AXE_EXTENSION__) {
+	throw new Error(
+		'You must disable your axe/attest browser extension in order to run the test suite.'
+	);
+}
+
 /*eslint indent: 0*/
 var testUtils = {};
 


### PR DESCRIPTION
Currently running the `axe-core` test suite in a browser that has either the axe or attest extension enabled will yield unpredictable and confusing results. This patch causes the test suite to throw an error instructing people to disable their extension(s) before running their tests.

I ran into this while working on a feature and wasted ~1 day trying to debug. :'(

Side note - I'm opening a seperate PR into the extensions repository which exposes the `__AXE_EXTENSION__` global.`

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @isner
