### PR TITLE
fix: prevent TypeErrors in color-contrast checks

### DIFF
--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -284,6 +284,14 @@ color.filteredRectStack = function(elm) {
 			let rectA = rectStack[index - 1],
 				rectB = rectStack[index];
 
+			// If either rect are undefined, we cannot complete the test. We exit
+			// early to avoid unhelpful errors.
+			// See https://github.com/dequelabs/axe-core/issues/1306.
+			if (rectA === undefined || rectB === undefined) {
+				isSame = false;
+				return;
+			}
+
 			// if elements in clientRects are the same
 			// or the boundingClientRect contains the differing element, pass it
 			isSame =


### PR DESCRIPTION
This patch adds a safeguard to `color.filteredRectStack` which prevents a `TypeError: Cannot read property '0' of undefined` from being thrown.

This is not a perfect solution, but a stop-gap instead. It's still unclear why we're getting `undefined` here. More investigation is needed, but this can happen at a later date.

Closes #1306 and #1259.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
