### PR TITLE
fix(multiple-label): considers explicit labels in the same shadow tree

### DIFF
--- a/lib/checks/label/multiple-label.js
+++ b/lib/checks/label/multiple-label.js
@@ -1,6 +1,8 @@
 const id = axe.utils.escapeSelector(node.getAttribute('id'));
-let labels = Array.from(document.querySelectorAll(`label[for="${id}"]`));
 let parent = node.parentNode;
+let root = axe.commons.dom.getRootNode(node);
+root = root.documentElement || root;
+let labels = Array.from(root.querySelectorAll(`label[for="${id}"]`));
 
 if (labels.length) {
 	// filter out CSS hidden labels because they're fine


### PR DESCRIPTION
If the node is not contained in the ownerDocument it must be in shadow (open). Therefore, we climb the parentNode path to the first document fragment. Closed shadow is not supported. This fixes an issue where a single shadow tree held an input and valid label(s). Crossing shadow tree/document boundaries can not produce an accessible name.

Closes issue: #1559

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
