### PR TITLE
chore: Fix example dependency mistake

### DIFF
--- a/doc/examples/jest_react/package.json
+++ b/doc/examples/jest_react/package.json
@@ -18,7 +18,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "^1.5.0",
+    "enzyme-adapter-react-16": "^1.2.0",
     "jest": "^22.4.0",
     "jest-cli": "^23.0.1",
     "react": "^16.4.0",


### PR DESCRIPTION
For some reason Greenkeeper had us bump a dependency to a non-existing version.

Closes #1090

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu
