### PR TITLE
fix(tabindex): don't error when tabindex property is overridden

### DIFF
--- a/lib/checks/keyboard/tabindex.js
+++ b/lib/checks/keyboard/tabindex.js
@@ -1,4 +1,4 @@
-const tabIndex = parseInt(node.getAttribute('tabindex'));
+const tabIndex = parseInt(node.getAttribute('tabindex'), 10);
 
 // an invalid tabindex will either return 0 or -1 (based on the element) so
 // will never be above 0

--- a/lib/checks/keyboard/tabindex.js
+++ b/lib/checks/keyboard/tabindex.js
@@ -1,1 +1,6 @@
-return node.getAttribute('tabindex') <= 0;
+const tabIndex = parseInt(node.getAttribute('tabindex'));
+
+// an invalid tabindex will either return 0 or -1 (based on the element) so
+// will never be above 0
+// @see https://www.w3.org/TR/html51/editing.html#the-tabindex-attribute
+return isNaN(tabIndex) ? true : tabIndex <= 0;

--- a/lib/checks/keyboard/tabindex.js
+++ b/lib/checks/keyboard/tabindex.js
@@ -1,1 +1,1 @@
-return node.tabIndex <= 0;
+return node.getAttribute('tabindex') <= 0;

--- a/test/checks/keyboard/tabindex.js
+++ b/test/checks/keyboard/tabindex.js
@@ -31,4 +31,12 @@ describe('tabindex', function() {
 
 		assert.isFalse(checks.tabindex.evaluate(node));
 	});
+
+	it('should pass if tabindex is NaN', function() {
+		var node = document.createElement('div');
+		node.setAttribute('tabindex', 'foobar');
+		fixture.appendChild(node);
+
+		assert.isTrue(checks.tabindex.evaluate(node));
+	});
 });

--- a/test/checks/keyboard/tabindex.js
+++ b/test/checks/keyboard/tabindex.js
@@ -22,4 +22,13 @@ describe('tabindex', function() {
 
 		assert.isTrue(checks.tabindex.evaluate(node));
 	});
+
+	it('should look at the attribute and not the property', function() {
+		var node = document.createElement('div');
+		node.setAttribute('tabindex', '1');
+		node.tabindex = null;
+		fixture.appendChild(node);
+
+		assert.isFalse(checks.tabindex.evaluate(node));
+	});
 });


### PR DESCRIPTION
Closes issue: #1834

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
