### PR TITLE
feat(SerialVirtualNode): Allow serialised nodes in runNodesVirtual (experimental) [#1783]

### DIFF
--- a/lib/core/base/virtual-node/abstract-virtual-node.js
+++ b/lib/core/base/virtual-node/abstract-virtual-node.js
@@ -1,0 +1,40 @@
+const whitespaceRegex = /[\t\r\n\f]/g;
+
+class AbstractVirtualNode {
+	constructor() {
+		this.children = [];
+		this.parent = null;
+	}
+
+	get props() {
+		throw new Error(
+			'VirtualNode class must have a "props" object consisting ' +
+				'of "nodeType" and "nodeName" properties'
+		);
+	}
+
+	attr() {
+		throw new Error('VirtualNode class must have a "attr" function');
+	}
+
+	hasAttr() {
+		throw new Error('VirtualNode class must have a "hasAttr" function');
+	}
+
+	hasClass(className) {
+		// get the value of the class attribute as svgs return a SVGAnimatedString
+		// if you access the className property
+		let classAttr = this.attr('class');
+		if (!classAttr) {
+			return false;
+		}
+
+		let selector = ' ' + className + ' ';
+		return (
+			(' ' + classAttr + ' ').replace(whitespaceRegex, ' ').indexOf(selector) >=
+			0
+		);
+	}
+}
+
+axe.AbstractVirtualNode = AbstractVirtualNode;

--- a/lib/core/base/virtual-node/serial-virtual-node.js
+++ b/lib/core/base/virtual-node/serial-virtual-node.js
@@ -1,0 +1,80 @@
+// eslint-disable-next-line no-unused-vars
+class SerialVirtualNode extends axe.AbstractVirtualNode {
+	/**
+	 * Convert a serialised node into a VirtualNode object
+	 * @param {Object} node Serialised node
+	 */
+  constructor (serialNode) {
+    super()
+    this._props = normaliseProps(serialNode)
+    this._attrs = normaliseAttrs(serialNode)
+  }
+
+  // Accessof for DOM node properties
+  get props () {
+    return this._props
+  }
+
+	/**
+	 * Get the value of the given attribute name.
+	 * @param {String} attrName The name of the attribute.
+	 * @return {String|null} The value of the attribute or null if the attribute does not exist
+	 */
+  attr(attrName) {
+    return this._attrs[attrName] || null
+  }
+
+	/**
+	 * Determine if the element has the given attribute.
+	 * @param {String} attrName The name of the attribute
+	 * @return {Boolean} True if the element has the attribute, false otherwise.
+	 */
+  hasAttr(attrName) {
+    return this._attrs[attrName] !== undefined;
+  }
+}
+
+/**
+ * Convert between serialised props and DOM-like properties
+ * @param {Object} serialNode 
+ * @return {Object} normalProperties 
+ */
+function normaliseProps(serialNode) {
+  let { nodeName, nodeType = 1 } = serialNode
+  axe.utils.assert(nodeType !== undefined || nodeType !== 1, 
+    `SerialVirtualNode expects nodeType of undefined or 1, got '${nodeType}'`)
+  axe.utils.assert(typeof nodeName === 'string', 
+  `SerialVirtualNode expects nodeName to be a string, got '${nodeName}'`)
+
+  const props = {
+    ...serialNode,
+    nodeType,
+    nodeName: nodeName.toLowerCase()
+  }
+  delete props.attributes
+  return Object.freeze(props)
+}
+
+/**
+ * Convert between serialised attributes and DOM-like attributes
+ * @param {Object} serialNode 
+ * @return {Object} normalAttributes 
+ */
+function normaliseAttrs({ attributes = {} }) {
+  const attrMap = {
+    'htmlFor': 'for',
+    'className': 'class'
+  }
+
+  return Object.keys(attributes).reduce((attrs, attrName) => {
+    const value = attributes[attrName];
+    axe.utils.assert(typeof value !== 'object' || value === null, 
+      `SerialVirtualNode expects attributes not to be an object, '${attrName}' was`)
+
+    if (value !== undefined) {
+      const mappedName = attrMap[attrName] || attrName
+      attrs[mappedName] = value !== null ? String(value) : null
+    }
+    return attrs
+  }, {})
+}

--- a/lib/core/base/virtual-node/serial-virtual-node.js
+++ b/lib/core/base/virtual-node/serial-virtual-node.js
@@ -4,77 +4,83 @@ class SerialVirtualNode extends axe.AbstractVirtualNode {
 	 * Convert a serialised node into a VirtualNode object
 	 * @param {Object} node Serialised node
 	 */
-  constructor (serialNode) {
-    super()
-    this._props = normaliseProps(serialNode)
-    this._attrs = normaliseAttrs(serialNode)
-  }
+	constructor(serialNode) {
+		super();
+		this._props = normaliseProps(serialNode);
+		this._attrs = normaliseAttrs(serialNode);
+	}
 
-  // Accessof for DOM node properties
-  get props () {
-    return this._props
-  }
+	// Accessof for DOM node properties
+	get props() {
+		return this._props;
+	}
 
 	/**
 	 * Get the value of the given attribute name.
 	 * @param {String} attrName The name of the attribute.
 	 * @return {String|null} The value of the attribute or null if the attribute does not exist
 	 */
-  attr(attrName) {
-    return this._attrs[attrName] || null
-  }
+	attr(attrName) {
+		return this._attrs[attrName] || null;
+	}
 
 	/**
 	 * Determine if the element has the given attribute.
 	 * @param {String} attrName The name of the attribute
 	 * @return {Boolean} True if the element has the attribute, false otherwise.
 	 */
-  hasAttr(attrName) {
-    return this._attrs[attrName] !== undefined;
-  }
+	hasAttr(attrName) {
+		return this._attrs[attrName] !== undefined;
+	}
 }
 
 /**
  * Convert between serialised props and DOM-like properties
- * @param {Object} serialNode 
- * @return {Object} normalProperties 
+ * @param {Object} serialNode
+ * @return {Object} normalProperties
  */
 function normaliseProps(serialNode) {
-  let { nodeName, nodeType = 1 } = serialNode
-  axe.utils.assert(nodeType !== undefined || nodeType !== 1, 
-    `SerialVirtualNode expects nodeType of undefined or 1, got '${nodeType}'`)
-  axe.utils.assert(typeof nodeName === 'string', 
-  `SerialVirtualNode expects nodeName to be a string, got '${nodeName}'`)
+	let { nodeName, nodeType = 1 } = serialNode;
+	axe.utils.assert(
+		nodeType !== undefined || nodeType !== 1,
+		`SerialVirtualNode expects nodeType of undefined or 1, got '${nodeType}'`
+	);
+	axe.utils.assert(
+		typeof nodeName === 'string',
+		`SerialVirtualNode expects nodeName to be a string, got '${nodeName}'`
+	);
 
-  const props = {
-    ...serialNode,
-    nodeType,
-    nodeName: nodeName.toLowerCase()
-  }
-  delete props.attributes
-  return Object.freeze(props)
+	const props = {
+		...serialNode,
+		nodeType,
+		nodeName: nodeName.toLowerCase()
+	};
+	delete props.attributes;
+	return Object.freeze(props);
 }
 
 /**
  * Convert between serialised attributes and DOM-like attributes
- * @param {Object} serialNode 
- * @return {Object} normalAttributes 
+ * @param {Object} serialNode
+ * @return {Object} normalAttributes
  */
 function normaliseAttrs({ attributes = {} }) {
-  const attrMap = {
-    'htmlFor': 'for',
-    'className': 'class'
-  }
+	const attrMap = {
+		htmlFor: 'for',
+		className: 'class'
+	};
 
-  return Object.keys(attributes).reduce((attrs, attrName) => {
-    const value = attributes[attrName];
-    axe.utils.assert(typeof value !== 'object' || value === null, 
-      `SerialVirtualNode expects attributes not to be an object, '${attrName}' was`)
+	return Object.keys(attributes).reduce((attrs, attrName) => {
+		const value = attributes[attrName];
+		axe.utils.assert(
+			typeof value !== 'object' || value === null,
+			`SerialVirtualNode expects attributes not to be an object, '${attrName}' was`
+		);
 
-    if (value !== undefined) {
-      const mappedName = attrMap[attrName] || attrName
-      attrs[mappedName] = value !== null ? String(value) : null
-    }
-    return attrs
-  }, {})
+		if (value !== undefined) {
+			const mappedName = attrMap[attrName] || attrName;
+			attrs[mappedName] = value !== null ? String(value) : null;
+		}
+		return attrs;
+	}, {});
 }

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -1,34 +1,6 @@
-const whitespaceRegex = /[\t\r\n\f]/g;
-
-class AbstractVirtualNode {
-	constructor() {
-		this.children = [];
-		this.parent = null;
-	}
-
-	get props() {
-		throw new Error(
-			'VirtualNode class must have a "props" object consisting ' +
-				'of "nodeType" and "nodeName" properties'
-		);
-	}
-
-	hasClass() {
-		throw new Error('VirtualNode class must have a "hasClass" function');
-	}
-
-	attr() {
-		throw new Error('VirtualNode class must have a "attr" function');
-	}
-
-	hasAttr() {
-		throw new Error('VirtualNode class must have a "hasAttr" function');
-	}
-}
-
 // class is unused in the file...
 // eslint-disable-next-line no-unused-vars
-class VirtualNode extends AbstractVirtualNode {
+class VirtualNode extends axe.AbstractVirtualNode {
 	/**
 	 * Wrap the real node and provide list of the flattened children
 	 * @param {Node} node the node in question
@@ -61,27 +33,6 @@ class VirtualNode extends AbstractVirtualNode {
 			id,
 			type
 		};
-	}
-
-	/**
-	 * Determine if the actualNode has the given class name.
-	 * @see https://j11y.io/jquery/#v=2.0.3&fn=jQuery.fn.hasClass
-	 * @param {String} className The class to check for.
-	 * @return {Boolean} True if the actualNode has the given class, false otherwise.
-	 */
-	hasClass(className) {
-		// get the value of the class attribute as svgs return a SVGAnimatedString
-		// if you access the className property
-		let classAttr = this.attr('class');
-		if (!classAttr) {
-			return false;
-		}
-
-		let selector = ' ' + className + ' ';
-		return (
-			(' ' + classAttr + ' ').replace(whitespaceRegex, ' ').indexOf(selector) >=
-			0
-		);
 	}
 
 	/**
@@ -132,5 +83,3 @@ class VirtualNode extends AbstractVirtualNode {
 		return this._cache.tabbableElements;
 	}
 }
-
-axe.AbstractVirtualNode = AbstractVirtualNode;

--- a/lib/core/public/run-virtual-rule.js
+++ b/lib/core/public/run-virtual-rule.js
@@ -1,4 +1,4 @@
-/* global helpers */
+/* global helpers, SerialVirtualNode */
 
 /**
  * Run a rule in a non-browser environment
@@ -10,6 +10,10 @@
 axe.runVirtualRule = function(ruleId, vNode, options = {}) {
 	options.reporter = options.reporter || axe._audit.reporter || 'v1';
 	axe._selectorData = {};
+
+	if (vNode instanceof axe.AbstractVirtualNode === false) {
+		vNode = new SerialVirtualNode(vNode)
+	}
 
 	let rule = axe._audit.rules.find(rule => rule.id === ruleId);
 

--- a/lib/core/public/run-virtual-rule.js
+++ b/lib/core/public/run-virtual-rule.js
@@ -12,7 +12,7 @@ axe.runVirtualRule = function(ruleId, vNode, options = {}) {
 	axe._selectorData = {};
 
 	if (vNode instanceof axe.AbstractVirtualNode === false) {
-		vNode = new SerialVirtualNode(vNode)
+		vNode = new SerialVirtualNode(vNode);
 	}
 
 	let rule = axe._audit.rules.find(rule => rule.id === ruleId);

--- a/lib/core/utils/assert.js
+++ b/lib/core/utils/assert.js
@@ -1,0 +1,12 @@
+/* global axe*/
+
+/**
+ * If the first argument is falsey, throw an error using the second argument as a message.
+ * @param {boolean} bool
+ * @param {string} message
+ */
+axe.utils.assert = function assert (bool, message) {
+  if (!bool) {
+    throw new Error(message)
+  }
+}

--- a/lib/core/utils/assert.js
+++ b/lib/core/utils/assert.js
@@ -5,8 +5,8 @@
  * @param {boolean} bool
  * @param {string} message
  */
-axe.utils.assert = function assert (bool, message) {
-  if (!bool) {
-    throw new Error(message)
-  }
-}
+axe.utils.assert = function assert(bool, message) {
+	if (!bool) {
+		throw new Error(message);
+	}
+};

--- a/test/core/base/virtual-node/abstract-virtual-node.js
+++ b/test/core/base/virtual-node/abstract-virtual-node.js
@@ -1,110 +1,110 @@
 describe('AbstractVirtualNode', function() {
-  it('should be a function', function() {
-    assert.isFunction(axe.AbstractVirtualNode);
-  });
+	it('should be a function', function() {
+		assert.isFunction(axe.AbstractVirtualNode);
+	});
 
-  it('should throw an error when accessing props', function() {
-    function fn() {
-      var abstractNode = new axe.AbstractVirtualNode();
-      if (abstractNode.props.nodeType === 1) {
-        return;
-      }
-    }
+	it('should throw an error when accessing props', function() {
+		function fn() {
+			var abstractNode = new axe.AbstractVirtualNode();
+			if (abstractNode.props.nodeType === 1) {
+				return;
+			}
+		}
 
-    assert.throws(fn);
-  });
+		assert.throws(fn);
+	});
 
-  it('should throw an error when accessing hasClass', function() {
-    function fn() {
-      var abstractNode = new axe.AbstractVirtualNode();
-      if (abstractNode.hasClass('foo')) {
-        return;
-      }
-    }
+	it('should throw an error when accessing hasClass', function() {
+		function fn() {
+			var abstractNode = new axe.AbstractVirtualNode();
+			if (abstractNode.hasClass('foo')) {
+				return;
+			}
+		}
 
-    assert.throws(fn);
-  });
+		assert.throws(fn);
+	});
 
-  it('should throw an error when accessing attr', function() {
-    function fn() {
-      var abstractNode = new axe.AbstractVirtualNode();
-      if (abstractNode.attr('foo') === 'bar') {
-        return;
-      }
-    }
+	it('should throw an error when accessing attr', function() {
+		function fn() {
+			var abstractNode = new axe.AbstractVirtualNode();
+			if (abstractNode.attr('foo') === 'bar') {
+				return;
+			}
+		}
 
-    assert.throws(fn);
-  });
+		assert.throws(fn);
+	});
 
-  it('should throw an error when accessing hasAttr', function() {
-    function fn() {
-      var abstractNode = new axe.AbstractVirtualNode();
-      if (abstractNode.hasAttr('foo')) {
-        return;
-      }
-    }
+	it('should throw an error when accessing hasAttr', function() {
+		function fn() {
+			var abstractNode = new axe.AbstractVirtualNode();
+			if (abstractNode.hasAttr('foo')) {
+				return;
+			}
+		}
 
-    assert.throws(fn);
-  });
+		assert.throws(fn);
+	});
 
-  describe('hasClass, when attr is set', function() {
-    it('should return true when the element has the class', function() {
-      var vNode = new axe.AbstractVirtualNode();
-      vNode.attr = function () {
-        return 'my-class'
-      }
+	describe('hasClass, when attr is set', function() {
+		it('should return true when the element has the class', function() {
+			var vNode = new axe.AbstractVirtualNode();
+			vNode.attr = function() {
+				return 'my-class';
+			};
 
-      assert.isTrue(vNode.hasClass('my-class'));
-    });
+			assert.isTrue(vNode.hasClass('my-class'));
+		});
 
-    it('should return true when the element contains more than one class', function() {
-      var vNode = new axe.AbstractVirtualNode();
-      vNode.attr = function () {
-        return 'my-class a11y-focus visually-hidden'
-      }
+		it('should return true when the element contains more than one class', function() {
+			var vNode = new axe.AbstractVirtualNode();
+			vNode.attr = function() {
+				return 'my-class a11y-focus visually-hidden';
+			};
 
-      assert.isTrue(vNode.hasClass('my-class'));
-      assert.isTrue(vNode.hasClass('a11y-focus'));
-      assert.isTrue(vNode.hasClass('visually-hidden'));
-    });
+			assert.isTrue(vNode.hasClass('my-class'));
+			assert.isTrue(vNode.hasClass('a11y-focus'));
+			assert.isTrue(vNode.hasClass('visually-hidden'));
+		});
 
-    it('should return false when the element does not contain the class', function() {
-      var vNode = new axe.AbstractVirtualNode();
-      vNode.attr = function () {
-        return undefined
-      }
+		it('should return false when the element does not contain the class', function() {
+			var vNode = new axe.AbstractVirtualNode();
+			vNode.attr = function() {
+				return undefined;
+			};
 
-      assert.isFalse(vNode.hasClass('my-class'));
-    });
+			assert.isFalse(vNode.hasClass('my-class'));
+		});
 
-    it('should return false when the element contains only part of the class', function() {
-      var vNode = new axe.AbstractVirtualNode();
-      vNode.attr = function () {
-        return 'my-class'
-      }
-      assert.isFalse(vNode.hasClass('class'));
-    });
+		it('should return false when the element contains only part of the class', function() {
+			var vNode = new axe.AbstractVirtualNode();
+			vNode.attr = function() {
+				return 'my-class';
+			};
+			assert.isFalse(vNode.hasClass('class'));
+		});
 
-    it('should return false if className is not of type string', function() {
-      var vNode = new axe.AbstractVirtualNode();
-      vNode.attr = function () {
-        return null
-      }
+		it('should return false if className is not of type string', function() {
+			var vNode = new axe.AbstractVirtualNode();
+			vNode.attr = function() {
+				return null;
+			};
 
-      assert.isFalse(vNode.hasClass('my-class'));
-    });
+			assert.isFalse(vNode.hasClass('my-class'));
+		});
 
-    it('should return true for whitespace characters', function() {
-      var vNode = new axe.AbstractVirtualNode();
-      vNode.attr = function () {
-        return 'my-class\ta11y-focus\rvisually-hidden\ngrid\fcontainer'
-      }
+		it('should return true for whitespace characters', function() {
+			var vNode = new axe.AbstractVirtualNode();
+			vNode.attr = function() {
+				return 'my-class\ta11y-focus\rvisually-hidden\ngrid\fcontainer';
+			};
 
-      assert.isTrue(vNode.hasClass('my-class'));
-      assert.isTrue(vNode.hasClass('a11y-focus'));
-      assert.isTrue(vNode.hasClass('visually-hidden'));
-      assert.isTrue(vNode.hasClass('grid'));
-      assert.isTrue(vNode.hasClass('container'));
-    });
-  });
+			assert.isTrue(vNode.hasClass('my-class'));
+			assert.isTrue(vNode.hasClass('a11y-focus'));
+			assert.isTrue(vNode.hasClass('visually-hidden'));
+			assert.isTrue(vNode.hasClass('grid'));
+			assert.isTrue(vNode.hasClass('container'));
+		});
+	});
 });

--- a/test/core/base/virtual-node/abstract-virtual-node.js
+++ b/test/core/base/virtual-node/abstract-virtual-node.js
@@ -1,0 +1,110 @@
+describe('AbstractVirtualNode', function() {
+  it('should be a function', function() {
+    assert.isFunction(axe.AbstractVirtualNode);
+  });
+
+  it('should throw an error when accessing props', function() {
+    function fn() {
+      var abstractNode = new axe.AbstractVirtualNode();
+      if (abstractNode.props.nodeType === 1) {
+        return;
+      }
+    }
+
+    assert.throws(fn);
+  });
+
+  it('should throw an error when accessing hasClass', function() {
+    function fn() {
+      var abstractNode = new axe.AbstractVirtualNode();
+      if (abstractNode.hasClass('foo')) {
+        return;
+      }
+    }
+
+    assert.throws(fn);
+  });
+
+  it('should throw an error when accessing attr', function() {
+    function fn() {
+      var abstractNode = new axe.AbstractVirtualNode();
+      if (abstractNode.attr('foo') === 'bar') {
+        return;
+      }
+    }
+
+    assert.throws(fn);
+  });
+
+  it('should throw an error when accessing hasAttr', function() {
+    function fn() {
+      var abstractNode = new axe.AbstractVirtualNode();
+      if (abstractNode.hasAttr('foo')) {
+        return;
+      }
+    }
+
+    assert.throws(fn);
+  });
+
+  describe('hasClass, when attr is set', function() {
+    it('should return true when the element has the class', function() {
+      var vNode = new axe.AbstractVirtualNode();
+      vNode.attr = function () {
+        return 'my-class'
+      }
+
+      assert.isTrue(vNode.hasClass('my-class'));
+    });
+
+    it('should return true when the element contains more than one class', function() {
+      var vNode = new axe.AbstractVirtualNode();
+      vNode.attr = function () {
+        return 'my-class a11y-focus visually-hidden'
+      }
+
+      assert.isTrue(vNode.hasClass('my-class'));
+      assert.isTrue(vNode.hasClass('a11y-focus'));
+      assert.isTrue(vNode.hasClass('visually-hidden'));
+    });
+
+    it('should return false when the element does not contain the class', function() {
+      var vNode = new axe.AbstractVirtualNode();
+      vNode.attr = function () {
+        return undefined
+      }
+
+      assert.isFalse(vNode.hasClass('my-class'));
+    });
+
+    it('should return false when the element contains only part of the class', function() {
+      var vNode = new axe.AbstractVirtualNode();
+      vNode.attr = function () {
+        return 'my-class'
+      }
+      assert.isFalse(vNode.hasClass('class'));
+    });
+
+    it('should return false if className is not of type string', function() {
+      var vNode = new axe.AbstractVirtualNode();
+      vNode.attr = function () {
+        return null
+      }
+
+      assert.isFalse(vNode.hasClass('my-class'));
+    });
+
+    it('should return true for whitespace characters', function() {
+      var vNode = new axe.AbstractVirtualNode();
+      vNode.attr = function () {
+        return 'my-class\ta11y-focus\rvisually-hidden\ngrid\fcontainer'
+      }
+
+      assert.isTrue(vNode.hasClass('my-class'));
+      assert.isTrue(vNode.hasClass('a11y-focus'));
+      assert.isTrue(vNode.hasClass('visually-hidden'));
+      assert.isTrue(vNode.hasClass('grid'));
+      assert.isTrue(vNode.hasClass('container'));
+    });
+  });
+});

--- a/test/core/base/virtual-node/serial-virtual-node.js
+++ b/test/core/base/virtual-node/serial-virtual-node.js
@@ -1,173 +1,173 @@
 /*global axe, SerialVirtualNode */
 describe('SerialVirtualNode', function() {
-  it('extends AbstractVirtualNode', function () {
-    var vNode = new SerialVirtualNode({
-      nodeName: 'div'
-    });
-    assert.instanceOf(vNode, axe.AbstractVirtualNode);
-  });
+	it('extends AbstractVirtualNode', function() {
+		var vNode = new SerialVirtualNode({
+			nodeName: 'div'
+		});
+		assert.instanceOf(vNode, axe.AbstractVirtualNode);
+	});
 
-  describe('props', function () {
-    it('assigns any properties to .props', function () {
-      var props = {
-        nodeType: 1,
-        nodeName: 'div',
-        someType: 'bar',
-        somethingElse: 'baz'
-      }
-      var vNode = new SerialVirtualNode(props);
-      assert.deepEqual(vNode.props, props);
-    })
+	describe('props', function() {
+		it('assigns any properties to .props', function() {
+			var props = {
+				nodeType: 1,
+				nodeName: 'div',
+				someType: 'bar',
+				somethingElse: 'baz'
+			};
+			var vNode = new SerialVirtualNode(props);
+			assert.deepEqual(vNode.props, props);
+		});
 
-    it('returns a frozen object', function () {
-      var vNode = new SerialVirtualNode({ nodeName: 'div' });
-      assert.isTrue(Object.isFrozen(vNode.props), 'Expect object to be frozen');
-    })
+		it('returns a frozen object', function() {
+			var vNode = new SerialVirtualNode({ nodeName: 'div' });
+			assert.isTrue(Object.isFrozen(vNode.props), 'Expect object to be frozen');
+		});
 
-    it('has a default nodeType of 1', function () {
-      var vNode = new SerialVirtualNode({ nodeName: 'div' });
-      assert.equal(vNode.props.nodeType, 1)
-    })
+		it('has a default nodeType of 1', function() {
+			var vNode = new SerialVirtualNode({ nodeName: 'div' });
+			assert.equal(vNode.props.nodeType, 1);
+		});
 
-    it('converts nodeNames to lower case', function () {
-      var htmlNodes = [
-        'DIV',
-        'SPAN',
-        'INPUT',
-        'HeAdEr',
-        'TABLE',
-        'TITLE',
-        'BUTTON',
-        'Foo'
-      ]
-      htmlNodes.forEach(function (nodeName) {
-        var vNode = new SerialVirtualNode({ nodeName: nodeName });
-        assert.equal(vNode.props.nodeName, nodeName.toLowerCase())
-      })
-    })
+		it('converts nodeNames to lower case', function() {
+			var htmlNodes = [
+				'DIV',
+				'SPAN',
+				'INPUT',
+				'HeAdEr',
+				'TABLE',
+				'TITLE',
+				'BUTTON',
+				'Foo'
+			];
+			htmlNodes.forEach(function(nodeName) {
+				var vNode = new SerialVirtualNode({ nodeName: nodeName });
+				assert.equal(vNode.props.nodeName, nodeName.toLowerCase());
+			});
+		});
 
-    it('ignores the `attributes` property', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: {
-          'foo': 'foo',
-          'bar': 'bar',
-          'baz': 'baz'
-        }
-      });
-      assert.isUndefined(vNode.props.attributes)
-    })
-  })
+		it('ignores the `attributes` property', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: {
+					foo: 'foo',
+					bar: 'bar',
+					baz: 'baz'
+				}
+			});
+			assert.isUndefined(vNode.props.attributes);
+		});
+	});
 
-  describe('attr', function () {
-    it('returns a string value for the attribute', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: {
-          'foo': 'foo',
-          'bar': 123,
-          'baz': true
-        }
-      });
-      assert.equal(vNode.attr('foo'), 'foo');
-      assert.equal(vNode.attr('bar'), '123');
-      assert.equal(vNode.attr('baz'), 'true');
-    })
+	describe('attr', function() {
+		it('returns a string value for the attribute', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: {
+					foo: 'foo',
+					bar: 123,
+					baz: true
+				}
+			});
+			assert.equal(vNode.attr('foo'), 'foo');
+			assert.equal(vNode.attr('bar'), '123');
+			assert.equal(vNode.attr('baz'), 'true');
+		});
 
-    it('returns null if the attribute is null', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: { 'foo': null }
-      });
-      assert.isNull(vNode.attr('foo'));
-    })
+		it('returns null if the attribute is null', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: { foo: null }
+			});
+			assert.isNull(vNode.attr('foo'));
+		});
 
-    it('returns null if the attribute is not set', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div'
-      });
-      assert.isNull(vNode.attr('foo'));
-    })
+		it('returns null if the attribute is not set', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div'
+			});
+			assert.isNull(vNode.attr('foo'));
+		});
 
-    it('converts `className` to `class`', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: {
-          className: 'foo bar baz'
-        }
-      });
-      assert.equal(vNode.attr('class'), 'foo bar baz');
-    })
+		it('converts `className` to `class`', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: {
+					className: 'foo bar baz'
+				}
+			});
+			assert.equal(vNode.attr('class'), 'foo bar baz');
+		});
 
