### PR TITLE
test: disable es6 syntax usage within tests directory

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,7 +1,11 @@
 {
   "extends": ["prettier"],
+  "parserOptions":{
+    "ecmaVersion": 5
+  },
   "env": {
-    "browser": true
+    "browser": true,
+    "es6": false
   },
   "globals": {
     "describe": true,

--- a/test/checks/lists/dlitem.js
+++ b/test/checks/lists/dlitem.js
@@ -66,7 +66,7 @@ describe('dlitem', function() {
 	});
 
 	it('returns true if the dd/dt is in a div with a dl as grandparent', function() {
-		const nodeNames = ['dd', 'dt'];
+		var nodeNames = ['dd', 'dt'];
 		nodeNames.forEach(function(nodeName) {
 			var checkArgs = checkSetup(
 				'<dl><div><' +
@@ -80,7 +80,7 @@ describe('dlitem', function() {
 	});
 
 	it('returns false if the dd/dt is in a div with a role with a dl as grandparent with a list role', function() {
-		const nodeNames = ['dd', 'dt'];
+		var nodeNames = ['dd', 'dt'];
 		nodeNames.forEach(function(nodeName) {
 			var checkArgs = checkSetup(
 				'<dl><div role="list"><' +
@@ -94,7 +94,7 @@ describe('dlitem', function() {
 	});
 
 	it('returns false if the dd/dt is in a div[role=presentation] with a dl as grandparent', function() {
-		const nodeNames = ['dd', 'dt'];
+		var nodeNames = ['dd', 'dt'];
 		nodeNames.forEach(function(nodeName) {
 			var checkArgs = checkSetup(
 				'<dl><div role="presentation"><' +
@@ -108,7 +108,7 @@ describe('dlitem', function() {
 	});
 
 	it('returns false if the dd/dt is in a div[role=none] with a dl as grandparent', function() {
-		const nodeNames = ['dd', 'dt'];
+		var nodeNames = ['dd', 'dt'];
 		nodeNames.forEach(function(nodeName) {
 			var checkArgs = checkSetup(
 				'<dl><div role="none"><' +

--- a/test/checks/mobile/css-orientation-lock.js
+++ b/test/checks/mobile/css-orientation-lock.js
@@ -7,6 +7,7 @@ describe('css-orientation-lock tests', function() {
 		'Dynamic document for CSS Orientation Lock tests'
 	);
 	var isIE11 = axe.testUtils.isIE11;
+	var isPhantom = window.PHANTOMJS ? true : false;
 
 	afterEach(function() {
 		checks['css-orientation-lock'] = origCheck;
@@ -220,7 +221,7 @@ describe('css-orientation-lock tests', function() {
 	});
 
 	// This currently breaks in IE11
-	(isIE11 ? it.skip : it)(
+	(isIE11 || isPhantom ? it.skip : it)(
 		'returns false if TRANSFORM style applied is ROTATE, and is divisible by 90 and not divisible by 180',
 		function() {
 			var actual = checks['css-orientation-lock'].evaluate.call(

--- a/test/checks/mobile/css-orientation-lock.js
+++ b/test/checks/mobile/css-orientation-lock.js
@@ -30,7 +30,7 @@ describe('css-orientation-lock tests', function() {
 	};
 
 	function getSheet(data) {
-		const style = dynamicDoc.createElement('style');
+		var style = dynamicDoc.createElement('style');
 		style.type = 'text/css';
 		style.appendChild(dynamicDoc.createTextNode(data));
 		dynamicDoc.head.appendChild(style);

--- a/test/commons/aria/arialabel-text.js
+++ b/test/commons/aria/arialabel-text.js
@@ -18,7 +18,7 @@ describe('aria.arialabelText', function() {
 		var node = document.createElement('div');
 		var label = ' my label ';
 		node.setAttribute('aria-label', label);
-		const vNode = { actualNode: node };
+		var vNode = { actualNode: node };
 		assert.equal(aria.arialabelText(vNode), label);
 	});
 

--- a/test/commons/aria/is-aria-role-allowed-on-element.js
+++ b/test/commons/aria/is-aria-role-allowed-on-element.js
@@ -240,11 +240,11 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 	it('returns false, ensure evaluateRoleForElement in lookupTable is invoked', function() {
 		var overrideInvoked = false;
 		axe.commons.aria.lookupTable.evaluateRoleForElement = {
-			IMG: ({ node, out }) => {
+			IMG: function(options) {
 				overrideInvoked = true;
-				assert.isDefined(node);
-				assert.equal(node.nodeName.toUpperCase(), 'IMG');
-				assert.isBoolean(out);
+				assert.isDefined(options.node);
+				assert.equal(options.node.nodeName.toUpperCase(), 'IMG');
+				assert.isBoolean(options.out);
 				return false;
 			}
 		};
@@ -261,10 +261,10 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 	it('returns false if element with role MENU type context', function() {
 		var overrideInvoked = false;
 		axe.commons.aria.lookupTable.evaluateRoleForElement = {
-			LI: ({ node }) => {
+			LI: function(options) {
 				overrideInvoked = true;
-				assert.isDefined(node);
-				assert.equal(node.nodeName.toUpperCase(), 'LI');
+				assert.isDefined(options.node);
+				assert.equal(options.node.nodeName.toUpperCase(), 'LI');
 				return false;
 			}
 		};

--- a/test/commons/matches/from-definition.js
+++ b/test/commons/matches/from-definition.js
@@ -13,7 +13,7 @@ describe('matches.fromDefinition', function() {
 
 	it('matches a definition with a `nodeName` property', function() {
 		fixture.innerHTML = '<div>foo</div>';
-		const matchers = [
+		var matchers = [
 			'div',
 			['div', 'span'],
 			/div/,
@@ -37,7 +37,7 @@ describe('matches.fromDefinition', function() {
 
 	it('matches a definition with an `attributes` property', function() {
 		fixture.innerHTML = '<div foo="bar">foo</div>';
-		const matchers = [
+		var matchers = [
 			'bar',
 			['bar', 'baz'],
 			/bar/,
@@ -65,7 +65,7 @@ describe('matches.fromDefinition', function() {
 
 	it('matches a definition with a `properties` property', function() {
 		fixture.innerHTML = '<input />';
-		const matchers = [
+		var matchers = [
 			'text',
 			['text', 'password'],
 			/text/,

--- a/test/commons/matches/node-name.js
+++ b/test/commons/matches/node-name.js
@@ -61,7 +61,7 @@ describe('matches.nodeName', function() {
 
 	it('works with virtual nodes', function() {
 		fixture.innerHTML = '<h1>foo</h1>';
-		const virtualNode = { actualNode: fixture.firstChild };
+		var virtualNode = { actualNode: fixture.firstChild };
 		assert.isTrue(matchNodeName(virtualNode, 'h1'));
 		assert.isFalse(matchNodeName(virtualNode, 'div'));
 	});

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -1,4 +1,4 @@
-/*global Audit, Rule */
+/*global Audit, Rule, Promise */
 describe('Audit', function() {
 	'use strict';
 

--- a/test/core/reporters/raw-env.js
+++ b/test/core/reporters/raw-env.js
@@ -13,17 +13,8 @@ describe('reporters - raw-env', function() {
 	var mockResults;
 	var orig;
 	var rawResults;
-	var env;
 
 	before(function() {
-		/**
-		 * Ensure `axe._audit` exists, as it is called by `getEnvironmentData`
-		 */
-		axe._audit = {
-			brand: 'axe-test'
-		};
-		env = helpers.getEnvironmentData();
-
 		mockResults = [
 			{
 				id: 'gimmeLabel',
@@ -142,6 +133,7 @@ describe('reporters - raw-env', function() {
 			if (err) {
 				return done(err);
 			}
+			var env = helpers.getEnvironmentData();
 			assert.deepEqual(results.raw, rawResults);
 			assert.deepEqual(results.env, env);
 			done();

--- a/test/core/reporters/raw-env.js
+++ b/test/core/reporters/raw-env.js
@@ -13,9 +13,17 @@ describe('reporters - raw-env', function() {
 	var mockResults;
 	var orig;
 	var rawResults;
-	var env = helpers.getEnvironmentData();
+	var env;
 
 	before(function() {
+		/**
+		 * Ensure `axe._audit` exists, as it is called by `getEnvironmentData`
+		 */
+		axe._audit = {
+			brand: 'axe-test'
+		};
+		env = helpers.getEnvironmentData();
+
 		mockResults = [
 			{
 				id: 'gimmeLabel',

--- a/test/core/reporters/raw-env.js
+++ b/test/core/reporters/raw-env.js
@@ -13,7 +13,7 @@ describe('reporters - raw-env', function() {
 	var mockResults;
 	var orig;
 	var rawResults;
-	const env = helpers.getEnvironmentData();
+	var env = helpers.getEnvironmentData();
 
 	before(function() {
 		mockResults = [

--- a/test/core/utils/get-stylesheet-factory.js
+++ b/test/core/utils/get-stylesheet-factory.js
@@ -12,14 +12,14 @@ describe('axe.utils.getStyleSheetFactory', function() {
 	});
 
 	it('returns a function when passed argument of dynamicDocument', function() {
-		const actual = axe.utils.getStyleSheetFactory(dynamicDoc);
+		var actual = axe.utils.getStyleSheetFactory(dynamicDoc);
 		assert.isFunction(actual);
 	});
 
 	it('returns a CSSOM stylesheet, when invoked with data (text)', function() {
-		const stylesheetFactory = axe.utils.getStyleSheetFactory(dynamicDoc);
-		const actual = stylesheetFactory({
-			data: `.someStyle{background-color:red;}`,
+		var stylesheetFactory = axe.utils.getStyleSheetFactory(dynamicDoc);
+		var actual = stylesheetFactory({
+			data: '.someStyle{background-color:red;}',
 			root: document,
 			priority: [1, 0]
 		});

--- a/test/core/utils/parse-crossorigin-stylesheet.js
+++ b/test/core/utils/parse-crossorigin-stylesheet.js
@@ -22,7 +22,7 @@ describe('axe.utils.parseCrossOriginStylesheet', function() {
 		var options = {
 			rootNode: document,
 			shadowId: undefined,
-			convertDataToStylesheet,
+			convertDataToStylesheet: convertDataToStylesheet,
 			rootIndex: 1
 		};
 		var priority = [1, 0];
@@ -61,13 +61,13 @@ describe('axe.utils.parseCrossOriginStylesheet', function() {
 			});
 	});
 
-	it(`rejects when given url to fetch is not found`, function(done) {
+	it('rejects when given url to fetch is not found', function(done) {
 		var importUrl =
 			'https://make-up-a-website-that-does-not-exist.com/style.css';
 		var options = {
 			rootNode: document,
 			shadowId: undefined,
-			convertDataToStylesheet,
+			convertDataToStylesheet: convertDataToStylesheet,
 			rootIndex: 1
 		};
 		var priority = [1, 0];

--- a/test/core/utils/parse-sameorigin-stylesheet.js
+++ b/test/core/utils/parse-sameorigin-stylesheet.js
@@ -48,7 +48,7 @@ describe('axe.utils.parseSameOriginStylesheet', function() {
 			var options = {
 				rootNode: document,
 				shadowId: undefined,
-				convertDataToStylesheet
+				convertDataToStylesheet: convertDataToStylesheet
 			};
 			var priority = [1, 0];
 			var importedUrls = [];
@@ -86,7 +86,7 @@ describe('axe.utils.parseSameOriginStylesheet', function() {
 			var options = {
 				rootNode: document,
 				shadowId: undefined,
-				convertDataToStylesheet
+				convertDataToStylesheet: convertDataToStylesheet
 			};
 			var priority = [1, 0];
 			var importedUrls = [];
@@ -132,7 +132,7 @@ describe('axe.utils.parseSameOriginStylesheet', function() {
 			var options = {
 				rootNode: document,
 				shadowId: undefined,
-				convertDataToStylesheet
+				convertDataToStylesheet: convertDataToStylesheet
 			};
 			var priority = [1, 0];
 			var importedUrls = [];

--- a/test/core/utils/preload-cssom.js
+++ b/test/core/utils/preload-cssom.js
@@ -36,7 +36,7 @@ describe('axe.utils.preloadCssom', function() {
 	});
 
 	it('returns CSSOM object containing an array of sheets', function(done) {
-		var actual = axe.utils.preloadCssom({ treeRoot });
+		var actual = axe.utils.preloadCssom({ treeRoot: treeRoot });
 		actual
 			.then(function(cssom) {
 				assert.isAtLeast(cssom.length, 2);
@@ -48,7 +48,7 @@ describe('axe.utils.preloadCssom', function() {
 	});
 
 	it('returns CSSOM and ensure that each object have defined properties', function(done) {
-		var actual = axe.utils.preloadCssom({ treeRoot });
+		var actual = axe.utils.preloadCssom({ treeRoot: treeRoot });
 		actual
 			.then(function(cssom) {
 				assert.isAtLeast(cssom.length, 2);
@@ -69,7 +69,7 @@ describe('axe.utils.preloadCssom', function() {
 	});
 
 	it('returns false if number of sheets returned does not match stylesheets defined in document', function(done) {
-		var actual = axe.utils.preloadCssom({ treeRoot });
+		var actual = axe.utils.preloadCssom({ treeRoot: treeRoot });
 		actual
 			.then(function(cssom) {
 				assert.isFalse(cssom.length <= 1);
@@ -81,7 +81,7 @@ describe('axe.utils.preloadCssom', function() {
 	});
 
 	it('returns all stylesheets and ensure each sheet has property cssRules', function(done) {
-		var actual = axe.utils.preloadCssom({ treeRoot });
+		var actual = axe.utils.preloadCssom({ treeRoot: treeRoot });
 		actual
 			.then(function(cssom) {
 				cssom.forEach(function(s) {

--- a/test/integration/full/preload-cssom/preload-cssom.js
+++ b/test/integration/full/preload-cssom/preload-cssom.js
@@ -80,8 +80,8 @@ describe('preload cssom integration test', function() {
 	}
 
 	function getPreloadCssom(root) {
-		const treeRoot = axe.utils.getFlattenedTree(root ? root : document);
-		return axe.utils.preloadCssom({ treeRoot });
+		var treeRoot = axe.utils.getFlattenedTree(root ? root : document);
+		return axe.utils.preloadCssom({ treeRoot: treeRoot });
 	}
 
 	function commonTestsForRootNodeAndNestedFrame(root) {
@@ -89,7 +89,7 @@ describe('preload cssom integration test', function() {
 			stylesForPage = [styleSheets.crossOriginLinkHref];
 			attachStylesheets(
 				{
-					root,
+					root: root,
 					styles: stylesForPage
 				},
 				function(err) {
@@ -120,7 +120,7 @@ describe('preload cssom integration test', function() {
 			stylesForPage = [styleSheets.crossOriginLinkHrefMediaPrint];
 			attachStylesheets(
 				{
-					root,
+					root: root,
 					styles: stylesForPage
 				},
 				function(err) {
@@ -149,7 +149,7 @@ describe('preload cssom integration test', function() {
 			];
 			attachStylesheets(
 				{
-					root,
+					root: root,
 					styles: stylesForPage
 				},
 				function(err) {

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -55,7 +55,7 @@ describe('axe.utils.preload integration test', function() {
 		return axe.utils.preload({
 			preload: {
 				assets: ['cssom'],
-				timeout
+				timeout: timeout
 			}
 		});
 	}

--- a/test/integration/full/umd/umd-window.js
+++ b/test/integration/full/umd/umd-window.js
@@ -1,3 +1,4 @@
+/*global Promise */
 describe('UMD window', function() {
 	'use strict';
 

--- a/test/integration/rules/runner.tmpl
+++ b/test/integration/rules/runner.tmpl
@@ -13,7 +13,6 @@
 				ui: 'bdd'
 			});
 			var assert = chai.assert;
-			var global = {};
 		</script>
 		<% files.forEach(function (file) { %>
 			<script src="../../<%=file%>"></script>

--- a/test/runner.tmpl
+++ b/test/runner.tmpl
@@ -21,7 +21,6 @@
 				ui: 'bdd'
 			});
 			var assert = chai.assert;
-			var global = {};
 		</script>
 		<% files.forEach(function (file) { %>
 			<script src="/<%=file%>"></script>


### PR DESCRIPTION
Noticed a lot of IE11/ Appveyor tests were failing as a consequence of looked over es6 syntax which is used in `tests/*.js`.

This PR, changes `eslintrc` for `tests` directory to disable `es6` syntax & fixes all such usages.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
