### PR TITLE
test: only run IE11 tests in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,6 @@ test_script:
   - npm run build
   # Run test scaffolding
   - npx grunt testconfig fixture
-  # A few tests are flaky, causing occasional random failures
-  # When we have time, we should investigate to see if we can eliminate these flakes
-  - appveyor-retry npx grunt connect mocha
   - appveyor-retry npx grunt connect test-webdriver:ie
   - npm run test:examples
 


### PR DESCRIPTION
Our appveyor account only has a queue of 1, so we can only do one job at a time. With the full suite taking 10ish minutes to complete and allowing 3 times for failures, we're getting backed up having to run appveyor for each commit against both the branch and develop. 

Since we're already running the mocha tests in CircleCI, we can just focus on running the IE tests in appveyor to cover our missing test browser while speeding up the appveyor tests.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen