### PR TITLE
fix(only-listitem): add message about invalid role on li elements

### DIFF
--- a/lib/checks/lists/only-listitems.js
+++ b/lib/checks/lists/only-listitems.js
@@ -1,64 +1,45 @@
-const { dom } = axe.commons;
-const getIsListItemRole = (role, tagName) => {
-	return role === 'listitem' || (tagName === 'LI' && !role);
-};
+const { dom, aria } = axe.commons;
 
-const getHasListItem = (hasListItem, tagName, isListItemRole) => {
-	return hasListItem || (tagName === 'LI' && isListItemRole) || isListItemRole;
-};
+let hasNonEmptyTextNode = false;
+let atLeastOneListitem = false;
+let isEmpty = true;
+let badNodes = [];
 
-let base = {
-	badNodes: [],
-	isEmpty: true,
-	hasNonEmptyTextNode: false,
-	hasListItem: false,
-	liItemsWithRole: 0
-};
+virtualNode.children.forEach(vNode => {
+	const { actualNode } = vNode;
 
-let out = virtualNode.children.reduce((out, { actualNode }) => {
-	const tagName = actualNode.nodeName.toUpperCase();
-
-	if (actualNode.nodeType === 1 && dom.isVisible(actualNode, true, false)) {
-		const role = (actualNode.getAttribute('role') || '').toLowerCase();
-		const isListItemRole = getIsListItemRole(role, tagName);
-
-		out.hasListItem = getHasListItem(out.hasListItem, tagName, isListItemRole);
-
-		if (isListItemRole) {
-			out.isEmpty = false;
-		}
-		if (tagName === 'LI' && !isListItemRole) {
-			out.liItemsWithRole++;
-		}
-		if (tagName !== 'LI' && !isListItemRole) {
-			out.badNodes.push(actualNode);
-		}
-	}
-	if (actualNode.nodeType === 3) {
-		if (actualNode.nodeValue.trim() !== '') {
-			out.hasNonEmptyTextNode = true;
-		}
+	if (actualNode.nodeType === 3 && actualNode.nodeValue.trim() !== '') {
+		hasNonEmptyTextNode = true;
+		return;
 	}
 
-	return out;
-}, base);
-
-const virtualNodeChildrenOfTypeLi = virtualNode.children.filter(
-	({ actualNode }) => {
-		return actualNode.nodeName.toUpperCase() === 'LI';
+	if (actualNode.nodeType !== 1 || !dom.isVisible(actualNode, true, false)) {
+		return;
 	}
-);
 
-const allLiItemsHaveRole =
-	out.liItemsWithRole > 0 &&
-	virtualNodeChildrenOfTypeLi.length === out.liItemsWithRole;
+	isEmpty = false;
+	const isLi = actualNode.nodeName.toUpperCase() === 'LI';
+	const isListItemRole = aria.getRole(vNode) === 'listitem';
 
-if (out.badNodes.length) {
-	this.relatedNodes(out.badNodes);
+	if (!isLi && !isListItemRole) {
+		badNodes.push(actualNode);
+	}
+
+	if (isListItemRole) {
+		atLeastOneListitem = true;
+	}
+});
+
+if (hasNonEmptyTextNode || badNodes.length) {
+	this.relatedNodes(badNodes);
+	return true;
 }
 
-const isInvalidListItem = !(
-	out.hasListItem ||
-	(out.isEmpty && !allLiItemsHaveRole)
-);
-return isInvalidListItem || !!out.badNodes.length || out.hasNonEmptyTextNode;
+if (isEmpty || atLeastOneListitem) {
+	return false;
+}
+
+this.data({
+	messageKey: 'roleNotValid'
+});
+return true;

--- a/lib/checks/lists/only-listitems.js
+++ b/lib/checks/lists/only-listitems.js
@@ -4,6 +4,8 @@ let hasNonEmptyTextNode = false;
 let atLeastOneListitem = false;
 let isEmpty = true;
 let badNodes = [];
+let badRoleNodes = [];
+let badRoles = [];
 
 virtualNode.children.forEach(vNode => {
 	const { actualNode } = vNode;
@@ -19,10 +21,19 @@ virtualNode.children.forEach(vNode => {
 
 	isEmpty = false;
 	const isLi = actualNode.nodeName.toUpperCase() === 'LI';
-	const isListItemRole = aria.getRole(vNode) === 'listitem';
+	const role = aria.getRole(vNode);
+	const isListItemRole = role === 'listitem';
 
 	if (!isLi && !isListItemRole) {
 		badNodes.push(actualNode);
+	}
+
+	if (isLi && !isListItemRole) {
+		badRoleNodes.push(actualNode);
+
+		if (!badRoles.includes(role)) {
+			badRoles.push(role);
+		}
 	}
 
 	if (isListItemRole) {
@@ -39,7 +50,9 @@ if (isEmpty || atLeastOneListitem) {
 	return false;
 }
 
+this.relatedNodes(badRoleNodes);
 this.data({
-	messageKey: 'roleNotValid'
+	messageKey: 'roleNotValid',
+	roles: badRoles.join(', ')
 });
 return true;

--- a/lib/checks/lists/only-listitems.json
+++ b/lib/checks/lists/only-listitems.json
@@ -5,7 +5,10 @@
 		"impact": "serious",
 		"messages": {
 			"pass": "List element only has direct children that are allowed inside <li> elements",
-			"fail": "List element has direct children that are not allowed inside <li> elements"
+			"fail": {
+				"default": "List element has direct children that are not allowed inside <li> elements",
+				"roleNotValid": "List element has direct children with a role that is not allowed"
+			}
 		}
 	}
 }

--- a/lib/checks/lists/only-listitems.json
+++ b/lib/checks/lists/only-listitems.json
@@ -7,7 +7,7 @@
 			"pass": "List element only has direct children that are allowed inside <li> elements",
 			"fail": {
 				"default": "List element has direct children that are not allowed inside <li> elements",
-				"roleNotValid": "List element has direct children with a role that is not allowed"
+				"roleNotValid": "List element has direct children with a role that is not allowed: ${data.roles}"
 			}
 		}
 	}

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -128,6 +128,7 @@ describe('only-listitems', function() {
 		assert.isTrue(
 			checks['only-listitems'].evaluate.apply(checkContext, checkArgs)
 		);
+		assert.deepEqual(checkContext._data, { messageKey: 'roleNotValid' });
 	});
 
 	it('should return true if <link> is used along side only li items with their roles changed', function() {

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -123,12 +123,19 @@ describe('only-listitems', function() {
 
 	it('should return true if the list has only li items with their roles changed', function() {
 		var checkArgs = checkSetup(
-			'<ol id="target"><li role="menuitem">Not a list item</li><li role="menuitem">Not a list item</li></ol>'
+			'<ol id="target"><li id="fail1" role="menuitem">Not a list item</li><li id="fail2" role="menuitem">Not a list item</li></ol>'
 		);
 		assert.isTrue(
 			checks['only-listitems'].evaluate.apply(checkContext, checkArgs)
 		);
-		assert.deepEqual(checkContext._data, { messageKey: 'roleNotValid' });
+		assert.deepEqual(checkContext._data, {
+			messageKey: 'roleNotValid',
+			roles: 'menuitem'
+		});
+		assert.deepEqual(checkContext._relatedNodes, [
+			fixture.querySelector('#fail1'),
+			fixture.querySelector('#fail2')
+		]);
 	});
 
 	it('should return true if <link> is used along side only li items with their roles changed', function() {


### PR DESCRIPTION
Add a new message when an `<li>` element has a role that is not `listitem`. I also heavily refactored and simplified the code because it was super confusing to read through and try to figure out what was going on (lots of negation statements, a `reduce` that wasn't needed, confusing logic, didn't make use of `aria.getRole`, etc.).

Closes issue: #1919

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
