### PR TITLE
fix(utils): Fix error in IE when getting scroll state on page with SVG elements

### DIFF
--- a/lib/core/utils/scroll-state.js
+++ b/lib/core/utils/scroll-state.js
@@ -14,13 +14,16 @@ function setScroll(elm, top, left) {
  * Create an array scroll positions from descending elements
  */
 function getElmScrollRecursive(root) {
-	return Array.from(root.children).reduce((scrolls, elm) => {
-		const scroll = axe.utils.getScroll(elm);
-		if (scroll) {
-			scrolls.push(scroll);
-		}
-		return scrolls.concat(getElmScrollRecursive(elm));
-	}, []);
+	return Array.from(root.children || root.childNodes || []).reduce(
+		(scrolls, elm) => {
+			const scroll = axe.utils.getScroll(elm);
+			if (scroll) {
+				scrolls.push(scroll);
+			}
+			return scrolls.concat(getElmScrollRecursive(elm));
+		},
+		[]
+	);
 }
 
 /**

--- a/test/core/utils/scroll-state.js
+++ b/test/core/utils/scroll-state.js
@@ -125,6 +125,17 @@ describe('axe.utils.getScrollState', function() {
 			})
 		);
 	});
+
+	it('does not fail with svg elements', function() {
+		fixture.innerHTML =
+			'<svg class="svg" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">' +
+			'<path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>' +
+			'</svg>';
+
+		assert.doesNotThrow(function() {
+			getScrollState();
+		});
+	});
 });
 
 describe('axe.utils.setScrollState', function() {


### PR DESCRIPTION
For any page in IE that has an SVG element, accessing `.children` on an SVGElement when getting the scroll state would return `undefined` and ends up throwing an exception. Other browsers treat SVGs as HTMLCollections but IE treats them as SVGElement.

Closes issue: #525

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
