### PR TITLE
fix: Avoid "screen is not defined" error [#1404]

### DIFF
--- a/lib/core/reporters/helpers/get-environment-data.js
+++ b/lib/core/reporters/helpers/get-environment-data.js
@@ -5,6 +5,8 @@
  * @return {Object}
  */
 helpers.getEnvironmentData = function getEnvironmentData(win = window) {
+	// TODO: remove parameter once we are testing axe-core in jsdom and other
+	// supported environments
 	const {
 		screen = {},
 		navigator = {},

--- a/lib/core/reporters/helpers/get-environment-data.js
+++ b/lib/core/reporters/helpers/get-environment-data.js
@@ -4,12 +4,17 @@
  * Add information about the environment axe was run in.
  * @return {Object}
  */
-helpers.getEnvironmentData = function getEnvironmentData() {
-	'use strict';
-	var orientation = window.screen
-		? screen.msOrientation ||
-		  (screen.orientation || screen.mozOrientation || {})
-		: {};
+helpers.getEnvironmentData = function getEnvironmentData(win = window) {
+	const {
+		screen = {},
+		navigator = {},
+		location = {},
+		innerHeight,
+		innerWidth
+	} = win;
+
+	const orientation =
+		screen.msOrientation || screen.orientation || screen.mozOrientation || {};
 
 	return {
 		testEngine: {
@@ -21,12 +26,12 @@ helpers.getEnvironmentData = function getEnvironmentData() {
 		},
 		testEnvironment: {
 			userAgent: navigator.userAgent,
-			windowWidth: window.innerWidth,
-			windowHeight: window.innerHeight,
+			windowWidth: innerWidth,
+			windowHeight: innerHeight,
 			orientationAngle: orientation.angle,
 			orientationType: orientation.type
 		},
 		timestamp: new Date().toISOString(),
-		url: window.location.href
+		url: location.href
 	};
 };

--- a/test/core/reporters/helpers/get-environment-data.js
+++ b/test/core/reporters/helpers/get-environment-data.js
@@ -1,5 +1,14 @@
 describe('helpers.getEnvironmentData', function() {
 	'use strict';
+	var __audit;
+	before(function() {
+		__audit = axe._audit;
+		axe._audit = { brand: 'Deque' };
+	});
+
+	after(function() {
+		axe._audit = __audit;
+	});
 
 	it('should return a `testEngine` property', function() {
 		var data = helpers.getEnvironmentData();
@@ -32,5 +41,43 @@ describe('helpers.getEnvironmentData', function() {
 	it('should return a `url` property', function() {
 		var data = helpers.getEnvironmentData();
 		assert.isDefined(data.url);
+	});
+
+	it('gets data from the `win` parameter when passed', function() {
+		var data = helpers.getEnvironmentData({
+			screen: {
+				orientation: {
+					type: 'fictional',
+					angle: 'slanted'
+				}
+			},
+			navigator: {
+				userAgent: 'foo'
+			},
+			location: {
+				href: 'foo://'
+			},
+			innerWidth: 321,
+			innerHeight: 123
+		});
+
+		delete data.timestamp;
+		assert.deepEqual(data, {
+			testEngine: {
+				name: 'axe-core',
+				version: axe.version
+			},
+			testRunner: {
+				name: axe._audit.brand
+			},
+			testEnvironment: {
+				userAgent: 'foo',
+				windowWidth: 321,
+				windowHeight: 123,
+				orientationAngle: 'slanted',
+				orientationType: 'fictional'
+			},
+			url: 'foo://'
+		});
 	});
 });

--- a/test/core/reporters/helpers/get-environment-data.js
+++ b/test/core/reporters/helpers/get-environment-data.js
@@ -43,6 +43,9 @@ describe('helpers.getEnvironmentData', function() {
 		assert.isDefined(data.url);
 	});
 
+	// TODO: remove or update test once we are testing axe-core in jsdom and
+	// other supported environments as what this is testing should be done in
+	// those environment tests
 	it('gets data from the `win` parameter when passed', function() {
 		var data = helpers.getEnvironmentData({
 			screen: {


### PR DESCRIPTION
`helpers.getEnvironmentData` made the assumption that `window` is the name of the global object. This is not the case when running axe-core in a NodeJS environment such as when testing axe-core using JSDOM. Usually all props on window get copied over to the global to avoid this, but especially for something as uncommon as `screen` it is not surprising that this broke somewhere.

Closes #1404

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen