### PR TITLE
test: prevent timeout in parseCrossOriginStylesheet test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -338,6 +338,7 @@ module.exports = function(grunt) {
 			}
 		},
 		mocha: testConfig(grunt, {
+			timeout: 15000,
 			reporter: grunt.option('reporter') || 'Spec'
 		}),
 		connect: {

--- a/lib/core/utils/parse-crossorigin-stylesheet.js
+++ b/lib/core/utils/parse-crossorigin-stylesheet.js
@@ -19,7 +19,7 @@ axe.utils.parseCrossOriginStylesheet = function parseCrossOriginStylesheet(
 ) {
 	const axiosOptions = {
 		method: 'get',
-		timeout: 5000,
+		timeout: axe.constants.preload.timeout,
 		url
 	};
 

--- a/lib/core/utils/parse-crossorigin-stylesheet.js
+++ b/lib/core/utils/parse-crossorigin-stylesheet.js
@@ -19,6 +19,7 @@ axe.utils.parseCrossOriginStylesheet = function parseCrossOriginStylesheet(
 ) {
 	const axiosOptions = {
 		method: 'get',
+		timeout: 5000,
 		url
 	};
 

--- a/test/core/utils/parse-crossorigin-stylesheet.js
+++ b/test/core/utils/parse-crossorigin-stylesheet.js
@@ -60,7 +60,7 @@ describe('axe.utils.parseCrossOriginStylesheet', function() {
 	});
 
 	it('rejects when given url to fetch is not found', function(done) {
-		this.timeout(6000);
+		this.timeout(axe.constants.preload.timeout + 1000);
 
 		var importUrl =
 			'https://make-up-a-website-that-does-not-exist.com/style.css';

--- a/test/core/utils/parse-crossorigin-stylesheet.js
+++ b/test/core/utils/parse-crossorigin-stylesheet.js
@@ -60,6 +60,8 @@ describe('axe.utils.parseCrossOriginStylesheet', function() {
 	});
 
 	it('rejects when given url to fetch is not found', function(done) {
+		this.timeout(6000);
+
 		var importUrl =
 			'https://make-up-a-website-that-does-not-exist.com/style.css';
 		var options = {


### PR DESCRIPTION
This test was always timing out in Phantom in the terminal which was preventing running `npm test` and getting past it. Turns out axios was taking longer than the PhantomJS timeout, so I increased it and used the preload timeout for axios.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
