### PR TITLE
chore: exec lint as separate CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,14 @@ jobs:
           paths:
             - node_modules
 
+  # Run ESLINT
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *restore_dependency_cache
+      - run: npm run eslint
+
   # Run the test suite.
   test:
     <<: *defaults
@@ -61,6 +69,10 @@ workflows:
   build:
     jobs:
       - dependencies
+      # Run linting
+      - lint:
+          requires:
+            - dependencies
       # Run tests on all commits, but after installing dependencies
       - test:
           requires:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,6 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-mocha');
 	grunt.loadNpmTasks('grunt-parallel');
-	grunt.loadNpmTasks('grunt-run');
 	grunt.loadTasks('build/tasks');
 
 	var langs;
@@ -338,22 +337,12 @@ module.exports = function(grunt) {
 					base: ['.']
 				}
 			}
-		},
-		run: {
-			npm_run_eslint: {
-				cmd: 'npm',
-				args: ['run', 'eslint']
-			}
 		}
 	});
 
 	grunt.registerTask('default', ['build']);
 
-	grunt.registerTask('pre-build', [
-		'clean',
-		'generate-imports',
-		'run:npm_run_eslint'
-	]);
+	grunt.registerTask('pre-build', ['clean', 'generate-imports']);
 
 	grunt.registerTask('build', [
 		'pre-build',

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
 		"grunt-contrib-watch": "^1.1.0",
 		"grunt-mocha": "1.1.0",
 		"grunt-parallel": "^0.5.1",
-		"grunt-run": "^0.8.1",
 		"html-entities": "^1.2.0",
 		"husky": "^1.1.1",
 		"jquery": "^3.0.0",


### PR DESCRIPTION
Execute `lint` as a separate step in CI.

Closes issue: https://github.com/dequelabs/axe-core/issues/1252

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
