### PR TITLE
test: fix flakey test

### DIFF
--- a/test/core/reporters/raw-env.js
+++ b/test/core/reporters/raw-env.js
@@ -1,4 +1,3 @@
-/*global helpers */
 describe('reporters - raw-env', function() {
 	'use strict';
 
@@ -133,16 +132,12 @@ describe('reporters - raw-env', function() {
 			if (err) {
 				return done(err);
 			}
-			var env = helpers.getEnvironmentData();
 			assert.deepEqual(results.raw, rawResults);
-			assert.isDefined(results.env);
-			assert.isDefined(results.env.timestamp);
-
-			// remove datetime strings as they can be off by ms which fail
-			// equality tests
-			results.env.timestamp = '';
-			env.timestamp = '';
-			assert.deepEqual(results.env, env);
+			assert.isNotNull(results.env);
+			assert.isNotNull(results.env.url);
+			assert.isNotNull(results.env.timestamp);
+			assert.isNotNull(results.env.testEnvironement);
+			assert.isNotNull(results.env.testRunner);
 			done();
 		});
 	});

--- a/test/core/reporters/raw-env.js
+++ b/test/core/reporters/raw-env.js
@@ -135,6 +135,13 @@ describe('reporters - raw-env', function() {
 			}
 			var env = helpers.getEnvironmentData();
 			assert.deepEqual(results.raw, rawResults);
+			assert.isDefined(results.env);
+			assert.isDefined(results.env.timestamp);
+
+			// remove datetime strings as they can be off by ms which fail
+			// equality tests
+			results.env.timestamp = '';
+			env.timestamp = '';
 			assert.deepEqual(results.env, env);
 			done();
 		});


### PR DESCRIPTION
The raw env reporter compares two datetime strings together in an equality test. If the datetimes were off by 1 ms the test would fail. Just copied the test for environment data from the v1 reporter.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen