### PR TITLE
Renaming window.axe to avoid collisions.

### DIFF
--- a/doc/examples/chrome-debugging-protocol/axe-cdp.js
+++ b/doc/examples/chrome-debugging-protocol/axe-cdp.js
@@ -27,7 +27,7 @@ const example = async url => {
 		const browserCode = () => {
 			/* eslint-env browser */
 			return new Promise((resolve, reject) => {
-				const axe = window.axe;
+				const axe = window.__axe;
 				if (!axe) {
 					throw new Error('Unable to find axe-core');
 				}

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -24,7 +24,7 @@ if (
 	module.exports = axe;
 }
 if (typeof window.getComputedStyle === 'function') {
-	window.axe = axe;
+	window.__axe = axe;
 }
 // local namespace for common functions
 var commons;

--- a/test/core/export.js
+++ b/test/core/export.js
@@ -2,7 +2,7 @@ describe('export', function() {
 	'use strict';
 
 	it('should publish a global `axe` variable', function() {
-		assert.isDefined(window.axe);
+		assert.isDefined(window.__axe);
 	});
 	it('should define version', function() {
 		assert.equal(axe.version, 'x.y.z');

--- a/test/integration/full/umd/umd-window.html
+++ b/test/integration/full/umd/umd-window.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>UMD window.axe Test</title>
+		<title>UMD window.__axe Test</title>
 		<link
 			rel="stylesheet"
 			type="text/css"


### PR DESCRIPTION
refactor(window.axe): rename variable on window to avoid collision/overwrite with minified/compiled JS/TS

Rename the variable `window.axe` to `window.__axe` to make it less likely to be overwritten by compiled/minified JS/TS.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
