### PR TITLE
docs: Remove broken Greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # axe-core
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/dequelabs/axe-core.svg)](https://greenkeeper.io/) [![CircleCI](https://circleci.com/gh/dequelabs/axe-core.svg?style=svg)](https://circleci.com/gh/dequelabs/axe-core)
+[![CircleCI](https://circleci.com/gh/dequelabs/axe-core.svg?style=svg)](https://circleci.com/gh/dequelabs/axe-core)
 
 [![License](https://img.shields.io/npm/l/axe-core.svg)](LICENSE)
 [![Version](https://img.shields.io/npm/v/axe-core.svg)](https://www.npmjs.com/package/axe-core)


### PR DESCRIPTION
Greenkeeper badge is broken, looks bad on NPM and Github.