### PR TITLE
ci: allow retries in IE; skip flaky test for windows ci

### DIFF
--- a/build/test/config.js
+++ b/build/test/config.js
@@ -42,7 +42,12 @@ exports = module.exports = function(grunt, options) {
 					[
 						'test/integration/full/**/*.html',
 						'!test/integration/full/**/frames/**/*.html'
-					],
+					].concat([
+						// These tests can be flaky on AppVeyor in Chrome and frequently fail
+						process.env.APPVEYOR
+							? ['!test/integration/full/preload-cssom/preload-cssom.html']
+							: []
+					]),
 					'<%= connect.test.options.port %>'
 				),
 				run: true,

--- a/test/core/public/run-rules.js
+++ b/test/core/public/run-rules.js
@@ -2,6 +2,11 @@
 describe('runRules', function() {
 	'use strict';
 
+	// These tests can sometimes be flaky in IE, allow for up to 3 retries
+	if (axe.testUtils.isIE11) {
+		this.retries(3);
+	}
+
 	function iframeReady(src, context, id, cb) {
 		var i = document.createElement('iframe');
 		i.addEventListener('load', function() {

--- a/test/core/public/run.js
+++ b/test/core/public/run.js
@@ -5,6 +5,11 @@ describe('axe.run', function() {
 	var noop = function() {};
 	var origRunRules = axe._runRules;
 
+	// These tests can sometimes be flaky in IE, allow for up to 3 retries
+	if (axe.testUtils.isIE11) {
+		this.retries(3);
+	}
+
 	beforeEach(function() {
 		axe._load({
 			rules: [


### PR DESCRIPTION
Some tests are occasionally failing on AppVeyor, so skipping a specific CSSOM test in Chrome, and allowing for retries on some of the IE tests.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers