### PR TITLE
chore: update projects.md link to .NET integration library

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -45,4 +45,4 @@ Add your project/integration to this file and submit a pull request.
 1. [Vorlon.js Remote Debugger](https://github.com/MicrosoftDX/Vorlonjs)
 1. [Terra's Webdriver.io Accessibility Service](https://github.com/cerner/terra-toolkit/blob/master/docs/AxeService.md)
 1. [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter)
-1. [axe-selenium-csharp](https://github.com/javnov/axe-selenium-csharp)
+1. [Selenium.Axe for .NET](https://github.com/TroyWalshProf/SeleniumAxeDotnet)


### PR DESCRIPTION
`docs/projects.md` currently links to https://github.com/javnov/axe-selenium-csharp, which publishes the [Globant.Selenium.Axe NuGet package](https://www.nuget.org/packages/Globant.Selenium.Axe/). Unfortunately, this package hasn't been updated in 2 years; it is currently broken in Chrome 76, and we weren't able to contact the maintainer about contributing updates to it.

https://github.com/TroyWalshProf/SeleniumAxeDotnet is a more recent fork of that codebase that is actively maintained and published under the [Selenium.Axe NuGet package](https://www.nuget.org/packages/Selenium.Axe/). This fork is the one we're planning to start recommending in [microsoft/axe-pipelines-samples](https://github.com/microsoft/axe-pipelines-samples).

This PR updates the link to point to the maintained fork with the more general package name.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
