### PR TITLE
chore: Fix grunt dev:no-lint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -332,7 +332,7 @@ module.exports = function(grunt) {
 			npm_run_imports: {
 				cmd: 'npm',
 				args: ['run', 'imports-gen']
-      },
+			},
 			npm_run_eslint: {
 				cmd: 'npm',
 				args: ['run', 'eslint']
@@ -398,7 +398,7 @@ module.exports = function(grunt) {
 	]);
 
 	grunt.registerTask('dev:no-lint', [
-		'clean',
+		'pre-build',
 		'validate',
 		'concat:commons',
 		'configure',


### PR DESCRIPTION
Small bug fix. no-lint needs to run `run:npm_run_imports`.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