-    it('converts `htmlFor` to `for`', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: {
-          htmlFor: 'foo'
-        }
-      });
-      assert.equal(vNode.attr('for'), 'foo');
-    })
-  })
+		it('converts `htmlFor` to `for`', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: {
+					htmlFor: 'foo'
+				}
+			});
+			assert.equal(vNode.attr('for'), 'foo');
+		});
+	});
 
-  describe('hasAttr', function () {
-    it('returns true if the attribute has a value', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: {
-          'foo': '',
-          'bar': 0,
-          'baz': false
-        }
-      });
-      assert.isTrue(vNode.hasAttr('foo'));
-      assert.isTrue(vNode.hasAttr('bar'));
-      assert.isTrue(vNode.hasAttr('baz'));
-    })
+	describe('hasAttr', function() {
+		it('returns true if the attribute has a value', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: {
+					foo: '',
+					bar: 0,
+					baz: false
+				}
+			});
+			assert.isTrue(vNode.hasAttr('foo'));
+			assert.isTrue(vNode.hasAttr('bar'));
+			assert.isTrue(vNode.hasAttr('baz'));
+		});
 
-    it('returns true if the attribute is null', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: { 'foo': null }
-      });
-      assert.isTrue(vNode.hasAttr('foo'));
-    })
+		it('returns true if the attribute is null', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: { foo: null }
+			});
+			assert.isTrue(vNode.hasAttr('foo'));
+		});
 
-    it('returns false if the attribute is undefined', function () {
-      var vNode = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: { 'foo': undefined }
-      });
-      assert.isFalse(vNode.hasAttr('foo'));
-      assert.isFalse(vNode.hasAttr('bar'));
-    })
+		it('returns false if the attribute is undefined', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: { foo: undefined }
+			});
+			assert.isFalse(vNode.hasAttr('foo'));
+			assert.isFalse(vNode.hasAttr('bar'));
+		});
 
-    it('converts `htmlFor` to `for`', function () {
-      var nodeWithoutFor = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: {}
-      });
-      var nodeWithFor = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: { 'htmlFor': 'foo' }
-      });
+		it('converts `htmlFor` to `for`', function() {
+			var nodeWithoutFor = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: {}
+			});
+			var nodeWithFor = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: { htmlFor: 'foo' }
+			});
 
-      assert.isFalse(nodeWithoutFor.hasAttr('for'));
-      assert.isTrue(nodeWithFor.hasAttr('for'));
-    })
+			assert.isFalse(nodeWithoutFor.hasAttr('for'));
+			assert.isTrue(nodeWithFor.hasAttr('for'));
+		});
 
-    it('converts `className` to `class`', function () {
-      var nodeWithoutClass = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: {}
-      });
-      var nodeWithClass = new SerialVirtualNode({
-        nodeName: 'div',
-        attributes: { 'className': 'foo bar baz' }
-      });
+		it('converts `className` to `class`', function() {
+			var nodeWithoutClass = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: {}
+			});
+			var nodeWithClass = new SerialVirtualNode({
+				nodeName: 'div',
+				attributes: { className: 'foo bar baz' }
+			});
 
