### PR TITLE
chore: remove "linting" from Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,7 +232,7 @@ module.exports = function(grunt) {
 		},
 		watch: {
 			files: ['lib/**/*', 'test/**/*.js', 'Gruntfile.js'],
-			tasks: ['run:npm_run_eslint', 'build', 'testconfig', 'fixture']
+			tasks: ['build', 'testconfig', 'fixture']
 		},
 		testconfig: {
 			test: {
@@ -326,10 +326,6 @@ module.exports = function(grunt) {
 			npm_run_imports: {
 				cmd: 'npm',
 				args: ['run', 'imports-gen']
-			},
-			npm_run_eslint: {
-				cmd: 'npm',
-				args: ['run', 'eslint']
 			}
 		}
 	});
@@ -383,22 +379,7 @@ module.exports = function(grunt) {
 	]);
 
 	grunt.registerTask('dev', [
-		'run:npm_run_eslint',
 		'build',
-		'testconfig',
-		'fixture',
-		'connect',
-		'watch'
-	]);
-
-	grunt.registerTask('dev:no-lint', [
-		'pre-build',
-		'validate',
-		'concat:commons',
-		'configure',
-		'babel',
-		'concat:engine',
-		'uglify',
 		'testconfig',
 		'fixture',
 		'connect',

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
 		"fs-extra": "^7.0.0",
 		"grunt": "^1.0.3",
 		"globby": "^8.0.1",
-		"grunt": "^1.0.3",
 		"grunt-babel": "^7.0.0",
 		"grunt-contrib-clean": "^2.0.0",
 		"grunt-contrib-concat": "^1.0.1",


### PR DESCRIPTION
This patch removes all of the ESLint stuff from the Grunt configuration. There have been numerous efforts to "fix" the existing Grunt/ESLint setup which all seem unnecessary. Now, if you want to lint your code, just do `npm run eslint`. If you don't want to lint your code, then don't do `npm run eslint`.

Ref: #1342, #1314, #1267, #1255, #1247, and probably others...

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
