### PR TITLE
fix: frame wait time test case

### DIFF
--- a/test/integration/full/frame-wait-time/frame-wait-time.js
+++ b/test/integration/full/frame-wait-time/frame-wait-time.js
@@ -8,30 +8,22 @@ describe('frame-wait-time option', function() {
 	});
 
 	describe('when set', function() {
-		/**
-		 * Commenting out test, due to issue addressed beloe.
-		 * https://github.com/dequelabs/axe-core/issues/929
-		 */
-		// var opts = {
-		// 	frameWaitTime: 1
-		// };
-		it(
-			'should modify the default frame timeout'
-			// Issue -
-			// function (done) {
-			// 	var start = new Date();
-			// 	// Run axe with an unreasonably short wait time,
-			// 	// expecting the frame to time out
-			// 	axe.run('#frame', opts, function (err, res) {
-			// 		assert.isNotNull(err);
-			// 		assert.isUndefined(res);
-			// 		assert.equal(err.message, 'Axe in frame timed out: #frame');
-			// 		// Ensure that axe waited less than the default wait time
-			// 		assert.isBelow(new Date() - start, 60000);
-			// 		done();
-			// 	});
-			// }
-		);
+		var opts = {
+			frameWaitTime: 1
+		};
+		it('should modify the default frame timeout', function(done) {
+			var start = new Date();
+			// Run axe with an unreasonably short wait time,
+			// expecting the frame to time out
+			axe.run('#frame', opts, function(err, res) {
+				assert.isNotNull(err);
+				assert.isUndefined(res);
+				assert.equal(err.message, 'Axe in frame timed out: #frame');
+				// Ensure that axe waited less than the default wait time
+				assert.isBelow(new Date() - start, 60000);
+				done();
+			});
+		});
 	});
 
 	describe('when not set', function() {


### PR DESCRIPTION
- The bug is not relevant anymore, and believe has been fixed as a consequence of changes done to allow webdriver to have a larger timeout.
-  Ran multiple test runs on circle, both locally and https://circleci.com/gh/dequelabs/axe-core/tree/bug-frame-wait-time. Test assertions for `frame-wait-time` are as expected.

Closes issue: https://github.com/dequelabs/axe-core/issues/929

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers