### PR TITLE
fix(scrollable-region-focusable): exclude overflow:hidden as not scrollable

### DIFF
--- a/lib/core/utils/get-scroll.js
+++ b/lib/core/utils/get-scroll.js
@@ -19,8 +19,12 @@ axe.utils.getScroll = function getScroll(elm, buffer = 0) {
 	}
 
 	const style = window.getComputedStyle(elm);
-	const scrollableX = style.getPropertyValue('overflow-x') !== 'visible';
-	const scrollableY = style.getPropertyValue('overflow-y') !== 'visible';
+	const overflowXStyle = style.getPropertyValue('overflow-x');
+	const overflowYStyle = style.getPropertyValue('overflow-y');
+	const scrollableX =
+		overflowXStyle !== 'visible' && overflowXStyle !== 'hidden';
+	const scrollableY =
+		overflowYStyle !== 'visible' && overflowYStyle !== 'hidden';
 
 	/**
 	 * check direction of `overflow` and `scrollable`

--- a/test/core/utils/get-scroll.js
+++ b/test/core/utils/get-scroll.js
@@ -42,10 +42,10 @@ describe('axe.utils.getScroll', function() {
 				'</div>'
 		);
 		var actual = axe.utils.getScroll(target.actualNode);
-		assert.isDefined(actual);
-		assert.hasAllKeys(actual, ['elm', 'top', 'left']);
-		assert.equal(actual.top, 0);
-		assert.equal(actual.left, 0);
+		assert.isUndefined(actual);
+		// assert.hasAllKeys(actual, ['elm', 'top', 'left']);
+		// assert.equal(actual.top, 0);
+		// assert.equal(actual.left, 0);
 	});
 
 	it('returns scroll offset when element overflow is auto', function() {

--- a/test/core/utils/get-scroll.js
+++ b/test/core/utils/get-scroll.js
@@ -43,9 +43,6 @@ describe('axe.utils.getScroll', function() {
 		);
 		var actual = axe.utils.getScroll(target.actualNode);
 		assert.isUndefined(actual);
-		// assert.hasAllKeys(actual, ['elm', 'top', 'left']);
-		// assert.equal(actual.top, 0);
-		// assert.equal(actual.left, 0);
 	});
 
 	it('returns scroll offset when element overflow is auto', function() {

--- a/test/core/utils/scroll-state.js
+++ b/test/core/utils/scroll-state.js
@@ -53,7 +53,7 @@ describe('axe.utils.getScrollState', function() {
 		fixture.innerHTML =
 			'<div style="overflow:auto; height: 50px" id="tgt1">' +
 			'<div style="height: 100px"> Han Solo </div>' +
-			'<div style="overflow: hidden; height: 50px" id="tgt2">' +
+			'<div style="overflow: auto; height: 50px" id="tgt2">' +
 			'<div style="height: 100px"> Chewbacca </div>' +
 			'</div>' +
 			'</div>';

--- a/test/integration/rules/scrollable-region-focusable/scrollable-region-focusable.html
+++ b/test/integration/rules/scrollable-region-focusable/scrollable-region-focusable.html
@@ -1,9 +1,9 @@
 <!-- pass -->
-<div id="pass1" style="overflow: hidden; height: 5px;">
+<div id="pass1" style="overflow-y: scroll; height: 5px;">
 	<input type="text" />
 </div>
 
-<div id="pass2" style="height: 200px; overflow: hidden" tabindex="0">
+<div id="pass2" style="height: 200px; overflow-y: auto" tabindex="0">
 	<div style="height: 2000px">
 		<p>Content</p>
 	</div>
@@ -17,17 +17,11 @@
 </div>
 
 <!-- fail -->
-<div id="fail1" style="height: 200px; width: 200px; overflow: hidden">
-	<div style="height: 2000px; width: 100px;">
-		<p>Content</p>
-	</div>
-</div>
-
-<div id="fail2" style="height: 5px; overflow: auto;">
+<div id="fail1" style="height: 5px; overflow: auto;">
 	<input type="text" tabindex="-1" />
 </div>
 
-<div id="fail3" style="height: 5px; overflow: auto;">
+<div id="fail2" style="height: 5px; overflow: auto;">
 	<input type="text" tabindex="-1" />
 	<select tabindex="-1"></select>
 	<textarea tabindex="-1"></textarea>
@@ -65,6 +59,12 @@
 	tabindex="0"
 >
 	<div style="height: 2000px">
+		<p>Content</p>
+	</div>
+</div>
+
+<div id="inapplicable6" style="height: 200px; width: 200px; overflow: hidden">
+	<div style="height: 2000px; width: 100px;">
 		<p>Content</p>
 	</div>
 </div>

--- a/test/integration/rules/scrollable-region-focusable/scrollable-region-focusable.json
+++ b/test/integration/rules/scrollable-region-focusable/scrollable-region-focusable.json
@@ -1,6 +1,6 @@
 {
 	"description": "scrollable-region-focusable tests",
 	"rule": "scrollable-region-focusable",
-	"violations": [["#fail1"], ["#fail2"], ["#fail3"]],
+	"violations": [["#fail1"], ["#fail2"]],
 	"passes": [["#pass1"], ["#pass2"], ["#pass3"]]
 }

--- a/test/rule-matches/scrollable-region-focusable-matches.js
+++ b/test/rule-matches/scrollable-region-focusable-matches.js
@@ -42,7 +42,7 @@ describe('scrollable-region-focusable-matches', function() {
 		assert.isFalse(actual);
 	});
 
-	it('returns true when element is scrollable (overflow=hidden)', function() {
+	it('returns false when element is not scrollable (overflow=hidden)', function() {
 		var target = queryFixture(
 			'<div id="target" style="height: 200px; width: 200px; overflow: hidden">' +
 				'<div style="height: 2000px; width: 100px; background-color: pink;">' +
@@ -51,7 +51,7 @@ describe('scrollable-region-focusable-matches', function() {
 				'</div>'
 		);
 		var actual = rule.matches(target.actualNode, target);
-		assert.isTrue(actual);
+		assert.isFalse(actual);
 	});
 
 	it('returns true when element is scrollable (overflow=auto)', function() {


### PR DESCRIPTION
An element with `overflow: hidden` is not scrollable except through JavaScript `elm.scrollTop`. This prevents common CSS techniques to hide elements from visual users from failing the rule.

e.g.

```css
.sr-only {
  border: 0; 
  clip: rect(0 0 0 0); 
  height: 1px; 
  margin: -1px;
  overflow: hidden;
  padding: 0;
  position: absolute;
  width: 1px;
}
```

Linked issue: #1582

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
