### PR TITLE
fix: Scroll state had top and left properties flipped

### DIFF
--- a/lib/core/utils/scroll-state.js
+++ b/lib/core/utils/scroll-state.js
@@ -20,7 +20,7 @@ function getScroll(elm) {
  */
 function setScroll(elm, top, left) {
 	if (elm === window) {
-		return elm.scroll(top, left);
+		return elm.scroll(left, top);
 	} else {
 		elm.scrollTop = top;
 		elm.scrollLeft = left;

--- a/test/core/utils/scroll-state.js
+++ b/test/core/utils/scroll-state.js
@@ -155,7 +155,7 @@ describe('axe.utils.setScrollState', function() {
 	it('calls scroll() for the window element', function() {
 		var called;
 		var winScroll = window.scroll;
-		window.scroll = function(top, left) {
+		window.scroll = function(left, top) {
 			called = { top: top, left: left };
 		};
 		setScrollState([{ elm: window, top: 10, left: 20 }]);


### PR DESCRIPTION
The arguments for `window.scroll()` are [x-axis, y-axis](https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll); meaning that "top" value (vertical scrolling) was supposed to be passed as 2nd argument.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
