### PR TITLE
ci: create GitHub release after publishing to npm [WWD-1845]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,18 @@ jobs:
       - run: npm run build
       - run: npm publish
 
+  # Create a GitHub release.
+  github_release:
+    steps:
+      - checkout
+      - run: go get gopkg.in/aktau/github-release.v0
+      - run:
+          name: Download and run GitHub release script
+          command: |
+            curl https://raw.githubusercontent.com/dequelabs/attest-release-scripts/develop/src/node-github-release.sh -s -o ./node-github-release.sh
+            chmod +x ./node-github-release.sh
+            ./node-github-release.sh
+
 workflows:
   version: 2
   build:
@@ -121,3 +133,6 @@ workflows:
           filters:
             branches:
               only: master
+      - github_release:
+          requires:
+            - production_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,8 @@ jobs:
 
   # Create a GitHub release.
   github_release:
+    docker:
+      - image: circleci/golang:1.8
     steps:
       - checkout
       - run: go get gopkg.in/aktau/github-release.v0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run: npm publish --tag=next
 
   # Release a "production" version
-  production_release:
+  release:
     <<: *defaults
     steps:
       - checkout
@@ -127,7 +127,7 @@ workflows:
             branches:
               only: develop
       # Run a production release on "master" commits, but only after the tests pass and dependencies are installed
-      - production_release:
+      - release:
           requires:
             - dependencies
             - test
@@ -137,4 +137,4 @@ workflows:
               only: master
       - github_release:
           requires:
-            - production_release
+            - release


### PR DESCRIPTION
This patch adds CircleCI configuration for automatically creating a GitHub Release (tag) after we successfully deploy a production version to npm.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu
