### PR TITLE
chore: Update execa to latest version

### DIFF
--- a/build/rule-generator.js
+++ b/build/rule-generator.js
@@ -28,7 +28,7 @@ async function run() {
 				`Axe does not exist. Triggering build using - 'npm run build'. Rule generation will continue after build.`
 			)
 		);
-		await execa.shell('npm run build');
+		await execa('npm run build', { shell: true });
 	}
 
 	// rule-generator banner

--- a/doc/examples/test-examples.js
+++ b/doc/examples/test-examples.js
@@ -6,9 +6,9 @@ const exampleDirs = readdirSync(__dirname)
 	.filter(dir => statSync(dir).isDirectory());
 
 async function runner(dir) {
-	const config = { cwd: dir, stdio: 'inherit' };
-	await execa.shell('npm install', config);
-	return execa.shell('npm test', config);
+	const config = { cwd: dir, stdio: 'inherit', shell: true };
+	await execa('npm install', config);
+	return execa('npm test', config);
 }
 
 Promise.all(exampleDirs.map(runner))

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 		"es6-promise": "^4.2.6",
 		"eslint": "^5.14.0",
 		"eslint-config-prettier": "^6.0.0",
-		"execa": "^1.0.0",
+		"execa": "^2.0.2",
 		"fs-extra": "^8.0.1",
 		"globby": "^10.0.0",
 		"grunt": "^1.0.3",


### PR DESCRIPTION
[Execa v2.0.0 removed the `.shell` command](https://github.com/sindresorhus/execa/releases/tag/v2.0.0) and instead uses the [`shell` option](https://github.com/sindresorhus/execa#shell) to execute the command in a shell.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
