### PR TITLE
chore(is-ligature-icon): rename canvas to canvasContext

### DIFF
--- a/lib/commons/text/is-icon-ligature.js
+++ b/lib/commons/text/is-icon-ligature.js
@@ -82,14 +82,14 @@ text.isIconLigature = function(
 		return false;
 	}
 
-	if (!axe._cache.get('context')) {
+	if (!axe._cache.get('canvasContext')) {
 		axe._cache.set(
-			'context',
+			'canvasContext',
 			document.createElement('canvas').getContext('2d')
 		);
 	}
-	const context = axe._cache.get('context');
-	const canvas = context.canvas;
+	const canvasContext = axe._cache.get('canvasContext');
+	const canvas = canvasContext.canvas;
 
 	// keep track of each font encountered and the number of times it shows up
 	// as a ligature.
@@ -138,9 +138,9 @@ text.isIconLigature = function(
 	let fontStyle = `${fontSize}px ${fontFamily}`;
 
 	// set the size of the canvas to the width of the first letter
-	context.font = fontStyle;
+	canvasContext.font = fontStyle;
 	const firstChar = nodeValue.charAt(0);
-	let width = context.measureText(firstChar).width;
+	let width = canvasContext.measureText(firstChar).width;
 
 	// ensure font meets the 30px width requirement (30px font-size doesn't
 	// necessarily mean its 30px wide when drawn)
@@ -155,12 +155,12 @@ text.isIconLigature = function(
 
 	// changing the dimensions of a canvas resets all properties (include font)
 	// and clears it
-	context.font = fontStyle;
-	context.textAlign = 'left';
-	context.textBaseline = 'top';
-	context.fillText(firstChar, 0, 0);
+	canvasContext.font = fontStyle;
+	canvasContext.textAlign = 'left';
+	canvasContext.textBaseline = 'top';
+	canvasContext.fillText(firstChar, 0, 0);
 	const compareData = new Uint32Array(
-		context.getImageData(0, 0, width, fontSize).data.buffer
+		canvasContext.getImageData(0, 0, width, fontSize).data.buffer
 	);
 
 	// if the font doesn't even have character data for a single char then
@@ -170,10 +170,10 @@ text.isIconLigature = function(
 		return true;
 	}
 
-	context.clearRect(0, 0, width, fontSize);
-	context.fillText(nodeValue, 0, 0);
+	canvasContext.clearRect(0, 0, width, fontSize);
+	canvasContext.fillText(nodeValue, 0, 0);
 	const compareWith = new Uint32Array(
-		context.getImageData(0, 0, width, fontSize).data.buffer
+		canvasContext.getImageData(0, 0, width, fontSize).data.buffer
 	);
 
 	// calculate the number of differences between the first letter and the
@@ -191,9 +191,9 @@ text.isIconLigature = function(
 	// calculate the difference between the width of each character and the
 	// combined with of all characters
 	const expectedWidth = nodeValue.split('').reduce((width, char) => {
-		return width + context.measureText(char).width;
+		return width + canvasContext.measureText(char).width;
 	}, 0);
-	const actualWidth = context.measureText(nodeValue).width;
+	const actualWidth = canvasContext.measureText(nodeValue).width;
 
 	const pixelDifference = differences / compareData.length;
 	const sizeDifference = 1 - actualWidth / expectedWidth;


### PR DESCRIPTION
Tech debt to rename a variable to not collide with the context used in rules.

Closes issue: #1847

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
