### PR TITLE
chore: update example dependencies

### DIFF
--- a/doc/examples/chrome-debugging-protocol/package.json
+++ b/doc/examples/chrome-debugging-protocol/package.json
@@ -5,7 +5,7 @@
 		"test": "echo 'No test specified.'"
 	},
 	"dependencies": {
-		"axe-core": "^3.3.0",
+		"axe-core": "^3.3.1",
 		"chrome-remote-interface": "^0.27.1"
 	}
 }

--- a/doc/examples/jasmine/package.json
+++ b/doc/examples/jasmine/package.json
@@ -13,8 +13,8 @@
 		"test": "karma start karma.conf.js"
 	},
 	"devDependencies": {
-		"axe-core": "^3.3.0",
-		"karma": "^4.1.0",
+		"axe-core": "^3.3.1",
+		"karma": "^4.2.0",
 		"karma-chrome-launcher": "^3.0.0",
 		"karma-jasmine": "^2.0.1"
 	}

--- a/doc/examples/jest_react/.babelrc
+++ b/doc/examples/jest_react/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }

--- a/doc/examples/jest_react/package.json
+++ b/doc/examples/jest_react/package.json
@@ -13,14 +13,14 @@
 		"test": "jest"
 	},
 	"devDependencies": {
-		"axe-core": "^3.3.0",
-		"babel-jest": "^23.0.0",
-		"babel-preset-es2015": "^6.24.1",
-		"babel-preset-react": "^6.24.1",
-		"enzyme": "^3.9.0",
-		"enzyme-adapter-react-16": "^1.12.1",
-		"jest": "^22.4.0",
-		"jest-cli": "^23.0.1",
+		"@babel/preset-env": "^7.5.5",
+		"@babel/preset-react": "^7.0.0",
+		"axe-core": "^3.3.1",
+		"babel-jest": "^24.8.0",
+		"enzyme": "^3.10.0",
+		"enzyme-adapter-react-16": "^1.14.0",
+		"jest": "^24.8.0",
+		"jest-cli": "^24.8.0",
 		"react": "^16.4.0",
 		"react-dom": "^16.4.0",
 		"react-test-renderer": "^16.2.0"

--- a/doc/examples/jsdom/package.json
+++ b/doc/examples/jsdom/package.json
@@ -8,8 +8,8 @@
 		"test": "mocha"
 	},
 	"devDependencies": {
-		"axe-core": "^3.3.0",
-		"jsdom": "^15.0.0",
-		"mocha": "^6.1.4"
+		"axe-core": "^3.3.1",
+		"jsdom": "^15.1.1",
+		"mocha": "^6.2.0"
 	}
 }

--- a/doc/examples/mocha/package.json
+++ b/doc/examples/mocha/package.json
@@ -13,8 +13,8 @@
 		"test": "karma start karma.conf.js"
 	},
 	"devDependencies": {
-		"axe-core": "^3.3.0",
-		"karma": "^4.1.0",
+		"axe-core": "^3.3.1",
+		"karma": "^4.2.0",
 		"karma-chai": "^0.1.0",
 		"karma-chrome-launcher": "^3.0.0",
 		"karma-mocha": "^1.3.0"

--- a/doc/examples/phantomjs/package.json
+++ b/doc/examples/phantomjs/package.json
@@ -13,7 +13,7 @@
 		"test": "phantomjs axe-phantom.js https://www.deque.com"
 	},
 	"devDependencies": {
-		"axe-core": "^3.3.0",
+		"axe-core": "^3.3.1",
 		"phantomjs": "^2.1.7"
 	}
 }

--- a/doc/examples/puppeteer/package.json
+++ b/doc/examples/puppeteer/package.json
@@ -7,7 +7,7 @@
 		"test": "node axe-puppeteer.js https://deque.com"
 	},
 	"dependencies": {
-		"axe-core": "^3.3.0",
-		"puppeteer": "^1.6.0"
+		"axe-core": "^3.3.1",
+		"puppeteer": "^1.19.0"
 	}
 }

--- a/doc/examples/qunit/package.json
+++ b/doc/examples/qunit/package.json
@@ -13,7 +13,7 @@
 		"test": "grunt qunit"
 	},
 	"devDependencies": {
-		"axe-core": "^3.3.0",
+		"axe-core": "^3.3.1",
 		"grunt": "~1.0.2",
 		"grunt-contrib-qunit": "~3.1.0",
 		"qunitjs": "~2.4.1"


### PR DESCRIPTION
Just running `npm update` and `npm audit fix` in all our example dirs. Had to update our react example to use babel 7 and the [new presets](https://github.com/babel/babel/issues/8707) as well.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen