### PR TITLE
fix(doT.js): prevent errors in older versions of Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"@babel/plugin-proposal-object-rest-spread": "^7.5.4",
 		"@babel/polyfill": "^7.4.4",
 		"@babel/preset-env": "^7.5.4",
-		"@deque/dot": "^1.1.4",
+		"@deque/dot": "^1.1.5",
 		"aria-query": "^3.0.0",
 		"axios": "^0.19.0",
 		"babelify": "^10.0.0",


### PR DESCRIPTION
Fixes errors in older Safari from `__magic__` global code.

Closes issue: #1764

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
