### PR TITLE
chore: Update codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @WilcoFiers
+* @marcysutton
+* @dylanb


### PR DESCRIPTION
Adding Marcy and Dylan as code owners. Unlike most other axe / Attest repos, we wanted for this one to always have approval from a code owner on a PR to develop.

Closes issue: none

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jey(@jkodu)
