### PR TITLE
fix(is-visible): Clipped labels are only marked as hidden if clip is 0px in all directions

### DIFF
--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -13,7 +13,7 @@ function isClipped(clip) {
 	'use strict';
 
 	var matches = clip.match(
-		/rect\s*\(([0-9]+)px,?\s*([0-9]+)px,?\s*([0-9]+)px,?\s*([0-9]+)px\s*\)/
+		/rect\s*\((0+)px,?\s*(0+)px,?\s*(0+)px,?\s*(0+)px\s*\)/
 	);
 	if (matches && matches.length === 5) {
 		return matches[3] - matches[1] <= 0 && matches[2] - matches[4] <= 0;


### PR DESCRIPTION
    fix(is-visible): Clipped labels are only marked as hidden if clip is 0px in all directions

    Instead of marking all clipped labels as hidden, we're now checking their values as well

    Closes issue: #1176

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
