### PR TITLE
chore: add eslint to lint staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,8 +129,8 @@
 			"prettier --write",
 			"git add"
 		],
-		"*.{js}": [
-			"npm run eslint --fix",
+		"*.js": [
+			"eslint --fix",
 			"prettier --write",
 			"git add"
 		]

--- a/package.json
+++ b/package.json
@@ -125,7 +125,12 @@
 	},
 	"dependencies": {},
 	"lint-staged": {
-		"*.{md,json,js,ts}": [
+		"*.{md,json}": [
+			"prettier --write",
+			"git add"
+		],
+		"*.{js,ts}": [
+			"npm run eslint",
 			"prettier --write",
 			"git add"
 		]

--- a/package.json
+++ b/package.json
@@ -125,12 +125,12 @@
 	},
 	"dependencies": {},
 	"lint-staged": {
-		"*.{md,json}": [
+		"*.{md,json,ts}": [
 			"prettier --write",
 			"git add"
 		],
-		"*.{js,ts}": [
-			"npm run eslint",
+		"*.{js}": [
+			"npm run eslint --fix",
 			"prettier --write",
 			"git add"
 		]


### PR DESCRIPTION
**Note: looking for opinion**

Following this PR - https://github.com/dequelabs/axe-core/pull/1343, `npm run eslint` does not run locally at all, which leads to some basic lint errors getting into CI & then the developer having an Aha moment. 

It should not be developer overhead to remember to run `eslint` before pushing. Hence adding this step to `lint-staged` which should catch lint errors (albeit not only on staged files). 

Verified that it works, locally.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
