### PR TITLE
style: format all code with Prettier (again)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -332,7 +332,7 @@ module.exports = function(grunt) {
 			npm_run_imports: {
 				cmd: 'npm',
 				args: ['run', 'imports-gen']
-      },
+			},
 			npm_run_eslint: {
 				cmd: 'npm',
 				args: ['run', 'eslint']

--- a/lib/commons/aria/is-accessible-ref.js
+++ b/lib/commons/aria/is-accessible-ref.js
@@ -41,15 +41,13 @@ aria.isAccessibleRef = function isAccessibleRef(node) {
 			return true;
 		}
 		// See if there are any aria attributes that reference the node
-		return refAttrs
-			.filter(attr => elm.hasAttribute(attr))
-			.some(attr => {
-				const attrValue = elm.getAttribute(attr);
-				if (aria.lookupTable.attributes[attr].type === 'idref') {
-					return attrValue === id;
-				}
-				return axe.utils.tokenList(attrValue).includes(id);
-			});
+		return refAttrs.filter(attr => elm.hasAttribute(attr)).some(attr => {
+			const attrValue = elm.getAttribute(attr);
+			if (aria.lookupTable.attributes[attr].type === 'idref') {
+				return attrValue === id;
+			}
+			return axe.utils.tokenList(attrValue).includes(id);
+		});
 	});
 	return typeof refElm !== 'undefined';
 };

--- a/lib/commons/table/get-scope.js
+++ b/lib/commons/table/get-scope.js
@@ -41,11 +41,9 @@ table.getScope = function(cell) {
 	}
 
 	// The element is in a column with all th elements, that makes it a row header
-	var headerCol = tableGrid
-		.map(col => col[pos.x])
-		.reduce((headerCol, cell) => {
-			return headerCol && cell && cell.nodeName.toUpperCase() === 'TH';
-		}, true);
+	var headerCol = tableGrid.map(col => col[pos.x]).reduce((headerCol, cell) => {
+		return headerCol && cell && cell.nodeName.toUpperCase() === 'TH';
+	}, true);
 
 	if (headerCol) {
 		return 'row';

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -302,8 +302,8 @@ function getThreeLeastCommonFeatures(elm, selectorData) {
 				return a.species !== b.species && a.species === 'class'
 					? -1
 					: a.species === b.species
-					? 0
-					: 1;
+						? 0
+						: 1;
 			});
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"rule-gen": "node build/rule-generator",
 		"next-release": "standard-version --scripts.prebump=./build/next-version.js --skip.commit=true --skip.tag=true",
 		"sri-update": "grunt build && node build/sri-update && git add sri-history.json",
-		"fmt": "prettier --write *.{json,md,js} **/*.ts '{build,doc,lib,test}/**/*.{json,md,js,ts}'"
+		"fmt": "prettier --write *.{json,md,js} **/*.ts './{build,doc,lib,test}/**/*.{json,md,js,ts}'"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.1.5",


### PR DESCRIPTION
This patch was created by running `npm run fmt`. It appears a few files were added/committed without Prettier being run first.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
