### PR TITLE
Resolve Check.run immediately if not async

### DIFF
--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -90,9 +90,7 @@ Check.prototype.run = function(node, options, context, resolve, reject) {
 
 		if (!checkHelper.isAsync) {
 			checkResult.result = result;
-			setTimeout(function() {
-				resolve(checkResult);
-			}, 0);
+			resolve(checkResult);
 		}
 	} else {
 		resolve(null);


### PR DESCRIPTION
Running axe on [this URL](https://www.guidetoonlineschools.com/online-schools) takes ~13s. But towards the end of the profile is an interesting block of time:
![image](https://user-images.githubusercontent.com/39191/46381219-38606d80-c65a-11e8-83cf-3ed24ba24927.png)

Zoomed out it looks like a lot of work, but it's actually quite sparse when you zoom in:
![image](https://user-images.githubusercontent.com/39191/46381244-50d08800-c65a-11e8-908a-3332a1a58f33.png)
![image](https://user-images.githubusercontent.com/39191/46381256-57f79600-c65a-11e8-8c01-c77caa0b604f.png)

It's 1.3s of timers firing. :) Turns out each timer fire has about 0.1ms of overhead, and this was ~13,000 timers.  


I traced it back to the setTimeout here, which doesn't appear to be necessary.  But there may be context for why it was [originally added](https://github.com/dequelabs/axe-core/commit/4657dc5d8246c1d211532e70be95043b25767e28) that I don't know.   

If it is necessary to keep it deferred, you could collect all these as callbacks and then schedule one setTimeout which will then execute all of them. That'd be just as fast.



