### PR TITLE
fix(label-content-name-mismatch): ignore private space unicode

### DIFF
--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -91,6 +91,7 @@ function getUnicodeNonBmpRegExp() {
 		'\u25A0-\u25FF' + // Geometric Shapes
 		'\u2600-\u26FF' + // Misc Symbols
 		'\u2700-\u27BF' + // Dingbats
+		'\uE000-\uF8FF' + // Private Use
 			']'
 	);
 }

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -48,6 +48,7 @@ text.removeUnicode = function removeUnicode(str, options) {
 	}
 	if (nonBmp) {
 		str = str.replace(getUnicodeNonBmpRegExp(), '');
+		str = str.replace(getSupplementaryPrivateUseRegExp(), '');
 	}
 	if (punctuations) {
 		str = str.replace(getPunctuationRegExp(), '');
@@ -115,4 +116,17 @@ function getPunctuationRegExp() {
 	 * -> \u2E00-\u2E7F Reference
 	 */
 	return /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]/g;
+}
+
+/**
+ * Get regular expression for surrogate private use
+ *
+ * @returns {RegExp}
+ */
+function getSupplementaryPrivateUseRegExp() {
+	/**
+	 * Reference: https://www.unicode.org/charts/PDF/UD800.pdf
+	 * https://www.unicode.org/charts/PDF/UDC00.pdf
+	 */
+	return /[\uDB80-\uDBBF][\uDC00-\uDFFD]/g;
 }

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -119,7 +119,7 @@ function getPunctuationRegExp() {
 }
 
 /**
- * Get regular expression for surrogate private use
+ * Get regular expression for supplementary private use
  *
  * @returns {RegExp}
  */

--- a/test/checks/label/label-content-name-mismatch.js
+++ b/test/checks/label/label-content-name-mismatch.js
@@ -84,6 +84,14 @@ describe('label-content-name-mismatch tests', function() {
 		assert.isTrue(actual);
 	});
 
+	it('returns true when visible text excluding private use unicode is part of accessible name', function() {
+		var vNode = queryFixture(
+			'<button id="target" aria-label="Favorites"> Favorites</button>'
+		);
+		var actual = check.evaluate(vNode.actualNode, options, vNode);
+		assert.isTrue(actual);
+	});
+
 	it('returns undefined (needs review) when visible text name is only an emoji', function() {
 		var vNode = queryFixture(
 			'<button id="target" aria-label="comet">☄️</button>'

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -187,6 +187,13 @@ describe('text.removeUnicode', function() {
 		assert.equal(actual, '');
 	});
 
+	it('returns string removing all private use unicode', function() {
+		var actual = axe.commons.text.removeUnicode('', {
+			punctuations: true
+		});
+		assert.equal(actual, '');
+	});
+
 	it('returns string removing combination of unicode characters', function() {
 		var actual = axe.commons.text.removeUnicode(
 			'The ☀️ is orange, the ◓ is white.',

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -189,7 +189,7 @@ describe('text.removeUnicode', function() {
 
 	it('returns string removing all private use unicode', function() {
 		var actual = axe.commons.text.removeUnicode('', {
-			punctuations: true
+			nonBmp: true
 		});
 		assert.equal(actual, '');
 	});

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -194,6 +194,13 @@ describe('text.removeUnicode', function() {
 		assert.equal(actual, '');
 	});
 
+	it('returns string removing all surrogate private use unicode', function() {
+		var actual = axe.commons.text.removeUnicode('󰀀󿰀󿿽󰏽', {
+			nonBmp: true
+		});
+		assert.equal(actual, '');
+	});
+
 	it('returns string removing combination of unicode characters', function() {
 		var actual = axe.commons.text.removeUnicode(
 			'The ☀️ is orange, the ◓ is white.',

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -194,7 +194,7 @@ describe('text.removeUnicode', function() {
 		assert.equal(actual, '');
 	});
 
-	it('returns string removing all surrogate private use unicode', function() {
+	it('returns string removing all supplementary private use unicode', function() {
 		var actual = axe.commons.text.removeUnicode('󰀀󿰀󿿽󰏽', {
 			nonBmp: true
 		});


### PR DESCRIPTION
Part 1 for #1635 to fix using private use unicode characters. 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
