### PR TITLE
test: remove `window.PHANTOMJS` checks from tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -251,18 +251,7 @@ module.exports = function(grunt) {
 		},
 		testconfig: {
 			test: {
-				src: ['test/integration/rules/**/*.json'].concat(
-					process.env.APPVEYOR
-						? [
-								// These tests are causing PhantomJS to timeout on Appveyor
-								// Warning: PhantomJS timed out, possibly due to a missing Mocha run() call. Use --force to continue.
-								'!test/integration/rules/td-has-header/*.json',
-								'!test/integration/rules/label-content-name-mismatch/*.json',
-								'!test/integration/rules/label/*.json',
-								'!test/integration/rules/th-has-data-cells/*.json'
-						  ]
-						: []
-				),
+				src: ['test/integration/rules/**/*.json'],
 				dest: 'tmp/integration-tests.js'
 			}
 		},

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -40,7 +40,7 @@ To build axe.js, simply run `grunt build` in the root folder of the axe-core rep
 
 ### Running Tests
 
-To run all tests from the command line you can run `grunt test`, which will run all unit and integration tests using PhantomJS and Selenium Webdriver.
+To run all tests from the command line you can run `grunt test`, which will run all unit and integration tests using headless chrome and Selenium Webdriver.
 
 You can also load tests in any supported browser, which is helpful for debugging. Tests require a local server to run, you must first start a local server to serve files. You can use Grunt to start one by running `grunt dev`. Once your local server is running you can load the following pages in any browser to run tests:
 

