### PR TITLE
doc: fix typo in puppeteer README

### DIFF
--- a/doc/examples/puppeteer/README.md
+++ b/doc/examples/puppeteer/README.md
@@ -2,7 +2,7 @@
 
 This (very minimal) example demonstrates how to use `axe-core` with [Puppeteer](https://github.com/GoogleChrome/puppeteer).
 
-The example does not have feature pairty with [`axe-webdriverjs`](https://github.com/dequelabs/axe-webdriverjs), and does not run on `<iframe>`s.
+The example does not have feature parity with [`axe-webdriverjs`](https://github.com/dequelabs/axe-webdriverjs), and does not run on `<iframe>`s.
 
 ## To run the example
 


### PR DESCRIPTION
In linking to this demo from deque.com, I saw a typo that needed fixing.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen