### PR TITLE
fix: only load Promise polyfill if window.Promise is missing

### DIFF
--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -10,7 +10,9 @@
  * Polyfill `Promise`
  * Reference: https://www.npmjs.com/package/es6-promise
  */
-require('es6-promise').polyfill();
+if (!('Promise' in window)) {
+	require('es6-promise').polyfill();
+}
 
 /**
  * Namespace `axe.imports` which holds required external dependencies


### PR DESCRIPTION
`es6-promises` doesn't check if `window.Promise` exists before overriding it, but instead [checks if the browser natively supports Promises](https://github.com/taylorhakes/promise-polyfill/blob/master/src/polyfill.js) by seeing if `Promise.resolve()` returns `'[object Promise]'` when passed to `toString`:

```js
let P = local.Promise;

if (P) {
  var promiseToString = null;
  try {
    promiseToString = Object.prototype.toString.call(P.resolve());
  } catch(e) {
    // silently ignored
  }

  if (promiseToString === '[object Promise]' && !P.cast){
    return;
  }
}

local.Promise = Promise;
```

Adding a check before we run the polyfill to see if `window.Promise` exists. 

I looked at changing to anther promise library that would do the check better, but I'm not sure if @jkodu chose `es6-promsie` for a specific reason or not. `promise-polyfill` claims it's <1 kb when gzipped, which appears to be [much smaller than es6-promise](https://github.com/stefanpenner/es6-promise#downloads) (2.4 KB gzipped),  and it looks to see if `window.Promise` exists before polyfilling. 

Closes: #1468 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers
