### PR TITLE
fix: Fix broken 3.1.0 release script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -53,6 +53,7 @@ jobs:
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache
+      - run: npm run build
       - run: npm publish
 
 workflows:


### PR DESCRIPTION
The CI release script failed to run the build command.

Closes #1104 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @dylanb
