### PR TITLE
fix(matches-selector): don't call matches function if none exist on the element

### DIFF
--- a/lib/commons/dom/find-up.js
+++ b/lib/commons/dom/find-up.js
@@ -48,9 +48,15 @@ dom.findUpVirtual = function(element, target) {
 		}
 	} while (
 		parent &&
+		parent !== document &&
 		!axe.utils.matchesSelector(parent, target) &&
 		parent !== document.documentElement
 	);
+
+	// return null before we check matchesSelector otherwise it will fail in IE11
+	if (parent === document) {
+		return null;
+	}
 
 	if (!axe.utils.matchesSelector(parent, target)) {
 		return null;

--- a/lib/commons/dom/find-up.js
+++ b/lib/commons/dom/find-up.js
@@ -48,13 +48,11 @@ dom.findUpVirtual = function(element, target) {
 		}
 	} while (
 		parent &&
-		parent !== document &&
 		!axe.utils.matchesSelector(parent, target) &&
 		parent !== document.documentElement
 	);
 
-	// return null before we check matchesSelector otherwise it will fail in IE11
-	if (parent === document) {
+	if (!parent) {
 		return null;
 	}
 

--- a/lib/core/utils/element-matches.js
+++ b/lib/core/utils/element-matches.js
@@ -34,6 +34,10 @@ axe.utils.matchesSelector = (function() {
 			method = getMethod(node);
 		}
 
-		return node[method](selector);
+		if (node[method]) {
+			return node[method](selector);
+		}
+
+		return false;
 	};
 })();

--- a/test/core/utils/element-matches.js
+++ b/test/core/utils/element-matches.js
@@ -49,4 +49,22 @@ describe('utils.matchesSelector', function() {
 
 		fixture.innerHTML = '';
 	});
+
+	it('should return false if the element does not have a matching method', function() {
+		var target,
+			fixture = document.getElementById('fixture');
+
+		fixture.innerHTML = '<div id="test">Hi</div>';
+		target = document.getElementById('test');
+
+		target.matches = null;
+		target.matchesSelector = null;
+		target.mozMatchesSelector = null;
+		target.webkitMatchesSelector = null;
+		target.msMatchesSelector = null;
+
+		assert.isFalse(matchesSelector(target, '#test'));
+
+		fixture.innerHTML = '';
+	});
 });


### PR DESCRIPTION
When passing no context to `axe.run`, the `<html>` element would try to find-up and get the `document` node as the parent, which doesn't have any matches function and so would error in `element-matches.js` when calling `node[method](selector)`.

Linked issue: #1585

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: stephen
