### PR TITLE
chore: remove redundant promise dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
 		"mkdirp": "^0.5.1",
 		"mocha": "^6.0.0",
 		"prettier": "^1.14.0",
-		"promise": "~8.0.1",
 		"retire": "^2.0.1",
 		"revalidator": "~0.3.1",
 		"selenium-webdriver": "~3.6.0",


### PR DESCRIPTION
Removing a dependency, that @WilcoFiers added 2+ years ago, in an attempt to use Promise.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