--- a/lib/core/utils/contains.js
+++ b/lib/core/utils/contains.js
@@ -1,5 +1,5 @@
 /**
- * Wrapper for Node#contains; PhantomJS does not support Node#contains and erroneously reports that it does
+ * Wrapper for Node#contains
  * @method contains
  * @memberof axe.utils
  * @param  {VirtualNode} vNode     The candidate container VirtualNode

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -105,12 +105,8 @@ describe('color-contrast', function() {
 		var params = checkSetup(
 			'<p>Text oh heyyyy <a href="#" id="target">and here\'s <br>a link</a></p>'
 		);
-		if (window.PHANTOMJS) {
-			assert.ok('PhantomJS is a liar');
-		} else {
-			assert.isTrue(contrastEvaluate.apply(checkContext, params));
-			assert.deepEqual(checkContext._relatedNodes, []);
-		}
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
 	it('should return undefined for inline elements spanning multiple lines that are overlapped', function() {
@@ -228,12 +224,8 @@ describe('color-contrast', function() {
 		fixtureSetup('<label id="target">' + 'My text <input type="text"></label>');
 		var target = fixture.querySelector('#target');
 		var virtualNode = axe.utils.getNodeFromTree(target);
-		if (window.PHANTOMJS) {
-			assert.ok('PhantomJS is a liar');
-		} else {
-			var result = contrastEvaluate.call(checkContext, target, {}, virtualNode);
-			assert.isTrue(result);
-		}
+		var result = contrastEvaluate.call(checkContext, target, {}, virtualNode);
+		assert.isTrue(result);
 	});
 
 	it("should return true when a label wraps a text input but doesn't overlap", function() {

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -233,14 +233,10 @@ describe('color.getBackgroundColor', function() {
 			document.getElementById('target'),
 			[]
 		);
-		if (window.PHANTOMJS) {
-			assert.ok('PhantomJS is a liar');
-		} else {
-			assert.isNotNull(actual);
-			assert.equal(Math.round(actual.blue), 0);
-			assert.equal(Math.round(actual.red), 0);
-			assert.equal(Math.round(actual.green), 0);
-		}
+		assert.isNotNull(actual);
+		assert.equal(Math.round(actual.blue), 0);
+		assert.equal(Math.round(actual.red), 0);
+		assert.equal(Math.round(actual.green), 0);
 	});
 
 	it('should return null if a multiline inline element does not fully cover background', function() {

--- a/test/commons/color/get-own-background-color.js
+++ b/test/commons/color/get-own-background-color.js
@@ -4,7 +4,6 @@ describe('color.getOwnBackgroundColor', function() {
 	var fixture = document.getElementById('fixture');
 	var queryFixture = axe.testUtils.queryFixture;
 	var getOwnBackgroundColor = axe.commons.color.getOwnBackgroundColor;
-	var isPhantom = window.PHANTOMJS ? true : false;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
@@ -21,9 +20,7 @@ describe('color.getOwnBackgroundColor', function() {
 		assert.equal(actual.red, 0);
 		assert.equal(actual.green, 0);
 		assert.equal(actual.blue, 0);
-		if (!isPhantom) {
-			assert.equal(actual.alpha, 0);
-		}
+		assert.equal(actual.alpha, 0);
 	});
 
 	it('returns color with rgba values of specified background-color value', function() {
@@ -37,9 +34,7 @@ describe('color.getOwnBackgroundColor', function() {
 		assert.equal(actual.red, 255);
 		assert.equal(actual.green, 192);
 		assert.equal(actual.blue, 203);
-		if (!isPhantom) {
-			assert.equal(actual.alpha, 1);
-		}
+		assert.equal(actual.alpha, 1);
 	});
 
 	it('returns color with rgba values and alpha', function() {
@@ -53,9 +48,7 @@ describe('color.getOwnBackgroundColor', function() {
 		assert.equal(actual.red, 0);
 		assert.equal(actual.green, 128);
 		assert.equal(actual.blue, 0);
-		if (!isPhantom) {
-			assert.equal(actual.alpha, 0.5);
-		}
+		assert.equal(actual.alpha, 0.5);
 	});
 
 	it('returns color with rgba values and opacity (for blending)', function() {
@@ -69,9 +62,7 @@ describe('color.getOwnBackgroundColor', function() {
 		assert.equal(actual.red, 0);
 		assert.equal(actual.green, 128);
 		assert.equal(actual.blue, 0);
-		if (!isPhantom) {
-			assert.equal(actual.alpha, 0.5);
-		}
+		assert.equal(actual.alpha, 0.5);
 	});
 
 	it('returns color with rgba values, alpha and opacity', function() {
@@ -85,8 +76,6 @@ describe('color.getOwnBackgroundColor', function() {
 		assert.equal(actual.red, 0);
 		assert.equal(actual.green, 128);
 		assert.equal(actual.blue, 0);
-		if (!isPhantom) {
-			assert.equal(actual.alpha, 0.25);
-		}
+		assert.equal(actual.alpha, 0.25);
 	});
 });

--- a/test/commons/dom/is-offscreen.js
+++ b/test/commons/dom/is-offscreen.js
@@ -36,12 +36,7 @@ describe('dom.isOffscreen', function() {
 		fixture.innerHTML =
 			'<div id="target" style="position: absolute; height: 50px; top: -51px;">Offscreen?</div>';
 		var el = document.getElementById('target');
-
-		if (window.PHANTOMJS) {
-			assert.ok('PhantomJS is a liar');
-		} else {
-			assert.isTrue(axe.commons.dom.isOffscreen(el));
-		}
+		assert.isTrue(axe.commons.dom.isOffscreen(el));
 	});
 
 	it('should never detect elements positioned outside the bottom edge', function() {

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -192,7 +192,7 @@ describe('dom.isVisible', function() {
 
 		// IE11 either only supports clip paths defined by url() or not at all,
 		// MDN and caniuse.com give different results...
-		(isIE11 || window.PHANTOMJS ? it.skip : it)(
+		(isIE11 ? it.skip : it)(
 			'should detect clip-path hidden text technique',
 			function() {
 				fixture.innerHTML =
@@ -203,7 +203,7 @@ describe('dom.isVisible', function() {
 			}
 		);
 
-		(isIE11 || window.PHANTOMJS ? it.skip : it)(
+		(isIE11 ? it.skip : it)(
 			'should detect clip-path hidden text technique on parent',
 			function() {
 				fixture.innerHTML =

--- a/test/commons/table/is-data-table.js
+++ b/test/commons/table/is-data-table.js
@@ -316,10 +316,6 @@ describe('table.isDataTable', function() {
 	});
 
 	it('should be true if it has zebra rows', function() {
-		if (window.PHANTOMJS) {
-			assert.ok('PhantomJS is a liar');
-			return;
-		}
 		fixture.innerHTML =
 			'<table>' +
 			'<tr><td></td><td></td></tr>' +
@@ -333,10 +329,6 @@ describe('table.isDataTable', function() {
 	});
 
 	it('should be true if it has zebra rows - background image', function() {
-		if (window.PHANTOMJS) {
-			assert.ok('PhantomJS is a liar');
-			return;
-		}
 		fixture.innerHTML =
 			'<table>' +
 			'<tr><td></td><td></td></tr>' +

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -2881,13 +2881,11 @@ describe('text.accessibleTextVirtual', function() {
 
 		// Skip from 128 - 138 as those are name description cases
 
-		// Note: PhantomJS did not detect `style .hidden` appended via innerHTML
-		// hence falling back to `display: none`
 		it('passes test 139', function() {
 			fixture.innerHTML =
-				// '<style>' +
-				// '  .hidden { display: none; }' +
-				// '</style>' +
+				'<style>' +
+				'  .hidden { display: none; }' +
+				'</style>' +
 				'<div id="test" role="link" tabindex="0">' +
 				'  <span aria-hidden="true"><i> Hello, </i></span>' +
 				'  <span>My</span> name is' +
@@ -2897,8 +2895,7 @@ describe('text.accessibleTextVirtual', function() {
 				'  </span>' +
 				'  <span>the weird.</span>' +
 				'  (QED)' +
-				// '  <span  class="hidden"><i><b>and don\'t you forget it.</b></i></span>' +
-				'  <span style="display:none;"><i><b>and don\'t you forget it.</b></i></span>' +
+				'  <span  class="hidden"><i><b>and don\'t you forget it.</b></i></span>' +
 				'  <table>' +
 				'    <tr>' +
 				'      <td>Where</td>' +
@@ -2920,13 +2917,11 @@ describe('text.accessibleTextVirtual', function() {
 			);
 		});
 
-		// Note: PhantomJS did not detect `style .hidden` appended via innerHTML
-		// hence falling back to `display: none`
 		it('passes test 140', function() {
 			fixture.innerHTML =
-				// '<style>' +
-				// '  .hidden { display: none; }' +
-				// '</style>' +
+				'<style>' +
+				'  .hidden { display: none; }' +
+				'</style>' +
 				'<input id="test" type="text" aria-labelledby="lblId" />' +
 				'<div id="lblId" >' +
 				'  <span aria-hidden="true"><i> Hello, </i></span>' +
@@ -2937,8 +2932,7 @@ describe('text.accessibleTextVirtual', function() {
 				'  </span>' +
 				'  <span>the weird.</span>' +
 				'  (QED)' +
-				// '  <span class="hidden"><i><b>and don\'t you forget it.</b></i></span>' +
-				'  <span style="display:none;"><i><b>and don\'t you forget it.</b></i></span>' +
+				'  <span class="hidden"><i><b>and don\'t you forget it.</b></i></span>' +
 				'  <table>' +
 				'    <tr>' +
 				'      <td>Where</td>' +
@@ -3119,22 +3113,18 @@ describe('text.accessibleTextVirtual', function() {
 			assert.equal(accessibleText(target), 'This is a test.');
 		});
 
-		// Note: PhantomJS did not detect `style .hidden` appended via innerHTML
-		// hence falling back to `display: none`
 		it('passes test 153', function() {
 			fixture.innerHTML =
-				// '<style>' +
-				// '  .hidden { display: none; }' +
-				// '</style>' +
+				'<style>' +
+				'  .hidden { display: none; }' +
+				'</style>' +
 				'<input type="file" id="test" />' +
 				'<label for="test">' +
-				// '  <span class="hidden">1</span><span>2</span>' +
-				'  <span style="display:none">1</span><span>2</span>' +
+				'  <span class="hidden">1</span><span>2</span>' +
 				'  <span style="visibility: hidden;">3</span><span>4</span>' +
 				'  <span hidden>5</span><span>6</span>' +
 				'  <span aria-hidden="true">7</span><span>8</span>' +
-				// '  <span aria-hidden="false" class="hidden">9</span><span>10</span>' +
-				'  <span aria-hidden="false" style="display:none">9</span><span>10</span>' +
+				'  <span aria-hidden="false" class="hidden">9</span><span>10</span>' +
 				'</label>';
 			axe.testUtils.flatTreeSetup(fixture);
 			var target = fixture.querySelector('#test');
@@ -3181,13 +3171,11 @@ describe('text.accessibleTextVirtual', function() {
 			assert.equal(accessibleText(target), 'Flash the screen 1 times.');
 		});
 
-		// Note: PhantomJS did not detect `style .hidden` appended via innerHTML
-		// hence falling back to `display: none`
 		it('passes test 156', function() {
 			fixture.innerHTML =
-				// '<style>' +
-				// '  .hidden { display: none; }' +
-				// '</style>' +
+				'<style>' +
+				'  .hidden { display: none; }' +
+				'</style>' +
 				'<div id="test" role="link" tabindex="0">' +
 				'  <span aria-hidden="true"><i> Hello, </i></span>' +
 				'  <span>My</span> name is' +
@@ -3195,8 +3183,7 @@ describe('text.accessibleTextVirtual', function() {
 				'  <span role="presentation" aria-label="Eli"><span aria-label="Garaventa">Zambino</span></span>' +
 				'  <span>the weird.</span>' +
 				'  (QED)' +
-				// '  <span class="hidden"><i><b>and don\'t you forget it.</b></i></span>' +
-				'  <span style="display:none"><i><b>and don\'t you forget it.</b></i></span>' +
+				'  <span class="hidden"><i><b>and don\'t you forget it.</b></i></span>' +
 				'</div>';
 			axe.testUtils.flatTreeSetup(fixture);
 			var target = fixture.querySelector('#test');

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -604,319 +604,303 @@ describe('Audit', function() {
 			);
 		});
 
-		// PhantomJs does not have Promise support
-		(window.PHANTOMJS ? xit : it)(
-			'should run rules (that do not need preload) and preload assets simultaneously',
-			function(done) {
-				/**
-				 * Note:
-				 * overriding and resolving both check and preload with a delay,
-				 * but the invoked timestamp should ensure that they were invoked almost immediately
-				 */
+		it('should run rules (that do not need preload) and preload assets simultaneously', function(done) {
+			/**
+			 * Note:
+			 * overriding and resolving both check and preload with a delay,
+			 * but the invoked timestamp should ensure that they were invoked almost immediately
+			 */
 
-				fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
+			fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
 
-				var runStartTime = new Date();
-				var preloadInvokedTime = new Date();
-				var noPreloadCheckedInvokedTime = new Date();
-				var noPreloadRuleCheckEvaluateInvoked = false;
-				var preloadOverrideInvoked = false;
+			var runStartTime = new Date();
+			var preloadInvokedTime = new Date();
+			var noPreloadCheckedInvokedTime = new Date();
+			var noPreloadRuleCheckEvaluateInvoked = false;
+			var preloadOverrideInvoked = false;
 
-				// override preload method
-				axe.utils.preload = function(options) {
-					preloadInvokedTime = new Date();
-					preloadOverrideInvoked = true;
+			// override preload method
+			axe.utils.preload = function(options) {
+				preloadInvokedTime = new Date();
+				preloadOverrideInvoked = true;
 
-					return new Promise(function(res, rej) {
-						setTimeout(function() {
-							res(true);
-						}, 2000);
-					});
-				};
-
-				var audit = new Audit();
-				// add a rule and check that does not need preload
-				audit.addRule({
-					id: 'no-preload',
-					selector: 'div#div1',
-					any: ['no-preload-check'],
-					preload: false
+				return new Promise(function(res, rej) {
+					setTimeout(function() {
+						res(true);
+					}, 2000);
 				});
-				audit.addCheck({
-					id: 'no-preload-check',
-					evaluate: function(node, options, vNode, context) {
-						noPreloadCheckedInvokedTime = new Date();
-						noPreloadRuleCheckEvaluateInvoked = true;
-						var ready = this.async();
-						setTimeout(function() {
-							ready(true);
-						}, 1000);
-					}
+			};
+
+			var audit = new Audit();
+			// add a rule and check that does not need preload
+			audit.addRule({
+				id: 'no-preload',
+				selector: 'div#div1',
+				any: ['no-preload-check'],
+				preload: false
+			});
+			audit.addCheck({
+				id: 'no-preload-check',
+				evaluate: function(node, options, vNode, context) {
+					noPreloadCheckedInvokedTime = new Date();
+					noPreloadRuleCheckEvaluateInvoked = true;
+					var ready = this.async();
+					setTimeout(function() {
+						ready(true);
+					}, 1000);
+				}
+			});
+
+			// add a rule which needs preload
+			audit.addRule({
+				id: 'yes-preload',
+				selector: 'div#div2',
+				preload: true
+			});
+
+			var preloadOptions = {
+				preload: {
+					assets: ['cssom']
+				}
+			};
+
+			var allowedDiff = 50;
+
+			audit.run(
+				{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
+				{
+					preload: preloadOptions
+				},
+				function(results) {
+					assert.isDefined(results);
+					// assert that check was invoked for rule(s)
+					assert.isTrue(noPreloadRuleCheckEvaluateInvoked);
+					// assert preload was invoked
+					assert.isTrue(preloadOverrideInvoked);
+					// assert that time diff(s)
+					// assert that run check invoked immediately
+					// choosing 5ms as an arbitary number
+					assert.isBelow(
+						noPreloadCheckedInvokedTime - runStartTime,
+						allowedDiff
+					);
+					// assert that preload  invoked immediately
+					assert.isBelow(preloadInvokedTime - runStartTime, allowedDiff);
+					// ensure cache is clear
+					assert.isTrue(typeof axe._selectCache === 'undefined');
+					// done
+					done();
+				},
+				noop
+			);
+		});
+
+		it('should pass assets from preload to rule check that needs assets as context', function(done) {
+			fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
+
+			var yesPreloadRuleCheckEvaluateInvoked = false;
+			var preloadOverrideInvoked = false;
+
+			var preloadData = {
+				data: 'you got it!'
+			};
+			// override preload method
+			axe.utils.preload = function(options) {
+				preloadOverrideInvoked = true;
+				return Promise.resolve({
+					cssom: preloadData
 				});
+			};
 
-				// add a rule which needs preload
-				audit.addRule({
-					id: 'yes-preload',
-					selector: 'div#div2',
-					preload: true
-				});
+			var audit = new Audit();
+			// add a rule and check that does not need preload
+			audit.addRule({
+				id: 'no-preload',
+				selector: 'div#div1',
+				preload: false
+			});
+			// add a rule which needs preload
+			audit.addRule({
+				id: 'yes-preload',
+				selector: 'div#div2',
+				preload: true,
+				any: ['yes-preload-check']
+			});
+			audit.addCheck({
+				id: 'yes-preload-check',
+				evaluate: function(node, options, vNode, context) {
+					yesPreloadRuleCheckEvaluateInvoked = true;
+					this.data(context);
+					return true;
+				}
+			});
 
-				var preloadOptions = {
-					preload: {
-						assets: ['cssom']
-					}
-				};
+			var preloadOptions = {
+				preload: {
+					assets: ['cssom']
+				}
+			};
+			audit.run(
+				{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
+				{
+					preload: preloadOptions
+				},
+				function(results) {
+					assert.isDefined(results);
+					// assert that check was invoked for rule(s)
+					assert.isTrue(yesPreloadRuleCheckEvaluateInvoked);
+					// assert preload was invoked
+					assert.isTrue(preloadOverrideInvoked);
 
-				var allowedDiff = 50;
+					// assert preload data that was passed to check
+					var ruleResult = results.filter(function(r) {
+						return (r.id = 'yes-preload' && r.nodes.length > 0);
+					})[0];
+					var checkResult = ruleResult.nodes[0].any[0];
+					assert.isDefined(checkResult.data);
+					assert.property(checkResult.data, 'cssom');
+					assert.deepEqual(checkResult.data.cssom, preloadData);
+					// ensure cache is clear
+					assert.isTrue(typeof axe._selectCache === 'undefined');
+					// done
+					done();
+				},
+				noop
+			);
+		});
 
-				audit.run(
-					{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
-					{
-						preload: preloadOptions
-					},
-					function(results) {
-						assert.isDefined(results);
-						// assert that check was invoked for rule(s)
-						assert.isTrue(noPreloadRuleCheckEvaluateInvoked);
-						// assert preload was invoked
-						assert.isTrue(preloadOverrideInvoked);
-						// assert that time diff(s)
-						// assert that run check invoked immediately
-						// choosing 5ms as an arbitary number
-						assert.isBelow(
-							noPreloadCheckedInvokedTime - runStartTime,
-							allowedDiff
-						);
-						// assert that preload  invoked immediately
-						assert.isBelow(preloadInvokedTime - runStartTime, allowedDiff);
-						// ensure cache is clear
-						assert.isTrue(typeof axe._selectCache === 'undefined');
-						// done
-						done();
-					},
-					noop
-				);
-			}
-		);
+		it('should continue to run rules and return result when preload is rejected', function(done) {
+			fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
 
-		// PhantomJs does not have Promise support
-		(window.PHANTOMJS ? xit : it)(
-			'should pass assets from preload to rule check that needs assets as context',
-			function(done) {
-				fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
+			var preloadOverrideInvoked = false;
+			var preloadNeededCheckInvoked = false;
+			var rejectionMsg =
+				'Boom! Things went terribly wrong! (But this was intended in this test)';
 
-				var yesPreloadRuleCheckEvaluateInvoked = false;
-				var preloadOverrideInvoked = false;
+			// override preload method
+			axe.utils.preload = function(options) {
+				preloadOverrideInvoked = true;
+				return Promise.reject(rejectionMsg);
+			};
 
-				var preloadData = {
-					data: 'you got it!'
-				};
-				// override preload method
-				axe.utils.preload = function(options) {
-					preloadOverrideInvoked = true;
-					return Promise.resolve({
-						cssom: preloadData
-					});
-				};
+			var audit = new Audit();
+			// add a rule and check that does not need preload
+			audit.addRule({
+				id: 'no-preload',
+				selector: 'div#div1',
+				preload: false
+			});
+			// add a rule which needs preload
+			audit.addRule({
+				id: 'yes-preload',
+				selector: 'div#div2',
+				preload: true,
+				any: ['yes-preload-check']
+			});
+			audit.addCheck({
+				id: 'yes-preload-check',
+				evaluate: function(node, options, vNode, context) {
+					preloadNeededCheckInvoked = true;
+					this.data(context);
+					return true;
+				}
+			});
 
-				var audit = new Audit();
-				// add a rule and check that does not need preload
-				audit.addRule({
-					id: 'no-preload',
-					selector: 'div#div1',
-					preload: false
-				});
-				// add a rule which needs preload
-				audit.addRule({
-					id: 'yes-preload',
-					selector: 'div#div2',
-					preload: true,
-					any: ['yes-preload-check']
-				});
-				audit.addCheck({
-					id: 'yes-preload-check',
-					evaluate: function(node, options, vNode, context) {
-						yesPreloadRuleCheckEvaluateInvoked = true;
-						this.data(context);
-						return true;
-					}
-				});
+			var preloadOptions = {
+				preload: {
+					assets: ['cssom']
+				}
+			};
+			audit.run(
+				{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
+				{
+					preload: preloadOptions
+				},
+				function(results) {
+					assert.isDefined(results);
+					// assert preload was invoked
+					assert.isTrue(preloadOverrideInvoked);
 
-				var preloadOptions = {
-					preload: {
-						assets: ['cssom']
-					}
-				};
-				audit.run(
-					{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
-					{
-						preload: preloadOptions
-					},
-					function(results) {
-						assert.isDefined(results);
-						// assert that check was invoked for rule(s)
-						assert.isTrue(yesPreloadRuleCheckEvaluateInvoked);
-						// assert preload was invoked
-						assert.isTrue(preloadOverrideInvoked);
+					// assert that both rules ran, although preload failed
+					assert.lengthOf(results, 2);
 
-						// assert preload data that was passed to check
-						var ruleResult = results.filter(function(r) {
-							return (r.id = 'yes-preload' && r.nodes.length > 0);
-						})[0];
-						var checkResult = ruleResult.nodes[0].any[0];
-						assert.isDefined(checkResult.data);
-						assert.property(checkResult.data, 'cssom');
-						assert.deepEqual(checkResult.data.cssom, preloadData);
-						// ensure cache is clear
-						assert.isTrue(typeof axe._selectCache === 'undefined');
-						// done
-						done();
-					},
-					noop
-				);
-			}
-		);
+					// assert that because preload failed
+					// cssom was not populated on context of repective check
+					assert.isTrue(preloadNeededCheckInvoked);
+					var ruleResult = results.filter(function(r) {
+						return (r.id = 'yes-preload' && r.nodes.length > 0);
+					})[0];
+					var checkResult = ruleResult.nodes[0].any[0];
+					assert.isDefined(checkResult.data);
+					assert.notProperty(checkResult.data, 'cssom');
+					// done
+					done();
+				},
+				noop
+			);
+		});
 
-		// PhantomJs does not have Promise support
-		(window.PHANTOMJS ? xit : it)(
-			'should continue to run rules and return result when preload is rejected',
-			function(done) {
-				fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
+		it('should continue to run rules and return result when axios time(s)out and rejects preload', function(done) {
+			fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
 
-				var preloadOverrideInvoked = false;
-				var preloadNeededCheckInvoked = false;
-				var rejectionMsg =
-					'Boom! Things went terribly wrong! (But this was intended in this test)';
+			// there is no stubbing here,
+			// the actual axios call is invoked, and timedout immediately as timeout is set to 0.1
 
-				// override preload method
-				axe.utils.preload = function(options) {
-					preloadOverrideInvoked = true;
-					return Promise.reject(rejectionMsg);
-				};
+			var preloadNeededCheckInvoked = false;
+			var audit = new Audit();
+			// add a rule and check that does not need preload
+			audit.addRule({
+				id: 'no-preload',
+				selector: 'div#div1',
+				preload: false
+			});
+			// add a rule which needs preload
+			audit.addRule({
+				id: 'yes-preload',
+				selector: 'div#div2',
+				preload: true,
+				any: ['yes-preload-check']
+			});
+			audit.addCheck({
+				id: 'yes-preload-check',
+				evaluate: function(node, options, vNode, context) {
+					preloadNeededCheckInvoked = true;
+					this.data(context);
+					return true;
+				}
+			});
 
-				var audit = new Audit();
-				// add a rule and check that does not need preload
-				audit.addRule({
-					id: 'no-preload',
-					selector: 'div#div1',
-					preload: false
-				});
-				// add a rule which needs preload
-				audit.addRule({
-					id: 'yes-preload',
-					selector: 'div#div2',
-					preload: true,
-					any: ['yes-preload-check']
-				});
-				audit.addCheck({
-					id: 'yes-preload-check',
-					evaluate: function(node, options, vNode, context) {
-						preloadNeededCheckInvoked = true;
-						this.data(context);
-						return true;
-					}
-				});
+			var preloadOptions = {
+				preload: {
+					assets: ['cssom'],
+					timeout: 0.1
+				}
+			};
+			audit.run(
+				{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
+				{
+					preload: preloadOptions
+				},
+				function(results) {
+					assert.isDefined(results);
+					// assert that both rules ran, although preload failed
+					assert.lengthOf(results, 2);
 
-				var preloadOptions = {
-					preload: {
-						assets: ['cssom']
-					}
-				};
-				audit.run(
-					{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
-					{
-						preload: preloadOptions
-					},
-					function(results) {
-						assert.isDefined(results);
-						// assert preload was invoked
-						assert.isTrue(preloadOverrideInvoked);
-
-						// assert that both rules ran, although preload failed
-						assert.lengthOf(results, 2);
-
-						// assert that because preload failed
-						// cssom was not populated on context of repective check
-						assert.isTrue(preloadNeededCheckInvoked);
-						var ruleResult = results.filter(function(r) {
-							return (r.id = 'yes-preload' && r.nodes.length > 0);
-						})[0];
-						var checkResult = ruleResult.nodes[0].any[0];
-						assert.isDefined(checkResult.data);
-						assert.notProperty(checkResult.data, 'cssom');
-						// done
-						done();
-					},
-					noop
-				);
-			}
-		);
-
-		// PhantomJs does not have Promise support
-		(window.PHANTOMJS ? xit : it)(
-			'should continue to run rules and return result when axios time(s)out and rejects preload',
-			function(done) {
-				fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
-
-				// there is no stubbing here,
-				// the actual axios call is invoked, and timedout immediately as timeout is set to 0.1
-
-				var preloadNeededCheckInvoked = false;
-				var audit = new Audit();
-				// add a rule and check that does not need preload
-				audit.addRule({
-					id: 'no-preload',
-					selector: 'div#div1',
-					preload: false
-				});
-				// add a rule which needs preload
-				audit.addRule({
-					id: 'yes-preload',
-					selector: 'div#div2',
-					preload: true,
-					any: ['yes-preload-check']
-				});
-				audit.addCheck({
-					id: 'yes-preload-check',
-					evaluate: function(node, options, vNode, context) {
-						preloadNeededCheckInvoked = true;
-						this.data(context);
-						return true;
-					}
-				});
-
-				var preloadOptions = {
-					preload: {
-						assets: ['cssom'],
-						timeout: 0.1
-					}
-				};
-				audit.run(
-					{ include: [axe.utils.getFlattenedTree(fixture)[0]] },
-					{
-						preload: preloadOptions
-					},
-					function(results) {
-						assert.isDefined(results);
-						// assert that both rules ran, although preload failed
-						assert.lengthOf(results, 2);
-
-						// assert that because preload failed
-						// cssom was not populated on context of repective check
-						assert.isTrue(preloadNeededCheckInvoked);
-						var ruleResult = results.filter(function(r) {
-							return (r.id = 'yes-preload' && r.nodes.length > 0);
-						})[0];
-						var checkResult = ruleResult.nodes[0].any[0];
-						assert.isDefined(checkResult.data);
-						assert.notProperty(checkResult.data, 'cssom');
-						// done
-						done();
-					},
-					noop
-				);
-			}
-		);
+					// assert that because preload failed
+					// cssom was not populated on context of repective check
+					assert.isTrue(preloadNeededCheckInvoked);
+					var ruleResult = results.filter(function(r) {
+						return (r.id = 'yes-preload' && r.nodes.length > 0);
+					})[0];
+					var checkResult = ruleResult.nodes[0].any[0];
+					assert.isDefined(checkResult.data);
+					assert.notProperty(checkResult.data, 'cssom');
+					// done
+					done();
+				},
+				noop
+			);
+		});
 
 		it('should assign an empty array to axe._selectCache', function(done) {
 			var saved = axe.utils.ruleShouldRun;

--- a/test/core/utils/is-html-element.js
+++ b/test/core/utils/is-html-element.js
@@ -25,17 +25,15 @@ describe('axe.utils.isHtmlElement', function() {
 		assert.isFalse(axe.utils.isHtmlElement(node));
 	});
 
-	window.PHANTOMJS
-		? it.skip
-		: it('returns false if node has inherited svg namespace', function() {
-				var svgNameSpace = 'http://www.w3.org/2000/svg';
-				var node = document.createElementNS(svgNameSpace, 'svg');
-				var child = document.createElementNS(svgNameSpace, 'a');
-				child.setAttribute('href', '');
-				child.textContent = 'Child Node';
-				node.appendChild(child);
+	it('returns false if node has inherited svg namespace', function() {
+		var svgNameSpace = 'http://www.w3.org/2000/svg';
+		var node = document.createElementNS(svgNameSpace, 'svg');
+		var child = document.createElementNS(svgNameSpace, 'a');
+		child.setAttribute('href', '');
+		child.textContent = 'Child Node';
+		node.appendChild(child);
 
-				var childNode = node.querySelector('a');
-				assert.isFalse(axe.utils.isHtmlElement(childNode));
-		  });
+		var childNode = node.querySelector('a');
+		assert.isFalse(axe.utils.isHtmlElement(childNode));
+	});
 });

--- a/test/core/utils/preload.js
+++ b/test/core/utils/preload.js
@@ -1,51 +1,44 @@
 describe('axe.utils.preload', function() {
 	'use strict';
 
-	var isPhantom = window.PHANTOMJS ? true : false;
 	var fixture = document.getElementById('fixture');
 
 	before(function() {
 		axe._tree = axe.utils.getFlattenedTree(fixture);
 	});
 
-	(isPhantom ? it.skip : it)(
-		'returns `undefined` when `preload` option is set to false.',
-		function(done) {
-			var options = {
-				preload: false
-			};
-			var actual = axe.utils.preload(options);
-			actual
-				.then(function(results) {
-					assert.isUndefined(results);
-					done();
-				})
-				.catch(function(error) {
-					done(error);
-				});
-		}
-	);
-
-	(isPhantom ? it.skip : it)(
-		'returns assets with `cssom`, verify result is same output from `preloadCssom` fn',
-		function(done) {
-			var options = {
-				preload: {
-					assets: ['cssom']
-				}
-			};
-			var actual = axe.utils.preload(options);
-			actual.then(function(results) {
-				assert.isDefined(results);
-				assert.property(results, 'cssom');
-
-				axe.utils.preloadCssom(options).then(function(resultFromPreloadCssom) {
-					assert.deepEqual(results.cssom, resultFromPreloadCssom);
-					done();
-				});
+	it('returns `undefined` when `preload` option is set to false.', function(done) {
+		var options = {
+			preload: false
+		};
+		var actual = axe.utils.preload(options);
+		actual
+			.then(function(results) {
+				assert.isUndefined(results);
+				done();
+			})
+			.catch(function(error) {
+				done(error);
 			});
-		}
-	);
+	});
+
+	it('returns assets with `cssom`, verify result is same output from `preloadCssom` fn', function(done) {
+		var options = {
+			preload: {
+				assets: ['cssom']
+			}
+		};
+		var actual = axe.utils.preload(options);
+		actual.then(function(results) {
+			assert.isDefined(results);
+			assert.property(results, 'cssom');
+
+			axe.utils.preloadCssom(options).then(function(resultFromPreloadCssom) {
+				assert.deepEqual(results.cssom, resultFromPreloadCssom);
+				done();
+			});
+		});
+	});
 
 	describe('axe.utils.shouldPreload', function() {
 		it('should return true if preload configuration is valid', function() {

--- a/test/integration/adapter.js
+++ b/test/integration/adapter.js
@@ -2,28 +2,27 @@
 var failedTests = [];
 (function() {
 	'use strict';
-	if (navigator.userAgent.indexOf('PhantomJS') < 0) {
-		var runner = mocha.run();
-		runner.on('end', function() {
-			window.mochaResults = runner.stats;
-			window.mochaResults.reports = failedTests;
+
+	var runner = mocha.run();
+	runner.on('end', function() {
+		window.mochaResults = runner.stats;
+		window.mochaResults.reports = failedTests;
+	});
+	runner.on('fail', function logFailure(test, err) {
+		var flattenTitles = function(test) {
+			var titles = [];
+			while (test.parent.title) {
+				titles.push(test.parent.title);
+				test = test.parent;
+			}
+			return titles.reverse();
+		};
+		failedTests.push({
+			name: test.title,
+			result: false,
+			message: err.message,
+			stack: err.stack,
+			titles: flattenTitles(test)
 		});
-		runner.on('fail', function logFailure(test, err) {
-			var flattenTitles = function(test) {
-				var titles = [];
-				while (test.parent.title) {
-					titles.push(test.parent.title);
-					test = test.parent;
-				}
-				return titles.reverse();
-			};
-			failedTests.push({
-				name: test.title,
-				result: false,
-				message: err.message,
-				stack: err.stack,
-				titles: flattenTitles(test)
-			});
-		});
-	}
+	});
 })();

--- a/test/integration/full/css-orientation-lock/incomplete.js
+++ b/test/integration/full/css-orientation-lock/incomplete.js
@@ -1,14 +1,6 @@
 describe('css-orientation-lock incomplete test', function() {
 	'use strict';
 
-	var isPhantom = window.PHANTOMJS ? true : false;
-
-	before(function() {
-		if (isPhantom) {
-			this.skip();
-		}
-	});
-
 	it('returns INCOMPLETE if preload is set to FALSE', function(done) {
 		axe.run(
 			{

--- a/test/integration/full/css-orientation-lock/passes.js
+++ b/test/integration/full/css-orientation-lock/passes.js
@@ -2,7 +2,6 @@ describe('css-orientation-lock passes test', function() {
 	'use strict';
 
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
-	var isPhantom = window.PHANTOMJS ? true : false;
 
 	var styleSheets = [
 		{
@@ -16,18 +15,14 @@ describe('css-orientation-lock passes test', function() {
 	];
 
 	before(function(done) {
-		if (isPhantom) {
-			this.skip();
-		} else {
-			axe.testUtils
-				.addStyleSheets(styleSheets)
-				.then(function() {
-					done();
-				})
-				.catch(function(error) {
-					done(new Error('Could not load stylesheets for testing. ' + error));
-				});
-		}
+		axe.testUtils
+			.addStyleSheets(styleSheets)
+			.then(function() {
+				done();
+			})
+			.catch(function(error) {
+				done(new Error('Could not load stylesheets for testing. ' + error));
+			});
 	});
 
 	it('returns PASSES when page has STYLE with MEDIA rules (not orientation)', function(done) {

--- a/test/integration/full/css-orientation-lock/violations.js
+++ b/test/integration/full/css-orientation-lock/violations.js
@@ -2,7 +2,6 @@ describe('css-orientation-lock violations test', function() {
 	'use strict';
 
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
-	var isPhantom = window.PHANTOMJS ? true : false;
 	var isIE11 = axe.testUtils.isIE11;
 
 	var styleSheets = [
@@ -16,18 +15,14 @@ describe('css-orientation-lock violations test', function() {
 	];
 
 	before(function(done) {
-		if (isPhantom) {
-			this.skip();
-		} else {
-			axe.testUtils
-				.addStyleSheets(styleSheets)
-				.then(function() {
-					done();
-				})
-				.catch(function(error) {
-					done(new Error('Could not load stylesheets for testing. ' + error));
-				});
-		}
+		axe.testUtils
+			.addStyleSheets(styleSheets)
+			.then(function() {
+				done();
+			})
+			.catch(function(error) {
+				done(new Error('Could not load stylesheets for testing. ' + error));
+			});
 	});
 
 	function assertViolatedSelectors(relatedNodes, violatedSelectors) {

--- a/test/integration/full/preload-cssom/preload-cssom.js
+++ b/test/integration/full/preload-cssom/preload-cssom.js
@@ -3,7 +3,6 @@ describe('preload cssom integration test', function() {
 	'use strict';
 
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
-	var isPhantom = window.PHANTOMJS ? true : false;
 	var isIE11 = axe.testUtils.isIE11;
 	var styleSheets = {
 		crossOriginLinkHref: {
@@ -171,12 +170,6 @@ describe('preload cssom integration test', function() {
 	}
 
 	describe('tests for root (document)', function() {
-		before(function() {
-			if (isPhantom || isIE11) {
-				this.skip();
-			}
-		});
-
 		var shadowFixture;
 
 		beforeEach(function() {
@@ -433,7 +426,7 @@ describe('preload cssom integration test', function() {
 
 	describe('tests for nested document', function() {
 		before(function() {
-			if (isPhantom || !nestedFrame || isIE11) {
+			if (!nestedFrame || isIE11) {
 				this.skip();
 			}
 		});

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -2,7 +2,6 @@
 describe('axe.utils.preload integration test', function() {
 	'use strict';
 
-	var isPhantom = window.PHANTOMJS ? true : false;
 	var isIE11 = axe.testUtils.isIE11;
 	var styleSheets = {
 		crossOriginLinkHref: {
@@ -121,7 +120,7 @@ describe('axe.utils.preload integration test', function() {
 
 		before(function(done) {
 			// These tests currently break in IE11
-			if (isPhantom || isIE11) {
+			if (isIE11) {
 				this.skip();
 			} else {
 				/**

--- a/test/integration/full/strict-csp/strict-csp.html
+++ b/test/integration/full/strict-csp/strict-csp.html
@@ -2,18 +2,15 @@
 <html lang="en">
 	<head>
 		<meta charset="utf8" />
-		<script id="check-phantomjs">
-			// phantomjs requires running in non-strict csp
-			if (!window.PHANTOMJS) {
-				var thisScript = document.getElementById('check-phantomjs');
-				var meta = document.createElement('meta');
-				meta.setAttribute('http-equiv', 'Content-Security-Policy');
-				meta.setAttribute(
-					'content',
-					"script-src 'nonce-4AEemGb0xJptoIGFP3Nd'; style-src 'nonce-4AEemGb0xJptoIGFP3Nd'"
-				);
-				document.head.appendChild(meta);
-			}
+		<script id="strict-csp">
+			var thisScript = document.getElementById('strict-csp');
+			var meta = document.createElement('meta');
+			meta.setAttribute('http-equiv', 'Content-Security-Policy');
+			meta.setAttribute(
+				'content',
+				"script-src 'nonce-4AEemGb0xJptoIGFP3Nd'; style-src 'nonce-4AEemGb0xJptoIGFP3Nd'"
+			);
+			document.head.appendChild(meta);
 		</script>
 		<link
 			nonce="4AEemGb0xJptoIGFP3Nd"
@@ -38,6 +35,7 @@
 			var assert = chai.assert;
 		</script>
 	</head>
+
 	<body>
 		<div id="mocha"></div>
 		<script nonce="4AEemGb0xJptoIGFP3Nd" src="/test/testutils.js"></script>

--- a/test/integration/full/strict-csp/strict-csp.js
+++ b/test/integration/full/strict-csp/strict-csp.js
@@ -1,5 +1,4 @@
-// phantomjs requires running in non-strict csp
-(window.PHANTOMJS ? describe.skip : describe)('strict-csp', function() {
+describe('strict-csp', function() {
 	'use strict';
 
 	it('should parse without errors', function() {

--- a/test/runner.tmpl
+++ b/test/runner.tmpl
@@ -44,7 +44,6 @@
 		<%  }); %>
 
 		<script>
-			if (navigator.userAgent.indexOf('PhantomJS') < 0) {
 				var runner = mocha.run();
 				var failedTests = [];
 				runner.on('end', function() {
@@ -68,7 +67,6 @@
 						titles: flattenTitles(test)
 					});
 				});
-			}
 		</script>
 	</body>
 

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -46,7 +46,6 @@ testUtils.MockCheckContext = function() {
 
 /**
  * Provide an API for determining Shadow DOM v0 and v1 support in tests.
- * PhantomJS doesn't have Shadow DOM support, while some browsers do.
  *
  * @param HTMLDocumentElement		The document of the current context
  * @return Object


### PR DESCRIPTION
Remove checks like `window.PHANTOMJS` from variety of tests.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
