### PR TITLE
chore: add es6 promise

### DIFF
--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -7,12 +7,14 @@
  */
 
 /**
- * Override global `window`
+ * Polyfill `Promise`
+ * Reference: https://www.npmjs.com/package/es6-promise
  */
 require('es6-promise').polyfill();
 
 /**
- * Namespace `axe.imports`
+ * Namespace `axe.imports` which holds required external dependencies
+ *
  * @namespace imports
  * @memberof axe
  */

--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -1,9 +1,18 @@
 /* global axe */
 
-// Note: the below is run via `browserify` build task - `build/imports-generator` and output into the `tmp` directory.
+/**
+ * Note:
+ * Npm script -> `imports-gen` runs browserify
+ * to pull in the required dependencies.
+ */
 
 /**
- * Namespace for imports which holds globals of external dependencies.
+ * Override global `window`
+ */
+require('es6-promise').polyfill();
+
+/**
+ * Namespace `axe.imports`
  * @namespace imports
  * @memberof axe
  */

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"clone": "~2.1.1",
 		"css-selector-parser": "^1.3.0",
 		"dot": "~1.1.2",
+		"es6-promise": "^4.2.5",
 		"eslint": "^5.9.0",
 		"eslint-config-prettier": "^3.4.0",
 		"execa": "^1.0.0",

--- a/test/integration/full/umd/umd-window.js
+++ b/test/integration/full/umd/umd-window.js
@@ -5,6 +5,46 @@ describe('UMD window', function() {
 		assert.property(window, 'axe');
 	});
 
+	it('should expose Promise as a property of window', function() {
+		assert.property(window, 'Promise');
+	});
+
+	it('should resolve Promise(s)', function(done) {
+		var p1 = new Promise(function(resolve, reject) {
+			setTimeout(function() {
+				resolve('Hello');
+			});
+		});
+		var p2 = new Promise(function(resolve, reject) {
+			setTimeout(function() {
+				resolve('World!');
+			});
+		});
+		Promise.all([p1, p2])
+			.then(function(values) {
+				assert.lengthOf(values, 2);
+				assert.equal(values.join(' '), 'Hello World!');
+			})
+			.catch(function() {
+				done(new Error('Expected to resolve.'));
+			})
+			.finally(done);
+	});
+	it('should reject Promise', function(done) {
+		new Promise(function(resolve, reject) {
+			setTimeout(function() {
+				reject(new Error('Boom!'));
+			});
+		})
+			.then(function() {
+				done(new Error('Expected to reject.'));
+			})
+			.catch(function(err) {
+				assert.isDefined(err);
+				done();
+			});
+	});
+
 	it('should ensure axe has prototype chained keys', function() {
 		assert.hasAnyKeys(axe, ['utils', 'commons', 'core']);
 	});

--- a/test/integration/full/umd/umd-window.js
+++ b/test/integration/full/umd/umd-window.js
@@ -10,12 +10,12 @@ describe('UMD window', function() {
 	});
 
 	it('should resolve Promise(s)', function(done) {
-		var p1 = new Promise(function(resolve, reject) {
+		var p1 = new Promise(function(resolve) {
 			setTimeout(function() {
 				resolve('Hello');
 			});
 		});
-		var p2 = new Promise(function(resolve, reject) {
+		var p2 = new Promise(function(resolve) {
 			setTimeout(function() {
 				resolve('World!');
 			});


### PR DESCRIPTION
- Requiring `es6-promise` to `window`.

- Verified in Windows 10 Machine, IE11 browser, for existence of `window.Promise`

- Added tests to verify `Promise` usage.

![image](https://user-images.githubusercontent.com/20978252/52628318-44600580-2e6c-11e9-9eeb-33175e61dd1a.png)

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers
