### PR TITLE
chore: format generated documentation before writing to disk

### DIFF
--- a/build/shared/format.js
+++ b/build/shared/format.js
@@ -1,0 +1,12 @@
+const prettier = require('prettier');
+const prettierConfig = require('../../package.json').prettier;
+
+/**
+ * Format the given `content` string, optionally using `filename` for error messages.
+ *
+ * @param {String} content
+ * @param {String} [filename]
+ */
+
+module.exports = (content, filename) =>
+	prettier.format(content, { ...prettierConfig, filepath: filename });

--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -3,6 +3,7 @@
 
 const { roles, aria: props } = require('aria-query');
 const mdTable = require('markdown-table');
+const format = require('../shared/format');
 
 module.exports = function(grunt) {
 	grunt.registerMultiTask(
@@ -103,7 +104,11 @@ module.exports = function(grunt) {
 						...getDiff(aQaria, axe.commons.aria.lookupTable.attributes)
 					])
 				);
-				grunt.file.write(destFile, content);
+
+				// Format the content so Prettier doesn't create a diff after running.
+				// See https://github.com/dequelabs/axe-core/issues/1310.
+				const formattedContent = format(content, destFile);
+				grunt.file.write(destFile, formattedContent);
 			};
 
 			generateDoc();

--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -1,6 +1,8 @@
 /*eslint-env node */
 'use strict';
 var buildRules = require('../configure');
+var format = require('../shared/format');
+
 module.exports = function(grunt) {
 	grunt.registerMultiTask(
 		'configure',
@@ -25,7 +27,14 @@ module.exports = function(grunt) {
 
 				buildRules(grunt, options, commons, function(result) {
 					grunt.file.write(file.dest.auto, 'axe._load(' + result.auto + ');');
-					grunt.file.write(file.dest.descriptions, result.descriptions);
+
+					// Format the content so Prettier doesn't create a diff after running.
+					// See https://github.com/dequelabs/axe-core/issues/1310.
+					const descriptionsContent = format(
+						result.descriptions,
+						file.dest.descriptions
+					);
+					grunt.file.write(file.dest.descriptions, descriptionsContent);
 					done();
 				});
 			});


### PR DESCRIPTION
This patch runs Prettier over the generated `aria-supported.md` and `rule-descriptions.md` files. This ensures `npm run build` does not create any unstaged changes.

Closes #1310.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
