### PR TITLE
fix: html-lang-valid should consider xml:lang

### DIFF
--- a/lib/rules/html-lang-valid.json
+++ b/lib/rules/html-lang-valid.json
@@ -1,6 +1,6 @@
 {
   "id": "html-lang-valid",
-  "selector": "html[lang]",
+  "selector": "html[lang], html[xml\\:lang]",
   "tags": [
     "cat.language",
     "wcag2a",

--- a/test/integration/full/html-lang-valid/frames/level1.html
+++ b/test/integration/full/html-lang-valid/frames/level1.html
@@ -8,5 +8,7 @@
 <body>
 	<iframe id="frame2" src="level2.html"></iframe>
 	<iframe id="frame3" src="level2-a.html"></iframe>
+	<iframe id="frame4" src="level2-b.html"></iframe>
+	<iframe id="frame5" src="level2-c.html"></iframe>
 </body>
 </html>

--- a/test/integration/full/html-lang-valid/frames/level2-b.html
+++ b/test/integration/full/html-lang-valid/frames/level2-b.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html id="pass2b" xml:lang="en">
+<head>
+	<title>No lang test</title>
+	<meta charset="utf8">
+	<script src="/axe.js"></script>
+</head>
+<body>
+	Hi
+</body>
+</html>

--- a/test/integration/full/html-lang-valid/frames/level2-c.html
+++ b/test/integration/full/html-lang-valid/frames/level2-c.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html id="violation2c" xml:lang="unknownLang">
+<head>
+	<title>No lang test</title>
+	<meta charset="utf8">
+	<script src="/axe.js"></script>
+</head>
+<body>
+	Hi
+</body>
+</html>

--- a/test/integration/full/html-lang-valid/html-lang-valid.html
+++ b/test/integration/full/html-lang-valid/html-lang-valid.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html id="ignored1">
+
 <head>
 	<title>html-lang-valid test</title>
 	<meta charset="utf8">
@@ -16,10 +17,12 @@
 		var assert = chai.assert;
 	</script>
 </head>
+
 <body>
 	<iframe id="frame1" src="frames/level1.html"></iframe>
 	<div id="mocha"></div>
 	<script src="html-lang-valid.js"></script>
 	<script src="/test/integration/adapter.js"></script>
 </body>
+
 </html>

--- a/test/integration/full/html-lang-valid/html-lang-valid.js
+++ b/test/integration/full/html-lang-valid/html-lang-valid.js
@@ -1,6 +1,8 @@
 describe('html-lang-valid test', function() {
 	'use strict';
+
 	var results;
+
 	before(function(done) {
 		axe.testUtils.awaitNestedLoad(function() {
 			axe.run(
@@ -15,34 +17,53 @@ describe('html-lang-valid test', function() {
 	});
 
 	describe('violations', function() {
-		it('should find 2', function() {
-			assert.lengthOf(results.violations[0].nodes, 2);
+		var violations = results.violations[0];
+
+		it('should find 3', function() {
+			assert.lengthOf(violations.nodes, 3);
 		});
+
 		it('should find first level iframe', function() {
-			assert.deepEqual(results.violations[0].nodes[0].target, [
-				'#frame1',
-				'#violation1'
-			]);
+			assert.deepEqual(violations.nodes[0].target, ['#frame1', '#violation1']);
 		});
+
 		it('should find second level iframe', function() {
-			assert.deepEqual(results.violations[0].nodes[1].target, [
+			assert.deepEqual(violations.nodes[1].target, [
 				'#frame1',
 				'#frame2',
 				'#violation2'
 			]);
 		});
+
+		it('should find #violation2c', function() {
+			assert.deepEqual(violations.nodes[2].target, [
+				'#frame1',
+				'#frame5',
+				'#violation2c'
+			]);
+		});
 	});
 
 	describe('passes', function() {
-		it('should find 1', function() {
-			assert.lengthOf(results.passes[0].nodes, 1);
+		var passes = results.passes[0];
+
+		it('should find 2', function() {
+			assert.lengthOf(passes.nodes, 2);
 		});
 
 		it('should find #pass1', function() {
-			assert.deepEqual(results.passes[0].nodes[0].target, [
+			assert.deepEqual(passes.nodes[0].target, [
 				'#frame1',
 				'#frame3',
 				'#pass1'
+			]);
+		});
+
+		it('should find #pass2b', function() {
+			assert.deepEqual(passes.nodes[1].target, [
+				'#frame1',
+				'#frame4',
+				'#pass2b'
 			]);
 		});
 	});

--- a/test/integration/full/html-lang-valid/html-lang-valid.js
+++ b/test/integration/full/html-lang-valid/html-lang-valid.js
@@ -17,18 +17,19 @@ describe('html-lang-valid test', function() {
 	});
 
 	describe('violations', function() {
-		var violations = results.violations[0];
-
 		it('should find 3', function() {
-			assert.lengthOf(violations.nodes, 3);
+			assert.lengthOf(results.violations[0].nodes, 3);
 		});
 
 		it('should find first level iframe', function() {
-			assert.deepEqual(violations.nodes[0].target, ['#frame1', '#violation1']);
+			assert.deepEqual(results.violations[0].nodes[0].target, [
+				'#frame1',
+				'#violation1'
+			]);
 		});
 
 		it('should find second level iframe', function() {
-			assert.deepEqual(violations.nodes[1].target, [
+			assert.deepEqual(results.violations[0].nodes[1].target, [
 				'#frame1',
 				'#frame2',
 				'#violation2'
@@ -36,7 +37,7 @@ describe('html-lang-valid test', function() {
 		});
 
 		it('should find #violation2c', function() {
-			assert.deepEqual(violations.nodes[2].target, [
+			assert.deepEqual(results.violations[0].nodes[2].target, [
 				'#frame1',
 				'#frame5',
 				'#violation2c'
@@ -45,14 +46,12 @@ describe('html-lang-valid test', function() {
 	});
 
 	describe('passes', function() {
-		var passes = results.passes[0];
-
 		it('should find 2', function() {
-			assert.lengthOf(passes.nodes, 2);
+			assert.lengthOf(results.passes[0].nodes, 2);
 		});
 
 		it('should find #pass1', function() {
-			assert.deepEqual(passes.nodes[0].target, [
+			assert.deepEqual(results.passes[0].nodes[0].target, [
 				'#frame1',
 				'#frame3',
 				'#pass1'
@@ -60,7 +59,7 @@ describe('html-lang-valid test', function() {
 		});
 
 		it('should find #pass2b', function() {
-			assert.deepEqual(passes.nodes[1].target, [
+			assert.deepEqual(results.passes[0].nodes[1].target, [
 				'#frame1',
 				'#frame4',
 				'#pass2b'


### PR DESCRIPTION
This PR enhances `html-lang-valid` rule to allow `xml:lang` attribute.

Closes issue:
- https://github.com/dequelabs/axe-core/issues/1140

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
