### PR TITLE
ci: do not use `npx` binary

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -43,7 +43,7 @@ jobs:
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache
-      - run: npx standard-version --scripts.prebump=./build/next-version.js --skip.commit=true --skip.tag=true
+      - run: npm run next-release
       - run: npm publish --tag=next
 
   # Release a "production" version

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prepublishOnly": "grunt build",
     "postinstall": "node build/utils/postinstall.js",
     "release": "standard-version -a",
+    "next-release": "standard-version --scripts.prebump=./build/next-version.js --skip.commit=true --skip.tag=true",
     "sri-update": "grunt build && node build/sri-update && git add sri-history.json",
     "fmt": "prettier --write  *.js, **/*.ts '{build,doc,lib,test}/**/*.js'",
     "precommit": "lint-staged"


### PR DESCRIPTION
The `npx` package doesn't ship with the version of `npm` we're using (which is 3.x in node v6.12.3). Instead of relying on it, we execute the `standard-version` binary via `npm script` instead.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
