### PR TITLE
ci: run test tasks with appveyor-retry to allow flaky tests to re-run

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,12 @@ test_script:
   - node --version
   - npm --version
   - npm run build
+  # Run test scaffolding
+  - grunt testconfig fixture
   # A few tests are flaky, causing occasional random failures
   # When we have time, we should investigate to see if we can eliminate these flakes
-  - appveyor-retry npm run test
+  - appveyor-retry grunt connect mocha
+  - appveyor-retry grunt connect test-webdriver:ie
   - npm run test:examples
 
  # Don't actually build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,11 @@ test_script:
   - npm --version
   - npm run build
   # Run test scaffolding
-  - grunt testconfig fixture
+  - npx grunt testconfig fixture
   # A few tests are flaky, causing occasional random failures
   # When we have time, we should investigate to see if we can eliminate these flakes
-  - appveyor-retry grunt connect mocha
-  - appveyor-retry grunt connect test-webdriver:ie
+  - appveyor-retry npx grunt connect mocha
+  - appveyor-retry npx grunt connect test-webdriver:ie
   - npm run test:examples
 
  # Don't actually build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ test_script:
   - npm run build
   # A few tests are flaky, causing occasional random failures
   # When we have time, we should investigate to see if we can eliminate these flakes
-  # - npm run test
+  - appveyor-retry npm run test
   - npm run test:examples
 
  # Don't actually build.


### PR DESCRIPTION
* Run test scaffolding commands isolated
* Split up test commands between phantom/webdriver to allow for quicker runs if something flakes out
* Only run `webdriver:ie` tests

I did a bit of testing around this. Ran 40+ iterations on CI after the change and there was only a single failure due to flaky tests being unable to run after 3 attempts (the other failures were due to random appveyor issues). This change could potentially make tests run longer (up to ~30 minutes), but will provide greater confidence levels that there aren't breaking windows changes.

It _does not_ resolve any of the underlying issues that may be contributing to potential flakiness on Windows.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen