### PR TITLE
fix(commons): Allow any node in aria.getRole

### DIFF
--- a/lib/commons/aria/get-role.js
+++ b/lib/commons/aria/get-role.js
@@ -18,6 +18,10 @@ aria.getRole = function getRole(
 	node,
 	{ noImplicit, fallback, abstracts, dpub } = {}
 ) {
+	node = node.actualNode || node;
+	if (node.nodeType !== 1) {
+		return null;
+	}
 	const roleAttr = (node.getAttribute('role') || '').trim().toLowerCase();
 	const roleList = fallback ? axe.utils.tokenList(roleAttr) : [roleAttr];
 

--- a/test/commons/aria/get-role.js
+++ b/test/commons/aria/get-role.js
@@ -53,6 +53,17 @@ describe('aria.getRole', function() {
 		assert.isNull(aria.getRole(node));
 	});
 
+	it('accepts virtualNode objects', function() {
+		var node = document.createElement('div');
+		node.setAttribute('role', 'button');
+		assert.equal(aria.getRole({ actualNode: node }), 'button');
+	});
+
+	it('returns null if the node is not an element', function() {
+		var node = document.createTextNode('foo bar baz');
+		assert.isNull(aria.getRole(node));
+	});
+
 	describe('noImplicit', function() {
 		it('returns the implicit role by default', function() {
 			var node = document.createElement('li');


### PR DESCRIPTION
Simple change I need for the accName update in #1163.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
