### PR TITLE
docs: update preload default value

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -396,7 +396,7 @@ Additionally, there are a number or properties that allow configuration of diffe
 | `elementRef`       | `false` | Return element references in addition to the target                                                                                     |
 | `restoreScroll`    | `false` | Scrolls elements back to before axe started                                                                                             |
 | `frameWaitTime`    | `60000` | How long (in milliseconds) axe waits for a response from embedded frames before timing out                                              |
-| `preload`          | `false` | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
+| `preload`          | `true` | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
 | `performanceTimer` | `false` | Log rule performance metrics to the console                                                                                             |
 
 ###### Options Parameter Examples


### PR DESCRIPTION
Fixed inconsistency of `preload` default value in docs API.

Closes issue: #1817

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
