### PR TITLE
docs(project-list): update community project list to include Patternfly

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -42,3 +42,4 @@ Add your project/integration to this file and submit a pull request.
 1. [Web Audit University of Nebraska-Lincoln](https://webaudit.unl.edu/)
 1. [Vorlon.js Remote Debugger](https://github.com/MicrosoftDX/Vorlonjs)
 1. [Terra's Webdriver.io Accessibility Service](https://github.com/cerner/terra-toolkit/blob/master/docs/AxeService.md)
+1. [Patternfly](https://github.com/patternfly/patternfly-next)


### PR DESCRIPTION
Hello, lovely library. We use it quite a bit over in [Patternfly](https://www.patternfly.org/) and would love a mention on the community projects list if it makes sense.

Let me know if you have questions or need more details. Thank you!!