### PR TITLE
chore: Resolve a few a11y-name comments

### DIFF
--- a/lib/commons/aria/arialabelledby-text.js
+++ b/lib/commons/aria/arialabelledby-text.js
@@ -22,7 +22,7 @@ aria.arialabelledbyText = function arialabelledbyText(node, context = {}) {
 	 * 		each ref type separately.
 	 *
 	 * Axe-core's implementation behaves most closely like Firefox as it seems
-	 *  to be the most common deniminator. Main difference is that Firefox
+	 *  to be the common deniminator. Main difference is that Firefox
 	 *  includes the value of form controls in addition to aria-label(s),
 	 *  something no other browser seems to do. Axe doesn't do that.
 	 */

--- a/lib/commons/aria/arialabelledby-text.js
+++ b/lib/commons/aria/arialabelledby-text.js
@@ -22,7 +22,7 @@ aria.arialabelledbyText = function arialabelledbyText(node, context = {}) {
 	 * 		each ref type separately.
 	 *
 	 * Axe-core's implementation behaves most closely like Firefox as it seems
-	 *  to be the common deniminator. Main difference is that Firefox
+	 *  to be the common denominator. Main difference is that Firefox
 	 *  includes the value of form controls in addition to aria-label(s),
 	 *  something no other browser seems to do. Axe doesn't do that.
 	 */

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -41,7 +41,6 @@ describe('text.accessibleTextVirtual', function() {
 	});
 
 	it('should match the second example from the ARIA spec', function() {
-		// TODO: Figure out of input value really should trump aria-label
 		fixture.innerHTML =
 			'<fieldset>' +
 			'  <legend>Meeting alarms</legend>' +
@@ -62,8 +61,9 @@ describe('text.accessibleTextVirtual', function() {
 		var rule2a = axe.utils.querySelectorAll(axe._tree, '#beep')[0];
 		var rule2b = axe.utils.querySelectorAll(axe._tree, '#flash')[0];
 		assert.equal(axe.commons.text.accessibleTextVirtual(rule2a), 'Beep');
-		// Chrome 72: "Flash the screen Number of times to flash screen times"
-		// Firefox 62: "Flash the screen Number of times to flash screen 3 times"
+		// Chrome 72: "Flash the screen 3 times"
+		// Firefox 62: "Flash the screen 3 times"
+		// Safari 12.0: "Flash the screen 3 times"
 		assert.equal(
 			axe.commons.text.accessibleTextVirtual(rule2b),
 			'Flash the screen 3 times'


### PR DESCRIPTION
Following up on a few comments in #1163

Closes issue: none

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
