### PR TITLE
chore: run prettier formatting

### DIFF
--- a/doc/backwards-compatibility-doc.md
+++ b/doc/backwards-compatibility-doc.md
@@ -26,7 +26,7 @@ In a minor release, we may add support for new technologies in the Public Utils 
 
 If the HTML page is unchanged, calls to the analysis function(s) when compared across minor or patch releases will return the same exact selector for the nodes in any of the result arrays. If the HTML page has changed, it is possible for the selector to be different but it is not guaranteed that the selector will be different.
 
-APIs may be deprecated in a major or minor release. APIs that have been deprecated for 6 months or more will be removed in the next major release. 
+APIs may be deprecated in a major or minor release. APIs that have been deprecated for 6 months or more will be removed in the next major release.
 
 A major or a minor release may introduce new Public Utils.
 


### PR DESCRIPTION
Merging from `develop` into a branch where I was authoring rules, crept in a formatting change, see - https://github.com/dequelabs/axe-core/pull/1649/files#diff-a0a8316da4851cf2b614c43ecd9834c2.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
