### PR TITLE
docs: add jsdom example and tests

### DIFF
--- a/doc/examples/jsdom/package.json
+++ b/doc/examples/jsdom/package.json
@@ -3,11 +3,6 @@
 	"description": "Axe JSDOM Example",
 	"version": "0.0.1",
 	"private": true,
-	"author": {
-		"name": "David Sturley",
-		"organization": "Deque Systems, Inc.",
-		"url": "http://deque.com/"
-	},
 	"dependencies": {},
 	"scripts": {
 		"test": "mocha"

--- a/doc/examples/jsdom/package.json
+++ b/doc/examples/jsdom/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "axe-jsdom-example",
+	"description": "Axe JSDOM Example",
+	"version": "0.0.1",
+	"private": true,
+	"author": {
+		"name": "David Sturley",
+		"organization": "Deque Systems, Inc.",
+		"url": "http://deque.com/"
+	},
+	"dependencies": {},
+	"scripts": {
+		"test": "mocha"
+	},
+	"devDependencies": {
+		"axe-core": "^3.2.2",
+		"jsdom": "^15.0.0",
+		"mocha": "^6.1.4"
+	}
+}

--- a/doc/examples/jsdom/test/a11y.js
+++ b/doc/examples/jsdom/test/a11y.js
@@ -1,0 +1,61 @@
+/* global describe, it */
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
+const assert = require('assert');
+
+describe('axe', () => {
+	const { window } = new JSDOM(`<!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <title>JSDOM Example</title>
+    </head>
+    <body>
+      <div id="working">
+        <label for="has-label">Label for this text field.</label>
+        <input type="text" id="has-label">
+      </div>
+      <div id="broken">
+        <p>Not a label</p><input type="text" id="no-label">
+      </div>
+    </body>
+  </html>`);
+
+	global.document = window.document;
+	global.window = window;
+
+	// needed by axios lib/helpers/isURLSameOrigin.js
+	global.navigator = window.navigator;
+
+	// needed by axe /lib/core/public/run.js
+	global.Node = window.Node;
+	global.NodeList = window.NodeList;
+
+	// needed by axe /lib/core/base/context.js
+	global.Element = window.Element;
+	global.Document = window.Document;
+
+	const axe = require('axe-core');
+	const config = {
+		rules: {
+			'color-contrast': { enabled: false }
+		}
+	};
+
+	it('should report that good HTML is good', function(done) {
+		var n = window.document.getElementById('working');
+		axe.run(n, config, function(err, result) {
+			assert.equal(err, null, 'Error is not null');
+			assert.equal(result.violations.length, 0, 'Violations is not empty');
+			done();
+		});
+	});
+
+	it('should report that bad HTML is bad', function(done) {
+		var n = window.document.getElementById('broken');
+		axe.run(n, config, function(err, result) {
+			assert.equal(err, null, 'Error is not null');
+			assert.equal(result.violations.length, 1, 'Violations.length is not 1');
+			done();
+		});
+	});
+});


### PR DESCRIPTION
There were a lot more things needed for the global object than I thought there would be.

Axe needed:

* `document`
* `window`
* `Node`
* `NodeList`
* `Element`
* `Document`

and Axios needed:

* `navigator`

Linked issue: #1473

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
