### PR TITLE
perf: Improve performance of various functions

### DIFF
--- a/lib/commons/aria/is-accessible-ref.js
+++ b/lib/commons/aria/is-accessible-ref.js
@@ -11,11 +11,12 @@ function cacheIdRefs(node, refAttrs) {
 
 		for (let i = 0; i < refAttrs.length; ++i) {
 			const attr = refAttrs[i];
-			const attrValue = node.hasAttribute(attr) && node.getAttribute(attr);
 
-			if (attrValue === false) {
+			if (!node.hasAttribute(attr)) {
 				continue;
 			}
+
+			const attrValue = node.getAttribute(attr);
 
 			const tokens = axe.utils.tokenList(attrValue);
 

--- a/lib/commons/aria/is-accessible-ref.js
+++ b/lib/commons/aria/is-accessible-ref.js
@@ -3,18 +3,26 @@ const idRefsRegex = /^idrefs?$/;
 
 function cacheIdRefs(node, refAttrs) {
 	if (node.hasAttribute) {
+		const idRefs = axe._cache.get('idRefs');
+
 		if (node.nodeName.toUpperCase() === 'LABEL' && node.hasAttribute('for')) {
-			axe._cache.get('idRefs')[node.getAttribute('for')] = true;
+			idRefs[node.getAttribute('for')] = true;
 		}
 
-		refAttrs
-			.filter(attr => node.hasAttribute(attr))
-			.forEach(attr => {
-				const attrValue = node.getAttribute(attr);
-				axe.utils.tokenList(attrValue).forEach(id => {
-					axe._cache.get('idRefs')[id] = true;
-				});
-			});
+		for (let i = 0; i < refAttrs.length; ++i) {
+			const attr = refAttrs[i];
+			const attrValue = node.hasAttribute(attr) && node.getAttribute(attr);
+
+			if (attrValue === false) {
+				continue;
+			}
+
+			const tokens = axe.utils.tokenList(attrValue);
+
+			for (let k = 0; k < tokens.length; ++k) {
+				idRefs[tokens[k]] = true;
+			}
+		}
 	}
 
 	for (let i = 0; i < node.children.length; i++) {

--- a/lib/commons/dom/is-focusable.js
+++ b/lib/commons/dom/is-focusable.js
@@ -8,7 +8,7 @@
 function focusDisabled(el) {
 	return (
 		el.disabled ||
-		(dom.isHiddenWithCSS(el) && el.nodeName.toUpperCase() !== 'AREA')
+		(el.nodeName.toUpperCase() !== 'AREA' && dom.isHiddenWithCSS(el))
 	);
 }
 

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -195,17 +195,19 @@ function validateContext(context) {
 function getRootNode({ include, exclude }) {
 	const selectors = Array.from(include).concat(Array.from(exclude));
 	// Find the first Element.ownerDocument or Document
-	const localDocument = selectors.reduce((result, item) => {
-		if (result) {
-			return result;
-		} else if (item instanceof Element) {
-			return item.ownerDocument;
-		} else if (item instanceof Document) {
-			return item;
-		}
-	}, null);
+	for (var i = 0; i < selectors.length; ++i) {
+		var item = selectors[i];
 
-	return (localDocument || document).documentElement;
+		if (item instanceof Element) {
+			return item.ownerDocument.documentElement;
+		}
+
+		if (item instanceof Document) {
+			return item.documentElement;
+		}
+	}
+
+	return document.documentElement;
 }
 
 /**

--- a/lib/core/utils/are-styles-set.js
+++ b/lib/core/utils/are-styles-set.js
@@ -3,19 +3,16 @@
 function areStylesSet(el, styles, stopAt) {
 	'use strict';
 	var styl = window.getComputedStyle(el, null);
-	var set = false;
 	if (!styl) {
 		return false;
 	}
-	styles.forEach(function(att) {
+	for (var i = 0; i < styles.length; ++i) {
+		var att = styles[i];
 		if (styl.getPropertyValue(att.property) === att.value) {
-			set = true;
+			return true;
 		}
-	});
-	if (set) {
-		return true;
 	}
-	if (el.nodeName.toUpperCase() === stopAt.toUpperCase() || !el.parentNode) {
+	if (!el.parentNode || el.nodeName.toUpperCase() === stopAt.toUpperCase()) {
 		return false;
 	}
 	return areStylesSet(el.parentNode, styles, stopAt);

--- a/lib/core/utils/get-scroll.js
+++ b/lib/core/utils/get-scroll.js
@@ -19,29 +19,17 @@ axe.utils.getScroll = function getScroll(elm, buffer = 0) {
 	}
 
 	const style = window.getComputedStyle(elm);
-
-	// Checking Y before X since we assume that
-	// most scrolling is across the Y axis.
-	const overflowYStyle = style.getPropertyValue('overflow-y');
-	const scrollableY =
-		overflowYStyle !== 'visible' && overflowYStyle !== 'hidden';
-
-	if (overflowY && scrollableY) {
-		return {
-			elm,
-			top: elm.scrollTop,
-			left: elm.scrollLeft
-		};
-	}
-
 	const overflowXStyle = style.getPropertyValue('overflow-x');
+	const overflowYStyle = style.getPropertyValue('overflow-y');
 	const scrollableX =
 		overflowXStyle !== 'visible' && overflowXStyle !== 'hidden';
+	const scrollableY =
+		overflowYStyle !== 'visible' && overflowYStyle !== 'hidden';
 
 	/**
 	 * check direction of `overflow` and `scrollable`
 	 */
-	if (overflowX && scrollableX) {
+	if ((overflowX && scrollableX) || (overflowY && scrollableY)) {
 		return {
 			elm,
 			top: elm.scrollTop,

--- a/lib/core/utils/get-scroll.js
+++ b/lib/core/utils/get-scroll.js
@@ -19,17 +19,29 @@ axe.utils.getScroll = function getScroll(elm, buffer = 0) {
 	}
 
 	const style = window.getComputedStyle(elm);
-	const overflowXStyle = style.getPropertyValue('overflow-x');
+
+	// Checking Y before X since we assume that
+	// most scrolling is across the Y axis.
 	const overflowYStyle = style.getPropertyValue('overflow-y');
-	const scrollableX =
-		overflowXStyle !== 'visible' && overflowXStyle !== 'hidden';
 	const scrollableY =
 		overflowYStyle !== 'visible' && overflowYStyle !== 'hidden';
+
+	if (overflowY && scrollableY) {
+		return {
+			elm,
+			top: elm.scrollTop,
+			left: elm.scrollLeft
+		};
+	}
+
+	const overflowXStyle = style.getPropertyValue('overflow-x');
+	const scrollableX =
+		overflowXStyle !== 'visible' && overflowXStyle !== 'hidden';
 
 	/**
 	 * check direction of `overflow` and `scrollable`
 	 */
-	if ((overflowX && scrollableX) || (overflowY && scrollableY)) {
+	if (overflowX && scrollableX) {
 		return {
 			elm,
 			top: elm.scrollTop,

--- a/lib/core/utils/is-html-element.js
+++ b/lib/core/utils/is-html-element.js
@@ -127,9 +127,9 @@ const htmlTags = [
  * @return {Boolean} true/ false
  */
 axe.utils.isHtmlElement = function isHtmlElement(node) {
-	const tagName = node.nodeName.toLowerCase();
-	return (
-		htmlTags.includes(tagName) &&
-		node.namespaceURI !== 'http://www.w3.org/2000/svg'
-	);
+	if (node.namespaceURI === 'http://www.w3.org/2000/svg') {
+		return false;
+	}
+
+	return htmlTags.includes(node.nodeName.toLowerCase());
 };

--- a/lib/core/utils/is-shadow-root.js
+++ b/lib/core/utils/is-shadow-root.js
@@ -27,11 +27,11 @@ const possibleShadowRoots = [
  * @return {Boolean}
  */
 axe.utils.isShadowRoot = function isShadowRoot(node) {
-	const nodeName = node.nodeName.toLowerCase();
 	if (node.shadowRoot) {
+		const nodeName = node.nodeName.toLowerCase();
 		if (
-			/^[a-z][a-z0-9_.-]*-[a-z0-9_.-]*$/.test(nodeName) ||
-			possibleShadowRoots.includes(nodeName)
+			possibleShadowRoots.includes(nodeName) ||
+			/^[a-z][a-z0-9_.-]*-[a-z0-9_.-]*$/.test(nodeName)
 		) {
 			return true;
 		}

--- a/lib/core/utils/qsa.js
+++ b/lib/core/utils/qsa.js
@@ -18,10 +18,10 @@ function matchesClasses(vNode, exp) {
 function matchesAttributes(vNode, exp) {
 	return (
 		!exp.attributes ||
-		exp.attributes.reduce((result, att) => {
+		exp.attributes.every(att => {
 			var nodeAtt = vNode.attr(att.key);
-			return result && nodeAtt !== null && (!att.value || att.test(nodeAtt));
-		}, true)
+			return nodeAtt !== null && (!att.value || att.test(nodeAtt));
+		})
 	);
 }
 
@@ -32,17 +32,14 @@ function matchesId(vNode, exp) {
 function matchesPseudos(target, exp) {
 	if (
 		!exp.pseudos ||
-		exp.pseudos.reduce((result, pseudo) => {
+		exp.pseudos.every(pseudo => {
 			if (pseudo.name === 'not') {
-				return (
-					result &&
-					!matchExpressions([target], pseudo.expressions, false).length
-				);
+				return !matchExpressions([target], pseudo.expressions, false).length;
 			}
 			throw new Error(
 				'the pseudo selector ' + pseudo.name + ' has not yet been implemented'
 			);
-		}, true)
+		})
 	) {
 		return true;
 	}
@@ -231,8 +228,8 @@ matchExpressions = function(domTree, expressions, recurse, filter) {
 		for (let i = 0; i < combined.length; i++) {
 			let exp = combined[i];
 			if (
-				matchesSelector(vNode, exp) &&
-				(!exp[0].id || vNode.shadowId === currentLevel.parentShadowId)
+				(!exp[0].id || vNode.shadowId === currentLevel.parentShadowId) &&
+				matchesSelector(vNode, exp)
 			) {
 				if (exp.length === 1) {
 					if (!added && (!filter || filter(vNode))) {
@@ -257,8 +254,8 @@ matchExpressions = function(domTree, expressions, recurse, filter) {
 				}
 			}
 			if (
-				currentLevel.anyLevel.includes(exp) &&
-				(!exp[0].id || vNode.shadowId === currentLevel.parentShadowId)
+				(!exp[0].id || vNode.shadowId === currentLevel.parentShadowId) &&
+				currentLevel.anyLevel.includes(exp)
 			) {
 				childAny.push(exp);
 			}

--- a/lib/rules/duplicate-id-active-matches.js
+++ b/lib/rules/duplicate-id-active-matches.js
@@ -5,4 +5,4 @@ const idMatchingElms = Array.from(
 	dom.getRootNode(node).querySelectorAll(idSelector)
 );
 
-return idMatchingElms.some(dom.isFocusable) && !aria.isAccessibleRef(node);
+return !aria.isAccessibleRef(node) && idMatchingElms.some(dom.isFocusable);

--- a/lib/rules/duplicate-id-misc-matches.js
+++ b/lib/rules/duplicate-id-misc-matches.js
@@ -6,6 +6,6 @@ const idMatchingElms = Array.from(
 );
 
 return (
-	idMatchingElms.every(elm => !dom.isFocusable(elm)) &&
-	!aria.isAccessibleRef(node)
+	!aria.isAccessibleRef(node) &&
+	idMatchingElms.every(elm => !dom.isFocusable(elm))
 );


### PR DESCRIPTION
Optimize various functions. Most of the optimizations fall in one of the following categories:
 - Switch the order of conditions in `if` statements to order to execute the cheapest operation first
 - Short-circuit searches in arrays
 - Avoid allocating intermediary arrays

`axe https://www.theguardian.com/international` shows an improvement of ~200ms.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
