### PR TITLE
doc: add axe-selenium-python to projects

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -23,6 +23,7 @@ Add your project/integration to this file and submit a pull request.
 1. [Sonarwhal](https://sonarwhal.com/)
 1. [Web Accessibility Checker for Visual Studio](https://visualstudiogallery.msdn.microsoft.com/3aabefab-1681-4fea-8f95-6a62e2f0f1ec)
 1. [Ace, by DAISY](https://daisy.github.io/ace)
+1. [axe Selenium Python](https://github.com/mozilla-services/axe-selenium-python)
 1. [aXe audit runner for CrawlKit](https://github.com/crawlkit/runner-axe)
 1. [Selenium IDE aXe Extension](https://github.com/bkardell/selenium-ide-axe)
 1. [Axegrinder](https://github.com/claflamme/axegrinder)


### PR DESCRIPTION
Added a project for Python projects maintained by Mozilla: https://github.com/mozilla-services/axe-selenium-python

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jey (@jkodu)
