### PR TITLE
chore: remove version number from axe.d.ts

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for axe-core 3.0.2
+// Type definitions for axe-core
 // Project: https://github.com/dequelabs/axe-core
 // Definitions by: Marcy Sutton <https://github.com/marcysutton>
 


### PR DESCRIPTION
This patch removes the version number from `axe.d.ts`. I think the original idea behind keeping it here was to update it every time we release, but this hasn't been happening lately.

Removing the version does not have any effect on TypeScript users; instead, it just removes an easy to break/forget part of our internal processes 😃



## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
