### PR TITLE
chore: Ensure generated files exist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:6.12.3-browsers
+    - image: circleci/node:10-browsers-legacy
   working_directory: ~/axe-core
 
 restore_dependency_cache: &restore_dependency_cache

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,5 @@ package-lock.json
 !lib/core/imports/index.js
 lib/core/imports/*.js
 
-# running circleci locally to verify build, ignoring relevant files
-# if circle and docker is configured locally (copy circle.yml to .circleci/config.yml) - run -> circleci build
-.circleci/**/*.* 
-
 # ignore jsdoc api documentation generated files
 doc/api/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -252,6 +252,13 @@ module.exports = function(grunt) {
 				}
 			}
 		},
+		'file-exists': {
+			data: langs.reduce(function(out, lang) {
+				out.push('axe' + lang + '.js');
+				out.push('axe' + lang + '.min.js');
+				return out;
+			}, [])
+		},
 		watch: {
 			files: ['lib/**/*', 'test/**/*.js', 'Gruntfile.js'],
 			tasks: ['build', 'testconfig', 'fixture']
@@ -391,6 +398,7 @@ module.exports = function(grunt) {
 
 	grunt.registerTask('test', [
 		'build',
+		'file-exists',
 		'retire',
 		'testconfig',
 		'fixture',

--- a/build/tasks/file-exists.js
+++ b/build/tasks/file-exists.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = function(grunt) {
+	grunt.registerMultiTask(
+		'file-exists',
+		'Task to ensure existence of generated build assets',
+		function() {
+			this.data.forEach(function(f) {
+				var files = grunt.file.expand({ nonull: true }, f);
+				files.forEach(function(filepath) {
+					var exists = grunt.file.exists(filepath);
+					if (!!exists) {
+						grunt.log.writeln('File: ' + filepath + ', exists.');
+					} else {
+						grunt.fail.fatal('File: ' + filepath + ', does not exist.');
+					}
+				});
+			});
+		}
+	);
+};

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test": "npm run test-dts && grunt test",
     "test-fast": "grunt test-fast",
     "version": "echo \"use 'npm run release' to bump axe-core version\" && exit 1",
-    "prepublishOnly": "grunt build",
+    "prepublishOnly": "grunt build && grunt file-exists",
     "postinstall": "node build/utils/postinstall.js",
     "release": "standard-version -a",
     "next-release": "standard-version --scripts.prebump=./build/next-version.js --skip.commit=true --skip.tag=true",


### PR DESCRIPTION
This PR introduces a new task which ensures, existence of a given set of files. In this case it checks, for `axe.***.js` files for all langs specified. If the build generated files do not exist, a fatal error is thrown. Also, the same files are checked for existence as a part of `prepublishOnly` step.


<img width="504" alt="screen shot 2018-09-12 at 08 54 26" src="https://user-images.githubusercontent.com/20978252/45410410-85f44680-b669-11e8-9649-8d02dc4bb3df.png">


Closes issue:
- https://github.com/dequelabs/axe-core/issues/1117

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
