### PR TITLE
chore: remove CircleCI button from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # axe-core
 
-[![CircleCI](https://circleci.com/gh/dequelabs/axe-core.svg?style=svg)](https://circleci.com/gh/dequelabs/axe-core)
-
 [![License](https://img.shields.io/npm/l/axe-core.svg)](LICENSE)
 [![Version](https://img.shields.io/npm/v/axe-core.svg)](https://www.npmjs.com/package/axe-core)
 [![Total npm downloads](https://img.shields.io/npm/dt/axe-core.svg)](https://www.npmjs.com/package/axe-core)


### PR DESCRIPTION
There's no good reason for this button to be here. Anyone who needs to see this knows where to find it, and having the occasional "FAIL" sit at the top of our readme isn't a good look.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
