### PR TITLE
chore: update eslint version to 6.1.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-**/node_modules/**/*.js
+**/node_modules/*
 
 build/tasks/aria-supported.js
 

--- a/lib/core/utils/escape-selector.js
+++ b/lib/core/utils/escape-selector.js
@@ -7,7 +7,7 @@
  */
 axe.utils.escapeSelector = function(value) {
 	'use strict';
-	/*eslint no-bitwise: 0, eqeqeq: 0, one-var: 0, -W041: 0 */
+	/*eslint no-bitwise: 0, eqeqeq: 0, one-var: 0 */
 	var string = String(value);
 	var length = string.length;
 	var index = -1;

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 		"derequire": "^2.0.6",
 		"emoji-regex": "8.0.0",
 		"es6-promise": "^4.2.6",
-		"eslint": "^5.14.0",
+		"eslint": "^6.1.0",
 		"eslint-config-prettier": "^6.0.0",
 		"execa": "^2.0.2",
 		"fs-extra": "^8.0.1",


### PR DESCRIPTION
eslint 6.0.0 seems to have removed the `W041` rule. Also our `.eslintignore` was not properly ignoring all `node_modules` files and would try to load the eslint config from the `doc/examples/jasmine/node_modules/extend/.eslintrc` which tried to extend a dev dependency of that module, which would fail.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
