### PR TITLE
fix(typedefs): do not require brand and application

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -91,8 +91,8 @@ declare namespace axe {
 	}
 	interface Spec {
 		branding?: {
-			brand: string;
-			application: string;
+			brand?: string;
+			application?: string;
 		};
 		reporter?: ReporterVersion;
 		checks?: Check[];


### PR DESCRIPTION
We don't always set both. For example, see [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs/blob/v2.0.1/lib/axe-injector.js#L28).



## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
