### PR TITLE
test: update to skip test if no shadowDOM support

### DIFF
--- a/test/commons/dom/idrefs.js
+++ b/test/commons/dom/idrefs.js
@@ -43,8 +43,9 @@ describe('dom.idrefs', function() {
 		);
 	});
 
-	it('should find only referenced nodes within the current root: shadow DOM', function() {
-		if (shadowSupported) {
+	(shadowSupported ? it : xit)(
+		'should find only referenced nodes within the current root: shadow DOM',
+		function() {
 			// shadow DOM v1 - note: v0 is compatible with this code, so no need
 			// to specifically test this
 			fixture.innerHTML = '<div target="target"><div id="target"></div></div>';
@@ -58,10 +59,11 @@ describe('dom.idrefs', function() {
 				'should only find stuff in the shadow DOM'
 			);
 		}
-	});
+	);
 
-	it('should find only referenced nodes within the current root: document', function() {
-		if (shadowSupported) {
+	(shadowSupported ? it : xit)(
+		'should find only referenced nodes within the current root: document',
+		function() {
 			// shadow DOM v1 - note: v0 is compatible with this code, so no need
 			// to specifically test this
 			fixture.innerHTML =
@@ -76,7 +78,7 @@ describe('dom.idrefs', function() {
 				'should only find stuff in the document'
 			);
 		}
-	});
+	);
 
 	it('should insert null if a reference is not found', function() {
 		fixture.innerHTML =

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -159,47 +159,49 @@ describe('dom.isVisible', function() {
 			el = document.getElementById('target');
 			assert.isFalse(axe.commons.dom.isVisible(el));
 		});
-		it('should correctly handle visible slotted elements', function() {
-			function createContentSlotted() {
-				var group = document.createElement('div');
-				group.innerHTML = '<div id="target">Stuff<slot></slot></div>';
-				return group;
-			}
-			function makeShadowTree(node) {
-				var root = node.attachShadow({ mode: 'open' });
-				var div = document.createElement('div');
-				root.appendChild(div);
-				div.appendChild(createContentSlotted());
-			}
-			if (shadowSupported) {
+		(shadowSupported ? it : xit)(
+			'should correctly handle visible slotted elements',
+			function() {
+				function createContentSlotted() {
+					var group = document.createElement('div');
+					group.innerHTML = '<div id="target">Stuff<slot></slot></div>';
+					return group;
+				}
+				function makeShadowTree(node) {
+					var root = node.attachShadow({ mode: 'open' });
+					var div = document.createElement('div');
+					root.appendChild(div);
+					div.appendChild(createContentSlotted());
+				}
 				fixture.innerHTML = '<div><a>hello</a></div>';
 				makeShadowTree(fixture.firstChild);
 				var tree = axe.utils.getFlattenedTree(fixture.firstChild);
 				var el = axe.utils.querySelectorAll(tree, 'a')[0];
 				assert.isTrue(axe.commons.dom.isVisible(el.actualNode));
 			}
-		});
-		it('should correctly handle hidden slotted elements', function() {
-			function createContentSlotted() {
-				var group = document.createElement('div');
-				group.innerHTML =
-					'<div id="target" style="display:none;">Stuff<slot></slot></div>';
-				return group;
-			}
-			function makeShadowTree(node) {
-				var root = node.attachShadow({ mode: 'open' });
-				var div = document.createElement('div');
-				root.appendChild(div);
-				div.appendChild(createContentSlotted());
-			}
-			if (shadowSupported) {
+		);
+		(shadowSupported ? it : xit)(
+			'should correctly handle hidden slotted elements',
+			function() {
+				function createContentSlotted() {
+					var group = document.createElement('div');
+					group.innerHTML =
+						'<div id="target" style="display:none;">Stuff<slot></slot></div>';
+					return group;
+				}
+				function makeShadowTree(node) {
+					var root = node.attachShadow({ mode: 'open' });
+					var div = document.createElement('div');
+					root.appendChild(div);
+					div.appendChild(createContentSlotted());
+				}
 				fixture.innerHTML = '<div><p><a>hello</a></p></div>';
 				makeShadowTree(fixture.firstChild);
 				var tree = axe.utils.getFlattenedTree(fixture.firstChild);
 				var el = axe.utils.querySelectorAll(tree, 'a')[0];
 				assert.isFalse(axe.commons.dom.isVisible(el.actualNode));
 			}
-		});
+		);
 	});
 
 	describe('screen readers', function() {

--- a/test/commons/text/visible-virtual.js
+++ b/test/commons/text/visible-virtual.js
@@ -77,25 +77,26 @@ describe('text.visible', function() {
 			assert.equal(visibleVirtual(tree[0]), 'Hello');
 		});
 
-		it('should correctly handle slotted elements', function() {
-			function createContentSlotted() {
-				var group = document.createElement('div');
-				group.innerHTML = '<div id="target">Stuff<slot></slot></div>';
-				return group;
-			}
-			function makeShadowTree(node) {
-				var root = node.attachShadow({ mode: 'open' });
-				var div = document.createElement('div');
-				root.appendChild(div);
-				div.appendChild(createContentSlotted());
-			}
-			if (shadowSupported) {
+		(shadowSupported ? it : xit)(
+			'should correctly handle slotted elements',
+			function() {
+				function createContentSlotted() {
+					var group = document.createElement('div');
+					group.innerHTML = '<div id="target">Stuff<slot></slot></div>';
+					return group;
+				}
+				function makeShadowTree(node) {
+					var root = node.attachShadow({ mode: 'open' });
+					var div = document.createElement('div');
+					root.appendChild(div);
+					div.appendChild(createContentSlotted());
+				}
 				fixture.innerHTML = '<div><a>hello</a></div>';
 				makeShadowTree(fixture.firstChild);
 				var tree = axe.utils.getFlattenedTree(fixture.firstChild);
 				assert.equal(visibleVirtual(tree[0]), 'Stuffhello');
 			}
-		});
+		);
 	});
 
 	describe('screen reader', function() {

--- a/test/core/utils/contains.js
+++ b/test/core/utils/contains.js
@@ -57,24 +57,25 @@ describe('axe.utils.contains', function() {
 		assert.isTrue(axe.utils.contains(node1, node2));
 	});
 
-	it('should work when the child is inside shadow DOM', function() {
-		var tree, node1, node2;
+	(shadowSupported ? it : xit)(
+		'should work when the child is inside shadow DOM',
+		function() {
+			var tree, node1, node2;
 
-		function createContentContains() {
-			var group = document.createElement('div');
-			group.innerHTML =
-				'<label id="mylabel">Label</label><input aria-labelledby="mylabel" type="text" />';
-			return group;
-		}
+			function createContentContains() {
+				var group = document.createElement('div');
+				group.innerHTML =
+					'<label id="mylabel">Label</label><input aria-labelledby="mylabel" type="text" />';
+				return group;
+			}
 
-		function makeShadowTreeContains(node) {
-			var root = node.attachShadow({ mode: 'open' });
-			var div = document.createElement('div');
-			div.className = 'parent';
-			root.appendChild(div);
-			div.appendChild(createContentContains());
-		}
-		if (shadowSupported) {
+			function makeShadowTreeContains(node) {
+				var root = node.attachShadow({ mode: 'open' });
+				var div = document.createElement('div');
+				div.className = 'parent';
+				root.appendChild(div);
+				div.appendChild(createContentContains());
+			}
 			// shadow DOM v1 - note: v0 is compatible with this code, so no need
 			// to specifically test this
 			fixture.innerHTML = '<div></div>';
@@ -84,25 +85,26 @@ describe('axe.utils.contains', function() {
 			node2 = axe.utils.querySelectorAll(tree, 'input')[0];
 			assert.isTrue(axe.utils.contains(node1, node2));
 		}
-	});
+	);
 
-	it('should work with slotted elements inside shadow DOM', function() {
-		var tree, node1, node2;
+	(shadowSupported ? it : xit)(
+		'should work with slotted elements inside shadow DOM',
+		function() {
+			var tree, node1, node2;
 
-		function createContentSlotted() {
-			var group = document.createElement('div');
-			group.innerHTML = '<div id="target">Stuff<slot></slot></div>';
-			return group;
-		}
-		function makeShadowTree(node) {
-			var root = node.attachShadow({ mode: 'open' });
-			var div = document.createElement('div');
-			var a = document.createElement('a');
-			div.appendChild(a);
-			root.appendChild(div);
-			div.appendChild(createContentSlotted());
-		}
-		if (shadowSupported) {
+			function createContentSlotted() {
+				var group = document.createElement('div');
+				group.innerHTML = '<div id="target">Stuff<slot></slot></div>';
+				return group;
+			}
+			function makeShadowTree(node) {
+				var root = node.attachShadow({ mode: 'open' });
+				var div = document.createElement('div');
+				var a = document.createElement('a');
+				div.appendChild(a);
+				root.appendChild(div);
+				div.appendChild(createContentSlotted());
+			}
 			fixture.innerHTML = '<div></div>';
 			makeShadowTree(fixture.firstChild);
 			tree = axe.utils.getFlattenedTree(fixture.firstChild)[0].children;
@@ -110,7 +112,7 @@ describe('axe.utils.contains', function() {
 			node2 = axe.utils.querySelectorAll(tree, 'a')[0];
 			assert.isTrue(axe.utils.contains(node1, node2));
 		}
-	});
+	);
 
 	it('should work', function() {
 		fixture.innerHTML = '<div id="outer"><div id="inner"></div></div>';

--- a/test/core/utils/get-root-node.js
+++ b/test/core/utils/get-root-node.js
@@ -25,10 +25,10 @@ describe('axe.utils.getRootNode', function() {
 		var node = document.createElement('div');
 		assert.isTrue(axe.utils.getRootNode(node) === document);
 	});
-	it('should return the shadow root when it is inside the shadow DOM', function() {
-		var shadEl;
-
-		if (shadowSupported) {
+	(shadowSupported ? it : xit)(
+		'should return the shadow root when it is inside the shadow DOM',
+		function() {
+			var shadEl;
 			// shadow DOM v1 - note: v0 is compatible with this code, so no need
 			// to specifically test this
 			fixture.innerHTML = '<div></div>';
@@ -39,5 +39,5 @@ describe('axe.utils.getRootNode', function() {
 				axe.utils.getRootNode(shadEl) === fixture.firstChild.shadowRoot
 			);
 		}
-	});
+	);
 });

--- a/test/core/utils/is-hidden.js
+++ b/test/core/utils/is-hidden.js
@@ -74,10 +74,10 @@ describe('axe.utils.isHidden', function() {
 		assert.isFalse(axe.utils.isHidden(el));
 	});
 
-	it('not hidden: should work when the element is inside shadow DOM', function() {
-		var tree, node;
-
-		if (shadowSupported) {
+	(shadowSupported ? it : xit)(
+		'not hidden: should work when the element is inside shadow DOM',
+		function() {
+			var tree, node;
 			// shadow DOM v1 - note: v0 is compatible with this code, so no need
 			// to specifically test this
 			fixture.innerHTML = '<div></div>';
@@ -86,12 +86,12 @@ describe('axe.utils.isHidden', function() {
 			node = axe.utils.querySelectorAll(tree, 'input')[0];
 			assert.isFalse(axe.utils.isHidden(node.actualNode));
 		}
-	});
+	);
 
-	it('hidden: should work when the element is inside shadow DOM', function() {
-		var tree, node;
-
-		if (shadowSupported) {
+	(shadowSupported ? it : xit)(
+		'hidden: should work when the element is inside shadow DOM',
+		function() {
+			var tree, node;
 			// shadow DOM v1 - note: v0 is compatible with this code, so no need
 			// to specifically test this
 			fixture.innerHTML = '<div style="display:none"></div>';
@@ -100,26 +100,28 @@ describe('axe.utils.isHidden', function() {
 			node = axe.utils.querySelectorAll(tree, 'input')[0];
 			assert.isTrue(axe.utils.isHidden(node.actualNode));
 		}
-	});
-	it('should work with hiddent slotted elements', function() {
-		function createContentSlotted() {
-			var group = document.createElement('div');
-			group.innerHTML =
-				'<div id="target" style="display:none;">Stuff<slot></slot></div>';
-			return group;
-		}
-		function makeShadowTree(node) {
-			var root = node.attachShadow({ mode: 'open' });
-			var div = document.createElement('div');
-			root.appendChild(div);
-			div.appendChild(createContentSlotted());
-		}
-		if (shadowSupported) {
+	);
+
+	(shadowSupported ? it : xit)(
+		'should work with hidden slotted elements',
+		function() {
+			function createContentSlotted() {
+				var group = document.createElement('div');
+				group.innerHTML =
+					'<div id="target" style="display:none;">Stuff<slot></slot></div>';
+				return group;
+			}
+			function makeShadowTree(node) {
+				var root = node.attachShadow({ mode: 'open' });
+				var div = document.createElement('div');
+				root.appendChild(div);
+				div.appendChild(createContentSlotted());
+			}
 			fixture.innerHTML = '<div><p><a>hello</a></p></div>';
 			makeShadowTree(fixture.firstChild);
 			var tree = axe.utils.getFlattenedTree(fixture.firstChild);
 			var el = axe.utils.querySelectorAll(tree, 'a')[0];
 			assert.isTrue(axe.utils.isHidden(el.actualNode));
 		}
-	});
+	);
 });


### PR DESCRIPTION
This is a maintenance PR.

Adding logic to skip tests if no shadowDOM support, as against skipping assertion with in the test blocks.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
