### PR TITLE
chore: error eslint on debugger statement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,7 @@
       5
     ],
     "no-cond-assign": 0,
-    "no-debugger": 0,
+    "no-debugger": 2,
     "no-eq-null": 0,
     "no-eval": 0,
     "no-unused-expressions": 0,

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -47,7 +47,7 @@
     ],
     "semi": 0,
     "no-cond-assign": 0,
-    "no-debugger": 0,
+    "no-debugger": 2,
     "no-eq-null": 0,
     "no-eval": 0,
     "no-unused-expressions": 0,

--- a/lib/checks/.eslintrc
+++ b/lib/checks/.eslintrc
@@ -43,7 +43,7 @@
       5
     ],
     "no-cond-assign": 0,
-    "no-debugger": 0,
+    "no-debugger": 2,
     "no-eq-null": 0,
     "no-eval": 0,
     "no-unused-expressions": 0,

--- a/lib/commons/.eslintrc
+++ b/lib/commons/.eslintrc
@@ -40,7 +40,7 @@
       5
     ],
     "no-cond-assign": 0,
-    "no-debugger": 0,
+    "no-debugger": 2,
     "no-eq-null": 0,
     "no-eval": 0,
     "no-unused-expressions": 0,

--- a/lib/rules/.eslintrc
+++ b/lib/rules/.eslintrc
@@ -43,7 +43,7 @@
       5
     ],
     "no-cond-assign": 0,
-    "no-debugger": 0,
+    "no-debugger": 2,
     "no-eq-null": 0,
     "no-eval": 0,
     "no-unused-expressions": 0,

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -56,7 +56,7 @@
       50
     ],
     "no-cond-assign": 0,
-    "no-debugger": 0,
+    "no-debugger": 2,
     "no-eq-null": 0,
     "no-eval": 0,
     "no-unused-expressions": 0,

--- a/test/checks/.eslintrc
+++ b/test/checks/.eslintrc
@@ -52,7 +52,7 @@
       50
     ],
     "no-cond-assign": 0,
-    "no-debugger": 0,
+    "no-debugger": 2,
     "no-eq-null": 0,
     "no-eval": 0,
     "no-unused-expressions": 0,


### PR DESCRIPTION
`debugger` statements should error on eslint. Unsure why they were set to off previously.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
