### PR TITLE
refactor: fix test suite titles

### DIFF
--- a/test/rule-matches/duplicate-id-active-matches.js
+++ b/test/rule-matches/duplicate-id-active-matches.js
@@ -1,4 +1,4 @@
-describe('duplicate-id-mismatches', function() {
+describe('duplicate-id-active matches', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');

--- a/test/rule-matches/duplicate-id-aria-matches.js
+++ b/test/rule-matches/duplicate-id-aria-matches.js
@@ -1,4 +1,4 @@
-describe('duplicate-id-mismatches', function() {
+describe('duplicate-id-aria matches', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');

--- a/test/rule-matches/duplicate-id-misc-matches.js
+++ b/test/rule-matches/duplicate-id-misc-matches.js
@@ -1,4 +1,4 @@
-describe('duplicate-id-mismatches', function() {
+describe('duplicate-id-misc matches', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');


### PR DESCRIPTION
When debugging, noticed that some test suite names were not correct & also filename seemed to be a copy pasted (eg: filename.2.js). 

This PR fixes these nitpicks.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Steve
