### PR TITLE
fix(errormessage): check data is an array of IDs

### DIFF
--- a/lib/checks/aria/errormessage.js
+++ b/lib/checks/aria/errormessage.js
@@ -21,7 +21,7 @@ function validateAttrValue() {
 // limit results to elements that actually have this attribute
 if (options.indexOf(attr) === -1 && hasAttr) {
 	if (!validateAttrValue()) {
-		this.data(attr);
+		this.data(axe.utils.tokenList(attr));
 		return false;
 	}
 }

--- a/test/checks/aria/errormessage.js
+++ b/test/checks/aria/errormessage.js
@@ -56,6 +56,16 @@ describe('aria-errormessage', function() {
 		);
 	});
 
+	it('sets an array of IDs in data', function() {
+		var testHTML = '<div></div>';
+		testHTML += '<div id="plain"></div>';
+		fixture.innerHTML = testHTML;
+		var target = fixture.children[0];
+		target.setAttribute('aria-errormessage', ' foo  bar \tbaz  ');
+		checks['aria-errormessage'].evaluate.call(checkContext, target);
+		assert.deepEqual(checkContext._data, ['foo', 'bar', 'baz']);
+	});
+
 	(shadowSupported ? it : xit)(
 		'should return false if aria-errormessage value crosses shadow boundary',
 		function() {


### PR DESCRIPTION
The messages templates of the errormessage check expects data to be an array rather than a string. This fixes that issue. Instead of getting this:

> aria-errormessage values `m,y,-,i,d` must use a technique to announce the message (e.g., aria-live, aria-describedby, role=alert, etc.)

This fix returns:
> aria-errormessage value `my-id` must use a technique to announce the message (e.g., aria-live, aria-describedby, role=alert, etc.)

Closes issue: none

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jey(@jkodu)
