### PR TITLE
fix: link-name to be deciphered from children

### DIFF
--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -455,6 +455,11 @@ text.accessibleTextVirtual = function accessibleTextVirtual(
 			return element.actualNode.getAttribute('title');
 		}
 
+		//handle children with role presentation
+		if (role === 'presentation') {
+			return getInnerText(element, false, false);
+		}
+
 		return '';
 	};
 

--- a/test/checks/shared/has-visible-text.js
+++ b/test/checks/shared/has-visible-text.js
@@ -34,4 +34,81 @@ describe('has-visible-text', function() {
 			checks['has-visible-text'].evaluate.apply(checkContext, params)
 		);
 	});
+
+	it('should return true if there is children with role presentation and text content', function() {
+		var params = checkSetup(
+			'<a id="target" href="link"><span role="presentation">Link text</span></a>'
+		);
+		var actual = checks['has-visible-text'].evaluate.apply(
+			checkContext,
+			params
+		);
+		assert.isTrue(actual);
+	});
+
+	it('should return false if there is children with role presentation and empty text content', function() {
+		var params = checkSetup(
+			'<a id="target" href="link"><span role="presentation"></span></a>'
+		);
+		var actual = checks['has-visible-text'].evaluate.apply(
+			checkContext,
+			params
+		);
+		assert.isFalse(actual);
+	});
+
+	it('should return true if any of the nested children with role presentation has text content', function() {
+		var params = checkSetup(
+			'<a id="target" href="link"><div><span role="presentation">Link text</span></div></a>'
+		);
+		var actual = checks['has-visible-text'].evaluate.apply(
+			checkContext,
+			params
+		);
+		assert.isTrue(actual);
+	});
+
+	it('should return true if any of the nested children has text content', function() {
+		var params = checkSetup(
+			'<a id="target" href="link"><div>Some content<span role="presentation"></span></div></a>'
+		);
+		var actual = checks['has-visible-text'].evaluate.apply(
+			checkContext,
+			params
+		);
+		assert.isTrue(actual);
+	});
+
+	it('should return true if any of the siblings has text content', function() {
+		var params = checkSetup(
+			'<a id="target" href="link"><div>Some content</div><span role="presentation"></span></a>'
+		);
+		var actual = checks['has-visible-text'].evaluate.apply(
+			checkContext,
+			params
+		);
+		assert.isTrue(actual);
+	});
+
+	it('should return false if none of the siblings has text content', function() {
+		var params = checkSetup(
+			'<a id="target" href="link"><div></div><span></span><i></i></a>'
+		);
+		var actual = checks['has-visible-text'].evaluate.apply(
+			checkContext,
+			params
+		);
+		assert.isFalse(actual);
+	});
+
+	it('should return false if there is children with role presentation and empty text content', function() {
+		var params = checkSetup(
+			'<a id="target" href="link"><div><span role="presentation"></span></div></a>'
+		);
+		var actual = checks['has-visible-text'].evaluate.apply(
+			checkContext,
+			params
+		);
+		assert.isFalse(actual);
+	});
 });

--- a/test/integration/rules/link-name/link-name.html
+++ b/test/integration/rules/link-name/link-name.html
@@ -14,3 +14,13 @@
 <span role="link" href="#" tabindex="0" id="violation6" aria-labelledby="nonexistent"></span>
 
 <a href="#" role="button">Does not apply</a>
+
+<a id="pass8" href="link"><span role="presentation">Link text</span></a>
+<a id="pass9" href="link"><div><span role="presentation">Link text</span></div></a>
+<a id="pass10" href="link"><div>Some content<span role="presentation"></span></div></a>
+<a id="pass11" href="link"><div>Some content</div><span role="presentation"></span></a>
+
+
+<a id="fail1" href="link"><span role="presentation"></span></a>
+<a id="fail2" href="link"><div></div><span></span><i></i></a>
+<a id="fail3" href="link"><div><span role="presentation"></span></div></a>

--- a/test/integration/rules/link-name/link-name.json
+++ b/test/integration/rules/link-name/link-name.json
@@ -1,6 +1,26 @@
 {
 	"description": "link-name tests",
 	"rule": "link-name",
-	"violations": [["#violation1"], ["#violation2"], ["#violation3"], ["#violation4"], ["#violation5"], ["#violation6"]],
-	"passes":  [["#pass1"], ["#pass3"], ["#pass4"], ["#pass6"], ["#pass7"]]
+	"violations": [
+		["#violation1"], 
+		["#violation2"], 
+		["#violation3"], 
+		["#violation4"], 
+		["#violation5"], 
+		["#violation6"],
+		["#fail1"],
+		["#fail2"],
+		["#fail3"]
+	],
+	"passes":  [
+		["#pass1"], 
+		["#pass3"], 
+		["#pass4"], 
+		["#pass6"], 
+		["#pass7"],
+		["#pass8"],
+		["#pass9"],
+		["#pass10"],
+		["#pass11"]
+	]
 }


### PR DESCRIPTION
This PR fixes the rule `link-name` to take into consideration, nested children text content for deciphering `accessibleTextVirtual`.

This allows this rule to pass in scenarios like:

```html
<a href="link"><span role="presentation">Link text</span></a>

<a id="pass11" href="link"><div>Some content</div><span role="presentation"></span></a>
```


Closes issue:
- https://github.com/dequelabs/axe-core/issues/767

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
