### PR TITLE
Remove suspicious code from scope-value.js

### DIFF
--- a/lib/checks/tables/scope-value.js
+++ b/lib/checks/tables/scope-value.js
@@ -1,5 +1,4 @@
-options = options || {};
 var value = node.getAttribute('scope').toLowerCase();
-var validVals = ['row', 'col', 'rowgroup', 'colgroup'] || options.values;
+var validVals = ['row', 'col', 'rowgroup', 'colgroup'];
 
 return validVals.indexOf(value) !== -1;


### PR DESCRIPTION
The current implementation never falls back to `options.values` since the array on the LHS of `||` is always truthy.

This PR removes the dead code.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
