### PR TITLE
fix: Allow role presentation and none on object-alt rule

### DIFF
--- a/lib/rules/object-alt.json
+++ b/lib/rules/object-alt.json
@@ -17,7 +17,9 @@
     "has-visible-text",
     "aria-label",
     "aria-labelledby",
-    "non-empty-title"
+    "non-empty-title",
+    "role-presentation",
+    "role-none"
   ],
   "none": []
 }

--- a/test/integration/rules/object-alt/object-alt.html
+++ b/test/integration/rules/object-alt/object-alt.html
@@ -4,6 +4,8 @@
 <object id="pass3" aria-label="this object has text"></object>
 <span id="label1">this object has text</span>
 <object id="pass4" aria-labelledby="label1"></object>
+<object id="pass5" role='presentation'></object>
+<object id="pass6" role='none'></object>
 <object id="violation1"></object>
 <object id="violation2"><div> </div></object>
 <object id="violation3"><p style="display: none;">This object has no text.</p></object>

--- a/test/integration/rules/object-alt/object-alt.json
+++ b/test/integration/rules/object-alt/object-alt.json
@@ -2,5 +2,5 @@
 	"description": "object-alt tests",
 	"rule": "object-alt",
 	"violations": [["#violation1"], ["#violation2"], ["#violation3"]],
-	"passes":  [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"]]
+	"passes":  [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"], ["#pass6"]]
 }


### PR DESCRIPTION
This PR, allows role `presentation`/ `none` on `object`.

Closes issue: 
- https://github.com/dequelabs/axe-core/issues/1221

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
