### PR TITLE
feat(rule): add before function callback to rule spec

### DIFF
--- a/build/configure.js
+++ b/build/configure.js
@@ -96,7 +96,7 @@ function buildRules(grunt, options, commons, callback) {
 		function replaceFunctions(string) {
 			return string
 				.replace(
-					/"(evaluate|after|gather|matches|source|commons)":\s*("[^"]+?")/g,
+					/"(evaluate|after|gather|matches|before|source|commons)":\s*("[^"]+?")/g,
 					function(m, p1, p2) {
 						return m.replace(p2, getSource(p2.replace(/^"|"$/g, ''), p1));
 					}

--- a/build/templates.js
+++ b/build/templates.js
@@ -1,7 +1,7 @@
 module.exports = {
 	evaluate: 'function (node, options, virtualNode, context) {\n<%=source%>\n}',
 	after: 'function (results, options) {\n<%=source%>\n}',
-	gather: 'function (context) {\n<%=source%>\n}',
+	gather: 'function (context, options) {\n<%=source%>\n}',
 	matches: 'function (node, virtualNode, context) {\n<%=source%>\n}',
 	source: '(function () {\n<%=source%>\n}())',
 	commons: '<%=source%>'

--- a/build/templates.js
+++ b/build/templates.js
@@ -3,6 +3,7 @@ module.exports = {
 	after: 'function (results, options) {\n<%=source%>\n}',
 	gather: 'function (context, options) {\n<%=source%>\n}',
 	matches: 'function (node, virtualNode, context) {\n<%=source%>\n}',
+	before: 'function (context, options) {\n<%=source%>\n}',
 	source: '(function () {\n<%=source%>\n}())',
 	commons: '<%=source%>'
 };

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -66,9 +66,20 @@ function Rule(spec, parentAudit) {
 	 */
 	this.preload = spec.preload ? true : false;
 
+	/**
+	 * `before` function for rule
+	 */
+	if (spec.before) {
+		this.before = createExecutionContext(spec.before);
+	}
+
+	/**
+	 * `matches` function for rule
+	 */
 	if (spec.matches) {
 		/**
-		 * Optional function to test if rule should be run against a node, overrides Rule#matches
+		 * Optional function to test if rule should be run against a node,
+		 * overrides Rule#matches
 		 * @type {Function}
 		 */
 		this.matches = createExecutionContext(spec.matches);
@@ -76,7 +87,18 @@ function Rule(spec, parentAudit) {
 }
 
 /**
- * Optionally test each node against a `matches` function to determine if the rule should run against
+ * Optionally execute a function, that offers capability to load
+ * more `context` for the rule
+ */
+Rule.prototype.before = function() {
+	'use strict';
+
+	return;
+};
+
+/**
+ * Optionally test each node against a `matches` function
+ * to determine if the rule should run against
  * a given node.  Defaults to `true`.
  * @return {Boolean}    Whether the rule should run
  */
@@ -202,6 +224,9 @@ Rule.prototype.run = function(context, options = {}, resolve, reject) {
 	const q = axe.utils.queue();
 	const ruleResult = new RuleResult(this);
 	let nodes;
+
+	// Run the `before` function for the `rule`
+	this.before(context);
 
 	try {
 		// Matches throws an error when it lacks support for document methods


### PR DESCRIPTION
**Note: This PR has partial work done in https://github.com/dequelabs/axe-core/pull/1605**

- Whilst authoring proposal for a new rule [identical links serve same purpose](https://github.com/dequelabs/axe-core/issues/1505), there arises a need for running a process only **once**, as a `before` step to running the rule. 
- The results of the `before` callback can be `extended` in the `context` object.
- The `context` object is passed to all `checks` of the `rule`.
- This change will enable adding a callback to rule(`json`) like so: `"before":"my-rule-before.js"`

**_More context:_**
This functionality requirement was discussed in the past, when authoring `preload (cssom)`, and also when refactoring `color-contrast` rule. This change may also enable refactor to multiple rules to gain performance improvements.

Closes issue: 
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