-      assert.isFalse(nodeWithoutClass.hasAttr('class'));
-      assert.isTrue(nodeWithClass.hasAttr('class'));
-    })
-  })
+			assert.isFalse(nodeWithoutClass.hasAttr('class'));
+			assert.isTrue(nodeWithClass.hasAttr('class'));
+		});
+	});
 });

--- a/test/core/base/virtual-node/serial-virtual-node.js
+++ b/test/core/base/virtual-node/serial-virtual-node.js
@@ -1,0 +1,173 @@
+/*global axe, SerialVirtualNode */
+describe('SerialVirtualNode', function() {
+  it('extends AbstractVirtualNode', function () {
+    var vNode = new SerialVirtualNode({
+      nodeName: 'div'
+    });
+    assert.instanceOf(vNode, axe.AbstractVirtualNode);
+  });
+
+  describe('props', function () {
+    it('assigns any properties to .props', function () {
+      var props = {
+        nodeType: 1,
+        nodeName: 'div',
+        someType: 'bar',
+        somethingElse: 'baz'
+      }
+      var vNode = new SerialVirtualNode(props);
+      assert.deepEqual(vNode.props, props);
+    })
+
+    it('returns a frozen object', function () {
+      var vNode = new SerialVirtualNode({ nodeName: 'div' });
+      assert.isTrue(Object.isFrozen(vNode.props), 'Expect object to be frozen');
+    })
+
+    it('has a default nodeType of 1', function () {
+      var vNode = new SerialVirtualNode({ nodeName: 'div' });
+      assert.equal(vNode.props.nodeType, 1)
+    })
+
+    it('converts nodeNames to lower case', function () {
+      var htmlNodes = [
+        'DIV',
+        'SPAN',
+        'INPUT',
+        'HeAdEr',
+        'TABLE',
+        'TITLE',
+        'BUTTON',
+        'Foo'
+      ]
+      htmlNodes.forEach(function (nodeName) {
+        var vNode = new SerialVirtualNode({ nodeName: nodeName });
+        assert.equal(vNode.props.nodeName, nodeName.toLowerCase())
+      })
+    })
+
+    it('ignores the `attributes` property', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'foo': 'foo',
+          'bar': 'bar',
+          'baz': 'baz'
+        }
+      });
+      assert.isUndefined(vNode.props.attributes)
+    })
+  })
+
+  describe('attr', function () {
+    it('returns a string value for the attribute', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'foo': 'foo',
+          'bar': 123,
+          'baz': true
+        }
+      });
+      assert.equal(vNode.attr('foo'), 'foo');
+      assert.equal(vNode.attr('bar'), '123');
+      assert.equal(vNode.attr('baz'), 'true');
+    })
+
+    it('returns null if the attribute is null', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: { 'foo': null }
+      });
+      assert.isNull(vNode.attr('foo'));
+    })
+
+    it('returns null if the attribute is not set', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div'
+      });
+      assert.isNull(vNode.attr('foo'));
+    })
+
+    it('converts `className` to `class`', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          className: 'foo bar baz'
+        }
+      });
+      assert.equal(vNode.attr('class'), 'foo bar baz');
+    })
+
+    it('converts `htmlFor` to `for`', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          htmlFor: 'foo'
+        }
+      });
+      assert.equal(vNode.attr('for'), 'foo');
+    })
+  })
+
+  describe('hasAttr', function () {
+    it('returns true if the attribute has a value', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'foo': '',
+          'bar': 0,
+          'baz': false
+        }
+      });
+      assert.isTrue(vNode.hasAttr('foo'));
+      assert.isTrue(vNode.hasAttr('bar'));
+      assert.isTrue(vNode.hasAttr('baz'));
+    })
+
+    it('returns true if the attribute is null', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: { 'foo': null }
+      });
+      assert.isTrue(vNode.hasAttr('foo'));
+    })
+
+    it('returns false if the attribute is undefined', function () {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: { 'foo': undefined }
+      });
+      assert.isFalse(vNode.hasAttr('foo'));
+      assert.isFalse(vNode.hasAttr('bar'));
+    })
+
+    it('converts `htmlFor` to `for`', function () {
+      var nodeWithoutFor = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {}
+      });
+      var nodeWithFor = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: { 'htmlFor': 'foo' }
+      });
+
+      assert.isFalse(nodeWithoutFor.hasAttr('for'));
+      assert.isTrue(nodeWithFor.hasAttr('for'));
+    })
+
+    it('converts `className` to `class`', function () {
+      var nodeWithoutClass = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {}
+      });
+      var nodeWithClass = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: { 'className': 'foo bar baz' }
+      });
+
+      assert.isFalse(nodeWithoutClass.hasAttr('class'));
+      assert.isTrue(nodeWithClass.hasAttr('class'));
+    })
+  })
+});

--- a/test/core/base/virtual-node/virtual-node.js
+++ b/test/core/base/virtual-node/virtual-node.js
@@ -7,56 +7,6 @@ describe('VirtualNode', function() {
 		node = document.createElement('div');
 	});
 
-	describe('AbstractVirtualNode', function() {
-		it('should be a function', function() {
-			assert.isFunction(axe.AbstractVirtualNode);
-		});
-
-		it('should throw an error when accessing props', function() {
-			function fn() {
-				var abstractNode = new axe.AbstractVirtualNode();
-				if (abstractNode.props.nodeType === 1) {
-					return;
-				}
-			}
-
-			assert.throws(fn);
-		});
-
-		it('should throw an error when accessing hasClass', function() {
-			function fn() {
-				var abstractNode = new axe.AbstractVirtualNode();
-				if (abstractNode.hasClass('foo')) {
-					return;
-				}
-			}
-
-			assert.throws(fn);
-		});
-
-		it('should throw an error when accessing attr', function() {
-			function fn() {
-				var abstractNode = new axe.AbstractVirtualNode();
-				if (abstractNode.attr('foo') === 'bar') {
-					return;
-				}
-			}
-
-			assert.throws(fn);
-		});
-
-		it('should throw an error when accessing hasAttr', function() {
-			function fn() {
-				var abstractNode = new axe.AbstractVirtualNode();
-				if (abstractNode.hasAttr('foo')) {
-					return;
-				}
-			}
-
-			assert.throws(fn);
-		});
-	});
-
 	it('should be a function', function() {
 		assert.isFunction(VirtualNode);
 	});
