### PR TITLE
chore(non-empty-alt): use virtualNode instead of node

### DIFF
--- a/lib/checks/shared/non-empty-alt.js
+++ b/lib/checks/shared/non-empty-alt.js
@@ -1,2 +1,2 @@
-var label = node.getAttribute('alt');
+const label = virtualNode.attr('alt');
 return !!(label ? axe.commons.text.sanitize(label).trim() : '');

--- a/test/checks/shared/non-empty-alt.js
+++ b/test/checks/shared/non-empty-alt.js
@@ -2,39 +2,29 @@ describe('non-empty-alt', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var checkSetup = axe.testUtils.checkSetup;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 	});
 
 	it('should return true if an alt is present', function() {
-		var node = document.createElement('img');
-		node.setAttribute('alt', 'woohoo');
-		fixture.appendChild(node);
-
-		assert.isTrue(checks['non-empty-alt'].evaluate(node));
+		var params = checkSetup('<img id="target" alt="woohoo" />');
+		assert.isTrue(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 
 	it('should return false if an alt is not present', function() {
-		var node = document.createElement('img');
-		fixture.appendChild(node);
-
-		assert.isFalse(checks['non-empty-alt'].evaluate(node));
+		var params = checkSetup('<img id="target" />');
+		assert.isFalse(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 
 	it('should return false if an alt is present, but empty', function() {
-		var node = document.createElement('img');
-		node.setAttribute('alt', ' ');
-		fixture.appendChild(node);
-
-		assert.isFalse(checks['non-empty-alt'].evaluate(node));
+		var params = checkSetup('<img id="target" alt=" " />');
+		assert.isFalse(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 
 	it('should collapse whitespace', function() {
-		var node = document.createElement('div');
-		node.setAttribute('alt', ' \t \n \r \t  \t\r\n ');
-		fixture.appendChild(node);
-
-		assert.isFalse(checks['non-empty-alt'].evaluate(node));
+		var params = checkSetup('<img id="target" alt=" \t \n \r \t  \t\r\n " />');
+		assert.isFalse(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 });


### PR DESCRIPTION
Stop using DOM node in non-empty-alt check.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
