### PR TITLE
fix(get-background-color): scroll element into view horizontally

### DIFF
--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -25,6 +25,18 @@ color.getBackgroundColor = function getBackgroundColor(
 		const clientHeight = elm.getBoundingClientRect().height;
 		const alignToTop = clientHeight - 2 >= window.innerHeight * 2;
 		elm.scrollIntoView(alignToTop);
+
+		// ensure element is scrolled into view horizontally
+		let center;
+		do {
+			const rect = elm.getBoundingClientRect();
+			const x = 'x' in rect ? rect.x : rect.left;
+			center = x + rect.width / 2;
+
+			if (center < 0) {
+				getScrollParent(elm).scrollLeft = 0;
+			}
+		} while (center < 0);
 	}
 
 	let bgColors = [];
@@ -376,6 +388,36 @@ function contentOverlapping(targetElement, bgNode) {
 		}
 	}
 	return false;
+}
+
+/**
+ * Return the scrolling parent element
+ * @see https://stackoverflow.com/questions/35939886/find-first-scrollable-parent#42543908
+ * @param {Element} element
+ * @param {Boolean} includeHidden
+ * @return {Element}
+ */
+function getScrollParent(element, includeHidden) {
+	var style = getComputedStyle(element);
+	var excludeStaticParent = style.position === 'absolute';
+	var overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/;
+
+	if (style.position === 'fixed') {
+		return document.documentElement;
+	}
+	for (var parent = element; (parent = parent.parentElement); ) {
+		style = getComputedStyle(parent);
+		if (excludeStaticParent && style.position === 'static') {
+			continue;
+		}
+		if (
+			overflowRegex.test(style.overflow + style.overflowY + style.overflowX)
+		) {
+			return parent;
+		}
+	}
+
+	return document.documentElement;
 }
 
 /**

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -30,6 +30,8 @@ color.getBackgroundColor = function getBackgroundColor(
 		let center, scrollParent;
 		do {
 			const rect = elm.getBoundingClientRect();
+
+			// 'x' does not exist in IE11
 			const x = 'x' in rect ? rect.x : rect.left;
 			center = x + rect.width / 2;
 

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -27,16 +27,17 @@ color.getBackgroundColor = function getBackgroundColor(
 		elm.scrollIntoView(alignToTop);
 
 		// ensure element is scrolled into view horizontally
-		let center;
+		let center, scrollParent;
 		do {
 			const rect = elm.getBoundingClientRect();
 			const x = 'x' in rect ? rect.x : rect.left;
 			center = x + rect.width / 2;
 
 			if (center < 0) {
-				getScrollParent(elm).scrollLeft = 0;
+				scrollParent = getScrollParent(elm);
+				scrollParent.scrollLeft = 0;
 			}
-		} while (center < 0);
+		} while (center < 0 && scrollParent !== document.documentElement);
 	}
 
 	let bgColors = [];

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -646,6 +646,19 @@ describe('color.getBackgroundColor', function() {
 		assert.notEqual(window.pageYOffset, 0);
 	});
 
+	it('scrolls horizontally into view when scroll is enabled', function() {
+		fixture.innerHTML =
+			'<div style="width: 1000px;"><span id="target">long text to test scrolling</span></div>';
+		var targetEl = fixture.querySelector('#target');
+		var bgNodes = [];
+		window.scroll(100, 0);
+
+		axe.testUtils.flatTreeSetup(fixture.firstChild);
+		axe.commons.color.getBackgroundColor(targetEl, bgNodes, false);
+
+		assert.equal(document.documentElement.scrollLeft, 0);
+	});
+
 	it('returns elements with negative z-index', function() {
 		fixture.innerHTML =
 			'<div id="sibling" ' +


### PR DESCRIPTION
In IE11 `scrollIntoView` does not accept an options parameter, so will treat any truthy value as passing the boolean `true`. This changes the behavior of the code that's currently there. 

So instead we'll just see if the center point of the element is within the viewport and if not, look for a scrollable parent element and scroll it. Should fix the issue without causing any problems in IE11.

Closes issue: #1730

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
