### PR TITLE
test: add test showing axe runs under strict csp

### DIFF
--- a/test/integration/full/strict-csp/strict-csp.html
+++ b/test/integration/full/strict-csp/strict-csp.html
@@ -6,10 +6,13 @@
 			// phantomjs requires running in non-strict csp
 			if (!window.PHANTOMJS) {
 				var thisScript = document.getElementById('check-phantomjs');
-				var csp = document.createElement('div');
-				csp.innerHTML =
-					'<meta http-equiv="Content-Security-Policy" content="script-src \'nonce-4AEemGb0xJptoIGFP3Nd\'; style-src \'nonce-4AEemGb0xJptoIGFP3Nd\'">';
-				document.head.appendChild(csp.firstElementChild);
+				var meta = document.createElement('meta');
+				meta.setAttribute('http-equiv', 'Content-Security-Policy');
+				meta.setAttribute(
+					'content',
+					"script-src 'nonce-4AEemGb0xJptoIGFP3Nd'; style-src 'nonce-4AEemGb0xJptoIGFP3Nd'"
+				);
+				document.head.appendChild(meta);
 			}
 		</script>
 		<link

--- a/test/integration/full/strict-csp/strict-csp.html
+++ b/test/integration/full/strict-csp/strict-csp.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf8" />
+		<script id="check-phantomjs">
+			// phantomjs requires running in non-strict csp
+			if (!window.PHANTOMJS) {
+				var thisScript = document.getElementById('check-phantomjs');
+				var csp = document.createElement('div');
+				csp.innerHTML =
+					'<meta http-equiv="Content-Security-Policy" content="script-src \'nonce-4AEemGb0xJptoIGFP3Nd\'; style-src \'nonce-4AEemGb0xJptoIGFP3Nd\'">';
+				document.head.appendChild(csp.firstElementChild);
+			}
+		</script>
+		<link
+			nonce="4AEemGb0xJptoIGFP3Nd"
+			rel="stylesheet"
+			type="text/css"
+			href="/node_modules/mocha/mocha.css"
+		/>
+		<script
+			nonce="4AEemGb0xJptoIGFP3Nd"
+			src="/node_modules/mocha/mocha.js"
+		></script>
+		<script
+			nonce="4AEemGb0xJptoIGFP3Nd"
+			src="/node_modules/chai/chai.js"
+		></script>
+		<script nonce="4AEemGb0xJptoIGFP3Nd" src="/axe.js"></script>
+		<script nonce="4AEemGb0xJptoIGFP3Nd">
+			mocha.setup({
+				timeout: 10000,
+				ui: 'bdd'
+			});
+			var assert = chai.assert;
+		</script>
+	</head>
+	<body>
+		<div id="mocha"></div>
+		<script nonce="4AEemGb0xJptoIGFP3Nd" src="/test/testutils.js"></script>
+		<script nonce="4AEemGb0xJptoIGFP3Nd" src="strict-csp.js"></script>
+		<script
+			nonce="4AEemGb0xJptoIGFP3Nd"
+			src="/test/integration/adapter.js"
+		></script>
+	</body>
+</html>

--- a/test/integration/full/strict-csp/strict-csp.js
+++ b/test/integration/full/strict-csp/strict-csp.js
@@ -1,0 +1,15 @@
+// phantomjs requires running in non-strict csp
+(window.PHANTOMJS ? describe.skip : describe)('strict-csp', function() {
+	'use strict';
+
+	it('should parse without errors', function() {
+		assert.isDefined(window.axe), 'axe is not defined';
+		assert.isDefined(window.axe.run, 'axe.run is not defined');
+	});
+
+	it('should run without errors', function(done) {
+		axe.run('#fixture', function() {
+			done();
+		});
+	});
+});

--- a/test/integration/full/strict-csp/strict-csp.js
+++ b/test/integration/full/strict-csp/strict-csp.js
@@ -8,7 +8,9 @@
 	});
 
 	it('should run without errors', function(done) {
-		axe.run('#fixture', function() {
+		axe.run(function(err, results) {
+			assert.isNull(err);
+			assert.isDefined(results);
 			done();
 		});
 	});


### PR DESCRIPTION
Integration test showing that axe can parse and run under a strict csp. If you want to see that this works, you can open the `strict-csp.html` file and change the source of axe to [3.3.0](https://unpkg.com/axe-core@3.3.0/axe.js), then `npm run start` and navigate to the test to see it fail.

![image](https://user-images.githubusercontent.com/2433219/62386336-bf010800-b514-11e9-8863-667c3dd4e374.png)

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
