### PR TITLE
fix: deprecate na reporter

### DIFF
--- a/lib/core/reporters/na.js
+++ b/lib/core/reporters/na.js
@@ -3,6 +3,10 @@
 axe.addReporter('na', function(results, options, callback) {
 	'use strict';
 
+	console.warn(
+		'"na" reporter will be deprecated in axe v4.0. Use the "v2" reporter instead.'
+	);
+
 	if (typeof options === 'function') {
 		callback = options;
 		options = {};

--- a/test/core/log.js
+++ b/test/core/log.js
@@ -5,10 +5,10 @@ describe('axe.log', function() {
 		assert.isFunction(axe.log);
 	});
 	it('should invoke console.log', function() {
+		var orig = window.console;
 		if (!window.console || window.console.log) {
 			window.console = { log: function() {} };
 		}
-		var orig = window.console.log;
 		var expected = ['hi', 'hello'];
 		var success = false;
 
@@ -21,6 +21,6 @@ describe('axe.log', function() {
 		axe.log.apply(axe.log, expected);
 		assert.isTrue(success);
 
-		window.console.log = orig;
+		window.console = orig;
 	});
 });


### PR DESCRIPTION
By request of Wilco. The na reporter is the exact same code as the v2 reporter.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen