### PR TITLE
test: fix test case for dlitem

### DIFF
--- a/test/checks/lists/dlitem.js
+++ b/test/checks/lists/dlitem.js
@@ -119,7 +119,9 @@ describe('dlitem', function() {
 			);
 			assert.isTrue(checks.dlitem.evaluate.apply(null, checkArgs));
 		});
-	})(shadowSupport.v1 ? it : xit)(
+	});
+
+	(shadowSupport.v1 ? it : xit)(
 		'should return true in a shadow DOM pass',
 		function() {
 			var node = document.createElement('div');


### PR DESCRIPTION
Missing `;` in test case. Believe `prettier` assumed it was all in one line.

![image](https://user-images.githubusercontent.com/20978252/50829076-3550d980-133b-11e9-9586-6a8b60dcc392.png)


Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
