### PR TITLE
docs: update readme to deprecate support for v0 Shadow DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Support means that we will fix bugs and attempt to test each browser regularly. 
 
 There is limited support for JSDOM. We will attempt to make all rules compatible with JSDOM but where this is not possible, we recommend turning those rules off. Currently the `color-contrast` rule is known not to work with JSDOM.
 
-We can only support environments where features are either natively supported or polyfilled correctly. We only support v1 Shadow DOM.
+We can only support environments where features are either natively supported or polyfilled correctly. We do not support the deprecated v0 Shadow DOM implementation.
 
 ## The Accessibility Rules
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ The [axe-core API](doc/API.md) fully supports the following browsers:
 - Apple Safari v7 and above
 - Internet Explorer v9, 10, 11
 
-Support means that we will fix bugs and attempt to test each browser regularly. Only Firefox and Chrome are currently tested on every pull request.
+Support means that we will fix bugs and attempt to test each browser regularly. Only Firefox, Chrome, and Internet Explorer 11 are currently tested on every pull request.
 
 There is limited support for JSDOM. We will attempt to make all rules compatible with JSDOM but where this is not possible, we recommend turning those rules off. Currently the `color-contrast` rule is known not to work with JSDOM.
 
-We can only support environments where features are either natively supported or polyfilled correctly.
+We can only support environments where features are either natively supported or polyfilled correctly. We only support v1 Shadow DOM.
 
 ## The Accessibility Rules
 


### PR DESCRIPTION
Also to note that we now test in IE11 with every pr.

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
