### PR TITLE
feat(reporter): adds the rawEnv reporter which wraps raw and env data

### DIFF
--- a/lib/core/reporters/raw-env.js
+++ b/lib/core/reporters/raw-env.js
@@ -1,0 +1,12 @@
+/*global helpers */
+axe.addReporter('rawEnv', function(results, options, callback) {
+	if (typeof options === 'function') {
+		callback = options;
+		options = {};
+	}
+	function rawCallback(raw) {
+		const env = helpers.getEnvironmentData();
+		callback({ raw, env });
+	}
+	axe.getReporter('raw')(results, options, rawCallback);
+});

--- a/test/core/reporters/raw-env.js
+++ b/test/core/reporters/raw-env.js
@@ -1,0 +1,142 @@
+/*global helpers */
+describe('reporters - raw-env', function() {
+	'use strict';
+
+	var fixture = document.getElementById('fixture');
+
+	function createDqElement() {
+		var node = document.createElement('div');
+		fixture.appendChild(node);
+		return new axe.utils.DqElement(node);
+	}
+
+	var mockResults;
+	var orig;
+	var rawResults;
+	const env = helpers.getEnvironmentData();
+
+	before(function() {
+		mockResults = [
+			{
+				id: 'gimmeLabel',
+				helpUrl: 'things',
+				description: 'something nifty',
+				tags: ['tag1'],
+				result: 'passed',
+				violations: [],
+				passes: [
+					{
+						result: 'passed',
+						any: [
+							{
+								result: true,
+								data: 'minkey'
+							}
+						],
+						all: [],
+						none: [],
+						node: createDqElement()
+					}
+				]
+			},
+			{
+				id: 'idkStuff',
+				description: 'something more nifty',
+				pageLevel: true,
+				result: 'failed',
+				impact: 'cats',
+				tags: ['tag2'],
+				passes: [],
+				violations: [
+					{
+						result: 'failed',
+						all: [
+							{
+								result: false,
+								data: 'pillock',
+								impact: 'cats'
+							}
+						],
+						any: [],
+						none: [],
+						node: createDqElement(),
+						impact: 'cats'
+					}
+				]
+			},
+			{
+				id: 'bypass',
+				description: 'something even more nifty',
+				tags: ['tag3'],
+				impact: 'monkeys',
+				result: 'failed',
+				passes: [],
+				violations: [
+					{
+						result: 'failed',
+						impact: 'monkeys',
+						none: [
+							{
+								data: 'foon',
+								impact: 'monkeys',
+								result: true
+							}
+						],
+						any: [],
+						all: [],
+						node: createDqElement()
+					}
+				]
+			},
+			{
+				id: 'blinky',
+				description: 'something awesome',
+				tags: ['tag4'],
+				violations: [],
+				result: 'passed',
+				passes: [
+					{
+						result: 'passed',
+						none: [
+							{
+								data: 'clueso',
+								result: true
+							}
+						],
+						node: createDqElement()
+					}
+				]
+			}
+		];
+
+		axe.testUtils.fixtureSetup();
+
+		axe._load({});
+		orig = axe._runRules;
+		axe._runRules = function(_, __, cb) {
+			cb(mockResults, function noop() {});
+		};
+		axe.run({ reporter: 'raw' }, function(err, results) {
+			if (err) {
+				return {};
+			}
+			rawResults = results;
+		});
+	});
+
+	after(function() {
+		axe._runRules = orig;
+		fixture.innerHTML = '';
+	});
+
+	it('should pass raw results and env object', function(done) {
+		axe.run({ reporter: 'rawEnv' }, function(err, results) {
+			if (err) {
+				return done(err);
+			}
+			assert.deepEqual(results.raw, rawResults);
+			assert.deepEqual(results.env, env);
+			done();
+		});
+	});
+});


### PR DESCRIPTION
`rawEnv` reporter calls the callback with `{raw, env}` where `raw` is the output of the `raw` reporter and `env` is the output of `helpers.getEnvironmentData()`.

Closes issue: #1534

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
