### PR TITLE
feat(v1-reporters): Add failureSummary to incomplete results

### DIFF
--- a/lib/core/reporters/v1.js
+++ b/lib/core/reporters/v1.js
@@ -9,11 +9,14 @@ axe.addReporter('v1', function(results, options, callback) {
 	}
 	var out = helpers.processAggregate(results, options);
 
-	out.violations.forEach(result =>
+	const addFailureSummaries = result => {
 		result.nodes.forEach(nodeResult => {
 			nodeResult.failureSummary = helpers.failureSummary(nodeResult);
-		})
-	);
+		});
+	};
+
+	out.incomplete.forEach(addFailureSummaries);
+	out.violations.forEach(addFailureSummaries);
 
 	callback({
 		...helpers.getEnvironmentData(),

--- a/test/core/reporters/v1.js
+++ b/test/core/reporters/v1.js
@@ -85,6 +85,34 @@ describe('reporters - v1', function() {
 				]
 			},
 			{
+				id: 'incomplete',
+				description: 'something yet more nifty',
+				tags: ['tag4'],
+				impact: 'monkeys',
+				result: 'failed',
+				passes: [],
+				violations: [],
+				incomplete: [
+					{
+						result: 'failed',
+						impact: 'monkeys',
+						none: [
+							{
+								data: 'foon',
+								impact: 'monkeys',
+								result: true
+							}
+						],
+						any: [],
+						all: [],
+						node: {
+							selector: ['foon'],
+							source: '<foon>telephone</foon>'
+						}
+					}
+				]
+			},
+			{
 				id: 'blinky',
 				description: 'something awesome',
 				tags: ['tag4'],
@@ -232,8 +260,11 @@ describe('reporters - v1', function() {
 	});
 	it('should add the failure summary to the node data', function(done) {
 		var origFn = window.helpers.failureSummary;
-		window.helpers.failureSummary = function() {
-			return 'your foon is ringing';
+		window.helpers.failureSummary = function(nodeData) {
+			if (!nodeData || !nodeData.target) {
+				return;
+			}
+			return 'selector: ' + nodeData.target;
 		};
 		axe.run(optionsV1, function(err, results) {
 			assert.isNull(err);
@@ -241,7 +272,11 @@ describe('reporters - v1', function() {
 			assert.equal(results.violations[0].nodes.length, 1);
 			assert.equal(
 				results.violations[0].nodes[0].failureSummary,
-				'your foon is ringing'
+				'selector: q,r,pillock'
+			);
+			assert.equal(
+				results.incomplete[0].nodes[0].failureSummary,
+				'selector: foon'
 			);
 			window.helpers.failureSummary = origFn;
 			done();


### PR DESCRIPTION
This change populates the `failureSummary` field in the v1 reporter for results categorized as `incomplete`.  At the time of writing, this field is currently only populated for `violations`.

Closes issue: #1971 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security