### PR TITLE
fix(types): add new properties to RunOptions

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -7,7 +7,7 @@ declare namespace axe {
 
 	type TagValue = 'wcag2a' | 'wcag2aa' | 'section508' | 'best-practice';
 
-	type ReporterVersion = 'v1' | 'v2';
+	type ReporterVersion = 'v1' | 'v2' | 'raw' | 'raw-env' | 'no-passes';
 
 	type RunOnlyType = 'rule' | 'rules' | 'tag' | 'tags';
 
@@ -47,6 +47,13 @@ declare namespace axe {
 		elementRef?: boolean;
 		selectors?: boolean;
 		resultTypes?: resultGroups[];
+		reporter?: ReporterVersion;
+		xpath?: boolean;
+		absolutePaths?: boolean;
+		restoreScroll?: boolean;
+		frameWaitTime?: number;
+		preload?: boolean;
+		performanceTimer?: boolean;
 	}
 	interface AxeResults {
 		toolOptions: RunOptions;


### PR DESCRIPTION
  Added new properties to RunOptions interface that are specified in documentation: https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#options-parameter

Closes #1696 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
