### PR TITLE
chore(prettier): ignore generated api doc files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 node_modules/
+doc/api


### PR DESCRIPTION
`doc/api` is ignored by git but not by prettier. Prettier breaks on quite a few of them if you've run `npm run api-docs` before running prettier.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen