### PR TITLE
fix: Avoid require conflict with Cypress [#1405]

### DIFF
--- a/build/imports-generator.js
+++ b/build/imports-generator.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const browserify = require('browserify');
+const derequire = require('derequire');
 const createFile = require('./shared/create-file');
 
 const inputFile = path.join(
@@ -25,6 +26,8 @@ async function run() {
 			throw new Error('Cannot browserify axe.imports', err);
 		}
 		try {
+			// Replace `require` calls with `_dereq_` in order not to confuse Cypress.js
+			result = derequire(result);
 			await createFile(outputFile, result);
 		} catch (error) {
 			throw new Error('Cannot write browserify generated axe.imports', error);

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
 		"chai": "~4.1.2",
 		"clone": "~2.1.1",
 		"css-selector-parser": "^1.3.0",
+		"derequire": "^2.0.6",
 		"dot": "~1.1.2",
 		"emoji-regex": "7.0.3",
 		"es6-promise": "^4.2.6",

--- a/test/integration/full/umd/umd-module-exports.js
+++ b/test/integration/full/umd/umd-module-exports.js
@@ -6,6 +6,16 @@ describe('UMD module.export', function() {
 		assert.strictEqual(module.exports, axe);
 	});
 
+	it('does not use `require` functions', function() {
+		// This is to avoid colliding with Cypress.js which overloads all
+		// uses of variables named `require`.
+		assert.notMatch(
+			axe.source,
+			/[^.]require\(/,
+			'Axe source should not contain `require` variables'
+		);
+	});
+
 	it('should ensure axe source includes axios', function() {
 		assert.isTrue(axe.source.includes(axe.imports.axios.toString()));
 	});


### PR DESCRIPTION
Use derequire the rename all uses of `require` to `_dereq_` to avoid the problem of Cypress overloading the `require` method.

Closes #1405

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen