### PR TITLE
fix(axe.d.ts): add optional xpath property to NodeResult

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -73,6 +73,7 @@ declare namespace axe {
 		html: string;
 		impact?: ImpactValue;
 		target: string[];
+		xpath?: string[];
 		any: CheckResult[];
 		all: CheckResult[];
 		none: CheckResult[];


### PR DESCRIPTION
When enabling the xpath option of `axe.run`, the `NodeResult` has an `xpath` string array. Added the property to the `NodeType` interface.

```js
axe.run({ xpath: true });

// sample violation result
{
    "any": [
      {
        "id": "aria-allowed-role",
        "data": [
          "tablist"
        ],
        "relatedNodes": [],
        "impact": "minor",
        "message": "ARIA role tablist  is not allowed for given element"
      }
    ],
    "all": [],
    "none": [],
    "impact": "minor",
    "html": "<nav class=\"tabnav-tabs \" role=\"tablist\">",
    "target": [
      ".comment-form-head.tabnav.flex-justify-between > .tabnav-tabs[role=\"tablist\"]"
    ],
    "xpath": [
      "/div[@id='discussion_bucket']/div[2]/div[2]/div[3]/form/div/div/div/nav"
    ],
    "failureSummary": "Fix any of the following:\n  ARIA role tablist  is not allowed for given element"
  }
```

Closes issue: #1636

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen 