### PR TITLE
fix: add grunt back to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"execa": "^1.0.0",
 		"fs-extra": "^7.0.0",
 		"globby": "^8.0.1",
+		"grunt": "^1.0.3",
 		"grunt-babel": "^7.0.0",
 		"grunt-contrib-clean": "^2.0.0",
 		"grunt-contrib-concat": "^1.0.1",


### PR DESCRIPTION
Two difference prs were merged that both tried to clean up the duplicate grunt dependency that was in the package.json. Resulted in it being removed completely. 

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen