### PR TITLE
chore(package): update eslint-config-prettier to version 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"emoji-regex": "8.0.0",
 		"es6-promise": "^4.2.6",
 		"eslint": "^6.1.0",
-		"eslint-config-prettier": "^6.0.0",
+		"eslint-config-prettier": "^6.2.0",
 		"execa": "^2.0.2",
 		"fs-extra": "^8.0.1",
 		"globby": "^10.0.0",


### PR DESCRIPTION
Not sure why this says it's failing. Seems to work locally. Testing here.

*Edit*: Seems appveyor timed out the first time for an unknown reason and never finished running the tests.

Closes: #1797
Closes: #1771

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
