### PR TITLE
fix(flatten-tree): do not call deprecated getDistributedNodes

### DIFF
--- a/lib/core/utils/flattened-tree.js
+++ b/lib/core/utils/flattened-tree.js
@@ -80,7 +80,10 @@ function flattenTree(node, shadowId, parent) {
 
 		return [retVal];
 	} else {
-		if (nodeName === 'content') {
+		if (
+			nodeName === 'content' &&
+			typeof node.getDistributedNodes === 'function'
+		) {
 			realArray = Array.from(node.getDistributedNodes());
 			return realArray.reduce((res, child) => {
 				return reduceShadowDOM(res, child, parent);

--- a/test/core/utils/flattened-tree.js
+++ b/test/core/utils/flattened-tree.js
@@ -291,6 +291,21 @@ describe('axe.utils.getFlattenedTree', function() {
 				assert.isDefined(vNode);
 				assert.equal(virtualDOM[0].actualNode, vNode.actualNode);
 			});
+			it('should not throw if getDistributedNodes is missing', function() {
+				var getDistributedNodes = fixture.getDistributedNodes;
+				fixture.getDistributedNodes = undefined;
+				try {
+					var virtualDOM = axe.utils.getFlattenedTree(fixture);
+					var vNode = axe.utils.getNodeFromTree(
+						virtualDOM[0],
+						virtualDOM[0].actualNode
+					);
+					assert.isDefined(vNode);
+					assert.equal(virtualDOM[0].actualNode, vNode.actualNode);
+				} finally {
+					fixture.getDistributedNodes = getDistributedNodes;
+				}
+			});
 		});
 	} else {
 		it('does not throw when slot elements are used', function() {


### PR DESCRIPTION
These changes seem to have been reverted [in this commit](https://github.com/dequelabs/axe-core/commit/4e12217e666ec66f64fbbef92010aeaf2f8db948), but for a detailed explanation check the previous PR https://github.com/dequelabs/axe-core/pull/1577.

Basically this fixes an error when running axe on certain pages in Firefox.

Closes issue: https://github.com/dequelabs/axe-core/issues/1512

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: << Name here >>
