### PR TITLE
test: don't run integration tests for deprecated rules

### DIFF
--- a/test/integration/rules/runner.js
+++ b/test/integration/rules/runner.js
@@ -29,7 +29,13 @@
 
 	var fixture = document.getElementById('fixture');
 	Object.keys(tests).forEach(function(ruleId) {
-		describe(ruleId, function() {
+		// don't run deprecated rules
+		var rule = axe._audit.rules.find(function(rule) {
+			return rule.id === ruleId;
+		});
+		var deprecated = rule.tags.indexOf('deprecated') !== -1;
+
+		(deprecated ? describe.skip : describe)(ruleId, function() {
 			tests[ruleId].forEach(function(test) {
 				var testName = test.description || ruleId + ' test';
 				describe(testName, function() {

--- a/test/integration/rules/runner.js
+++ b/test/integration/rules/runner.js
@@ -29,13 +29,19 @@
 
 	var fixture = document.getElementById('fixture');
 	Object.keys(tests).forEach(function(ruleId) {
-		// don't run deprecated rules
 		var rule = axe._audit.rules.find(function(rule) {
 			return rule.id === ruleId;
 		});
-		var deprecated = rule.tags.indexOf('deprecated') !== -1;
 
-		(deprecated ? describe.skip : describe)(ruleId, function() {
+		if (!rule) {
+			return;
+		}
+
+		// don't run rules that are deprecated and disabled
+		var deprecated = rule.tags.indexOf('deprecated') !== -1;
+		(deprecated && !rule.enabled
+			? describe.skip
+			: describe)(ruleId, function() {
 			tests[ruleId].forEach(function(test) {
 				var testName = test.description || ruleId + ' test';
 				describe(testName, function() {


### PR DESCRIPTION
When [trying to deprecate](https://github.com/dequelabs/axe-core/issues/1733) the `fieldset` and `group-labelledby` checks by disabling them using `enabled: false`, the deprecated rules using these checks would fail their integration tests since the check was no longer running for the rule. This change allows us to disable checks completely only if either all rules that use the check have been deprecated or if the check is removed from all the rules metadata.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen