### PR TITLE
fix(configure): use translations for failure summaries

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -62,6 +62,8 @@ Audit.prototype._setDefaultLocale = function() {
 	const locale = {
 		checks: {},
 		rules: {},
+		failureSummaries: {},
+		incompleteFallbackMessage: '',
 		lang: this.lang
 	};
 
@@ -86,6 +88,16 @@ Audit.prototype._setDefaultLocale = function() {
 		const { description, help } = rule;
 		locale.rules[id] = { description, help };
 	}
+
+	const failureSummaries = Object.keys(this.data.failureSummaries);
+	for (let i = 0; i < failureSummaries.length; i++) {
+		const type = failureSummaries[i];
+		const failureSummary = this.data.failureSummaries[type];
+		const { failureMessage } = failureSummary;
+		locale.failureSummaries[type] = { failureMessage };
+	}
+
+	locale.incompleteFallbackMessage = this.data.incompleteFallbackMessage;
 
 	this._defaultLocale = locale;
 };
@@ -179,6 +191,34 @@ const mergeRuleLocale = (a, b) => {
 };
 
 /**
+ * Merge two failure messages (a, b), favoring `b`.
+ */
+
+const mergeFailureMessage = (a, b) => {
+	let { failureMessage } = b;
+	// If the message(s) are Strings, they have not yet been run
+	// thru doT (which will return a Function).
+	if (typeof failureMessage === 'string') {
+		failureMessage = axe.imports.doT.compile(failureMessage);
+	}
+	return {
+		...a,
+		failureMessage: failureMessage || a.failureMessage
+	};
+};
+
+/**
+ * Merge two incomplete fallback messages (a, b), favoring `b`.
+ */
+
+const mergeFallbackMessage = (a, b) => {
+	if (typeof b === 'string') {
+		b = axe.imports.doT.compile(b);
+	}
+	return b || a;
+};
+
+/**
  * Apply locale for the given `checks`.
  */
 
@@ -210,6 +250,24 @@ Audit.prototype._applyRuleLocale = function(rules) {
 };
 
 /**
+ * Apply locale for the given failureMessage
+ */
+
+Audit.prototype._applyFailureSummaries = function(messages) {
+	const keys = Object.keys(messages);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		if (!this.data.failureSummaries[key]) {
+			throw new Error(`Locale provided for unknown failureMessage: "${key}"`);
+		}
+		this.data.failureSummaries[key] = mergeFailureMessage(
+			this.data.failureSummaries[key],
+			messages[key]
+		);
+	}
+};
+
+/**
  * Apply the given `locale`.
  *
  * @param {axe.Locale}
@@ -224,6 +282,17 @@ Audit.prototype.applyLocale = function(locale) {
 
 	if (locale.rules) {
 		this._applyRuleLocale(locale.rules);
+	}
+
+	if (locale.failureSummaries) {
+		this._applyFailureSummaries(locale.failureSummaries, 'failureSummaries');
+	}
+
+	if (locale.incompleteFallbackMessage) {
+		this.data.incompleteFallbackMessage = mergeFallbackMessage(
+			this.data.incompleteFallbackMessage,
+			locale.incompleteFallbackMessage.undefined.failureMessage
+		);
 	}
 
 	if (locale.lang) {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -32,5 +32,9 @@
 			"failureMessage": "Gebruik een van de volgende oplossingen:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "axe kon de reden niet vertellen. Tijd om de element inspecteur uit te breken!"
+	"incompleteFallbackMessage": {
+		"undefined": {
+			"failureMessage": "axe kon de reden niet vertellen. Tijd om de element inspecteur uit te breken!"
+		}
+	}
 }

--- a/test/core/public/configure.js
+++ b/test/core/public/configure.js
@@ -359,6 +359,97 @@ describe('axe.configure', function() {
 			assert.equal(axe._audit.lang, 'lol');
 		});
 
+		it('should update failure messages', function() {
+			axe._load({
+				data: {
+					failureSummaries: {
+						any: {
+							failureMessage: function() {
+								return 'failed any';
+							}
+						},
+						none: {
+							failureMessage: function() {
+								return 'failed none';
+							}
+						}
+					},
+					incompleteFallbackMessage: function() {
+						return 'failed incomplete';
+					}
+				}
+			});
+
+			axe.configure({
+				locale: {
+					lang: 'lol',
+					failureSummaries: {
+						any: {
+							failureMessage: 'foo'
+						},
+						none: {
+							failureMessage: 'bar'
+						}
+					},
+					incompleteFallbackMessage: {
+						undefined: {
+							failureMessage: 'baz'
+						}
+					}
+				}
+			});
+
+			var audit = axe._audit;
+			var localeData = audit.data;
+
+			assert.equal(localeData.failureSummaries.any.failureMessage(), 'foo');
+			assert.equal(localeData.failureSummaries.none.failureMessage(), 'bar');
+			assert.equal(localeData.incompleteFallbackMessage(), 'baz');
+		});
+
+		it('should merge failure messages', function() {
+			axe._load({
+				data: {
+					failureSummaries: {
+						any: {
+							failureMessage: function() {
+								return 'failed any';
+							}
+						},
+						none: {
+							failureMessage: function() {
+								return 'failed none';
+							}
+						}
+					},
+					incompleteFallbackMessage: function() {
+						return 'failed incomplete';
+					}
+				}
+			});
+
+			axe.configure({
+				locale: {
+					lang: 'lol',
+					failureSummaries: {
+						any: {
+							failureMessage: 'foo'
+						}
+					}
+				}
+			});
+
+			var audit = axe._audit;
+			var localeData = audit.data;
+
+			assert.equal(localeData.failureSummaries.any.failureMessage(), 'foo');
+			assert.equal(
+				localeData.failureSummaries.none.failureMessage(),
+				'failed none'
+			);
+			assert.equal(localeData.incompleteFallbackMessage(), 'failed incomplete');
+		});
+
 		describe('only given checks', function() {
 			it('should not error', function() {
 				assert.doesNotThrow(function() {
@@ -503,6 +594,18 @@ describe('axe.configure', function() {
 					}
 				});
 			}, /unknown check: "nope"/);
+		});
+
+		it('should error when provided an unknown failure summary', function() {
+			assert.throws(function() {
+				axe.configure({
+					locale: {
+						failureSummaries: {
+							nope: { failureMessage: 'helpme' }
+						}
+					}
+				});
+			});
 		});
 
 		it('should set default locale', function() {


### PR DESCRIPTION
Use the failure summaries from the passed in locale.

Discovered a bug in the translation file generator (#1810) and had to make `nl.json` match the incorrect structure so we don't try to do too much in this PR. Will fix the structure and bug in another PR.

Closes issue: #1750

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
