### PR TITLE
fix(accessible-text-virtual): ignores genericContainer elements with …

### DIFF
--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -2094,6 +2094,29 @@ lookupTable.role = {
 	}
 };
 
+lookupTable.rolesSupportingNameFromContent = [
+	'button',
+	'cell',
+	'checkbox',
+	'columnheader',
+	'gridcell',
+	'heading',
+	'link',
+	'menuitem',
+	'menuitemcheckbox',
+	'menuitemradio',
+	'option',
+	'radio',
+	'row',
+	'rowgroup',
+	'rowheader',
+	'switch',
+	'tab',
+	'tooltip',
+	'tree',
+	'treeitem'
+];
+
 // Source: https://www.w3.org/TR/html-aria/
 lookupTable.elementsAllowedNoRole = [
 	{

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -42,7 +42,7 @@ text.accessibleTextVirtual = function accessibleTextVirtual(
 		aria.arialabelText, // Step 2C
 		text.nativeTextAlternative, // Step 2D
 		text.formControlValue, // Step 2E
-		text.subtreeText, // Step 2F + Step 2H
+		subtreeText, // Step 2F + Step 2H
 		textNodeContent, // Step 2G (order with 2H does not matter)
 		text.titleText // Step 2I
 	];
@@ -150,3 +150,20 @@ text.accessibleTextVirtual.alreadyProcessed = function alreadyProcessed(
 	context.processed.push(virtualnode);
 	return false;
 };
+
+function subtreeText(virtualnode, context = {}) {
+	// should this be cached on the vnode?
+	const role =
+		virtualnode.actualNode.getAttribute('role') ||
+		axe.commons.aria.implicitRole(virtualnode.actualNode);
+
+	const allowedRoles =
+		axe.commons.aria.lookupTable.rolesSupportingNameFromContent;
+
+	const supportsNameFromContent = allowedRoles.includes(role);
+
+	if (!supportsNameFromContent) {
+		return '';
+	}
+	return text.subtreeText(virtualnode, context);
+}

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -3214,6 +3214,18 @@ describe('text.accessibleTextVirtual', function() {
 			assert.equal(accessibleText(target), 'Country of origin: United States');
 		});
 
+		it('ignores genericContainers with no interesting textNodes', function() {
+			fixture.innerHTML =
+				'<div id="test">' +
+				'<div class="container">' +
+				'<h1>Something Interesting</h1>' +
+				'</div>' +
+				'</div>';
+			axe.testUtils.flatTreeSetup(fixture);
+			var target = fixture.querySelector('#test');
+			assert.equal(accessibleText(target), '');
+		});
+
 		/**
 	// In case anyone even wants it, here's the script used to generate these test cases
 	function getTestCase(content, index = 0) {


### PR DESCRIPTION
…no interesting text


Based on [accName](https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te) step 2F adds list of roles from ["roles supporting name from content"](https://www.w3.org/TR/wai-aria/#namefromcontent) and only uses subtreeText when node's role is one of the listed roles.

otherwise, returns an empty accessible name.

issue: #1596

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
