### PR TITLE
ci: do not run the tests unless "lint" passes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ workflows:
       - test:
           requires:
             - dependencies
+            - lint
       # Hold for approval
       - hold:
           type: approval


### PR DESCRIPTION
This patch prevents our `test` CircleCI job from running until both `lint` and `dependencies` have passed. This ensures we "fail fast", which should (in theory) free up _some_ time with our limited container count.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
