### PR TITLE
Revert "fix(locales): fix incompeteMessageFallback to be a string rather than an object (#1853)

### DIFF
--- a/build/tasks/add-locale.js
+++ b/build/tasks/add-locale.js
@@ -62,10 +62,9 @@ module.exports = function(grunt) {
 							return out;
 						}, {}),
 						incompleteFallbackMessage: result.misc.reduce(function(out, misc) {
-							return misc.incompleteFallbackMessage
-								? misc.incompleteFallbackMessage
-								: out;
-						}, '')
+							out[misc.incompleteFallbackMessage] = misc.metadata;
+							return out;
+						}, {})
 					};
 
 					// update locale file if exists

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -291,7 +291,7 @@ Audit.prototype.applyLocale = function(locale) {
 	if (locale.incompleteFallbackMessage) {
 		this.data.incompleteFallbackMessage = mergeFallbackMessage(
 			this.data.incompleteFallbackMessage,
-			locale.incompleteFallbackMessage
+			locale.incompleteFallbackMessage.undefined.failureMessage
 		);
 	}
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -619,5 +619,9 @@
 			"failureMessage": "Korrigiere alle der folgenden Punkte:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": ""
+	"incompleteFallbackMessage": {
+		"undefined": {
+			"failureMessage": ""
+		}
+	}
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -769,5 +769,9 @@
 			"failureMessage": "Corregir (todas) las siguientes incidencias:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "Corregir (todas) las siguientes incidencias:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+	"incompleteFallbackMessage": {
+		"undefined": {
+			"failureMessage": "Corregir (todas) las siguientes incidencias:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+		}
+	}
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -659,5 +659,9 @@
 			"failureMessage": "Corriger tous les éléments suivants : {{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "Corriger tous les éléments suivants : {{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+	"incompleteFallbackMessage": {
+		"undefined": {
+			"failureMessage": "Corriger tous les éléments suivants : {{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+		}
+	}
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -778,5 +778,9 @@
 			"failureMessage": "次のすべてを修正します:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "次のすべてを修正します:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+	"incompleteFallbackMessage": {
+		"undefined": {
+			"failureMessage": "次のすべてを修正します:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+		}
+	}
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -32,5 +32,9 @@
 			"failureMessage": "Gebruik een van de volgende oplossingen:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "axe kon de reden niet vertellen. Tijd om de element inspecteur uit te breken!"
+	"incompleteFallbackMessage": {
+		"undefined": {
+			"failureMessage": "axe kon de reden niet vertellen. Tijd om de element inspecteur uit te breken!"
+		}
+	}
 }

--- a/locales/pt_BR.json
+++ b/locales/pt_BR.json
@@ -769,5 +769,9 @@
 			"failureMessage": "Corrija todos os itens a seguir:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "Corrija todos os itens a seguir:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+	"incompleteFallbackMessage": {
+		"undefined": {
+			"failureMessage": "Corrija todos os itens a seguir:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+		}
+	}
 }

--- a/test/core/public/configure.js
+++ b/test/core/public/configure.js
@@ -393,7 +393,11 @@ describe('axe.configure', function() {
 							failureMessage: 'bar'
 						}
 					},
-					incompleteFallbackMessage: 'baz'
+					incompleteFallbackMessage: {
+						undefined: {
+							failureMessage: 'baz'
+						}
+					}
 				}
 			});
 


### PR DESCRIPTION
I totally forgot about the code freeze :(. Probably could use something in place to prevent this from happening in the future.

This reverts commit 88677a93d0ffe32d7305984314a37e623fb51153.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
