### PR TITLE
test: createHTMLDocument needs mandatory title when invoked in IE

### DIFF
--- a/test/checks/mobile/css-orientation-lock.js
+++ b/test/checks/mobile/css-orientation-lock.js
@@ -3,7 +3,9 @@ describe('css-orientation-lock tests', function() {
 
 	var checkContext = axe.testUtils.MockCheckContext();
 	var origCheck = checks['css-orientation-lock'];
-	var dynamicDoc = document.implementation.createHTMLDocument('ie is dumb');
+	var dynamicDoc = document.implementation.createHTMLDocument(
+		'Dynamic document for CSS Orientation Lock tests'
+	);
 
 	afterEach(function() {
 		checks['css-orientation-lock'] = origCheck;

--- a/test/checks/mobile/css-orientation-lock.js
+++ b/test/checks/mobile/css-orientation-lock.js
@@ -3,7 +3,7 @@ describe('css-orientation-lock tests', function() {
 
 	var checkContext = axe.testUtils.MockCheckContext();
 	var origCheck = checks['css-orientation-lock'];
-	var dynamicDoc = document.implementation.createHTMLDocument();
+	var dynamicDoc = document.implementation.createHTMLDocument('ie is dumb');
 
 	afterEach(function() {
 		checks['css-orientation-lock'] = origCheck;


### PR DESCRIPTION
fix breaking test in IE.
Reference - https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen