### PR TITLE
Treat alt="" as 1.1.1 violation

### DIFF
--- a/lib/checks/shared/has-alt.js
+++ b/lib/checks/shared/has-alt.js
@@ -1,4 +1,4 @@
 var nn = node.nodeName.toLowerCase();
 return (
-	node.hasAttribute('alt') && (nn === 'img' || nn === 'input' || nn === 'area')
+	node.hasAttribute('alt') && node.getAttribute('alt') != "" && (nn === 'img' || nn === 'input' || nn === 'area')
 );

--- a/lib/checks/shared/has-alt.js
+++ b/lib/checks/shared/has-alt.js
@@ -1,4 +1,4 @@
 var nn = node.nodeName.toLowerCase();
 return (
-	node.hasAttribute('alt') && node.getAttribute('alt') != "" && (nn === 'img' || nn === 'input' || nn === 'area')
+	node.hasAttribute('alt') && node.getAttribute('alt') !== "" && (nn === 'img' || nn === 'input' || nn === 'area')
 );


### PR DESCRIPTION
Currently axe.core treats images with empty alt tag as having valid alt tag.
We should have images with empty alt tag trigger 1.1.1 accessibility error as it did not describe what the image looks like to accessible users.
This fix will trigger all <img alt="" src="..." /> as having 1.1.1 violations.


Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
