### PR TITLE
test: run example tests in sync

### DIFF
--- a/doc/examples/test-examples.js
+++ b/doc/examples/test-examples.js
@@ -12,15 +12,15 @@ function install(dir) {
 	return execa('npm install', { cwd: dir, ...config });
 }
 
-// but run tests synchronously so we can see which one threw an error
+// run tests synchronously so we can see which one threw an error
 function test(dir) {
 	return execa('npm test', { cwd: dir, ...config });
 }
 
 Promise.all(exampleDirs.map(install))
 	.then(async () => {
-		for (let i = 0; i < exampleDirs.length; i++) {
-			await test(exampleDirs[i]);
+		for (const dir of exampleDirs) {
+			await test(dir);
 		}
 
 		// Return successful exit

--- a/doc/examples/test-examples.js
+++ b/doc/examples/test-examples.js
@@ -5,14 +5,24 @@ const exampleDirs = readdirSync(__dirname)
 	.map(dir => join(__dirname, dir))
 	.filter(dir => statSync(dir).isDirectory());
 
-async function runner(dir) {
-	const config = { cwd: dir, stdio: 'inherit', shell: true };
-	await execa('npm install', config);
-	return execa('npm test', config);
+const config = { stdio: 'inherit', shell: true };
+
+// run npm install in parallel
+function install(dir) {
+	return execa('npm install', { cwd: dir, ...config });
 }
 
-Promise.all(exampleDirs.map(runner))
-	.then(() => {
+// but run tests synchronously so we can see which one threw an error
+function test(dir) {
+	return execa('npm test', { cwd: dir, ...config });
+}
+
+Promise.all(exampleDirs.map(install))
+	.then(async () => {
+		for (let i = 0; i < exampleDirs.length; i++) {
+			await test(exampleDirs[i]);
+		}
+
 		// Return successful exit
 		process.exit();
 	})


### PR DESCRIPTION
This will better let us see which example dir is failing the test as the tests now run in sync. To try to speed up the test though the `npm install` command is run async for each dir.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen