### PR TITLE
chore(has-alt): use virtualNode instead of node

### DIFF
--- a/lib/checks/shared/has-alt.js
+++ b/lib/checks/shared/has-alt.js
@@ -1,6 +1,6 @@
 const { nodeName } = virtualNode.props;
-if (['img', 'input', 'area'].includes(nodeName) === false) {
+if (!['img', 'input', 'area'].includes(nodeName)) {
 	return false;
 }
 
-return typeof virtualNode.attr('alt') === 'string';
+return virtualNode.hasAttr('alt');

--- a/lib/checks/shared/has-alt.js
+++ b/lib/checks/shared/has-alt.js
@@ -1,4 +1,6 @@
-var nn = node.nodeName.toLowerCase();
-return (
-	node.hasAttribute('alt') && (nn === 'img' || nn === 'input' || nn === 'area')
-);
+const { nodeName } = virtualNode.props;
+if (['img', 'input', 'area'].includes(nodeName) === false) {
+	return false;
+}
+
+return typeof virtualNode.attr('alt') === 'string';

--- a/test/checks/shared/has-alt.js
+++ b/test/checks/shared/has-alt.js
@@ -2,23 +2,24 @@ describe('has-alt', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var checkSetup = axe.testUtils.checkSetup;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 	});
 
 	it('should return true if an alt is present', function() {
-		var node = document.createElement('img');
-		node.setAttribute('alt', 'woohoo');
-		fixture.appendChild(node);
+		var checkArgs = checkSetup('<img id="target" alt="woohoo" />');
+		assert.isTrue(checks['has-alt'].evaluate.apply(null, checkArgs));
+	});
 
-		assert.isTrue(checks['has-alt'].evaluate(node));
+	it('should return true if an empty alt is present', function() {
+		var checkArgs = checkSetup('<img id="target" alt="" />');
+		assert.isTrue(checks['has-alt'].evaluate.apply(null, checkArgs));
 	});
 
 	it('should return false if an alt is not present', function() {
-		var node = document.createElement('img');
-		fixture.appendChild(node);
-
-		assert.isFalse(checks['has-alt'].evaluate(node));
+		var checkArgs = checkSetup('<img id="target" />');
+		assert.isFalse(checks['has-alt'].evaluate.apply(null, checkArgs));
 	});
 });

--- a/test/checks/shared/has-alt.js
+++ b/test/checks/shared/has-alt.js
@@ -18,6 +18,11 @@ describe('has-alt', function() {
 		assert.isTrue(checks['has-alt'].evaluate.apply(null, checkArgs));
 	});
 
+	it('should return true if a null alt is present', function() {
+		var checkArgs = checkSetup('<img id="target" alt />');
+		assert.isTrue(checks['has-alt'].evaluate.apply(null, checkArgs));
+	});
+
 	it('should return false if an alt is not present', function() {
 		var checkArgs = checkSetup('<img id="target" />');
 		assert.isFalse(checks['has-alt'].evaluate.apply(null, checkArgs));


### PR DESCRIPTION
Stop using DOM node in has-alt check.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
