### PR TITLE
test(examples): do not fail tests if deque.com has violations

### DIFF
--- a/doc/examples/phantomjs/axe-phantom.js
+++ b/doc/examples/phantomjs/axe-phantom.js
@@ -46,6 +46,8 @@ page.open(args[1], function(status) {
 			}
 		}
 
-		phantom.exit(msg.violations.length);
+		// NOTE: to fail the test when violations are found, uncomment the line below.
+		// phantom.exit(msg.violations.length);
+		phantom.exit(0);
 	};
 });


### PR DESCRIPTION
This patch updates the `phantomjs` example test, making it not fail if an axe-core violation is found on deque.com.

While it's extremely embarrassing that deque.com has violations, it's not something we control, so we shouldn't block merges based on it.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Steve
