### PR TITLE
docs(utils): add code comment in scroll-state for why childNodes is needed for SVGs in IE

### DIFF
--- a/lib/core/utils/scroll-state.js
+++ b/lib/core/utils/scroll-state.js
@@ -14,6 +14,7 @@ function setScroll(elm, top, left) {
  * Create an array scroll positions from descending elements
  */
 function getElmScrollRecursive(root) {
+	// Need to also get .childNodes since SVGs in IE don't have .children.
 	return Array.from(root.children || root.childNodes || []).reduce(
 		(scrolls, elm) => {
 			const scroll = axe.utils.getScroll(elm);


### PR DESCRIPTION
As suggested by @stephenmathieson on #1820,  adding a code comment in scroll-state for why childNodes is needed for SVGs in IE.

Closes issue: #525 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
