### PR TITLE
fix: arguments for gather function in build template

### DIFF
--- a/build/templates.js
+++ b/build/templates.js
@@ -1,7 +1,7 @@
 module.exports = {
 	evaluate: 'function (node, options, virtualNode, context) {\n<%=source%>\n}',
 	after: 'function (results, options) {\n<%=source%>\n}',
-	gather: 'function (context) {\n<%=source%>\n}',
+	gather: 'function (context, options) {\n<%=source%>\n}',
 	matches: 'function (node, virtualNode, context) {\n<%=source%>\n}',
 	source: '(function () {\n<%=source%>\n}())',
 	commons: '<%=source%>'


### PR DESCRIPTION
Noticed that the `gather` function in `Rule`, takes 2 arguments (See - https://github.com/dequelabs/axe-core/blob/develop/lib/core/base/rule.js#L386), but the build template for any override provided in the rule spec, passes the wrong number of arguments.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
