### PR TITLE
refactor: make th-has-data-cells check more readable

### DIFF
--- a/lib/checks/tables/th-has-data-cells.js
+++ b/lib/checks/tables/th-has-data-cells.js
@@ -40,7 +40,7 @@ headers.forEach(header => {
 
 	const pos = tableUtils.getCellPosition(header, tableGrid);
 
-	// look for the first column cell that has content and is not a column header
+	// look for any column cell that has content and is not a column header
 	let hasCell = false;
 	if (tableUtils.isColumnHeader(header)) {
 		hasCell = tableUtils
@@ -51,7 +51,7 @@ headers.forEach(header => {
 			);
 	}
 
-	// look for the first row cell that has content and is not a row header
+	// look for any row cell that has content and is not a row header
 	if (!hasCell && tableUtils.isRowHeader(header)) {
 		hasCell = tableUtils
 			.traverse('right', pos, tableGrid)

--- a/lib/checks/tables/th-has-data-cells.js
+++ b/lib/checks/tables/th-has-data-cells.js
@@ -1,23 +1,23 @@
-var tableUtils = axe.commons.table;
-var cells = tableUtils.getAllCells(node);
-var checkResult = this;
+const tableUtils = axe.commons.table;
+const cells = tableUtils.getAllCells(node);
+const checkResult = this;
 
 // Get a list of all headers reffed to in this rule
-var reffedHeaders = [];
+let reffedHeaders = [];
 cells.forEach(function(cell) {
-	var headers = cell.getAttribute('headers');
+	const headers = cell.getAttribute('headers');
 	if (headers) {
 		reffedHeaders = reffedHeaders.concat(headers.split(/\s+/));
 	}
 
-	var ariaLabel = cell.getAttribute('aria-labelledby');
+	const ariaLabel = cell.getAttribute('aria-labelledby');
 	if (ariaLabel) {
 		reffedHeaders = reffedHeaders.concat(ariaLabel.split(/\s+/));
 	}
 });
 
 // Get all the headers
-var headers = cells.filter(function(cell) {
+const headers = cells.filter(function(cell) {
 	if (axe.commons.text.sanitize(cell.textContent) === '') {
 		return false;
 	}
@@ -27,42 +27,38 @@ var headers = cells.filter(function(cell) {
 	);
 });
 
-var tableGrid = tableUtils.toGrid(node);
+const tableGrid = tableUtils.toGrid(node);
 
-// Look for all the bad headers
-var out = headers.reduce(function(res, header) {
+let out = true;
+headers.forEach(header => {
 	if (
 		header.getAttribute('id') &&
 		reffedHeaders.includes(header.getAttribute('id'))
 	) {
-		return !res ? res : true;
+		return;
 	}
 
-	var hasCell = false;
-	var pos = tableUtils.getCellPosition(header, tableGrid);
+	const pos = tableUtils.getCellPosition(header, tableGrid);
 
-	// Look for any data cells or row headers that this might refer to
+	// look for the first column cell that has content and is not a column header
+	let hasCell = false;
 	if (tableUtils.isColumnHeader(header)) {
 		hasCell = tableUtils
 			.traverse('down', pos, tableGrid)
-			.reduce((out, cell) => {
-				return (
-					out ||
-					(axe.commons.dom.hasContent(cell) && !tableUtils.isColumnHeader(cell))
-				);
-			}, false);
+			.some(
+				cell =>
+					axe.commons.dom.hasContent(cell) && !tableUtils.isColumnHeader(cell)
+			);
 	}
 
-	// Look for any data cells or column headers that this might refer to
+	// look for the first row cell that has content and is not a row header
 	if (!hasCell && tableUtils.isRowHeader(header)) {
 		hasCell = tableUtils
 			.traverse('right', pos, tableGrid)
-			.reduce((out, cell) => {
-				return (
-					out ||
-					(axe.commons.dom.hasContent(cell) && !tableUtils.isRowHeader(cell))
-				);
-			}, false);
+			.some(
+				cell =>
+					axe.commons.dom.hasContent(cell) && !tableUtils.isRowHeader(cell)
+			);
 	}
 
 	// report the node as having failed
@@ -70,7 +66,7 @@ var out = headers.reduce(function(res, header) {
 		checkResult.relatedNodes(header);
 	}
 
-	return res && hasCell;
-}, true);
+	out = out && hasCell;
+});
 
 return out ? true : undefined;


### PR DESCRIPTION
Removes most `reduces` for either `.forEach` iteration or `.some` for better readability of the code. Also updates to ES6 syntax. 

Thanks to @AdnoC for the help.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen
