### PR TITLE
chore: Simplify codeowner stuff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,3 @@
 
 # Localisation
 locales/ja.json @mlca11y/mlca11y @dequelabs/axe-codeowners
-
-# Core features
-lib/core/* @stephenmathieson @dequelabs/axe-codeowners
-test/core/* @stephenmathieson @dequelabs/axe-codeowners
-build/* @stephenmathieson @dequelabs/axe-codeowners
-Gruntfile.js @stephenmathieson @dequelabs/axe-codeowners


### PR DESCRIPTION
I added Stephen to the codeowners instead. Adding two code owners doesn't really work as I was hoping it might. Stephen will have to just be mindful not to approve PRs that involve rule changes.

Closes issue: none

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen