### PR TITLE
chore(alt-space-value): use virtualNode instead of node

### DIFF
--- a/lib/checks/label/alt-space-value.js
+++ b/lib/checks/label/alt-space-value.js
@@ -1,2 +1,3 @@
-const validAttrValue = /^\s+$/.test(node.getAttribute('alt'));
-return node.hasAttribute('alt') && validAttrValue;
+const alt = virtualNode.attr('alt');
+const isOnlySpace = /^\s+$/;
+return typeof alt === 'string' && isOnlySpace.test(alt);


### PR DESCRIPTION
Stop using DOM node in alt-space-value check.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
