### PR TITLE
chore: disable "max-statements" and "complexity" ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,14 +42,6 @@
       2,
       5
     ],
-    "max-statements": [
-      2,
-      15
-    ],
-    "complexity": [
-      1,
-      12
-    ],
     "no-cond-assign": 0,
     "no-debugger": 0,
     "no-eq-null": 0,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,4 @@
 /*eslint
-complexity: ["error",12],
-max-statements: ["error", 35],
 camelcase: ["error", {"properties": "never"}]
 */
 var testConfig = require('./build/test/config');

--- a/build/configure.js
+++ b/build/configure.js
@@ -1,5 +1,5 @@
 /*eslint-env node */
-/*eslint max-statements: ["error", 20], max-len: off */
+/*eslint max-len: off */
 'use strict';
 
 var clone = require('clone');

--- a/build/tasks/test-webdriver.js
+++ b/build/tasks/test-webdriver.js
@@ -1,7 +1,4 @@
 /*global window */
-/*eslint
-max-statements: ["error", 20],
-*/
 'use strict';
 
 var WebDriver = require('selenium-webdriver');

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -38,10 +38,6 @@
       2,
       5
     ],
-    "max-statements": [
-      2,
-      16
-    ],
     "max-len": [
       2,
       {

--- a/lib/checks/.eslintrc
+++ b/lib/checks/.eslintrc
@@ -42,14 +42,6 @@
       2,
       5
     ],
-    "max-statements": [
-      2,
-      15
-    ],
-    "complexity": [
-      2,
-      10
-    ],
     "no-cond-assign": 0,
     "no-debugger": 0,
     "no-eq-null": 0,

--- a/lib/checks/aria/required-children.js
+++ b/lib/checks/aria/required-children.js
@@ -39,7 +39,6 @@ function ariaOwns(nodes, role) {
 }
 
 function missingRequiredChildren(node, childRoles, all, role) {
-	/* eslint max-statements: ["error", 22], complexity: ["error", 17] */
 	var i,
 		l = childRoles.length,
 		missing = [],

--- a/lib/checks/lists/only-listitems.js
+++ b/lib/checks/lists/only-listitems.js
@@ -16,10 +16,6 @@ let base = {
 };
 
 let out = virtualNode.children.reduce((out, { actualNode }) => {
-	/*eslint 
-		max-statements: ["error", 20]
-		complexity: ["error", 12]
-		*/
 	const tagName = actualNode.nodeName.toUpperCase();
 
 	if (actualNode.nodeType === 1 && dom.isVisible(actualNode, true, false)) {

--- a/lib/checks/mobile/css-orientation-lock.js
+++ b/lib/checks/mobile/css-orientation-lock.js
@@ -78,8 +78,6 @@ Object.keys(rulesGroupByDocumentFragment).forEach(key => {
 		// a media query has framents of css styles applied to various selectors
 		// iteration through cssRules and see if orientation lock has been applied
 		Array.from(r.cssRules).forEach(cssRule => {
-			/* eslint max-statements: ["error", 20], complexity: ["error", 15] */
-
 			// ensure selectorText exists
 			if (!cssRule.selectorText) {
 				return;

--- a/lib/commons/.eslintrc
+++ b/lib/commons/.eslintrc
@@ -39,10 +39,6 @@
       2,
       5
     ],
-    "max-statements": [
-      2,
-      20
-    ],
     "no-cond-assign": 0,
     "no-debugger": 0,
     "no-eq-null": 0,

--- a/lib/commons/aria/validate-attr-value.js
+++ b/lib/commons/aria/validate-attr-value.js
@@ -10,7 +10,6 @@
  * @return {Boolean}
  */
 aria.validateAttrValue = function validateAttrValue(node, attr) {
-	/*eslint complexity: ["error",17]*/
 	'use strict';
 	var matches,
 		list,

--- a/lib/commons/dom/find-up.js
+++ b/lib/commons/dom/find-up.js
@@ -29,7 +29,6 @@ dom.findUp = function(element, target) {
  * @return {HTMLElement|null} Either the matching HTMLElement or `null` if there was no match
  */
 dom.findUpVirtual = function(element, target) {
-	/*eslint complexity: ["error", 12]*/
 	let parent;
 
 	parent = element.actualNode;

--- a/lib/commons/dom/get-scroll-offset.js
+++ b/lib/commons/dom/get-scroll-offset.js
@@ -1,5 +1,4 @@
 /* global dom */
-/*eslint complexity: ["error", 14]*/
 /**
  * Get the scroll offset of the document passed in
  * @method getScrollOffset

--- a/lib/commons/dom/is-focusable.js
+++ b/lib/commons/dom/is-focusable.js
@@ -1,5 +1,4 @@
 /* global dom */
-/* eslint complexity: ["error",20] */
 
 /**
  * Determines if focusing has been disabled on an element.

--- a/lib/commons/dom/is-hidden-with-css.js
+++ b/lib/commons/dom/is-hidden-with-css.js
@@ -1,4 +1,3 @@
-/* eslint complexity: ["error", 13], max-statements: ["error", 25] */
 /* global dom */
 
 /**

--- a/lib/commons/dom/is-in-text-block.js
+++ b/lib/commons/dom/is-in-text-block.js
@@ -26,7 +26,6 @@ function getBlockParent(node) {
  * @return {Boolean}      [description]
  */
 dom.isInTextBlock = function isInTextBlock(node) {
-	/* eslint complexity: ["error",17]*/
 	if (isBlock(node)) {
 		// Ignore if the link is a block
 		return false;

--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -1,5 +1,4 @@
 /* global dom */
-/* eslint complexity: ["error", 20] */
 
 /**
  * Determines if an element is hidden with the clip rect technique
@@ -33,7 +32,6 @@ function isClipped(clip) {
  * @return {Boolean} The element's visibilty status
  */
 dom.isVisible = function(el, screenReader, recursed) {
-	//eslint complexity: 13
 	'use strict';
 	var style, nodeName, parent;
 

--- a/lib/commons/dom/is-visual-content.js
+++ b/lib/commons/dom/is-visual-content.js
@@ -1,5 +1,4 @@
 /*global dom */
-/*eslint complexity: ["error",20] */
 
 const visualRoles = [
 	'checkbox',

--- a/lib/commons/dom/visually-contains.js
+++ b/lib/commons/dom/visually-contains.js
@@ -1,5 +1,4 @@
 /* global dom */
-/* eslint complexity: ["error",17] */
 
 /**
  * Checks whether a parent element visually contains its child, either directly or via scrolling.

--- a/lib/commons/dom/visually-overlaps.js
+++ b/lib/commons/dom/visually-overlaps.js
@@ -1,5 +1,4 @@
 /* global dom */
-/* eslint complexity: ["error",15] */
 
 /**
  * Checks whether a parent element visually overlaps a rectangle, either directly or via scrolling.

--- a/lib/commons/table/is-data-table.js
+++ b/lib/commons/table/is-data-table.js
@@ -1,5 +1,4 @@
 /* global table, dom */
-/* eslint max-statements: ["error",70], complexity: ["error",47] */
 
 /**
  * Determines whether a table is a data table

--- a/lib/commons/text/is-valid-autocomplete.js
+++ b/lib/commons/text/is-valid-autocomplete.js
@@ -74,7 +74,6 @@ text.isValidAutocomplete = function isValidAutocomplete(
 		qualifiedTerms = []
 	} = {}
 ) {
-	/*eslint max-statements: ["error", 23] */
 	autocomplete = autocomplete.toLowerCase().trim();
 	stateTerms = stateTerms.concat(text.autocomplete.stateTerms);
 	if (stateTerms.includes(autocomplete) || autocomplete === '') {

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -552,7 +552,6 @@ Audit.prototype.getRule = function(ruleId) {
  * @return {Object}          Validated options object
  */
 Audit.prototype.normalizeOptions = function(options) {
-	/* eslint max-statements: ["error", 22] */
 	'use strict';
 	var audit = this;
 

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -58,7 +58,6 @@ Check.prototype.enabled = true;
  * @param  {Function} callback Function to fire when check is complete
  */
 Check.prototype.run = function(node, options, context, resolve, reject) {
-	/* eslint max-statements: ["error", 17] */
 	'use strict';
 	options = options || {};
 	var enabled = options.hasOwnProperty('enabled')

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -68,7 +68,6 @@ function pushUniqueFrameSelector(context, type, selectorArray) {
  * @return {Object}         Normalized context spec to include both `include` and `exclude` arrays
  */
 function normalizeContext(context) {
-	/*eslint complexity: ["error", 13] */
 	'use strict';
 
 	// typeof NodeList.length in PhantomJS === function
@@ -230,7 +229,7 @@ function getRootNode({ include, exclude }) {
  * @param {Object} spec Configuration or "specification" object
  */
 function Context(spec) {
-	/* eslint max-statements:["error",22], no-unused-vars:0 */
+	/* eslint no-unused-vars:0 */
 	'use strict';
 
 	this.frames = [];

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -1,7 +1,6 @@
 /*global RuleResult, createExecutionContext, SupportError */
 
 function Rule(spec, parentAudit) {
-	/*eslint complexity: ["error", 11] */
 	'use strict';
 
 	this._audit = parentAudit;
@@ -142,8 +141,6 @@ Rule.prototype.runChecks = function(
  * @param  {Function} callback Function to call when evaluate is complete; receives a RuleResult instance
  */
 Rule.prototype.run = function(context, options, resolve, reject) {
-	/*eslint max-statements: ["error",17] */
-
 	const q = axe.utils.queue();
 	const ruleResult = new RuleResult(this);
 	const markStart = 'mark_rule_start_' + this.id;
@@ -336,7 +333,7 @@ Rule.prototype.after = function(result, options) {
  * @param {Object} spec - the attributes to be reconfigured
  */
 Rule.prototype.configure = function(spec) {
-	/*eslint complexity:["error",14], max-statements:["error",22], no-eval:0 */
+	/*eslint no-eval:0 */
 	'use strict';
 
 	if (spec.hasOwnProperty('selector')) {

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -1,6 +1,5 @@
 /* global reporters */
 function configureChecksRulesAndBranding(spec) {
-	/*eslint max-statements: ["error",21]*/
 	'use strict';
 	var audit;
 

--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -1,4 +1,3 @@
-/*eslint indent: 0, complexity:["error", 12]*/
 function isContext(potential) {
 	'use strict';
 	switch (true) {
@@ -81,7 +80,6 @@ function normalizeRunParams(context, options, callback) {
  * @return {Promise}           Resolves with the axe results. Only available when natively supported
  */
 axe.run = function(context, options, callback) {
-	/*eslint max-statements:["error",18] */
 	'use strict';
 	if (!axe._audit) {
 		throw new Error('No audit configured');

--- a/lib/core/utils/escape-selector.js
+++ b/lib/core/utils/escape-selector.js
@@ -7,8 +7,7 @@
  */
 axe.utils.escapeSelector = function(value) {
 	'use strict';
-	/*eslint no-bitwise: 0, eqeqeq: 0, complexity: ["error",27],
-	max-statements:["error", 25], one-var: 0, -W041: 0 */
+	/*eslint no-bitwise: 0, eqeqeq: 0, one-var: 0, -W041: 0 */
 	var string = String(value);
 	var length = string.length;
 	var index = -1;

--- a/lib/core/utils/flattened-tree.js
+++ b/lib/core/utils/flattened-tree.js
@@ -77,7 +77,6 @@ function getSlotChildren(node) {
  */
 axe.utils.getFlattenedTree = function(node, shadowId) {
 	// using a closure here and therefore cannot easily refactor toreduce the statements
-	/*eslint max-statements: ["error", 31] */
 	var retVal, realArray, nodeName;
 	function reduceShadowDOM(res, child) {
 		var replacements = axe.utils.getFlattenedTree(child, shadowId);

--- a/lib/core/utils/get-check-option.js
+++ b/lib/core/utils/get-check-option.js
@@ -1,4 +1,3 @@
-/*eslint complexity: ["error", 12]*/
 /**
  * Determines which CheckOption to use, either defined on the rule options, global check options or the check itself
  * @param  {Check} check    The Check object

--- a/lib/core/utils/get-friendly-uri-end.js
+++ b/lib/core/utils/get-friendly-uri-end.js
@@ -1,4 +1,4 @@
-/* eslint max-statements:["error",18], complexity:["error",27], no-script-url:0 */
+/* eslint no-script-url:0 */
 /**
  * Check if a string contains mostly numbers
  */

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -79,7 +79,7 @@ function filterAttributes(at) {
  *														the counts for how many elements with that feature exist
  */
 axe.utils.getSelectorData = function(domTree) {
-	/* eslint max-statements:["error", 22], no-loop-func:0*/
+	/* eslint no-loop-func:0*/
 
 	// Initialize the return structure with the three maps
 	let data = {
@@ -306,8 +306,8 @@ function getThreeLeastCommonFeatures(elm, selectorData) {
 				return a.species !== b.species && a.species === 'class'
 					? -1
 					: a.species === b.species
-					? 0
-					: 1;
+						? 0
+						: 1;
 			});
 		}
 	}
@@ -334,7 +334,7 @@ function getThreeLeastCommonFeatures(elm, selectorData) {
  */
 
 function generateSelector(elm, options, doc) {
-	/*eslint max-statements:["error", 22], no-loop-func:0*/
+	/*eslint no-loop-func:0*/
 	if (!axe._selectorData) {
 		throw new Error('Expect axe._selectorData to be set up');
 	}

--- a/lib/core/utils/get-xpath.js
+++ b/lib/core/utils/get-xpath.js
@@ -1,6 +1,5 @@
 /*global axe */
 
-/*eslint max-statements: ["error", 36], complexity: ["error", 22]*/
 function getXPathArray(node, path) {
 	var sibling, count;
 	// Gets an XPath for an element which describes its hierarchical location.

--- a/lib/core/utils/qsa.js
+++ b/lib/core/utils/qsa.js
@@ -66,13 +66,11 @@ var escapeRegExp = (function() {
 var reUnescape = /\\/g;
 
 function convertAttributes(atts) {
-	/*eslint indent:0*/
 	/*! Credit Mootools Copyright Mootools, MIT License */
 	if (!atts) {
 		return;
 	}
 	return atts.map(att => {
-		// eslint complexity:["error", 13]
 		var attributeKey = att.name.replace(reUnescape, '');
 		var attributeValue = (att.value || '').replace(reUnescape, '');
 		var test, regexp;
@@ -218,7 +216,6 @@ function matchesSelector(node, exp) {
 }
 
 matchExpressions = function(domTree, expressions, recurse, filter) {
-	/*eslint max-statements:["error", 34], complexity:["error", 22]*/
 	let stack = [];
 	let nodes = Array.isArray(domTree) ? domTree : [domTree];
 	let currentLevel = createLocalVariables(

--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -206,7 +206,6 @@
 		window.addEventListener(
 			'message',
 			function(e) {
-				/* eslint max-statements: ["error", 20]*/
 				var data = parseMessage(e.data);
 				if (!data) {
 					return;

--- a/lib/core/utils/rule-should-run.js
+++ b/lib/core/utils/rule-should-run.js
@@ -5,7 +5,6 @@
  * @param  {object}	runOnly Value of runOnly with type=tags
  * @return {bool}
  */
-/* eslint complexity: ["error", 14]*/
 function matchTags(rule, runOnly) {
 	'use strict';
 	var include, exclude, matching;

--- a/lib/core/utils/select.js
+++ b/lib/core/utils/select.js
@@ -100,7 +100,6 @@ function reduceIncludes(includes) {
  * @param  {Context} context  The "resolved" context object, @see Context
  * @return {Array}            Matching virtual DOM nodes sorted by DOM order
  */
-/*eslint max-statements:["error", 20]*/
 axe.utils.select = function select(selector, context) {
 	'use strict';
 

--- a/lib/core/utils/uuid.js
+++ b/lib/core/utils/uuid.js
@@ -1,5 +1,4 @@
-/*eslint no-bitwise: 0, eqeqeq: 0, curly: 0, strict: 0, no-eq-null: 0,
-max-statements: 0, complexity: 0, no-shadow: 0, no-undef: 0 */
+/*eslint no-bitwise: 0, eqeqeq: 0, curly: 0, strict: 0, no-eq-null: 0, no-shadow: 0, no-undef: 0 */
 //		 uuid.js
 //
 //		 Copyright (c) 2010-2012 Robert Kieffer

--- a/lib/rules/.eslintrc
+++ b/lib/rules/.eslintrc
@@ -42,14 +42,6 @@
       2,
       5
     ],
-    "max-statements": [
-      2,
-      15
-    ],
-    "complexity": [
-      2,
-      10
-    ],
     "no-cond-assign": 0,
     "no-debugger": 0,
     "no-eq-null": 0,

--- a/test/core/utils/escape-selector.js
+++ b/test/core/utils/escape-selector.js
@@ -1,4 +1,3 @@
-/*eslint max-statements: 0 */
 describe('utils.escapeSelector', function() {
 	'use strict';
 	var escapeSelector = axe.utils.escapeSelector;


### PR DESCRIPTION
This patch removes the arbitrary and ignored "max-statements" and "complexity" ESLint rules. Though the intention of having small functions with a low cyclomatic complexity is great, we have not followed these rules in practice. Instead, we've just repeatedly increased the thresholds when necessary. Doing so just adds noise for the reader of the code sift through, and is a tedious chore for the author of the code to have to do.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Steve
