### PR TITLE
chore: update Babel dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.4.4",
 		"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
-		"@babel/polyfill": "^7.2.5",
+		"@babel/polyfill": "^7.4.4",
 		"@babel/preset-env": "^7.3.4",
 		"aria-query": "^3.0.0",
 		"axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"fmt": "prettier --write *.{json,md,js} **/*.ts './{build,doc,lib,test}/**/*.{json,md,js,ts,html}'"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.3.4",
+		"@babel/core": "^7.4.4",
 		"@babel/plugin-proposal-object-rest-spread": "^7.3.4",
 		"@babel/polyfill": "^7.2.5",
 		"@babel/preset-env": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.4.4",
-		"@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+		"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
 		"@babel/polyfill": "^7.2.5",
 		"@babel/preset-env": "^7.3.4",
 		"aria-query": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"@babel/core": "^7.4.4",
 		"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
 		"@babel/polyfill": "^7.4.4",
-		"@babel/preset-env": "^7.3.4",
+		"@babel/preset-env": "^7.4.4",
 		"aria-query": "^3.0.0",
 		"axios": "^0.18.0",
 		"babelify": "^10.0.0",


### PR DESCRIPTION
Greenkeeper keeps flagging issues that aren't actual issues due to appveyor breaking the build.

Closes issue: #1523 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
