### PR TITLE
fix(flatten-tree): do not call deprecated getDistributedNodes

### DIFF
--- a/lib/core/utils/flattened-tree.js
+++ b/lib/core/utils/flattened-tree.js
@@ -108,7 +108,10 @@ function flattenTree(node, shadowId) {
 		retVal.children = realArray.reduce(reduceShadowDOM, []);
 		return [retVal];
 	} else {
-		if (nodeName === 'content') {
+		if (
+			nodeName === 'content' &&
+			typeof node.getDistributedNodes === 'function'
+		) {
 			realArray = Array.from(node.getDistributedNodes());
 			return realArray.reduce(reduceShadowDOM, []);
 		} else if (


### PR DESCRIPTION
The `<content>` tag is deprecated and the `getDistributedNodes()` method on it's element is also deprecated. We used to unconditionally call it, but the method was removed in Firefox, and could potentially be removed from an upcoming version of Chrome.

A `<content>` tag was replaced by `<slot>` in shadow DOM v1 and behaves like a `<div>` now. So it is safe to treat it like any other node.

Closes issue: https://github.com/dequelabs/axe-core/issues/1576

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Steve
