### PR TITLE
fix(run): throw error if axe.run is called after a run has started but not completed

### DIFF
--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -107,7 +107,6 @@ axe.run = function(context, options, callback) {
 		});
 	}
 
-	// axe is already running so don't run again
 	if (axe._running) {
 		const err =
 			'Axe is already running. Use `await axe.run()` to wait ' +

--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -107,11 +107,23 @@ axe.run = function(context, options, callback) {
 		});
 	}
 
+	// axe is already running so don't run again
+	if (axe._running) {
+		const err =
+			'Axe is already running. Use `await axe.run()` to wait ' +
+			'for the previous run to finish before starting a new run.';
+		callback(err);
+		reject(err);
+		return p;
+	}
+
+	axe._running = true;
 	axe._runRules(
 		context,
 		options,
 		function(rawResults, cleanup) {
 			let respond = function(results) {
+				axe._running = false;
 				cleanup();
 				try {
 					callback(null, results);
@@ -131,12 +143,14 @@ axe.run = function(context, options, callback) {
 					respond(results);
 				}
 			} catch (err) {
+				axe._running = false;
 				cleanup();
 				callback(err);
 				reject(err);
 			}
 		},
 		function(err) {
+			axe._running = false;
 			callback(err);
 			reject(err);
 		}

--- a/test/core/public/run.js
+++ b/test/core/public/run.js
@@ -35,6 +35,7 @@ describe('axe.run', function() {
 		fixture.innerHTML = '';
 		axe._audit = null;
 		axe._runRules = origRunRules;
+		axe._running = false;
 	});
 
 	it('takes context, options and callback as parameters', function(done) {
@@ -113,6 +114,14 @@ describe('axe.run', function() {
 		};
 
 		axe.run({ someOption: true }, noop);
+	});
+
+	it('should error if axe is already running', function(done) {
+		axe.run(noop);
+		axe.run(function(err) {
+			assert.isTrue(err.indexOf('Axe is already running') !== -1);
+			done();
+		});
 	});
 
 	describe('callback', function() {


### PR DESCRIPTION
Concurrent runs of axe is not supported and something we've decided not to support. This should prevent `Expect axe._selectorData to be set up` errors from showing up (which happen due to a concurrent run) and give a way more helpful error as to what the problem is and how to solve it.

Closes issue: #1041 
Closes issue: #1867

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
