### PR TITLE
fix(aria-allowed-attr): allow 'aria-readonly' on listbox

### DIFF
--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -1165,6 +1165,7 @@ lookupTable.role = {
 			allowed: [
 				'aria-activedescendant',
 				'aria-multiselectable',
+				'aria-readonly',
 				'aria-required',
 				'aria-expanded',
 				'aria-orientation',

--- a/test/integration/rules/aria-allowed-attr/passes.html
+++ b/test/integration/rules/aria-allowed-attr/passes.html
@@ -659,6 +659,7 @@
 	aria-live="value"
 	aria-owns="value"
 	aria-relevant="value"
+	aria-readonly="value"
 >
 	ok
 </div>


### PR DESCRIPTION
[`aria-readonly` is an allowed attribute](https://www.w3.org/TR/wai-aria-1.1/#listbox) on `listbox`

Closes issue: #1821 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
