### PR TITLE
refactor: for tests listen to onload for added stylesheets in before hook

### DIFF
--- a/test/integration/full/css-orientation-lock/passes.js
+++ b/test/integration/full/css-orientation-lock/passes.js
@@ -4,20 +4,6 @@ describe('css-orientation-lock passes test', function() {
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var isPhantom = window.PHANTOMJS ? true : false;
 
-	function addSheet(data) {
-		if (data.href) {
-			var link = document.createElement('link');
-			link.rel = 'stylesheet';
-			link.href = data.href;
-			document.head.appendChild(link);
-		} else {
-			const style = document.createElement('style');
-			style.type = 'text/css';
-			style.appendChild(document.createTextNode(data.text));
-			document.head.appendChild(style);
-		}
-	}
-
 	var styleSheets = [
 		{
 			href:
@@ -34,9 +20,15 @@ describe('css-orientation-lock passes test', function() {
 			this.skip();
 			done();
 		} else {
-			styleSheets.forEach(addSheet);
-			// wait for network request to complete for added sheets
-			setTimeout(done, 5000);
+			axe.testUtils
+				.addStyleSheets(styleSheets)
+				.then(function() {
+					done();
+				})
+				.catch(function(error) {
+					console.error('Could not load stylesheets for testing.', error);
+					done();
+				});
 		}
 	});
 

--- a/test/integration/full/css-orientation-lock/violations.js
+++ b/test/integration/full/css-orientation-lock/violations.js
@@ -4,20 +4,6 @@ describe('css-orientation-lock violations test', function() {
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var isPhantom = window.PHANTOMJS ? true : false;
 
-	function addSheet(data) {
-		if (data.href) {
-			var link = document.createElement('link');
-			link.rel = 'stylesheet';
-			link.href = data.href;
-			document.head.appendChild(link);
-		} else {
-			const style = document.createElement('style');
-			style.type = 'text/css';
-			style.appendChild(document.createTextNode(data.text));
-			document.head.appendChild(style);
-		}
-	}
-
 	var styleSheets = [
 		{
 			href:
@@ -33,9 +19,15 @@ describe('css-orientation-lock violations test', function() {
 			this.skip();
 			done();
 		} else {
-			styleSheets.forEach(addSheet);
-			// wait for network request to complete for added sheets
-			setTimeout(done, 5000);
+			axe.testUtils
+				.addStyleSheets(styleSheets)
+				.then(function() {
+					done();
+				})
+				.catch(function(error) {
+					console.error('Could not load stylesheets for testing.', error);
+					done();
+				});
 		}
 	});
 

--- a/test/integration/full/preload-cssom/preload-cssom.js
+++ b/test/integration/full/preload-cssom/preload-cssom.js
@@ -6,23 +6,6 @@ describe('preload cssom integration test', function() {
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var isPhantom = window.PHANTOMJS ? true : false;
 
-	function addSheet(data) {
-		if (data.href) {
-			var link = document.createElement('link');
-			link.rel = 'stylesheet';
-			link.href = data.href;
-			if (data.mediaPrint) {
-				link.media = 'print';
-			}
-			document.head.appendChild(link);
-		} else {
-			const style = document.createElement('style');
-			style.type = 'text/css';
-			style.appendChild(document.createTextNode(data.text));
-			document.head.appendChild(style);
-		}
-	}
-
 	var styleSheets = [
 		{
 			href:
@@ -44,14 +27,15 @@ describe('preload cssom integration test', function() {
 			this.skip();
 			done();
 		} else {
-			styleSheets.forEach(addSheet);
-			// cache original axios object
-			if (axe.imports.axios) {
-				origAxios = axe.imports.axios;
-			}
-
-			// wait for network request to complete for added sheets
-			setTimeout(done, 5000);
+			axe.testUtils
+				.addStyleSheets(styleSheets)
+				.then(function() {
+					done();
+				})
+				.catch(function(error) {
+					console.error('Could not load stylesheets for testing.', error);
+					done();
+				});
 		}
 	});
 

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -5,23 +5,6 @@ describe('preload integration test', function() {
 	var origAxios;
 	var isPhantom = window.PHANTOMJS ? true : false;
 
-	function addSheet(data) {
-		if (data.href) {
-			var link = document.createElement('link');
-			link.rel = 'stylesheet';
-			link.href = data.href;
-			if (data.mediaPrint) {
-				link.media = 'print';
-			}
-			document.head.appendChild(link);
-		} else {
-			const style = document.createElement('style');
-			style.type = 'text/css';
-			style.appendChild(document.createTextNode(data.text));
-			document.head.appendChild(style);
-		}
-	}
-
 	var styleSheets = [
 		{
 			href: 'https://unpkg.com/gutenberg-css@0.4'
@@ -41,8 +24,6 @@ describe('preload integration test', function() {
 			this.skip();
 			done();
 		} else {
-			styleSheets.forEach(addSheet);
-
 			// cache originals
 			if (axe.imports.axios) {
 				origAxios = axe.imports.axios;
@@ -82,9 +63,16 @@ describe('preload integration test', function() {
 					}
 				]
 			});
-
-			// wait for network request to complete for added sheets
-			setTimeout(done, 5000);
+			// load stylesheets
+			axe.testUtils
+				.addStyleSheets(styleSheets)
+				.then(function() {
+					done();
+				})
+				.catch(function(error) {
+					console.error('Could not load stylesheets for testing.', error);
+					done();
+				});
 		}
 	});
 


### PR DESCRIPTION
This PR refactors the `addStyleSheet` helper for CSSOM based tests into `axe.testUtils` object. The function also returns a promise, thereby allowing to wait until the stylesheets are loaded in the `before` hook, thus ensuring assets are available before running respective tests.

Closes issue: 
- https://github.com/dequelabs/axe-core/issues/1086

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
