### PR TITLE
fix(aria-valid-attr-value): allow aria-owns to pass when element is not in the DOM

### DIFF
--- a/lib/checks/aria/valid-attr-value.js
+++ b/lib/checks/aria/valid-attr-value.js
@@ -15,6 +15,12 @@ const preChecks = {
 			node.getAttribute('aria-expanded') !== 'false' &&
 			node.getAttribute('aria-selected') !== 'false'
 		);
+	},
+	// aria-owns should only check if element exists if the element
+	// doesn't have aria-expanded=false (combobox)
+	// @see https://github.com/dequelabs/axe-core/issues/1524
+	'aria-owns': function() {
+		return node.getAttribute('aria-expanded') !== 'false';
 	}
 };
 

--- a/test/checks/aria/valid-attr-value.js
+++ b/test/checks/aria/valid-attr-value.js
@@ -177,6 +177,26 @@ describe('aria-valid-attr-value', function() {
 		);
 	});
 
+	it('should pass on aria-owns and aria-expanded=false when the element is not in the DOM', function() {
+		fixtureSetup(
+			'<button aria-owns="test" aria-expanded="false">Button</button>'
+		);
+		var passing1 = fixture.querySelector('button');
+		assert.isTrue(
+			checks['aria-valid-attr-value'].evaluate.call(checkContext, passing1)
+		);
+	});
+
+	it('should fail on aria-owns and aria-expanded=true when the element is not in the DOM', function() {
+		fixtureSetup(
+			'<button aria-owns="test" aria-expanded="true">Button</button>'
+		);
+		var failing1 = fixture.querySelector('button');
+		assert.isFalse(
+			checks['aria-valid-attr-value'].evaluate.call(checkContext, failing1)
+		);
+	});
+
 	describe('options', function() {
 		it('should exclude supplied attributes', function() {
 			fixture.innerHTML =

--- a/test/checks/aria/valid-attr-value.js
+++ b/test/checks/aria/valid-attr-value.js
@@ -197,6 +197,14 @@ describe('aria-valid-attr-value', function() {
 		);
 	});
 
+	it('should fail on aria-owns when the element is not in the DOM', function() {
+		fixtureSetup('<button aria-owns="test">Button</button>');
+		var failing1 = fixture.querySelector('button');
+		assert.isFalse(
+			checks['aria-valid-attr-value'].evaluate.call(checkContext, failing1)
+		);
+	});
+
 	describe('options', function() {
 		it('should exclude supplied attributes', function() {
 			fixture.innerHTML =


### PR DESCRIPTION
Allow `aria-owns` to pass `aria-valid-attr-value` when element has `aria-expanded=false` and the owned element is not in the DOM.

Linked issue: #1524 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
