### PR TITLE
fix(is-focusable): use tabindex attribute instead of property

### DIFF
--- a/lib/commons/dom/is-focusable.js
+++ b/lib/commons/dom/is-focusable.js
@@ -83,7 +83,11 @@ dom.isNativelyFocusable = function(el) {
  * if its tabindex were removed. Else, false.
  */
 dom.insertedIntoFocusOrder = function(el) {
-	return (
-		el.tabIndex > -1 && dom.isFocusable(el) && !dom.isNativelyFocusable(el)
-	);
+	let tabIndex = parseInt(el.getAttribute('tabIndex'), 10);
+
+	// an element that has an invalid tabindex will return 0 or -1 based on
+	// if it is natively focusable or not, which will always be false for this
+	// check as NaN is not > 1
+	// @see https://www.w3.org/TR/html51/editing.html#the-tabindex-attribute
+	return tabIndex > -1 && dom.isFocusable(el) && !dom.isNativelyFocusable(el);
 };

--- a/lib/commons/dom/is-focusable.js
+++ b/lib/commons/dom/is-focusable.js
@@ -83,7 +83,7 @@ dom.isNativelyFocusable = function(el) {
  * if its tabindex were removed. Else, false.
  */
 dom.insertedIntoFocusOrder = function(el) {
-	let tabIndex = parseInt(el.getAttribute('tabIndex'), 10);
+	let tabIndex = parseInt(el.getAttribute('tabindex'), 10);
 
 	// an element that has an invalid tabindex will return 0 or -1 based on
 	// if it is natively focusable or not, which will always be false for this

--- a/test/commons/dom/is-focusable.js
+++ b/test/commons/dom/is-focusable.js
@@ -563,5 +563,12 @@ describe('is-focusable', function() {
 
 			assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
 		});
+
+		it('should return false for an invalid tabindex', function() {
+			fixtureSetup('<span id="spanTabindexInvalid" tabindex="invalid"></span>');
+			var node = fixture.querySelector('#spanTabindexInvalid');
+
+			assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
+		});
 	});
 });


### PR DESCRIPTION
## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
