### PR TITLE
chore: easy cache bust of npm modules in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ defaults: &defaults
 restore_dependency_cache: &restore_dependency_cache
   restore_cache:
     keys:
-      - $CACHE_VERSION-npm-cache-{{ checksum "package.json" }}
-      - $CACHE_VERSION-npm-cache-
+      - ${CACHE_VERSION}-npm-cache-{{ checksum "package.json" }}
+      - ${CACHE_VERSION}-npm-cache-
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
@@ -24,7 +24,7 @@ jobs:
       - <<: *restore_dependency_cache
       - run: npm install
       - save_cache:
-          key: $CACHE_VERSION-npm-cache-{{ checksum "package.json" }}
+          key: ${CACHE_VERSION}-npm-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ defaults: &defaults
 restore_dependency_cache: &restore_dependency_cache
   restore_cache:
     keys:
-      - {{ .Environment.CACHE_VERSION }}-npm-cache-{{ checksum "package.json" }}
-      - {{ .Environment.CACHE_VERSION }}-npm-cache-
+      - v{{ .Environment.CACHE_VERSION }}-npm-cache-{{ checksum "package.json" }}
+      - v{{ .Environment.CACHE_VERSION }}-npm-cache-
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
@@ -24,7 +24,7 @@ jobs:
       - <<: *restore_dependency_cache
       - run: npm install
       - save_cache:
-          key: {{ .Environment.CACHE_VERSION }}-npm-cache-{{ checksum "package.json" }}
+          key: v{{ .Environment.CACHE_VERSION }}-npm-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ defaults: &defaults
 restore_dependency_cache: &restore_dependency_cache
   restore_cache:
     keys:
-      - v1-npm-cache-{{ checksum "package.json" }}
-      - v1-npm-cache-
+      - $CACHE_VERSION-npm-cache-{{ checksum "package.json" }}
+      - $CACHE_VERSION-npm-cache-
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
@@ -24,7 +24,7 @@ jobs:
       - <<: *restore_dependency_cache
       - run: npm install
       - save_cache:
-          key: v1-npm-cache-{{ checksum "package.json" }}
+          key: $CACHE_VERSION-npm-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ defaults: &defaults
 restore_dependency_cache: &restore_dependency_cache
   restore_cache:
     keys:
-      - ${CACHE_VERSION}-npm-cache-{{ checksum "package.json" }}
-      - ${CACHE_VERSION}-npm-cache-
+      - {{ .Environment.CACHE_VERSION }}-npm-cache-{{ checksum "package.json" }}
+      - {{ .Environment.CACHE_VERSION }}-npm-cache-
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
@@ -24,7 +24,7 @@ jobs:
       - <<: *restore_dependency_cache
       - run: npm install
       - save_cache:
-          key: ${CACHE_VERSION}-npm-cache-{{ checksum "package.json" }}
+          key: {{ .Environment.CACHE_VERSION }}-npm-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
 


### PR DESCRIPTION
Moving npm cache version management for CI builds as a Circle Environment Variable, to allow for easier cache busting.

Reasoning being, had a recent npm dependencies cache issue as a part of the eslint PRs - #1247 and #1250.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
