### PR TITLE
fix(get-selector): don't throw error for disconnected fragment

### DIFF
--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -390,6 +390,9 @@ axe.utils.getSelector = function createUniqueSelector(elm, options = {}) {
 	let doc = (elm.getRootNode && elm.getRootNode()) || document;
 	if (doc.nodeType === 11) {
 		// DOCUMENT_FRAGMENT
+		if (!doc.host) {
+			return '';
+		}
 		let stack = [];
 		while (doc.nodeType === 11) {
 			stack.push({ elm: elm, doc: doc });

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -390,11 +390,11 @@ axe.utils.getSelector = function createUniqueSelector(elm, options = {}) {
 	let doc = (elm.getRootNode && elm.getRootNode()) || document;
 	if (doc.nodeType === 11) {
 		// DOCUMENT_FRAGMENT
-		if (!doc.host) {
-			return '';
-		}
 		let stack = [];
 		while (doc.nodeType === 11) {
+			if (!doc.host) {
+				return '';
+			}
 			stack.push({ elm: elm, doc: doc });
 			elm = doc.host;
 			doc = elm.getRootNode();

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -594,17 +594,13 @@ describe('axe.utils.getSelector', function() {
 		assert.isTrue(test === top);
 	});
 
-	(window.PHANTOMJS ? it.skip : it)(
-		'should not error if fragment is no longer in the DOM',
-		function() {
-			var template = document.createElement('template');
-			template.innerHTML = '<div></div>';
-			var node = template.content.querySelector('div');
-			fixtureSetup(template);
-			template.remove();
-			assert.doesNotThrow(function() {
-				axe.utils.getSelector(node);
-			});
-		}
-	);
+	it('should not error if fragment is no longer in the DOM', function() {
+		var fragment = document.createDocumentFragment();
+		var node = document.createElement('div');
+		fragment.appendChild(node);
+		fixtureSetup();
+		assert.doesNotThrow(function() {
+			axe.utils.getSelector(node);
+		});
+	});
 });

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -594,13 +594,17 @@ describe('axe.utils.getSelector', function() {
 		assert.isTrue(test === top);
 	});
 
-	it('should not error if elm is no longer in the DOM', function() {
-		var fragment = document.createDocumentFragment();
-		var node = document.createElement('div');
-		fragment.appendChild(node);
-		fixtureSetup(fragment);
-		assert.doesNotThrow(function() {
-			axe.utils.getSelector(fragment);
-		});
-	});
+	(window.PHANTOMJS ? it.skip : it)(
+		'should not error if fragment is no longer in the DOM',
+		function() {
+			var template = document.createElement('template');
+			template.innerHTML = '<div></div>';
+			var node = template.content.querySelector('div');
+			fixtureSetup(template);
+			template.remove();
+			assert.doesNotThrow(function() {
+				axe.utils.getSelector(node);
+			});
+		}
+	);
 });

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -593,4 +593,14 @@ describe('axe.utils.getSelector', function() {
 		var test = document.querySelector(sel);
 		assert.isTrue(test === top);
 	});
+
+	it('should not error if elm is no longer in the DOM', function() {
+		var fragment = document.createDocumentFragment();
+		var node = document.createElement('div');
+		fragment.appendChild(node);
+		fixtureSetup(fragment);
+		assert.doesNotThrow(function() {
+			axe.utils.getSelector(fragment);
+		});
+	});
 });


### PR DESCRIPTION
There was a bug where after running color-contrast, the page would be scrolled to the bottom and a fragment element would then be removed from the DOM (due to an `onscroll` event). If the fragment element was the target of a rule, axe would throw an error say since `doc.host` would return `undefined`.

Closes issue: #1589

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
