### PR TITLE
fix(imports): try/catch with fallback to avoid CSP issues

### DIFF
--- a/build/tasks/generate-imports.js
+++ b/build/tasks/generate-imports.js
@@ -91,9 +91,19 @@ module.exports = grunt => {
 					// envs, the UMD method should be used instead.
 					const wrappedLibrary = `
 						(function (module, exports, define, require, process) {
-							// Get a reference to the "true" global scope. This works in
-							// ES5's "strict mode", browsers, node.js and other environments.
-							var global = Function('return this')();
+							// Get a reference to the "true" global scope. This works in ES5's 
+							// "strict mode", browsers, node.js and other environments. We 
+							// try/catch the usage of "Function" to prevent CSP issues and 
+							// fall-back to using "window".
+							//
+							// NOTE: we don't just reference "window" or "global" here, as axe
+							// clobbers them both in "/lib/intro.stub".
+							var global;
+							try {
+								global = Function('return this')();
+							} catch (error) {
+								global = window
+							}
 
 							// If there was a global prior to our script, make sure we
 							// "save" it (think "$.noConflict()").


### PR DESCRIPTION
This patch updates the logic we use to get a reference to the global scope. Previously, if a page (or Chrome extension) had a strict CSP set ("unsafe-eval"), we caused an exception to be thrown by using the `Function` constructor. Now we `try/catch` the statement and fallback to using `window`.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
