### PR TITLE
fix(axe.d.ts): RunOnly.values should not accept a RunOnlyOption

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -13,14 +13,14 @@ declare namespace axe {
 
 	type resultGroups = 'inapplicable' | 'passes' | 'incomplete' | 'violations';
 
-	type RunOnlyObject = {
+	type ContextObject = {
 		include?: string[] | string[][];
 		exclude?: string[] | string[][];
 	};
 
 	type RunCallback = (error: Error, results: AxeResults) => void;
 
-	type ElementContext = Node | string | RunOnlyObject;
+	type ElementContext = Node | string | ContextObject;
 
 	interface TestEngine {
 		name: string;
@@ -38,7 +38,7 @@ declare namespace axe {
 	}
 	interface RunOnly {
 		type: RunOnlyType;
-		values?: TagValue[] | string[] | RunOnlyObject;
+		values: TagValue[] | string[];
 	}
 	interface RunOptions {
 		runOnly?: RunOnly;

--- a/doc/API.md
+++ b/doc/API.md
@@ -102,8 +102,8 @@ The current set of tags supported are listed in the following table:
 
 | Tag Name        |       Accessibility Standard/Purpose        |
 | --------------- | :-----------------------------------------: |
-| `wcag2a`        |              WCAG 2.0 & WCAG 2.1 Level A    |
-| `wcag2aa`       |              WCAG 2.0 & WCAG 2.1 Level AA   |
+| `wcag2a`        |         WCAG 2.0 & WCAG 2.1 Level A         |
+| `wcag2aa`       |        WCAG 2.0 & WCAG 2.1 Level AA         |
 | `wcag21a`       |              WCAG 2.1 Level A               |
 | `wcag21aa`      |              WCAG 2.1 Level AA              |
 | `section508`    |                 Section 508                 |
@@ -397,7 +397,7 @@ Additionally, there are a number or properties that allow configuration of diffe
 | `elementRef`       | `false` | Return element references in addition to the target                                                                                     |
 | `restoreScroll`    | `false` | Scrolls elements back to before axe started                                                                                             |
 | `frameWaitTime`    | `60000` | How long (in milliseconds) axe waits for a response from embedded frames before timing out                                              |
-| `preload`          | `true` | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
+| `preload`          | `true`  | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
 | `performanceTimer` | `false` | Log rule performance metrics to the console                                                                                             |
 
 ###### Options Parameter Examples
@@ -518,29 +518,6 @@ axe.run(
 ```
 
 This example includes all level A rules except for valid-lang, and in addition will include the level AA color-contrast rule.
-
-5. Run only some tags, but exclude others
-
-Similar to scope, the runOnly option can accept an object with an 'include' and 'exclude' property. Only those checks that match an included tag will run, except those that share a tag from the exclude list.
-
-```js
-axe.run(
-	{
-		runOnly: {
-			type: 'tags',
-			values: {
-				include: ['wcag2a', 'wcag2aa'],
-				exclude: ['experimental']
-			}
-		}
-	},
-	(err, results) => {
-		// ...
-	}
-);
-```
-
-This example first includes all `wcag2a` and `wcag2aa` rules. All rules that are tagged as `experimental` are than removed from the list of rules to run.
 
 6. Only process certain types of results
 

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -62,21 +62,6 @@ axe.run(
 	{
 		runOnly: {
 			type: 'tags',
-			values: {
-				include: ['wcag2a', 'wcag2aa'],
-				exclude: ['experimental']
-			}
-		}
-	},
-	(error: Error, results: axe.AxeResults) => {
-		console.log(error || results);
-	}
-);
-axe.run(
-	context,
-	{
-		runOnly: {
-			type: 'tags',
 			values: ['wcag2a', 'wcag2aa']
 		} as axe.RunOnly
 	},


### PR DESCRIPTION
As per [Wilco's comment](https://github.com/dequelabs/axe-core/issues/894#issuecomment-425159052), `RunOnly` interface should not accept a `RunOnlyObject` for the `values` property. It only can accept a [non-empty array](https://github.com/dequelabs/axe-core/blob/develop/lib/core/base/audit.js#L646-L648).

Closes issue: #894 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
