### PR TITLE
Avoid false positives when checking for only list items

### DIFF
--- a/lib/checks/lists/only-listitems.js
+++ b/lib/checks/lists/only-listitems.js
@@ -15,33 +15,39 @@ let base = {
 	liItemsWithRole: 0
 };
 
-let out = virtualNode.children.reduce((out, { actualNode }) => {
-	const tagName = actualNode.nodeName.toUpperCase();
+let out = virtualNode.children
+	.filter(node => node.nodeType !== Node.COMMENT_NODE)
+	.reduce((out, { actualNode }) => {
+		const tagName = actualNode.nodeName.toUpperCase();
 
-	if (actualNode.nodeType === 1 && dom.isVisible(actualNode, true, false)) {
-		const role = (actualNode.getAttribute('role') || '').toLowerCase();
-		const isListItemRole = getIsListItemRole(role, tagName);
+		if (actualNode.nodeType === 1 && dom.isVisible(actualNode, true, false)) {
+			const role = (actualNode.getAttribute('role') || '').toLowerCase();
+			const isListItemRole = getIsListItemRole(role, tagName);
 
-		out.hasListItem = getHasListItem(out.hasListItem, tagName, isListItemRole);
+			out.hasListItem = getHasListItem(
+				out.hasListItem,
+				tagName,
+				isListItemRole
+			);
 
-		if (isListItemRole) {
-			out.isEmpty = false;
+			if (isListItemRole) {
+				out.isEmpty = false;
+			}
+			if (tagName === 'LI' && !isListItemRole) {
+				out.liItemsWithRole++;
+			}
+			if (tagName !== 'LI' && !isListItemRole) {
+				out.badNodes.push(actualNode);
+			}
 		}
-		if (tagName === 'LI' && !isListItemRole) {
-			out.liItemsWithRole++;
+		if (actualNode.nodeType === 3) {
+			if (actualNode.nodeValue.trim() !== '') {
+				out.hasNonEmptyTextNode = true;
+			}
 		}
-		if (tagName !== 'LI' && !isListItemRole) {
-			out.badNodes.push(actualNode);
-		}
-	}
-	if (actualNode.nodeType === 3) {
-		if (actualNode.nodeValue.trim() !== '') {
-			out.hasNonEmptyTextNode = true;
-		}
-	}
 
-	return out;
-}, base);
+		return out;
+	}, base);
 
 const virtualNodeChildrenOfTypeLi = virtualNode.children.filter(
 	({ actualNode }) => {

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -37,6 +37,36 @@ describe('only-listitems', function() {
 		);
 	});
 
+	it('should return false if the list has a comment after list items', function() {
+		var checkArgs = checkSetup(
+			'<ol id="target"><li>Item</li><!-- here is a comment --></ol>'
+		);
+
+		assert.isFalse(
+			checks['only-listitems'].evaluate.apply(checkContext, checkArgs)
+		);
+	});
+
+	it('should return false if the list has a comment before list items', function() {
+		var checkArgs = checkSetup(
+			'<ol id="target"><!-- here is a comment --><li>Item</li></ol>'
+		);
+
+		assert.isFalse(
+			checks['only-listitems'].evaluate.apply(checkContext, checkArgs)
+		);
+	});
+
+	it('should return false if the list has a comment between list items', function() {
+		var checkArgs = checkSetup(
+			'<ol id="target"><li>Item</li><!-- here is a comment --><li>Another Item</li></ol>'
+		);
+
+		assert.isFalse(
+			checks['only-listitems'].evaluate.apply(checkContext, checkArgs)
+		);
+	});
+
 	it('should return false if the list has only an element with role listitem', function() {
 		var checkArgs = checkSetup(
 			'<ol id="target"><div role="listitem">A list</div></ol>'


### PR DESCRIPTION
The list rule limiting direct children of `<ol>` and  `<ul>` was picking up comment nodes as false positives. This commit updates the `only-listitems.js` behavior to only consider non-comment nodes. Also add tests.

For example, this generates a violation (as of version `axe-core: 3.3.1`)
```html
<ul>
  <li>My item</li>
  <!-- my comment -->
</ul>
```

This PR fixes that behavior.

Closes issue: n/a

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
