### PR TITLE
fix: exclude noscript and template from dom.isVisible

### DIFF
--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -1,5 +1,5 @@
 /* global dom */
-/* eslint complexity: ["error", 18] */
+/* eslint complexity: ["error", 20] */
 
 /**
  * Determines if an element is hidden with the clip rect technique
@@ -58,6 +58,8 @@ dom.isVisible = function(el, screenReader, recursed) {
 		style.getPropertyValue('display') === 'none' ||
 		nodeName.toUpperCase() === 'STYLE' ||
 		nodeName.toUpperCase() === 'SCRIPT' ||
+		nodeName.toUpperCase() === 'NOSCRIPT' ||
+		nodeName.toUpperCase() === 'TEMPLATE' ||
 		(!screenReader && isClipped(style.getPropertyValue('clip'))) ||
 		(!recursed &&
 			// visibility is only accurate on the first element

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -1,6 +1,8 @@
 describe('dom.isVisible', function() {
 	'use strict';
+
 	var fixture = document.getElementById('fixture');
+	var fixtureSetup = axe.testUtils.fixtureSetup;
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var fakeNode = {
 		nodeType: Node.ELEMENT_NODE,
@@ -76,6 +78,33 @@ describe('dom.isVisible', function() {
 
 		it('should return true on a document', function() {
 			assert.isTrue(axe.commons.dom.isVisible(document));
+		});
+
+		it('should return false on STYLE tag', function() {
+			var fixture = fixtureSetup(
+				'<style id="target"> @import "https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.css"; .green { background-color: green; } </style>'
+			);
+			var node = fixture.querySelector('#target');
+			var actual = axe.commons.dom.isVisible(node);
+			assert.isFalse(actual);
+		});
+
+		it('should return false on NOSCRIPT tag', function() {
+			var fixture = fixtureSetup(
+				'<noscript id="target"><p class="invisible"><img src="/piwik/piwik.php?idsite=1" alt="" /></p></noscript>'
+			);
+			var node = fixture.querySelector('#target');
+			var actual = axe.commons.dom.isVisible(node);
+			assert.isFalse(actual);
+		});
+
+		it('should return false on TEMPLATE tag', function() {
+			var fixture = fixtureSetup(
+				'<template id="target"><div>Name:</div></template>'
+			);
+			var node = fixture.querySelector('#target');
+			var actual = axe.commons.dom.isVisible(node);
+			assert.isFalse(actual);
 		});
 
 		it('should return true if positioned staticly but top/left is set', function() {


### PR DESCRIPTION
PR does the below:
- excludes `NOSCRIPT` and `TEMPLATE` when computing `isVisible`.

Closes issue: https://github.com/dequelabs/axe-core/issues/864

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
