### PR TITLE
chore: update code owners with fallback to global owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,13 @@
+# Reference - https://help.github.com/articles/about-code-owners/
+
 # Complete repo
 * @dequelabs/axe-codeowners
 
 # Localisation
-locales/ja.json @mlca11y/mlca11y
+locales/ja.json @mlca11y/mlca11y @dequelabs/axe-codeowners
 
 # Core features
-lib/core/* @stephenmathieson
-test/core/* @stephenmathieson
-build/* @stephenmathieson
-Gruntfile.js @stephenmathieson
+lib/core/* @stephenmathieson @dequelabs/axe-codeowners
+test/core/* @stephenmathieson @dequelabs/axe-codeowners
+build/* @stephenmathieson @dequelabs/axe-codeowners
+Gruntfile.js @stephenmathieson @dequelabs/axe-codeowners


### PR DESCRIPTION
Allow different code owners for various paths of the code with a global fallback.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
