### PR TITLE
feat(rule): add more perf timing metrics to rules

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -338,19 +338,20 @@ The options parameter is flexible way to configure how `axe.run` operates. The d
 
 Additionally, there are a number or properties that allow configuration of different options:
 
-| Property        | Default | Description                                                                                                                             |
-| --------------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------- |
-| `runOnly`       | n/a     | Limit which rules are executed, based on names or tags                                                                                  |
-| `rules`         | n/a     | Allow customizing a rule's properties (including { enable: false })                                                                     |
-| `reporter`      | `v1`    | Which reporter to use (see [Configuration](#api-name-axeconfigure))                                                                     |
-| `resultTypes`   | n/a     | Limit which result types are processed and aggregated                                                                                   |
-| `xpath`         | `false` | Return xpath selectors for elements                                                                                                     |
-| `absolutePaths` | `false` | Use absolute paths when creating element selectors                                                                                      |
-| `iframes`       | `true`  | Tell axe to run inside iframes                                                                                                          |
-| `elementRef`    | `false` | Return element references in addition to the target                                                                                     |
-| `restoreScroll` | `false` | Scrolls elements back to before axe started                                                                                             |
-| `frameWaitTime` | `60000` | How long (in milliseconds) axe waits for a response from embedded frames before timing out                                              |
-| `preload`       | `false` | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
+| Property           | Default | Description                                                                                                                             |
+| ------------------ | :------ | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| `runOnly`          | n/a     | Limit which rules are executed, based on names or tags                                                                                  |
+| `rules`            | n/a     | Allow customizing a rule's properties (including { enable: false })                                                                     |
+| `reporter`         | `v1`    | Which reporter to use (see [Configuration](#api-name-axeconfigure))                                                                     |
+| `resultTypes`      | n/a     | Limit which result types are processed and aggregated                                                                                   |
+| `xpath`            | `false` | Return xpath selectors for elements                                                                                                     |
+| `absolutePaths`    | `false` | Use absolute paths when creating element selectors                                                                                      |
+| `iframes`          | `true`  | Tell axe to run inside iframes                                                                                                          |
+| `elementRef`       | `false` | Return element references in addition to the target                                                                                     |
+| `restoreScroll`    | `false` | Scrolls elements back to before axe started                                                                                             |
+| `frameWaitTime`    | `60000` | How long (in milliseconds) axe waits for a response from embedded frames before timing out                                              |
+| `preload`          | `false` | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
+| `performanceTimer` | `false` | Log rule performance metrics to the console                                                                                             |
 
 ###### Options Parameter Examples
 

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -90,16 +90,49 @@ Rule.prototype.matches = function() {
 /**
  * Selects `HTMLElement`s based on configured selector
  * @param  {Context} context The resolved Context object
+ * @param  {Mixed}   options Options specific to this rule
  * @return {Array}           All matching `HTMLElement`s
  */
-Rule.prototype.gather = function(context) {
+Rule.prototype.gather = function(context, options) {
 	'use strict';
+	const markStart = 'mark_gather_start_' + this.id;
+	const markEnd = 'mark_gather_end_' + this.id;
+	const markHiddenStart = 'mark_isHidden_start_' + this.id;
+	const markHiddenEnd = 'mark_isHidden_end_' + this.id;
+
+	if (options.performanceTimer) {
+		axe.utils.performanceTimer.mark(markStart);
+	}
+
 	var elements = axe.utils.select(this.selector, context);
 	if (this.excludeHidden) {
-		return elements.filter(function(element) {
+		if (options.performanceTimer) {
+			axe.utils.performanceTimer.mark(markHiddenStart);
+		}
+
+		elements = elements.filter(function(element) {
 			return !axe.utils.isHidden(element.actualNode);
 		});
+
+		if (options.performanceTimer) {
+			axe.utils.performanceTimer.mark(markHiddenEnd);
+			axe.utils.performanceTimer.measure(
+				'rule_' + this.id + '#gather_axe.utils.isHidden',
+				markHiddenStart,
+				markHiddenEnd
+			);
+		}
 	}
+
+	if (options.performanceTimer) {
+		axe.utils.performanceTimer.mark(markEnd);
+		axe.utils.performanceTimer.measure(
+			'rule_' + this.id + '#gather',
+			markStart,
+			markEnd
+		);
+	}
+
 	return elements;
 };
 
@@ -155,9 +188,7 @@ Rule.prototype.run = function(context, options, resolve, reject) {
 
 	try {
 		// Matches throws an error when it lacks support for document methods
-		nodes = this.gather(context).filter(node =>
-			this.matches(node.actualNode, node, context)
-		);
+		nodes = gatherAndMatchNodes(this, context, options);
 	} catch (error) {
 		// Exit the rule execution if matches fails
 		reject(new SupportError({ cause: error, ruleId: this.id }));
@@ -166,6 +197,7 @@ Rule.prototype.run = function(context, options, resolve, reject) {
 
 	if (options.performanceTimer) {
 		axe.log(
+			this.id,
 			'gather (',
 			nodes.length,
 			'):',
@@ -217,7 +249,7 @@ Rule.prototype.run = function(context, options, resolve, reject) {
 		axe.utils.performanceTimer.mark(markChecksEnd);
 		axe.utils.performanceTimer.mark(markEnd);
 		axe.utils.performanceTimer.measure(
-			'runchecks_' + this.id,
+			'rule_' + this.id + '#runchecks',
 			markChecksStart,
 			markChecksEnd
 		);
@@ -227,6 +259,38 @@ Rule.prototype.run = function(context, options, resolve, reject) {
 
 	q.then(() => resolve(ruleResult)).catch(error => reject(error));
 };
+
+/**
+ * Selects `HTMLElement`s based on configured selector and filters them based on
+ * the rules matches function
+ * @param  {Rule} rule The rule to check for after checks
+ * @param  {Context} context The resolved Context object
+ * @param  {Mixed}   options Options specific to this rule
+ * @return {Array}           All matching `HTMLElement`s
+ */
+function gatherAndMatchNodes(rule, context, options) {
+	const markMatchesStart = 'mark_matches_start_' + this.id;
+	const markMatchesEnd = 'mark_matches_end_' + this.id;
+
+	let nodes = this.gather(context, options);
+
+	if (options.performanceTimer) {
+		axe.utils.performanceTimer.mark(markMatchesStart);
+	}
+
+	nodes = nodes.filter(node => this.matches(node.actualNode, node, context));
+
+	if (options.performanceTimer) {
+		axe.utils.performanceTimer.mark(markMatchesEnd);
+		axe.utils.performanceTimer.measure(
+			'rule_' + rule.id + '#matches',
+			markMatchesStart,
+			markMatchesEnd
+		);
+	}
+
+	return nodes;
+}
 
 /**
  * Iterates the rule's Checks looking for ones that have an after function

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -187,7 +187,7 @@ Rule.prototype.run = function(context, options, resolve, reject) {
 
 	try {
 		// Matches throws an error when it lacks support for document methods
-		nodes = gatherAndMatchNodes(this, context, options);
+		nodes = this.gatherAndMatchNodes(context, options);
 	} catch (error) {
 		// Exit the rule execution if matches fails
 		reject(new SupportError({ cause: error, ruleId: this.id }));
@@ -267,29 +267,29 @@ Rule.prototype.run = function(context, options, resolve, reject) {
  * @param  {Mixed}   options Options specific to this rule
  * @return {Array}           All matching `HTMLElement`s
  */
-function gatherAndMatchNodes(rule, context, options) {
-	const markMatchesStart = 'mark_matches_start_' + rule.id;
-	const markMatchesEnd = 'mark_matches_end_' + rule.id;
+Rule.prototype.gatherAndMatchNodes = function(context, options) {
+	const markMatchesStart = 'mark_matches_start_' + this.id;
+	const markMatchesEnd = 'mark_matches_end_' + this.id;
 
-	let nodes = rule.gather(context, options);
+	let nodes = this.gather(context, options);
 
 	if (options.performanceTimer) {
 		axe.utils.performanceTimer.mark(markMatchesStart);
 	}
 
-	nodes = nodes.filter(node => rule.matches(node.actualNode, node, context));
+	nodes = nodes.filter(node => this.matches(node.actualNode, node, context));
 
 	if (options.performanceTimer) {
 		axe.utils.performanceTimer.mark(markMatchesEnd);
 		axe.utils.performanceTimer.measure(
-			'rule_' + rule.id + '#matches',
+			'rule_' + this.id + '#matches',
 			markMatchesStart,
 			markMatchesEnd
 		);
 	}
 
 	return nodes;
-}
+};
 
 /**
  * Iterates the rule's Checks looking for ones that have an after function

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -269,16 +269,16 @@ Rule.prototype.run = function(context, options, resolve, reject) {
  * @return {Array}           All matching `HTMLElement`s
  */
 function gatherAndMatchNodes(rule, context, options) {
-	const markMatchesStart = 'mark_matches_start_' + this.id;
-	const markMatchesEnd = 'mark_matches_end_' + this.id;
+	const markMatchesStart = 'mark_matches_start_' + rule.id;
+	const markMatchesEnd = 'mark_matches_end_' + rule.id;
 
-	let nodes = this.gather(context, options);
+	let nodes = rule.gather(context, options);
 
 	if (options.performanceTimer) {
 		axe.utils.performanceTimer.mark(markMatchesStart);
 	}
 
-	nodes = nodes.filter(node => this.matches(node.actualNode, node, context));
+	nodes = nodes.filter(node => rule.matches(node.actualNode, node, context));
 
 	if (options.performanceTimer) {
 		axe.utils.performanceTimer.mark(markMatchesEnd);

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -93,8 +93,7 @@ Rule.prototype.matches = function() {
  * @param  {Mixed}   options Options specific to this rule
  * @return {Array}           All matching `HTMLElement`s
  */
-Rule.prototype.gather = function(context, options) {
-	'use strict';
+Rule.prototype.gather = function(context, options = {}) {
 	const markStart = 'mark_gather_start_' + this.id;
 	const markEnd = 'mark_gather_end_' + this.id;
 	const markHiddenStart = 'mark_isHidden_start_' + this.id;

--- a/lib/core/utils/performance-timer.js
+++ b/lib/core/utils/performance-timer.js
@@ -90,7 +90,12 @@ utils.performanceTimer = (function() {
 				window.performance &&
 				window.performance.getEntriesByType !== undefined
 			) {
-				var measures = window.performance.getEntriesByType('measure');
+				// only output measures that were started after axe started, otherwise
+				// we get measures made by the page before axe ran (which is confusing)
+				var axeStart = window.performance.getEntriesByName('mark_axe_start')[0];
+				var measures = window.performance
+					.getEntriesByType('measure')
+					.filter(measure => measure.startTime >= axeStart.startTime);
 				for (var i = 0; i < measures.length; ++i) {
 					var req = measures[i];
 					if (req.name === measureName) {


### PR DESCRIPTION
Add metrics for `rule.gather`, `rule.matches` and `axe.utils.isHidden`. This allows us to see where a rule is taking the most time better. Also rename rules to be sortable based on id. Lastly, have axe only output metrics that were done after axe run, otherwise you get metrics that the website ran before axe did, which makes it really confusing when reading the metric logs.

Example output:

```
Measure rule_aria-valid-attr-value#gather_axe.utils.isHidden took 931ms
Measure rule_aria-valid-attr-value#gather took 931ms
Measure rule_aria-valid-attr-value took 937ms
Measure rule_aria-valid-attr-value#matches took 4ms
Measure rule_aria-valid-attr-value#runchecks took 2ms
Measure rule_aria-valid-attr#gather_axe.utils.isHidden took 960ms
Measure rule_aria-valid-attr#gather took 960ms
Measure rule_aria-valid-attr took 969ms
Measure rule_aria-valid-attr#matches took 9ms
Measure rule_aria-valid-attr#runchecks took 0ms
Measure rule_color-contrasr#gather_axe.utils.isHidden took 0ms
Measure rule_color-contrast#gather took 0ms 
Measure rule_color-contrast#matches took 860ms 
Measure rule_color-contrast took 1264ms 
Measure rule_color-contrast#runchecks took 404ms
```

Closes issue: N/A

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen