### PR TITLE
ci: remove hold for "next" releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,6 @@ workflows:
             - dependencies
             - test
             - test_examples
-            - hold
           filters:
             branches:
               only: develop


### PR DESCRIPTION
This patch removes the CircleCI "hold" for canary releases. As result, all (green) `develop` commits will be published to npm as `axe-core@next`.



## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jason