@@ -95,76 +45,6 @@ describe('VirtualNode', function() {
 			var vNode = new VirtualNode(node);
 
 			assert.equal(vNode.props.nodeName, 'foobar');
-		});
-
-		describe('hasClass', function() {
-			it('should return true when the element has the class', function() {
-				node.setAttribute('class', 'my-class');
-				var vNode = new VirtualNode(node);
-
-				assert.isTrue(vNode.hasClass('my-class'));
-			});
-
-			it('should return true when the element contains more than one class', function() {
-				node.setAttribute('class', 'my-class a11y-focus visually-hidden');
-				var vNode = new VirtualNode(node);
-
-				assert.isTrue(vNode.hasClass('my-class'));
-				assert.isTrue(vNode.hasClass('a11y-focus'));
-				assert.isTrue(vNode.hasClass('visually-hidden'));
-			});
-
-			it('should return true for svg elements', function() {
-				node = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-				node.setAttribute('class', 'my-class');
-				var vNode = new VirtualNode(node);
-
-				assert.isTrue(vNode.hasClass('my-class'));
-			});
-
-			it('should return false when the element does not contain the class', function() {
-				var vNode = new VirtualNode(node);
-
-				assert.isFalse(vNode.hasClass('my-class'));
-			});
-
-			it('should return false when the element contains only part of the class', function() {
-				node.setAttribute('class', 'my-class');
-				var vNode = new VirtualNode(node);
-
-				assert.isFalse(vNode.hasClass('class'));
-			});
-
-			it('should return false for text nodes', function() {
-				node.textContent = 'hello';
-				var vNode = new VirtualNode(node.firstChild);
-
-				assert.isFalse(vNode.hasClass('my-class'));
-			});
-
-			it('should return false if className is not of type string', function() {
-				var node = {
-					nodeName: 'DIV',
-					className: null
-				};
-				var vNode = new VirtualNode(node);
-
-				assert.isFalse(vNode.hasClass('my-class'));
-			});
-
-			it('should return true for whitespace characters', function() {
-				node.setAttribute(
-					'class',
-					'my-class\ta11y-focus\rvisually-hidden\ngrid\fcontainer'
-				);
-				var vNode = new VirtualNode(node);
-
-				assert.isTrue(vNode.hasClass('my-class'));
-				assert.isTrue(vNode.hasClass('a11y-focus'));
-				assert.isTrue(vNode.hasClass('visually-hidden'));
-				assert.isTrue(vNode.hasClass('grid'));
-				assert.isTrue(vNode.hasClass('container'));
-			});
 		});
 
 		describe('attr', function() {

--- a/test/core/public/run-virtual-rule.js
+++ b/test/core/public/run-virtual-rule.js
@@ -1,33 +1,6 @@
+/* global SerialVirtualNode */
 describe('axe.runVirtualRule', function() {
-	'use strict';
-
 	var origRunRules = axe._runRules;
-	var vNode = {
-		shadowId: undefined,
-		children: [],
-		parent: undefined,
-		_cache: {},
-		_isHidden: null,
-		_attrs: {
-			type: 'text',
-			autocomplete: 'not-on-my-watch'
-		},
-		props: {
-			nodeType: 1,
-			nodeName: 'input',
-			id: null,
-			type: 'text'
-		},
-		hasClass: function() {
-			return false;
-		},
-		attr: function(attrName) {
-			return this._attrs[attrName];
-		},
-		hasAttr: function(attrName) {
-			return !!this._attrs[attrName];
-		}
-	};
 
 	beforeEach(function() {
 		axe._load({
@@ -57,7 +30,7 @@ describe('axe.runVirtualRule', function() {
 	it('should throw if the rule does not exist', function() {
 		axe._audit.rules = [];
 		function fn() {
-			axe.runVirtualRule('aria-roles');
+			axe.runVirtualRule('aria-roles', { nodeName: 'div' });
 		}
 
 		assert.throws(fn);
@@ -79,7 +52,7 @@ describe('axe.runVirtualRule', function() {
 			}
 		];
 
-		axe.runVirtualRule('aria-roles');
+		axe.runVirtualRule('aria-roles', { nodeName: 'div' });
 	});
 
 	it('should not modify the original rule', function() {
@@ -98,7 +71,7 @@ describe('axe.runVirtualRule', function() {
 			}
 		];
 
-		axe.runVirtualRule('aria-roles');
+		axe.runVirtualRule('aria-roles', { nodeName: 'div' });
 	});
 
 	it('should call rule.runSync', function() {
@@ -116,12 +89,12 @@ describe('axe.runVirtualRule', function() {
 			}
 		];
 
-		axe.runVirtualRule('aria-roles');
+		axe.runVirtualRule('aria-roles', { nodeName: 'div' });
 		assert.isTrue(called);
 	});
 
 	it('should pass a virtual context to rule.runSync', function() {
-		var node = {};
+		var node = new SerialVirtualNode({ nodeName: 'div'});
 		axe._audit.rules = [
 			{
 				id: 'aria-roles',
@@ -156,18 +129,42 @@ describe('axe.runVirtualRule', function() {
 			}
 		];
 
-		axe.runVirtualRule('aria-roles', null, { foo: 'bar' });
+		axe.runVirtualRule('aria-roles',
+			{ nodeName: 'div' },
+			{ foo: 'bar' }
+		);
 	});
 
-	it('should run a rule without needing actual node', function() {
-		function fn() {
-			axe.runVirtualRule('test', vNode);
-		}
-		assert.doesNotThrow(fn);
+	it('should convert a serialised node into a VirtualNode', function() {
+		var serialNode = {
+			nodeName: 'div',
+			foo: 'bar',
+			attributes: {
+				'bar': 'baz'
+			}
+		};
+		axe._audit.rules = [
+			{
+				id: 'aria-roles',
+				runSync: function(context) {
+					var node = context.include[0]
+					assert.instanceOf(node, axe.AbstractVirtualNode)
+					assert.equal(node.props.foo, 'bar')
+					assert.equal(node.attr('bar'), 'baz')
+
+					return {
+						id: 'aria-roles',
+						nodes: []
+					};
+				}
+			}
+		];
+
+		axe.runVirtualRule('aria-roles', serialNode);
 	});
 
 	it('should return correct structure', function() {
-		var results = axe.runVirtualRule('test', vNode);
+		var results = axe.runVirtualRule('test', { nodeName: 'div' });
 		assert.isDefined(results.violations);
 		assert.isDefined(results.passes);
 		assert.isDefined(results.incomplete);

--- a/test/core/public/run-virtual-rule.js
+++ b/test/core/public/run-virtual-rule.js
@@ -94,7 +94,7 @@ describe('axe.runVirtualRule', function() {
 	});
 
 	it('should pass a virtual context to rule.runSync', function() {
-		var node = new SerialVirtualNode({ nodeName: 'div'});
+		var node = new SerialVirtualNode({ nodeName: 'div' });
 		axe._audit.rules = [
 			{
 				id: 'aria-roles',
@@ -129,10 +129,7 @@ describe('axe.runVirtualRule', function() {
 			}
 		];
 
-		axe.runVirtualRule('aria-roles',
-			{ nodeName: 'div' },
-			{ foo: 'bar' }
-		);
+		axe.runVirtualRule('aria-roles', { nodeName: 'div' }, { foo: 'bar' });
 	});
 
 	it('should convert a serialised node into a VirtualNode', function() {
@@ -140,17 +137,17 @@ describe('axe.runVirtualRule', function() {
 			nodeName: 'div',
 			foo: 'bar',
 			attributes: {
-				'bar': 'baz'
+				bar: 'baz'
 			}
 		};
 		axe._audit.rules = [
 			{
 				id: 'aria-roles',
 				runSync: function(context) {
-					var node = context.include[0]
-					assert.instanceOf(node, axe.AbstractVirtualNode)
-					assert.equal(node.props.foo, 'bar')
-					assert.equal(node.attr('bar'), 'baz')
+					var node = context.include[0];
+					assert.instanceOf(node, axe.AbstractVirtualNode);
+					assert.equal(node.props.foo, 'bar');
+					assert.equal(node.attr('bar'), 'baz');
 
 					return {
 						id: 'aria-roles',

--- a/test/core/utils/assert.js
+++ b/test/core/utils/assert.js
@@ -1,36 +1,36 @@
-describe('axe.utils.assert', function () {
-  it('does nothing when passed a truthy value', function () {
-    assert.doesNotThrow(function () {
-      axe.utils.assert(true)
-      axe.utils.assert('foo')
-      axe.utils.assert(123)
-      axe.utils.assert([])
-      axe.utils.assert({})
-    })
-  })
+describe('axe.utils.assert', function() {
+	it('does nothing when passed a truthy value', function() {
+		assert.doesNotThrow(function() {
+			axe.utils.assert(true);
+			axe.utils.assert('foo');
+			axe.utils.assert(123);
+			axe.utils.assert([]);
+			axe.utils.assert({});
+		});
+	});
 
-  it('throws an error when passed a falsey value', function () {
-    assert.throws(function () {
-      axe.utils.assert(false)
-    })
-    assert.throws(function () {
-      axe.utils.assert(0)
-    })
-    assert.throws(function () {
-      axe.utils.assert(null)
-    })
-    assert.throws(function () {
-      axe.utils.assert(undefined)
-    })
-  })
+	it('throws an error when passed a falsey value', function() {
+		assert.throws(function() {
+			axe.utils.assert(false);
+		});
+		assert.throws(function() {
+			axe.utils.assert(0);
+		});
+		assert.throws(function() {
+			axe.utils.assert(null);
+		});
+		assert.throws(function() {
+			axe.utils.assert(undefined);
+		});
+	});
 
-  it('sets second argument as the error message', function () {
-    var message = 'Something went wrong'
-    try {
-      axe.utils.assert(false, message)
-    } catch (e) {
-      assert.instanceOf(e, Error)
-      assert.equal(e.message, message)
-    }
-  })
-})
+	it('sets second argument as the error message', function() {
+		var message = 'Something went wrong';
+		try {
+			axe.utils.assert(false, message);
+		} catch (e) {
+			assert.instanceOf(e, Error);
+			assert.equal(e.message, message);
+		}
+	});
+});

--- a/test/core/utils/assert.js
+++ b/test/core/utils/assert.js
@@ -1,0 +1,36 @@
+describe('axe.utils.assert', function () {
+  it('does nothing when passed a truthy value', function () {
+    assert.doesNotThrow(function () {
+      axe.utils.assert(true)
+      axe.utils.assert('foo')
+      axe.utils.assert(123)
+      axe.utils.assert([])
+      axe.utils.assert({})
+    })
+  })
+
+  it('throws an error when passed a falsey value', function () {
+    assert.throws(function () {
+      axe.utils.assert(false)
+    })
+    assert.throws(function () {
+      axe.utils.assert(0)
+    })
+    assert.throws(function () {
+      axe.utils.assert(null)
+    })
+    assert.throws(function () {
+      axe.utils.assert(undefined)
+    })
+  })
+
+  it('sets second argument as the error message', function () {
+    var message = 'Something went wrong'
+    try {
+      axe.utils.assert(false, message)
+    } catch (e) {
+      assert.instanceOf(e, Error)
+      assert.equal(e.message, message)
+    }
+  })
+})


### PR DESCRIPTION
**Don't squash this, merge it instead**

This PR adds an **experimental** feature for running `runNodesVirtual` with a serialised DOM node. This feature only supports individual elements at the moment. Child and parent relationships may be added in the future, if the direction we're taking with this pans out.

Closes issue: #1783

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
