### PR TITLE
fix: Do not flag font icons in color-contrast rule

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -1,42 +1,44 @@
-if (!axe.commons.dom.isVisible(node, false)) {
+const { dom, color, text } = axe.commons;
+
+if (!dom.isVisible(node, false)) {
 	return true;
 }
 
-var noScroll = !!(options || {}).noScroll;
-var bgNodes = [],
-	bgColor = axe.commons.color.getBackgroundColor(node, bgNodes, noScroll),
-	fgColor = axe.commons.color.getForegroundColor(node, noScroll);
+const noScroll = !!(options || {}).noScroll;
+const bgNodes = [];
+const bgColor = color.getBackgroundColor(node, bgNodes, noScroll);
+const fgColor = color.getForegroundColor(node, noScroll);
 
-var nodeStyle = window.getComputedStyle(node);
-var fontSize = parseFloat(nodeStyle.getPropertyValue('font-size'));
-var fontWeight = nodeStyle.getPropertyValue('font-weight');
-var bold =
+const nodeStyle = window.getComputedStyle(node);
+const fontSize = parseFloat(nodeStyle.getPropertyValue('font-size'));
+const fontWeight = nodeStyle.getPropertyValue('font-weight');
+const bold =
 	['bold', 'bolder', '600', '700', '800', '900'].indexOf(fontWeight) !== -1;
 
-var cr = axe.commons.color.hasValidContrastRatio(
-	bgColor,
-	fgColor,
-	fontSize,
-	bold
-);
+const cr = color.hasValidContrastRatio(bgColor, fgColor, fontSize, bold);
 
 // truncate ratio to three digits while rounding down
 // 4.499 = 4.49, 4.019 = 4.01
-var truncatedResult = Math.floor(cr.contrastRatio * 100) / 100;
+const truncatedResult = Math.floor(cr.contrastRatio * 100) / 100;
 
 // if fgColor or bgColor are missing, get more information.
-var missing;
+let missing;
 if (bgColor === null) {
-	missing = axe.commons.color.incompleteData.get('bgColor');
+	missing = color.incompleteData.get('bgColor');
 }
 
-let equalRatio = false;
-if (truncatedResult === 1) {
-	equalRatio = true;
-	missing = axe.commons.color.incompleteData.set('bgColor', 'equalRatio');
+const equalRatio = truncatedResult === 1;
+const shortTextContent =
+	text.visibleVirtual(virtualNode, false, true).length === 1;
+if (equalRatio) {
+	missing = color.incompleteData.set('bgColor', 'equalRatio');
+} else if (shortTextContent) {
+	// Check that the text content is a single character long
+	missing = 'shortTextContent';
 }
+
 // need both independently in case both are missing
-var data = {
+const data = {
 	fgColor: fgColor ? fgColor.toHexString() : undefined,
 	bgColor: bgColor ? bgColor.toHexString() : undefined,
 	contrastRatio: cr ? truncatedResult : undefined,
@@ -48,13 +50,21 @@ var data = {
 
 this.data(data);
 
-//We don't know, so we'll put it into Can't Tell
-if (fgColor === null || bgColor === null || equalRatio) {
+// We don't know, so we'll put it into Can't Tell
+if (
+	fgColor === null ||
+	bgColor === null ||
+	equalRatio ||
+	(shortTextContent && !cr.isValid)
+) {
 	missing = null;
-	axe.commons.color.incompleteData.clear();
+	color.incompleteData.clear();
 	this.relatedNodes(bgNodes);
 	return undefined;
-} else if (!cr.isValid) {
+}
+
+if (!cr.isValid) {
 	this.relatedNodes(bgNodes);
 }
+
 return cr.isValid;

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -16,6 +16,7 @@
         "elmPartiallyObscuring": "Element's background color could not be determined because it partially overlaps other elements",
         "outsideViewport": "Element's background color could not be determined because it's outside the viewport",
         "equalRatio": "Element has a 1:1 contrast ratio with the background",
+        "shortTextContent": "Element content is too short to determine if it is actual text content",
         "default": "Unable to determine contrast ratio"
       }
     }

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -3,9 +3,11 @@ describe('color-contrast', function() {
 
 	var fixture = document.getElementById('fixture');
 	var fixtureSetup = axe.testUtils.fixtureSetup;
+	var checkSetup = axe.testUtils.checkSetup;
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 	var checkContext = axe.testUtils.MockCheckContext();
+	var contrastEvaluate = checks['color-contrast'].evaluate;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
@@ -14,14 +16,14 @@ describe('color-contrast', function() {
 	});
 
 	it('should return the proper values stored in data', function() {
-		fixture.innerHTML =
-			'<div id="parent" style="color: black; background-color: white; font-size: 14pt"><b id="target">' +
-			'My text</b></div>';
-		var target = fixture.querySelector('#target');
-
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		var params = checkSetup(
+			'<div id="parent" style="color: black; background-color: white; font-size: 14pt">' +
+				'<b id="target">My text</b></div>'
+		);
 		var white = new axe.commons.color.Color(255, 255, 255, 1);
 		var black = new axe.commons.color.Color(0, 0, 0, 1);
+
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.equal(checkContext._data.bgColor, white.toHexString());
 		assert.equal(checkContext._data.fgColor, black.toHexString());
 		assert.equal(checkContext._data.contrastRatio, '21.00');
@@ -31,148 +33,138 @@ describe('color-contrast', function() {
 	});
 
 	it('should return true when there is sufficient contrast because of bold tag', function() {
-		fixture.innerHTML =
-			'<div id="parent" style="color: gray; background-color: white; font-size: 14pt"><b id="target">' +
-			'My text</b></div>';
-		var target = fixture.querySelector('#target');
+		var params = checkSetup(
+			'<div id="parent" style="color: gray; background-color: white; font-size: 14pt">' +
+				'<b id="target">My text</b></div>'
+		);
 
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return true when there is sufficient contrast because of font weight', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="color: gray; background-color: white; font-size: 14pt; font-weight: bold" id="target">' +
-			'My text</div>';
-		var target = fixture.querySelector('#target');
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+				'My text</div>'
+		);
+
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return true when there is sufficient contrast because of font size', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="color: gray; background-color: white; font-size: 18pt;" id="target">' +
-			'My text</div>';
-		var target = fixture.querySelector('#target');
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+				'My text</div>'
+		);
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return false when there is not sufficient contrast because of font size', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="color: gray; background-color: white; font-size: 8pt; -webkit-text-size-adjust: none;" id="target">' +
-			'My text</div>';
-		var target = fixture.querySelector('#target');
-		assert.isFalse(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				'My text</div>'
 		);
-		assert.deepEqual(checkContext._relatedNodes, [target]);
+
+		assert.isFalse(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._relatedNodes, [params[0]]);
 	});
 
 	it('should return true when there is sufficient contrast with explicit transparency', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div id="parent" style="color: white; background-color: white;">' +
-			'<span style="color: black; background-color: rgba(0,0,0,0)" id="target">My text</span></div>';
-		var target = fixture.querySelector('#target');
+				'<span style="color: black; background-color: rgba(0,0,0,0)" id="target">My text</span></div>'
+		);
 
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return true when there is sufficient contrast with implicit transparency', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div id="parent" style="color: white; background-color: white;">' +
-			'<span style="color: black;" id="target">My text</span></div>';
-		var target = fixture.querySelector('#target');
+				'<span style="color: black;" id="target">My text</span></div>'
+		);
 
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return true when there is sufficient contrast', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="color: black; background-color: white;" id="target">' +
-			'My text</div>';
-		var target = fixture.querySelector('#target');
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+				'My text</div>'
+		);
+
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return true for inline elements with sufficient contrast spanning multiple lines', function() {
-		fixture.innerHTML =
-			'<p>Text oh heyyyy <a href="#" id="target">and here\'s <br>a link</a></p>';
-		var target = fixture.querySelector('#target');
+		var params = checkSetup(
+			'<p>Text oh heyyyy <a href="#" id="target">and here\'s <br>a link</a></p>'
+		);
 		if (window.PHANTOMJS) {
 			assert.ok('PhantomJS is a liar');
 		} else {
-			assert.isTrue(
-				checks['color-contrast'].evaluate.call(checkContext, target)
-			);
+			assert.isTrue(contrastEvaluate.apply(checkContext, params));
 			assert.deepEqual(checkContext._relatedNodes, []);
 		}
 	});
 
 	it('should return undefined for inline elements spanning multiple lines that are overlapped', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="position:relative;"><div style="background-color:rgba(0,0,0,1);position:absolute;width:300px;height:200px;"></div>' +
-			'<p>Text oh heyyyy <a href="#" id="target">and here\'s <br>a link</a></p></div>';
-		var target = fixture.querySelector('#target');
-		assert.isUndefined(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				'<p>Text oh heyyyy <a href="#" id="target">and here\'s <br>a link</a></p></div>'
 		);
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return true for inline elements with sufficient contrast', function() {
-		fixture.innerHTML =
-			'<p>Text oh heyyyy <b id="target">and here\'s bold text</b></p>';
-		var target = fixture.querySelector('#target');
-		var result = checks['color-contrast'].evaluate.call(checkContext, target);
-		assert.isTrue(result);
+		var params = checkSetup(
+			'<p>Text oh heyyyy <b id="target">and here\'s bold text</b></p>'
+		);
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return false when there is not sufficient contrast', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="color: yellow; background-color: white;" id="target">' +
-			'My text</div>';
-		var target = fixture.querySelector('#target');
-		assert.isFalse(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				'My text</div>'
 		);
-		assert.deepEqual(checkContext._relatedNodes, [target]);
+
+		assert.isFalse(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._relatedNodes, [params[0]]);
 	});
 
 	it('should ignore position:fixed elements above the target', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="background-color: #e5f1e5;" id="background">' +
-			'<div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; z-index: 200; color:#fff" >header</div>' +
-			'<div style="height: 6000px;"></div>' +
-			'stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span>' +
-			'<div style="height: 6000px;"></div>' +
-			'</div>';
-		var target = fixture.querySelector('#target');
-		var expectedRelatedNodes = fixture.querySelector('#background');
-		assert.isFalse(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				'<div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; z-index: 200; color:#fff" >header</div>' +
+				'<div style="height: 6000px;"></div>' +
+				'stuff <span id="target" style="color: rgba(91, 91, 90, 0.7)">This is some text</span>' +
+				'<div style="height: 6000px;"></div>' +
+				'</div>'
 		);
+		var expectedRelatedNodes = fixture.querySelector('#background');
+		assert.isFalse(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, [expectedRelatedNodes]);
 	});
 
 	it('should find contrast issues on position:fixed elements', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="background-color: #e5f1e5;" id="background">' +
-			'<div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; z-index: 200; color:#fff" id="target">header</div>' +
-			'<div style="height: 6000px;"></div>' +
-			'stuff <span style="color: rgba(91, 91, 90, 0.7)">This is some text</span>' +
-			'<div style="height: 6000px;"></div>' +
-			'</div>';
-
-		var target = fixture.querySelector('#target');
-		assert.isFalse(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				'<div style="width:100%; position:fixed; top:0; height:50px; background: #F0F0F0; z-index: 200; color:#fff" id="target">header</div>' +
+				'<div style="height: 6000px;"></div>' +
+				'stuff <span style="color: rgba(91, 91, 90, 0.7)">This is some text</span>' +
+				'<div style="height: 6000px;"></div>' +
+				'</div>'
 		);
-		assert.deepEqual(checkContext._relatedNodes, [target]);
+		assert.isFalse(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._relatedNodes, [params[0]]);
 	});
 
 	it('should return undefined for background-image elements', function() {
@@ -182,32 +174,28 @@ describe('color-contrast', function() {
 			'ABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKU' +
 			'E1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7';
 
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div id="background" style="background:url(' +
-			dataURI +
-			') no-repeat left center; padding: 5px 0 5px 25px;">' +
-			'<p id="target">Text 1</p>' +
-			'</div>';
-
-		var target = fixture.querySelector('#target');
-		assert.isUndefined(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				dataURI +
+				') no-repeat left center; padding: 5px 0 5px 25px;">' +
+				'<p id="target">Text 1</p>' +
+				'</div>'
 		);
+
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
 		assert.isUndefined(checkContext._data.bgColor);
 		assert.equal(checkContext._data.contrastRatio, 0);
 		assert.equal(checkContext._data.missingData, 'bgImage');
 	});
 
 	it('should return undefined for background-gradient elements', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div id="background" style="background-image:linear-gradient(red, orange);">' +
-			'<p id="target">Text 2</p>' +
-			'</div>';
-
-		var target = fixture.querySelector('#target');
-		assert.isUndefined(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				'<p id="target">Text 2</p>' +
+				'</div>'
 		);
+
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
 		assert.isUndefined(checkContext._data.bgColor);
 		assert.equal(checkContext._data.missingData, 'bgGradient');
 		assert.equal(checkContext._data.contrastRatio, 0);
@@ -216,11 +204,12 @@ describe('color-contrast', function() {
 	it('should return undefined when there are elements overlapping', function(done) {
 		// Give Edge time to scroll... :/
 		setTimeout(function() {
-			fixture.innerHTML =
+			var params = checkSetup(
 				'<div style="color: black; background-color: white; width: 200px; height: 100px; position: relative;" id="target">' +
-				'My text <div style="position: absolute; top:0; left: 0; background-color: white; width: 100%; height: 100%;"></div></div>';
-			var target = fixture.querySelector('#target');
-			var result = checks['color-contrast'].evaluate.call(checkContext, target);
+					'My text <div style="position: absolute; top:0; left: 0; background-color: white; width: 100%; height: 100%;"></div></div>'
+			);
+
+			var result = contrastEvaluate.apply(checkContext, params);
 			assert.isUndefined(result);
 			assert.equal(checkContext._data.missingData, 'bgOverlap');
 			assert.equal(checkContext._data.contrastRatio, 0);
@@ -229,10 +218,10 @@ describe('color-contrast', function() {
 	});
 
 	it('should return true when a form wraps mixed content', function() {
-		fixture.innerHTML =
-			'<form id="pass6"><p>Some text</p><label for="input6">Text</label><input id="input6"></form>';
-		var target = fixture.querySelector('#pass6');
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		var params = checkSetup(
+			'<form id="target"><p>Some text</p><label for="input6">Text</label><input id="input6"></form>'
+		);
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 	});
 
 	it('should return true when a label wraps a text input', function() {
@@ -242,54 +231,47 @@ describe('color-contrast', function() {
 		if (window.PHANTOMJS) {
 			assert.ok('PhantomJS is a liar');
 		} else {
-			var result = checks['color-contrast'].evaluate.call(
-				checkContext,
-				target,
-				{},
-				virtualNode
-			);
+			var result = contrastEvaluate.call(checkContext, target, {}, virtualNode);
 			assert.isTrue(result);
 		}
 	});
 
 	it("should return true when a label wraps a text input but doesn't overlap", function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<label id="target">' +
-			'My text <input type="text" style="position: absolute; top: 200px;"></label>';
-		var target = fixture.querySelector('#target');
-		var result = checks['color-contrast'].evaluate.call(checkContext, target);
+				'My text <input type="text" style="position: absolute; top: 200px;"></label>'
+		);
+		var result = contrastEvaluate.apply(checkContext, params);
 		assert.isTrue(result);
 	});
 
 	it('should return true when there is sufficient contrast based on thead', function() {
-		fixture.innerHTML =
-			'<table><thead style="background: #d00d2c"><tr><th id="target" style="color: #fff; padding: .5em">Col 1</th></tr></thead></table>';
-		var target = fixture.querySelector('#target');
-		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		var params = checkSetup(
+			'<table><thead style="background: #d00d2c"><tr><th id="target" style="color: #fff; padding: .5em">Col 1</th></tr></thead></table>'
+		);
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return true when there is sufficient contrast based on tbody', function() {
-		fixture.innerHTML =
-			'<table><tbody style="background: #d00d2c"><tr><td id="target" style="color: #fff; padding: .5em">Col 1</td></tr></tbody></table>';
-		var target = fixture.querySelector('#target');
-		axe._tree = axe.utils.getFlattenedTree(fixture.firstChild);
-		assert.isTrue(checks['color-contrast'].evaluate.call(checkContext, target));
+		var params = checkSetup(
+			'<table><tbody style="background: #d00d2c"><tr><td id="target" style="color: #fff; padding: .5em">Col 1</td></tr></tbody></table>'
+		);
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return undefined if element overlaps text content', function(done) {
 		// Give Edge time to scroll
 		setTimeout(function() {
-			fixture.innerHTML =
+			var params = checkSetup(
 				'<div style="background-color: white; height: 60px; width: 80px; border:1px solid;position: relative;">' +
-				'<div id="target" style="color: white; height: 40px; width: 60px; border:1px solid red;">Hi</div>' +
-				'<div style="position: absolute; top: 0; width: 60px; height: 40px;background-color: #000"></div>' +
-				'</div>';
-			var target = fixture.querySelector('#target');
-			var actual = checks['color-contrast'].evaluate.call(checkContext, target);
-			assert.isUndefined(actual);
+					'<div id="target" style="color: white; height: 40px; width: 60px; border:1px solid red;">Hi</div>' +
+					'<div style="position: absolute; top: 0; width: 60px; height: 40px;background-color: #000"></div>' +
+					'</div>'
+			);
+
+			assert.isUndefined(contrastEvaluate.apply(checkContext, params));
 			assert.equal(checkContext._data.missingData, 'bgOverlap');
 			assert.equal(checkContext._data.contrastRatio, 0);
 			done();
@@ -297,13 +279,13 @@ describe('color-contrast', function() {
 	});
 
 	it('should return undefined if element has same color as background', function() {
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div style="background-color: white;">' +
-			'<div style="color:white;" id="target">Text</div>' +
-			'</div>';
-		var target = fixture.querySelector('#target');
-		var actual = checks['color-contrast'].evaluate.call(checkContext, target);
-		assert.isUndefined(actual);
+				'<div style="color:white;" id="target">Text</div>' +
+				'</div>'
+		);
+
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
 		assert.equal(checkContext._data.missingData, 'equalRatio');
 		assert.equal(checkContext._data.contrastRatio, 1);
 	});
@@ -315,22 +297,42 @@ describe('color-contrast', function() {
 			'ABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKU' +
 			'E1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7';
 
-		fixture.innerHTML =
+		var params = checkSetup(
 			'<div id="background" style="background:url(' +
-			dataURI +
-			') no-repeat left center; padding: 5px 0 5px 25px;">' +
-			'<p id="target">Text 1</p>' +
-			'</div>';
-
-		var target = fixture.querySelector('#target');
-		assert.isUndefined(
-			checks['color-contrast'].evaluate.call(checkContext, target)
+				dataURI +
+				') no-repeat left center; padding: 5px 0 5px 25px;">' +
+				'<p id="target">Text 1</p>' +
+				'</div>'
 		);
 
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
 		assert.equal(
 			checkContext._relatedNodes[0],
 			document.querySelector('#background')
 		);
+	});
+
+	it('should return undefined for a single character text with insufficient contrast', function() {
+		var params = checkSetup(
+			'<div style="background-color: #FFF;">' +
+				'<div style="color:#DDD;" id="target">X</div>' +
+				'</div>'
+		);
+
+		var actual = contrastEvaluate.apply(checkContext, params);
+		assert.isUndefined(actual);
+		assert.equal(checkContext._data.missingData, 'shortTextContent');
+	});
+
+	it('should return true for a single character text with insufficient contrast', function() {
+		var params = checkSetup(
+			'<div style="background-color: #FFF;">' +
+				'<div style="color:#000;" id="target">X</div>' +
+				'</div>'
+		);
+
+		var actual = contrastEvaluate.apply(checkContext, params);
+		assert.isTrue(actual);
 	});
 
 	(shadowSupported ? it : xit)(
@@ -341,10 +343,7 @@ describe('color-contrast', function() {
 				'<p style="color: #333;" id="target">Text</p>'
 			);
 			var container = fixture.querySelector('#container');
-			var result = checks['color-contrast'].evaluate.apply(
-				checkContext,
-				params
-			);
+			var result = contrastEvaluate.apply(checkContext, params);
 			assert.isFalse(result);
 			assert.deepEqual(checkContext._relatedNodes, [container]);
 		}


### PR DESCRIPTION
This fix ensures that font icons and other single character elements are put into needs review for the color-contrast rule. 

Closes #1068

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
