### PR TITLE
fix(i18n): Fix Japanese translation

### DIFF
--- a/locales/ja.json
+++ b/locales/ja.json
@@ -118,11 +118,11 @@
       "help": "フレームはaxe-coreでテストする必要があります"
     },
     "frame-title-unique": {
-      "description": "<iframe>及び<frame>要素に一意のタイトル属性が含まれていることを確認してください",
+      "description": "<iframe>及び<frame>要素に一意のtitle属性が含まれていることを確認してください",
       "help": "フレームには一意のtitle属性がなければなりません"
     },
     "frame-title": {
-      "description": "<iframe>及び<frame>要素に空のタイトル属性が存在しないことを確認してください",
+      "description": "<iframe>及び<frame>要素に空のtitle属性が存在しないことを確認してください",
       "help": "フレームにはtitle属性がなければなりません"
     },
     "heading-order": {


### PR DESCRIPTION
Updating Japanese translation.
Some words were supposed to be left in English.

Closes issue: none

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
