### PR TITLE
fix(raw-reporter): do not output `DqElement`s

### DIFF
--- a/lib/core/reporters/raw.js
+++ b/lib/core/reporters/raw.js
@@ -1,8 +1,32 @@
 axe.addReporter('raw', function(results, options, callback) {
 	'use strict';
+
 	if (typeof options === 'function') {
 		callback = options;
 		options = {};
 	}
-	callback(results);
+
+	// Guard against tests which don't pass an array as the first param here.
+	if (!results || !Array.isArray(results)) {
+		return callback(results);
+	}
+
+	const transformedResults = results.map(result => {
+		const transformedResult = { ...result };
+		const types = ['passes', 'violations', 'incomplete', 'inapplicable'];
+		for (const type of types) {
+			// Some tests don't include all of the types, so we have to guard against that here.
+			// TODO: ensure tests always use "proper" results to avoid having these hacks in production code paths.
+			if (transformedResult[type] && Array.isArray(transformedResult[type])) {
+				transformedResult[type] = transformedResult[type].map(typeResult => ({
+					...typeResult,
+					node: typeResult.node.toJSON()
+				}));
+			}
+		}
+
+		return transformedResult;
+	});
+
+	callback(transformedResults);
 });

--- a/test/core/reporters/raw.js
+++ b/test/core/reporters/raw.js
@@ -1,18 +1,150 @@
 describe('reporters - raw', function() {
 	'use strict';
 
-	it('should pass through object', function() {
+	var fixture = document.getElementById('fixture');
+
+	function createDqElement() {
+		var node = document.createElement('div');
+		fixture.appendChild(node);
+		return new axe.utils.DqElement(node);
+	}
+
+	var mockResults;
+	var orig;
+
+	before(function() {
+		mockResults = [
+			{
+				id: 'gimmeLabel',
+				helpUrl: 'things',
+				description: 'something nifty',
+				tags: ['tag1'],
+				result: 'passed',
+				violations: [],
+				passes: [
+					{
+						result: 'passed',
+						any: [
+							{
+								result: true,
+								data: 'minkey'
+							}
+						],
+						all: [],
+						none: [],
+						node: createDqElement()
+					}
+				]
+			},
+			{
+				id: 'idkStuff',
+				description: 'something more nifty',
+				pageLevel: true,
+				result: 'failed',
+				impact: 'cats',
+				tags: ['tag2'],
+				passes: [],
+				violations: [
+					{
+						result: 'failed',
+						all: [
+							{
+								result: false,
+								data: 'pillock',
+								impact: 'cats'
+							}
+						],
+						any: [],
+						none: [],
+						node: createDqElement(),
+						impact: 'cats'
+					}
+				]
+			},
+			{
+				id: 'bypass',
+				description: 'something even more nifty',
+				tags: ['tag3'],
+				impact: 'monkeys',
+				result: 'failed',
+				passes: [],
+				violations: [
+					{
+						result: 'failed',
+						impact: 'monkeys',
+						none: [
+							{
+								data: 'foon',
+								impact: 'monkeys',
+								result: true
+							}
+						],
+						any: [],
+						all: [],
+						node: createDqElement()
+					}
+				]
+			},
+			{
+				id: 'blinky',
+				description: 'something awesome',
+				tags: ['tag4'],
+				violations: [],
+				result: 'passed',
+				passes: [
+					{
+						result: 'passed',
+						none: [
+							{
+								data: 'clueso',
+								result: true
+							}
+						],
+						node: createDqElement()
+					}
+				]
+			}
+		];
+
+		axe.testUtils.fixtureSetup();
+
 		axe._load({});
-		var orig = axe._runRules;
+		orig = axe._runRules;
 		axe._runRules = function(_, __, cb) {
-			cb('foo', function noop() {});
+			cb(mockResults, function noop() {});
 		};
+	});
 
-		axe.run({ reporter: 'raw' }, function(err, results) {
-			assert.isNull(err);
-			assert.equal(results, 'foo');
-		});
-
+	after(function() {
 		axe._runRules = orig;
+		fixture.innerHTML = '';
+	});
+
+	it('should pass through object', function(done) {
+		axe.run({ reporter: 'raw' }, function(err, results) {
+			if (err) {
+				return done(err);
+			}
+			assert.isTrue(Array.isArray(results));
+			done();
+		});
+	});
+
+	it('should serialize DqElements (#1195)', function(done) {
+		axe.run({ reporter: 'raw' }, function(err, results) {
+			if (err) {
+				return done(err);
+			}
+
+			for (var i = 0; i < results.length; i++) {
+				var result = results[i];
+				for (var j = 0; j < result.passes.length; j++) {
+					var p = result.passes[j];
+					assert.notInstanceOf(p.node, axe.utils.DqElement);
+				}
+			}
+
+			done();
+		});
 	});
 });

--- a/test/playground.html
+++ b/test/playground.html
@@ -2,18 +2,28 @@
 <html lang="en">
 	<title>O hai</title>
 
-	<p>
+	<p
+		id="target"
+		style="word-spacing: 200% !important; letter-spacing: 50rem !important; line-height: 3 !important;"
+	>
 		The quick brown fox jumped over the lazy dog
 	</p>
 
-	<input type="text" />
-
 	<script src="/axe.js"></script>
 	<script>
-		window.addEventListener('load', async () => {
-			axe.configure({ reporter: 'raw' });
-			const results = await axe.run();
-			console.log({ results });
+		window.addEventListener('load', function() {
+			axe.run(
+				{
+					runOnly: {
+						type: 'rule',
+						values: ['avoid-inline-spacing']
+					}
+				},
+				function(err, res) {
+					console.log(res.violations);
+					res.incomplete.forEach(issue => console.log(issue));
+				}
+			);
 		});
 	</script>
 </html>

--- a/test/playground.html
+++ b/test/playground.html
@@ -2,28 +2,18 @@
 <html lang="en">
 	<title>O hai</title>
 
-	<p
-		id="target"
-		style="word-spacing: 200% !important; letter-spacing: 50rem !important; line-height: 3 !important;"
-	>
+	<p>
 		The quick brown fox jumped over the lazy dog
 	</p>
 
+	<input type="text" />
+
 	<script src="/axe.js"></script>
 	<script>
-		window.addEventListener('load', function() {
-			axe.run(
-				{
-					runOnly: {
-						type: 'rule',
-						values: ['avoid-inline-spacing']
-					}
-				},
-				function(err, res) {
-					console.log(res.violations);
-					res.incomplete.forEach(issue => console.log(issue));
-				}
-			);
+		window.addEventListener('load', async () => {
+			axe.configure({ reporter: 'raw' });
+			const results = await axe.run();
+			console.log({ results });
 		});
 	</script>
 </html>


### PR DESCRIPTION
This patch updates our "raw" reporter, ensuring it does not pass `DqElement`s to its callback. Instead, it serializes the `DqElement` by using the `DqElement#toJSON()` method.

Unfortunately many of our tests pass non-results to the reporters, so several "guards" were added to the reporter ensuring we don't error while attempting to transform the provided results. In an ideal world, these tests would be rewritten to pass "proper" result objects to our reporters, but this felt out-of-scope for the task at hand.

Closes https://github.com/dequelabs/axe-core/issues/1195


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
