### PR TITLE
fix: banner comment in generated axe files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -231,7 +231,7 @@ module.exports = function(grunt) {
 						quote_style: 1
 					},
 					output: {
-						comments: /^!/
+						comments: /^\/*! aXe/
 					}
 				}
 			},
@@ -243,9 +243,8 @@ module.exports = function(grunt) {
 					};
 				}),
 				options: {
-					preserveComments: function(node, comment) {
-						// preserve comments that start with a bang
-						return /^!/.test(comment.value);
+					output: {
+						comments: /^\/*! aXe/
 					},
 					mangle: {
 						reserved: ['commons', 'utils', 'axe', 'window', 'document']


### PR DESCRIPTION
- This PR ensures, generation of banner comments on `axe.js` and `axe.min.js` files as a part of `grunt build` step.
- `grunt-contrib-uglify` > 2.x has some API changes which replaced `preserveComments` with `options.comments` which is now adapted here.

Closes issue:
- https://github.com/dequelabs/axe-core/issues/1108

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
