### PR TITLE
feat(color-contrast): add px unit to error messages

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -42,7 +42,7 @@ const data = {
 	fgColor: fgColor ? fgColor.toHexString() : undefined,
 	bgColor: bgColor ? bgColor.toHexString() : undefined,
 	contrastRatio: cr ? truncatedResult : undefined,
-	fontSize: ((fontSize * 72) / 96).toFixed(1) + 'pt',
+	fontSize: `${((fontSize * 72) / 96).toFixed(1)}pt / ${fontSize}px`,
 	fontWeight: bold ? 'bold' : 'normal',
 	missingData: missing,
 	expectedContrastRatio: cr.expectedContrastRatio + ':1'

--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -42,7 +42,7 @@ const data = {
 	fgColor: fgColor ? fgColor.toHexString() : undefined,
 	bgColor: bgColor ? bgColor.toHexString() : undefined,
 	contrastRatio: cr ? truncatedResult : undefined,
-	fontSize: `${((fontSize * 72) / 96).toFixed(1)}pt / ${fontSize}px`,
+	fontSize: `${((fontSize * 72) / 96).toFixed(1)}pt (${fontSize}px)`,
 	fontWeight: bold ? 'bold' : 'normal',
 	missingData: missing,
 	expectedContrastRatio: cr.expectedContrastRatio + ':1'


### PR DESCRIPTION
Add the size in px to the color contrast error message to avoid confusion with the pt unit.

```
"Fix any of the following:
  Element has insufficient color contrast of 3.87 (foreground color: #3d7e9a, background color: #eeeeee, font size: 12.0pt / 16px, font weight: normal). Expected contrast ratio of 4.5:1"
```

Linked issue: #1628

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @dylanb 