### PR TITLE
test: make the output of `test:examples` readable

### DIFF
--- a/doc/examples/test-examples.js
+++ b/doc/examples/test-examples.js
@@ -7,28 +7,33 @@ const exampleDirs = readdirSync(__dirname)
 	.map(dir => join(__dirname, dir))
 	.filter(dir => statSync(dir).isDirectory());
 
-const tasks = new Listr([
-	{
-		title: 'Install dependencies',
-		task: () =>
-			new Listr(
-				exampleDirs.map(dir => ({
-					title: basename(dir),
-					task: () => execa('npm install', { cwd: dir, shell: true })
-				}))
-			)
-	},
-	{
-		title: 'Run tests',
-		task: () =>
-			new Listr(
-				exampleDirs.map(dir => ({
-					title: basename(dir),
-					task: () => execa('npm test', { cwd: dir, shell: true })
-				}))
-			)
-	}
-]);
+const tasks = new Listr(
+	[
+		{
+			title: 'Install dependencies',
+			task: () =>
+				new Listr(
+					exampleDirs.map(dir => ({
+						title: basename(dir),
+						task: () => execa('npm install', { cwd: dir, shell: true })
+					})),
+					{ concurrent: true, nonTTYRenderer: 'silent' }
+				)
+		},
+		{
+			title: 'Run tests',
+			task: () =>
+				new Listr(
+					exampleDirs.map(dir => ({
+						title: basename(dir),
+						task: () => execa('npm test', { cwd: dir, shell: true })
+					})),
+					{ concurrent: true, nonTTYRenderer: 'silent' }
+				)
+		}
+	],
+	{ nonTTYRenderer: 'silent' }
+);
 
 tasks.run().catch(err => {
 	if (err.stdout) {

--- a/doc/examples/test-examples.js
+++ b/doc/examples/test-examples.js
@@ -17,7 +17,7 @@ const tasks = new Listr(
 						title: basename(dir),
 						task: () => execa('npm install', { cwd: dir, shell: true })
 					})),
-					{ concurrent: true, nonTTYRenderer: 'silent' }
+					{ nonTTYRenderer: 'silent' }
 				)
 		},
 		{
@@ -28,7 +28,7 @@ const tasks = new Listr(
 						title: basename(dir),
 						task: () => execa('npm test', { cwd: dir, shell: true })
 					})),
-					{ concurrent: true, nonTTYRenderer: 'silent' }
+					{ nonTTYRenderer: 'silent' }
 				)
 		}
 	],

--- a/doc/examples/test-examples.js
+++ b/doc/examples/test-examples.js
@@ -31,6 +31,12 @@ const tasks = new Listr([
 ]);
 
 tasks.run().catch(err => {
+	if (err.stdout) {
+		process.stdout.write(err.stdout);
+	}
+	if (err.stderr) {
+		process.stderr.write(err.stderr);
+	}
 	console.error(err);
 	process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
 		"jquery": "^3.0.0",
 		"jsdoc": "^3.5.5",
 		"lint-staged": "^9.0.0",
+		"listr": "^0.14.3",
 		"make-dir": "^3.0.0",
 		"markdown-table": "^1.1.2",
 		"minami": "^1.2.3",


### PR DESCRIPTION
This patch rewrites the program which runs the examples' tests with something more human (and coincidentally machine) readable. Rather than piping `npm install` and `npm test` output to `stdio` directly (and in parallel), we suppress the output (unless an error is raised) and run the tests serially. We give visual feedback letting the user running the tests know what's happening, but don't flood them with too much information (this is done via [`Listr`](http://npmjs.org/listr)).

This has the unfortunate side effect of increasing the time the `test:examples` script takes, but will make debugging the tests significantly easier.

![output from `npm run test:examples`](https://user-images.githubusercontent.com/571265/60839913-4d939b00-a19c-11e9-8031-0669eb41eb1d.gif)

A failed test will look something like:

<img width="1082" alt="failed test output" src="https://user-images.githubusercontent.com/571265/60840331-402ae080-a19d-11e9-96a7-f095190462e5.png">


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
