### PR TITLE
fix(link-name): test role=link when there is no href

### DIFF
--- a/lib/rules/link-name.json
+++ b/lib/rules/link-name.json
@@ -1,7 +1,6 @@
 {
 	"id": "link-name",
-	"selector": "a[href], [role=link][href]",
-	"matches": "role-not-button-matches.js",
+	"selector": "a[href]:not([role=button]), [role=link]",
 	"tags": [
 		"cat.name-role-value",
 		"wcag2a",
@@ -22,5 +21,7 @@
 		"role-presentation",
 		"role-none"
 	],
-	"none": ["focusable-no-name"]
+	"none": [
+		"focusable-no-name"
+	]
 }

--- a/lib/rules/role-not-button-matches.js
+++ b/lib/rules/role-not-button-matches.js
@@ -1,1 +1,0 @@
-return node.getAttribute('role') !== 'button';


### PR DESCRIPTION
The link-name rule shouldn't be limited to things with an href attribute.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
