### PR TITLE
chore: Update codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @WilcoFiers
-* @marcysutton
-* @dylanb
+* @dequelabs/axe-codeowners


### PR DESCRIPTION
Created a codeowners team to see if we can set it up so that at least one codeowner has to approve axe-core PRs to develop. Hope this works.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jey (@jkodu)
