### PR TITLE
fix: make nullable impact properties have nullable types per API docs

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -65,13 +65,13 @@ declare namespace axe {
 		help: string;
 		helpUrl: string;
 		id: string;
-		impact: ImpactValue;
+		impact?: ImpactValue;
 		tags: TagValue[];
 		nodes: NodeResult[];
 	}
 	interface NodeResult {
 		html: string;
-		impact: ImpactValue;
+		impact?: ImpactValue;
 		target: string[];
 		any: CheckResult[];
 		all: CheckResult[];


### PR DESCRIPTION
Update `axe.d.ts` to match `API.md` in terms of which result `impact` properties may sometimes be `null`

Closes issue: #1476

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen 
