### PR TITLE
feat: pass context to rule matches

### DIFF
--- a/build/templates.js
+++ b/build/templates.js
@@ -2,7 +2,7 @@ module.exports = {
 	evaluate: 'function (node, options, virtualNode, context) {\n<%=source%>\n}',
 	after: 'function (results, options) {\n<%=source%>\n}',
 	gather: 'function (context) {\n<%=source%>\n}',
-	matches: 'function (node, virtualNode) {\n<%=source%>\n}',
+	matches: 'function (node, virtualNode, context) {\n<%=source%>\n}',
 	source: '(function () {\n<%=source%>\n}())',
 	commons: '<%=source%>'
 };

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -156,7 +156,7 @@ Rule.prototype.run = function(context, options, resolve, reject) {
 	try {
 		// Matches throws an error when it lacks support for document methods
 		nodes = this.gather(context).filter(node =>
-			this.matches(node.actualNode, node)
+			this.matches(node.actualNode, node, context)
 		);
 	} catch (error) {
 		// Exit the rule execution if matches fails

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -204,6 +204,33 @@ describe('Rule', function() {
 				);
 			});
 
+			it('should pass a context to #matches', function(done) {
+				var div = document.createElement('div');
+				fixture.appendChild(div);
+				var success = false,
+					rule = new Rule({
+						matches: function(node, virtualNode, context) {
+							assert.isDefined(context);
+							assert.hasAnyKeys(context, ['cssom', 'include', 'exclude']);
+							assert.lengthOf(context.include, 1);
+							success = true;
+							return [];
+						}
+					});
+
+				rule.run(
+					{
+						include: [axe.utils.getFlattenedTree(div)[0]]
+					},
+					{},
+					function() {
+						assert.isTrue(success);
+						done();
+					},
+					isNotCalled
+				);
+			});
+
 			it('should handle an error in #matches', function(done) {
 				var div = document.createElement('div');
 				div.setAttribute('style', '#fff');


### PR DESCRIPTION
Passing the `context` object to the `matches` function for rules, to  allow for pre-filtering of nodes based on context.

Closes issue: https://github.com/dequelabs/axe-core/issues/1359

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
