### PR TITLE
test: require new release rule help docs to be active before creating release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,9 @@ workflows:
       - test_locales:
           requires:
             - test
+      - test_rule_help_version:
+          requires:
+            - test
       # Hold for approval
       - hold:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,8 @@ jobs:
       - run: npm run build
       - run: npm run test:locales
 
-  # Test newest axe-core version rule help docs are active
+  # Test newest axe-core version rule help docs are active (only on
+  # master prs)
   test_rule_help_version:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - run: npm run test:locales
 
   # Test locale files
-  test_rule-help-version:
+  test_rule_help_version:
     <<: *defaults
     steps:
       - checkout
@@ -144,7 +144,7 @@ workflows:
             - test
             - test_examples
             - test_locales
-            - test_rule-help-version
+            - test_rule_help_version
           filters:
             branches:
               only:
@@ -166,7 +166,7 @@ workflows:
             - test
             - test_examples
             - test_locales
-            - test_rule-help-version
+            - test_rule_help_version
             - hold
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,14 @@ jobs:
       - run: npm run build
       - run: npm run test:locales
 
+  # Test locale files
+  test_rule-help-version:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *restore_dependency_cache
+      - run: npm run test:rule-help-version
+
   # Release a "next" version
   next_release:
     <<: *defaults
@@ -136,6 +144,7 @@ workflows:
             - test
             - test_examples
             - test_locales
+            - test_rule-help-version
           filters:
             branches:
               only:
@@ -157,6 +166,7 @@ workflows:
             - test
             - test_examples
             - test_locales
+            - test_rule-help-version
             - hold
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run: npm run build
       - run: npm run test:locales
 
-  # Test locale files
+  # Test newest axe-core version rule help docs are active
   test_rule_help_version:
     <<: *defaults
     steps:

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"test": "npm run retire && tsc && grunt test",
 		"test:examples": "node ./doc/examples/test-examples",
 		"test:locales": "mocha test/test-locales.js",
+		"test:rule-help-version": "mocha test/test-rule-help-version.js",
 		"version": "echo \"use 'npm run release' to bump axe-core version\" && exit 1",
 		"prepublishOnly": "grunt build && grunt file-exists",
 		"retire": "retire --jspath lib --nodepath ./ --ignorefile .retireignore.json --severity medium",

--- a/test/test-rule-help-version.js
+++ b/test/test-rule-help-version.js
@@ -1,0 +1,16 @@
+var https = require('https');
+var path = require('path');
+var assert = require('assert');
+var packageJSON = require(path.join(__dirname, '../package.json'));
+
+var version = packageJSON.version.substr(
+	0,
+	packageJSON.version.lastIndexOf('.')
+);
+
+it('latest axe version rule help docs should be active', function(done) {
+	https.get('https://dequeuniversity.com/rules/axe/' + version, function(res) {
+		assert(res.statusCode >= 200 && res.statusCode <= 299);
+		done();
+	});
+});

--- a/test/test-rule-help-version.js
+++ b/test/test-rule-help-version.js
@@ -3,14 +3,17 @@ var path = require('path');
 var assert = require('assert');
 var packageJSON = require(path.join(__dirname, '../package.json'));
 
-var version = packageJSON.version.substr(
-	0,
-	packageJSON.version.lastIndexOf('.')
-);
+var versions = packageJSON.version.split('.');
+var version = versions[0] + '.' + versions[1];
 
-it('latest axe version rule help docs should be active', function(done) {
-	https.get('https://dequeuniversity.com/rules/axe/' + version, function(res) {
-		assert(res.statusCode >= 200 && res.statusCode <= 299);
-		done();
-	});
-});
+it(
+	'latest axe version (' + version + ') rule help docs should be active',
+	function(done) {
+		https.get('https://dequeuniversity.com/rules/axe/' + version, function(
+			res
+		) {
+			assert(res.statusCode >= 200 && res.statusCode <= 299);
+			done();
+		});
+	}
+);


### PR DESCRIPTION
This should block a release pr (a pr into `master` branch only) if the newest axe version rule help docs are not active.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen