### PR TITLE
fix(accessible-text-virtual): ignores genericContainer elements with no interesting text

### DIFF
--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -42,7 +42,7 @@ text.accessibleTextVirtual = function accessibleTextVirtual(
 		aria.arialabelText, // Step 2C
 		text.nativeTextAlternative, // Step 2D
 		text.formControlValue, // Step 2E
-		text.subtreeText, // Step 2F + Step 2H
+		subtreeText, // Step 2F + Step 2H
 		textNodeContent, // Step 2G (order with 2H does not matter)
 		text.titleText // Step 2I
 	];
@@ -150,3 +150,13 @@ text.accessibleTextVirtual.alreadyProcessed = function alreadyProcessed(
 	context.processed.push(virtualnode);
 	return false;
 };
+
+function subtreeText(virtualnode, context = {}) {
+	const hasNoInterestingText = !(virtualnode.children || [])
+		.filter(vchild => vchild.actualNode.nodeType === Node.TEXT_NODE)
+		.filter(vtextNode => vtextNode.actualNode.textContent.trim().length).length;
+	if (hasNoInterestingText) {
+		return '';
+	}
+	return text.subtreeText(virtualnode, context);
+}

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -3214,6 +3214,18 @@ describe('text.accessibleTextVirtual', function() {
 			assert.equal(accessibleText(target), 'Country of origin: United States');
 		});
 
+		it('ignores genericContainers with no interesting textNodes', function() {
+			fixture.innerHTML =
+				'<div id="test">' +
+				'<div class="container">' +
+				'<h1>Something Interesting</h1>' +
+				'</div>' +
+				'</div>';
+			axe.testUtils.flatTreeSetup(fixture);
+			var target = fixture.querySelector('#test');
+			assert.equal(accessibleText(target), '');
+		});
+
 		/**
 	// In case anyone even wants it, here's the script used to generate these test cases
 	function getTestCase(content, index = 0) {


### PR DESCRIPTION
Generic container elements with no "interesting" textNodes were calculating an accessible name by using the `text.subtreeText` function. This resulted in multiple nested elements presenting the same name. This code returns an empty accessible name for containers with no textNodes of their own with length.

issue: #1596 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
