### PR TITLE
fix(aria-form-field-name-matches): don't test combobox elements when they have a child input

### DIFF
--- a/lib/rules/aria-form-field-name-matches.js
+++ b/lib/rules/aria-form-field-name-matches.js
@@ -37,7 +37,7 @@ if (nodeName === 'BUTTON' || role === 'button') {
 }
 
 /**
- * Ignore combobox elements if they have a native textfield with a label
+ * Ignore combobox elements if they have a child input
  * (ARIA 1.1 pattern)
  */
 if (

--- a/lib/rules/aria-form-field-name-matches.js
+++ b/lib/rules/aria-form-field-name-matches.js
@@ -36,4 +36,15 @@ if (nodeName === 'BUTTON' || role === 'button') {
 	return false;
 }
 
+/**
+ * Ignore combobox elements if they have a native textfield with a label
+ * (ARIA 1.1 pattern)
+ */
+if (
+	role === 'combobox' &&
+	axe.utils.querySelectorAll(virtualNode, 'input:not([type="hidden"])').length
+) {
+	return false;
+}
+
 return true;

--- a/test/rule-matches/aria-form-field-name-matches.js
+++ b/test/rule-matches/aria-form-field-name-matches.js
@@ -65,4 +65,12 @@ describe('aria-form-field-name-matches', function() {
 			assert.isFalse(actual);
 		});
 	});
+
+	it('returns false when role=`combobox` has a child input', function() {
+		var vNode = queryFixture(
+			'<div id="target" role="combobox"><input type="text"/></div>'
+		);
+		var actual = rule.matches(vNode.actualNode, vNode);
+		assert.isFalse(actual);
+	});
 });


### PR DESCRIPTION
The combobox pattern following ARIA 1.1 uses a native textbox child element for the accessible name. Don't need to check the parent `role=combobox` for the accessible name.

Closes issue: #1711

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
