### PR TITLE
fix(image-redundant-alt): check for parent before calculating text

### DIFF
--- a/lib/checks/label/duplicate-img-label.js
+++ b/lib/checks/label/duplicate-img-label.js
@@ -8,6 +8,11 @@ const parent = dom.findUpVirtual(
 	virtualNode,
 	'button, [role="button"], a[href], p, li, td, th'
 );
+
+if (!parent) {
+	return false;
+}
+
 const parentVNode = axe.utils.getNodeFromTree(parent);
 const visibleText = text.visibleVirtual(parentVNode, true).toLowerCase();
 if (visibleText === '') {

--- a/test/checks/label/duplicate-img-label.js
+++ b/test/checks/label/duplicate-img-label.js
@@ -105,6 +105,20 @@ describe('duplicate-img-label', function() {
 		);
 	});
 
+	it('should return false if img does not have required parent', function() {
+		fixture.innerHTML =
+			'<main><img id="target" alt="Plain text and more"><p>Plain text</p></main>';
+		var node = fixture.querySelector('#target');
+		axe.testUtils.flatTreeSetup(fixture);
+		assert.isFalse(
+			checks['duplicate-img-label'].evaluate(
+				node,
+				undefined,
+				axe.utils.getNodeFromTree(node)
+			)
+		);
+	});
+
 	(shadowSupport.v1 ? it : xit)(
 		'should return true if the img is part of a shadow tree',
 		function() {


### PR DESCRIPTION
Linked issue: #1704

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
