### PR TITLE
fix(dom.isSkipLink): cache first page link

### DIFF
--- a/lib/commons/dom/is-skip-link.js
+++ b/lib/commons/dom/is-skip-link.js
@@ -16,13 +16,21 @@ dom.isSkipLink = function(element) {
 		return false;
 	}
 
-	// define a skip link as any anchor element whose href starts with `#...`
-	// and which precedes the first anchor element whose href doesn't start
-	// with  `#...` (that is, a link to a page)
-	const firstPageLink = axe.utils.querySelectorAll(
-		axe._tree,
-		'a:not([href^="#"]):not([href^="/#"]):not([href^="javascript"])'
-	)[0];
+	let firstPageLink;
+	if (typeof axe._cache.firstPageLink !== 'undefined') {
+		firstPageLink = axe._cache.firstPageLink;
+	} else {
+		// define a skip link as any anchor element whose href starts with `#...`
+		// and which precedes the first anchor element whose href doesn't start
+		// with  `#...` (that is, a link to a page)
+		firstPageLink = axe.utils.querySelectorAll(
+			axe._tree,
+			'a:not([href^="#"]):not([href^="/#"]):not([href^="javascript"])'
+		)[0];
+
+		// null will signify no first page link
+		axe._cache.firstPageLink = firstPageLink || null;
+	}
 
 	// if there are no page links then all all links will need to be
 	// considered as skip links


### PR DESCRIPTION
On https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#PrescriptionRefill takes the time to run the skip-link rule from 33s to 38ms.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
