### PR TITLE
test: watch integration html and json files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -242,7 +242,12 @@ module.exports = function(grunt) {
 			}, [])
 		},
 		watch: {
-			files: ['lib/**/*', 'test/**/*.js', 'Gruntfile.js'],
+			files: [
+				'lib/**/*',
+				'test/**/*.js',
+				'test/integration/**/!(index).{html,json}',
+				'Gruntfile.js'
+			],
 			tasks: ['build', 'testconfig', 'fixture']
 		},
 		testconfig: {


### PR DESCRIPTION
Making changes to integration html and json files did not retrigger the `npm start` build, so you would have to manually quit and restart the process to see changes. The `test/integration/index.html` file is a generated file so we exclude that file from the watch.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jason
