### PR TITLE
fix(virtual-node): fix hasClass to work with svg elements

### DIFF
--- a/lib/core/base/virtual-node.js
+++ b/lib/core/base/virtual-node.js
@@ -36,15 +36,17 @@ class VirtualNode {
 	 * @return {Boolean} True if the actualNode has the given class, false otherwise.
 	 */
 	hasClass(className) {
-		if (typeof this.actualNode.className !== 'string') {
+		// get the value of the class attribute as svgs return a SVGAnimatedString
+		// if you access the className property
+		let classAttr = this.attr('class');
+		if (!classAttr) {
 			return false;
 		}
 
 		let selector = ' ' + className + ' ';
 		return (
-			(' ' + this.actualNode.className + ' ')
-				.replace(whitespaceRegex, ' ')
-				.indexOf(selector) >= 0
+			(' ' + classAttr + ' ').replace(whitespaceRegex, ' ').indexOf(selector) >=
+			0
 		);
 	}
 

--- a/test/core/base/virtual-node.js
+++ b/test/core/base/virtual-node.js
@@ -59,6 +59,14 @@ describe('VirtualNode', function() {
 				assert.isTrue(vNode.hasClass('visually-hidden'));
 			});
 
+			it('should return true for svg elements', function() {
+				node = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+				node.setAttribute('class', 'my-class');
+				var vNode = new VirtualNode(node);
+
+				assert.isTrue(vNode.hasClass('my-class'));
+			});
+
 			it('should return false when the element does not contain the class', function() {
 				var vNode = new VirtualNode(node);
 


### PR DESCRIPTION
SVG elements return a `SVGAnimatedString` object and not a string when accessing `node.className`.

Linked issue: #1423

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen