### PR TITLE
docs: Add CircleCI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # axe-core
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/dequelabs/axe-core.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/dequelabs/axe-core.svg)](https://greenkeeper.io/) [![CircleCI](https://circleci.com/gh/dequelabs/axe-core.svg?style=svg)](https://circleci.com/gh/dequelabs/axe-core)
 
 [![License](https://img.shields.io/npm/l/axe-core.svg)](LICENSE)
 [![Version](https://img.shields.io/npm/v/axe-core.svg)](https://www.npmjs.com/package/axe-core)


### PR DESCRIPTION
This patch adds a CircleCI status badge to our README. This enables users to see how stable the `develop` branch is and allows us to quickly navigate to the `axe-core` landing page in CircleCI (which is something I do frequently).



## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
