### PR TITLE
[WIP] fix: run babel on test directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,7 +80,8 @@ module.exports = function(grunt) {
 		clean: ['dist', 'tmp', 'axe.js', 'axe.*.js'],
 		babel: {
 			options: {
-				compact: 'false'
+				compact: 'false',
+				presets: ['env']
 			},
 			core: {
 				files: [
@@ -89,6 +90,16 @@ module.exports = function(grunt) {
 						cwd: 'lib/core',
 						src: ['**/*.js'],
 						dest: 'tmp/core'
+					}
+				]
+			},
+			test: {
+				files: [
+					{
+						expand: true,
+						cwd: 'test/',
+						src: ['**/*.js'],
+						dest: 'tmp/test'
 					}
 				]
 			},
@@ -271,7 +282,8 @@ module.exports = function(grunt) {
 					fixture: 'test/runner.tmpl',
 					testCwd: 'test/core',
 					data: {
-						title: 'aXe Core Tests'
+						title: 'aXe Core Tests',
+						pathPrefix: 'tmp/test/core'
 					}
 				}
 			},
@@ -286,7 +298,8 @@ module.exports = function(grunt) {
 					fixture: 'test/runner.tmpl',
 					testCwd: 'test/checks',
 					data: {
-						title: 'aXe Check Tests'
+						title: 'aXe Check Tests',
+						pathPrefix: 'tmp/test/checks'
 					}
 				}
 			},
@@ -301,7 +314,8 @@ module.exports = function(grunt) {
 					fixture: 'test/runner.tmpl',
 					testCwd: 'test/commons',
 					data: {
-						title: 'aXe Commons Tests'
+						title: 'aXe Commons Tests',
+						pathPrefix: 'tmp/test/commons'
 					}
 				}
 			},
@@ -316,7 +330,8 @@ module.exports = function(grunt) {
 					fixture: 'test/runner.tmpl',
 					testCwd: 'test/rule-matches',
 					data: {
-						title: 'aXe Rule Matches Tests'
+						title: 'aXe Rule Matches Tests',
+						pathPrefix: 'tmp/test/rule-matches'
 					}
 				}
 			},
@@ -328,7 +343,8 @@ module.exports = function(grunt) {
 					testCwd: 'test/integration/rules',
 					tests: ['../../../tmp/integration-tests.js', 'runner.js'],
 					data: {
-						title: 'aXe Integration Tests'
+						title: 'aXe Integration Tests',
+						pathPrefix: 'tmp/test/integration'
 					}
 				}
 			}

--- a/test/integration/rules/runner.tmpl
+++ b/test/integration/rules/runner.tmpl
@@ -25,7 +25,7 @@
 		<div id="mocha"></div>
 		<div id="fixture"></div>
 		<% tests.forEach(function (file) { %>
-			<script src="<%=file%>"></script>
+			<script src="/<%=data.pathPrefix%>/<%=file%>"></script>
 		<%  }); %>
 
 		<script src="/test/integration/adapter.js"></script>

--- a/test/runner.tmpl
+++ b/test/runner.tmpl
@@ -27,7 +27,7 @@
 		<div id="fixture"></div>
 		<script src="/test/testutils.js"></script>
 		<% tests.forEach(function (file) { %>
-			<script src="<%=file%>"></script>
+			<script src="/<%=data.pathPrefix%>/<%=file%>"></script>
 		<%  }); %>
 
 		<script>


### PR DESCRIPTION
**NOTE: Status is WIP, do not review**

- Added grunt babel step to run against `test` directory.
- The transpiled files are generated into `tmp/test` directory.
- references to scripts in `runner.tmpl` files for unit and integration tests are changed to the above directory `tmp/test/<path-to-file>` for respective tests.

Closes issue: https://github.com/dequelabs/axe-core/issues/1059

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
