### PR TITLE
chore: update standard-version dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"revalidator": "~0.3.1",
 		"selenium-webdriver": "~3.6.0",
 		"sri-toolbox": "^0.2.0",
-		"standard-version": "^5.0.0",
+		"standard-version": "^6.0.0",
 		"typescript": "^2.9.2",
 		"uglify-js": "^3.4.4",
 		"weakmap-polyfill": "^2.0.0"


### PR DESCRIPTION
Our `npm run retire` script is failing CricleCI because Handlebars 4.0.0 has a high severity issue.

```
handlebars 4.1.0 has known vulnerabilities: severity: high; summary: A prototype pollution 
vulnerability in handlebars may lead to remote code execution if an attacker can control 
the template; 
https://snyk.io/vuln/SNYK-JS-HANDLEBARS-174183 
https://github.com/wycats/handlebars.js/issues/1495 
https://github.com/wycats/handlebars.js/commit/cd38583216dce3252831916323202749431c773e
```

`standard-version` brings in Handlebars and the latest version fixes the issue.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jason