### PR TITLE
fix: check if property exists in cache of flattenedTree

### DIFF
--- a/lib/core/utils/flattened-tree.js
+++ b/lib/core/utils/flattened-tree.js
@@ -34,13 +34,13 @@ function virtualDOMfromNode(node, shadowId) {
 		actualNode: node,
 		_isHidden: null, // will be populated by axe.utils.isHidden
 		get isFocusable() {
-			if (!vNodeCache._isFocusable) {
+			if (!vNodeCache.hasOwnProperty('_isFocusable')) {
 				vNodeCache._isFocusable = axe.commons.dom.isFocusable(node);
 			}
 			return vNodeCache._isFocusable;
 		},
 		get tabbableElements() {
-			if (!vNodeCache._tabbableElements) {
+			if (!vNodeCache.hasOwnProperty('_tabbableElements')) {
 				vNodeCache._tabbableElements = axe.commons.dom.getTabbableElements(
 					this
 				);


### PR DESCRIPTION
During a pairing session, noticed a bug with checking if a property already exists in the `_vNodeCache` of `flattenedTree`.

Previously because of this line https://github.com/dequelabs/axe-core/pull/1536/files#diff-a4aba2b3f5c65ff940eb4c8060dc57dfL37, if `isFocusable` is false, the utility function will be called. We should check if a cached value exists, rather than check against `true` or `false`, given that the values of some of these cached functions are boolean.

Closes issue: NA.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers
