### PR TITLE
tests: prepare tests for commons.matches change

### DIFF
--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -2170,7 +2170,12 @@ lookupTable.elementsAllowedNoRole = [
 	{
 		nodeName: 'select',
 		condition: node => {
-			return Number(node.getAttribute('size')) > 1;
+			const vNode =
+				node instanceof axe.AbstractVirtualNode
+					? node
+					: axe.utils.getNodeFromTree(node);
+
+			return Number(vNode.attr('size')) > 1;
 		},
 		properties: {
 			multiple: true

--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -2170,7 +2170,7 @@ lookupTable.elementsAllowedNoRole = [
 	{
 		nodeName: 'select',
 		condition: vNode => {
-			if (!vNode instanceof axe.AbstractVirtualNode) {
+			if (!(vNode instanceof axe.AbstractVirtualNode)) {
 				vNode = axe.utils.getNodeFromTree(vNode);
 			}
 

--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -2169,11 +2169,10 @@ lookupTable.elementsAllowedNoRole = [
 	},
 	{
 		nodeName: 'select',
-		condition: node => {
-			const vNode =
-				node instanceof axe.AbstractVirtualNode
-					? node
-					: axe.utils.getNodeFromTree(node);
+		condition: vNode => {
+			if (!vNode instanceof axe.AbstractVirtualNode) {
+				vNode = axe.utils.getNodeFromTree(vNode);
+			}
 
 			return Number(vNode.attr('size')) > 1;
 		},

--- a/test/checks/aria/aria-allowed-role.js
+++ b/test/checks/aria/aria-allowed-role.js
@@ -3,6 +3,7 @@ describe('aria-allowed-role', function() {
 
 	var fixture = document.getElementById('fixture');
 	var checkContext = axe.testUtils.MockCheckContext();
+	var flatTreeSetup = axe.testUtils.flatTreeSetup;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
@@ -13,6 +14,8 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('article');
 		node.setAttribute('role', 'presentation');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
+		flatTreeSetup(fixture);
 		var options = {
 			ignoredTags: ['article']
 		};
@@ -30,6 +33,7 @@ describe('aria-allowed-role', function() {
 		fixture.innerHTML =
 			'<table role="grid"><tr id="target" role="row"></tr></table>';
 		var target = fixture.querySelector('#target');
+		flatTreeSetup(fixture);
 		var options = {
 			allowImplicit: false
 		};
@@ -46,6 +50,8 @@ describe('aria-allowed-role', function() {
 	it('returns true when A has namespace as svg', function() {
 		var node = document.createElementNS('http://www.w3.org/2000/svg', 'a');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -56,6 +62,7 @@ describe('aria-allowed-role', function() {
 			'<button id="target" type="button" aria-hidden="true"' +
 			'role="presentation"></button>';
 		var target = fixture.querySelector('#target');
+		flatTreeSetup(fixture);
 		var actual = checks['aria-allowed-role'].evaluate.call(
 			checkContext,
 			target
@@ -70,6 +77,7 @@ describe('aria-allowed-role', function() {
 			'role="presentation"></button>' +
 			'</div>';
 		var target = fixture.querySelector('#target');
+		flatTreeSetup(fixture);
 		var actual = checks['aria-allowed-role'].evaluate.call(
 			checkContext,
 			target
@@ -82,6 +90,8 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'menu');
 		node.setAttribute('role', 'menuitem');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -91,6 +101,7 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('img');
 		node.setAttribute('role', 'presentation');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -107,6 +118,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('alt', '');
 		node.setAttribute('role', 'presentation');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -123,6 +135,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('alt', 'not empty');
 		node.setAttribute('role', 'presentation');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isFalse(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -138,6 +151,7 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('img');
 		node.setAttribute('type', 'image');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -149,6 +163,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'checkbox');
 		node.setAttribute('aria-pressed', '');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -159,6 +174,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'text');
 		node.setAttribute('role', 'combobox');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -169,6 +185,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'tel');
 		node.setAttribute('role', 'combobox');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -179,6 +196,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'url');
 		node.setAttribute('role', 'combobox');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -189,6 +207,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'search');
 		node.setAttribute('role', 'combobox');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -199,6 +218,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'email');
 		node.setAttribute('role', 'combobox');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -209,6 +229,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'text');
 		node.setAttribute('role', 'spinbutton');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -219,6 +240,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'text');
 		node.setAttribute('role', 'searchbox');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -228,6 +250,7 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('dd');
 		node.setAttribute('role', 'link');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isFalse(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -238,6 +261,7 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('div');
 		node.setAttribute('role', 'link');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -247,6 +271,7 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('a');
 		node.setAttribute('role', 'presentation');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -257,6 +282,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('role', 'link');
 		node.href = '';
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = checks['aria-allowed-role'].evaluate.call(checkContext, node);
 		assert.isTrue(actual);
 	});
@@ -266,6 +292,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('role', 'banner');
 		node.alt = 'some text';
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -276,6 +303,7 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('role', 'presentation');
 		node.alt = 'some text';
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isFalse(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -285,6 +313,7 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('select');
 		node.setAttribute('role', 'menu');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
 		);
@@ -295,6 +324,7 @@ describe('aria-allowed-role', function() {
 		var node = document.createElement('my-navbar');
 		node.setAttribute('role', 'navigation');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = checks['aria-allowed-role'].evaluate.call(checkContext, node);
 		assert.isTrue(actual);
 		assert.isNull(checkContext._data, null);
@@ -303,6 +333,7 @@ describe('aria-allowed-role', function() {
 	it('returns false if a dpub role’s type is not the element’s implicit role', function() {
 		fixture.innerHTML = '<article role="doc-biblioref" id="target"></article>';
 		var target = fixture.children[0];
+		flatTreeSetup(fixture);
 		assert.isFalse(
 			checks['aria-allowed-role'].evaluate.call(checkContext, target)
 		);
@@ -311,6 +342,7 @@ describe('aria-allowed-role', function() {
 	it('returns true if a dpub role’s type is the element’s implicit role', function() {
 		fixture.innerHTML = '<a href="foo" role="doc-biblioref" id="target"></a>';
 		var target = fixture.children[0];
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, target)
 		);

--- a/test/checks/aria/aria-allowed-role.js
+++ b/test/checks/aria/aria-allowed-role.js
@@ -15,7 +15,6 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('role', 'presentation');
 		fixture.appendChild(node);
 		flatTreeSetup(fixture);
-		flatTreeSetup(fixture);
 		var options = {
 			ignoredTags: ['article']
 		};
@@ -50,7 +49,6 @@ describe('aria-allowed-role', function() {
 	it('returns true when A has namespace as svg', function() {
 		var node = document.createElementNS('http://www.w3.org/2000/svg', 'a');
 		fixture.appendChild(node);
-		flatTreeSetup(fixture);
 		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)
@@ -90,7 +88,6 @@ describe('aria-allowed-role', function() {
 		node.setAttribute('type', 'menu');
 		node.setAttribute('role', 'menuitem');
 		fixture.appendChild(node);
-		flatTreeSetup(fixture);
 		flatTreeSetup(fixture);
 		assert.isTrue(
 			checks['aria-allowed-role'].evaluate.call(checkContext, node)

--- a/test/checks/shared/non-empty-title.js
+++ b/test/checks/shared/non-empty-title.js
@@ -2,6 +2,7 @@ describe('non-empty-title', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var flatTreeSetup = axe.testUtils.flatTreeSetup;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
@@ -11,6 +12,7 @@ describe('non-empty-title', function() {
 		var node = document.createElement('img');
 		node.setAttribute('title', 'woohoo');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 
 		assert.isTrue(checks['non-empty-title'].evaluate(node));
 	});
@@ -18,6 +20,7 @@ describe('non-empty-title', function() {
 	it('should return false if a title is not present', function() {
 		var node = document.createElement('img');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 
 		assert.isFalse(checks['non-empty-title'].evaluate(node));
 	});
@@ -26,6 +29,7 @@ describe('non-empty-title', function() {
 		var node = document.createElement('img');
 		node.setAttribute('title', ' ');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 
 		assert.isFalse(checks['non-empty-title'].evaluate(node));
 	});
@@ -34,6 +38,7 @@ describe('non-empty-title', function() {
 		var node = document.createElement('div');
 		node.setAttribute('title', ' \t \n \r \t  \t\r\n ');
 		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 
 		assert.isFalse(checks['non-empty-title'].evaluate(node));
 	});

--- a/test/commons/aria/get-element-unallowed-roles.js
+++ b/test/commons/aria/get-element-unallowed-roles.js
@@ -1,10 +1,19 @@
 describe('aria.getElementUnallowedRoles', function() {
+	var fixture = document.getElementById('fixture');
+	var flatTreeSetup = axe.testUtils.flatTreeSetup;
+
+	afterEach(function() {
+		fixture.innerHTML = '';
+	});
+
 	it('returns false for INPUT with role application', function() {
 		var node = document.createElement('input');
 		var role = 'application';
 		node.setAttribute('type', '');
 		node.setAttribute('aria-pressed', '');
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isNotEmpty(actual);
 		assert.include(actual, role);
@@ -14,6 +23,8 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('input');
 		node.setAttribute('type', 'checkbox');
 		node.setAttribute('aria-pressed', '');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -22,6 +33,8 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('li');
 		var role = 'menubar';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -31,6 +44,8 @@ describe('aria.getElementUnallowedRoles', function() {
 		var role = 'menuitemcheckbox';
 		node.setAttribute('role', role);
 		node.setAttribute('type', 'button');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -39,6 +54,8 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('section');
 		var role = 'option';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isNotEmpty(actual);
 		assert.include(actual, role);
@@ -49,6 +66,8 @@ describe('aria.getElementUnallowedRoles', function() {
 		var role = 'menuitemradio';
 		node.setAttribute('role', role);
 		node.setAttribute('type', 'radio');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -57,16 +76,18 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('input');
 		var role = 'textbox';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node, true);
 		assert.isEmpty(actual);
 	});
 
 	it('returns false with implicit role of row for TR when allowImplicit is set to false via options', function() {
-		var node = document.createElement('table');
-		node.setAttribute('role', 'grid');
-		var row = document.createElement('tr');
-		row.setAttribute('role', 'row');
-		var actual = axe.commons.aria.getElementUnallowedRoles(row, false);
+		var node = document.createElement('tr');
+		node.setAttribute('role', 'row');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
+		var actual = axe.commons.aria.getElementUnallowedRoles(node, false);
 		assert.isNotEmpty(actual);
 		assert.include(actual, 'row');
 	});

--- a/test/commons/aria/get-element-unallowed-roles.js
+++ b/test/commons/aria/get-element-unallowed-roles.js
@@ -1,10 +1,5 @@
 describe('aria.getElementUnallowedRoles', function() {
-	var fixture = document.getElementById('fixture');
 	var flatTreeSetup = axe.testUtils.flatTreeSetup;
-
-	afterEach(function() {
-		fixture.innerHTML = '';
-	});
 
 	it('returns false for INPUT with role application', function() {
 		var node = document.createElement('input');
@@ -12,8 +7,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		node.setAttribute('type', '');
 		node.setAttribute('aria-pressed', '');
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isNotEmpty(actual);
 		assert.include(actual, role);
@@ -23,8 +17,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('input');
 		node.setAttribute('type', 'checkbox');
 		node.setAttribute('aria-pressed', '');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -33,8 +26,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('li');
 		var role = 'menubar';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -44,8 +36,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		var role = 'menuitemcheckbox';
 		node.setAttribute('role', role);
 		node.setAttribute('type', 'button');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -54,8 +45,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('section');
 		var role = 'option';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isNotEmpty(actual);
 		assert.include(actual, role);
@@ -66,8 +56,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		var role = 'menuitemradio';
 		node.setAttribute('role', role);
 		node.setAttribute('type', 'radio');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
 		assert.isEmpty(actual);
 	});
@@ -76,8 +65,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		var node = document.createElement('input');
 		var role = 'textbox';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node, true);
 		assert.isEmpty(actual);
 	});
@@ -85,8 +73,7 @@ describe('aria.getElementUnallowedRoles', function() {
 	it('returns false with implicit role of row for TR when allowImplicit is set to false via options', function() {
 		var node = document.createElement('tr');
 		node.setAttribute('role', 'row');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node, false);
 		assert.isNotEmpty(actual);
 		assert.include(actual, 'row');

--- a/test/commons/aria/is-aria-role-allowed-on-element.js
+++ b/test/commons/aria/is-aria-role-allowed-on-element.js
@@ -1,5 +1,7 @@
 describe('aria.isAriaRoleAllowedOnElement', function() {
 	'use strict';
+	var fixture = document.getElementById('fixture');
+	var flatTreeSetup = axe.testUtils.flatTreeSetup;
 
 	var originalLookupTableRole;
 	var originalLookupTableElementsAllowedNoRole;
@@ -27,6 +29,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('section');
 		var role = 'alert';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		var expected = true;
 		assert.equal(actual, expected);
@@ -43,6 +47,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('section');
 		var role = 'checkbox';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		var expected = false;
 		assert.equal(actual, expected);
@@ -52,6 +58,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('svg');
 		var role = 'alertdialog';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isFalse(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -59,6 +67,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('object');
 		var role = 'application';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		assert.isTrue(actual);
 	});
@@ -67,6 +77,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('a');
 		var role = 'button';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -74,6 +86,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('article');
 		var role = 'cell';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isFalse(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -81,6 +95,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('button');
 		var role = 'checkbox';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -88,6 +104,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('iframe');
 		var role = 'document';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -95,6 +113,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('aside');
 		var role = 'feed';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -102,6 +122,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('figure');
 		var role = 'group';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -109,6 +131,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('svg');
 		var role = 'img';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -117,6 +141,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'link';
 		node.setAttribute('role', role);
 		node.setAttribute('type', 'image');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -137,6 +163,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'cats';
 		node.setAttribute('role', role);
 		node.setAttribute('value', 'cats');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		assert.isFalse(actual);
 	});
@@ -145,6 +173,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('header');
 		var role = 'none';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -152,6 +182,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('li');
 		var role = 'option';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -159,6 +191,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('h1');
 		var role = 'tab';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -166,11 +200,15 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('ol');
 		var role = 'tablist';
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
 	it('returns true when A has namespace as svg and role menuitem', function() {
 		var node = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(
 			axe.commons.aria.isAriaRoleAllowedOnElement(node, 'menuitem')
 		);
@@ -181,6 +219,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'menuitem';
 		node.setAttribute('type', 'menu');
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -189,18 +229,24 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'navigation';
 		node.setAttribute('type', 'context');
 		node.setAttribute('role', role);
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		assert.isFalse(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
 	it('returns true if given element can have any role', function() {
 		axe.commons.aria.lookupTable.elementsAllowedAnyRole = ['HEADER'];
 		var node = document.createElement('header');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'link');
 		assert.isTrue(actual);
 	});
 
 	it('returns true if given element can have any role', function() {
 		var node = document.createElement('div');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'banner');
 		assert.isTrue(actual);
 	});
@@ -208,12 +254,16 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 	it('returns false if given element cannot have any role', function() {
 		axe.commons.aria.lookupTable.elementsAllowedNoRole = ['NAV'];
 		var node = document.createElement('nav');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'alert'); // changed this
 		assert.isFalse(actual);
 	});
 
 	it('returns false if given element cannot have any role', function() {
 		var node = document.createElement('track');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'banner');
 		assert.isFalse(actual);
 	});
@@ -221,6 +271,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 	it('returns false if AREA element has href', function() {
 		var node = document.createElement('area');
 		node.setAttribute('href', '#yay');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -230,6 +282,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 
 	it('returns true if AREA element does not have href', function() {
 		var node = document.createElement('area');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -251,6 +305,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('img');
 		node.setAttribute('alt', '');
 		node.setAttribute('role', 'presentation');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -272,6 +328,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		};
 		var node = document.createElement('img');
 		node.setAttribute('role', 'presentation');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var presentationAllowed = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -294,6 +352,8 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		};
 		var node = document.createElement('li');
 		node.setAttribute('role', 'menuitem');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'menuitem');
 		assert.isTrue(overrideInvoked);
 		assert.isFalse(actual);

--- a/test/commons/aria/is-aria-role-allowed-on-element.js
+++ b/test/commons/aria/is-aria-role-allowed-on-element.js
@@ -1,6 +1,5 @@
 describe('aria.isAriaRoleAllowedOnElement', function() {
 	'use strict';
-	var fixture = document.getElementById('fixture');
 	var flatTreeSetup = axe.testUtils.flatTreeSetup;
 
 	var originalLookupTableRole;
@@ -29,8 +28,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('section');
 		var role = 'alert';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		var expected = true;
 		assert.equal(actual, expected);
@@ -47,8 +45,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('section');
 		var role = 'checkbox';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		var expected = false;
 		assert.equal(actual, expected);
@@ -58,8 +55,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('svg');
 		var role = 'alertdialog';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isFalse(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -67,8 +63,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('object');
 		var role = 'application';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		assert.isTrue(actual);
 	});
@@ -77,8 +72,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('a');
 		var role = 'button';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -86,8 +80,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('article');
 		var role = 'cell';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isFalse(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -95,8 +88,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('button');
 		var role = 'checkbox';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -104,8 +96,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('iframe');
 		var role = 'document';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -113,8 +104,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('aside');
 		var role = 'feed';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -122,8 +112,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('figure');
 		var role = 'group';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -131,8 +120,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('svg');
 		var role = 'img';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -141,8 +129,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'link';
 		node.setAttribute('role', role);
 		node.setAttribute('type', 'image');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -163,8 +150,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'cats';
 		node.setAttribute('role', role);
 		node.setAttribute('value', 'cats');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, role);
 		assert.isFalse(actual);
 	});
@@ -173,8 +159,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('header');
 		var role = 'none';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -182,8 +167,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('li');
 		var role = 'option';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -191,8 +175,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('h1');
 		var role = 'tab';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -200,15 +183,13 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('ol');
 		var role = 'tablist';
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
 	it('returns true when A has namespace as svg and role menuitem', function() {
 		var node = document.createElementNS('http://www.w3.org/2000/svg', 'a');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(
 			axe.commons.aria.isAriaRoleAllowedOnElement(node, 'menuitem')
 		);
@@ -219,8 +200,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'menuitem';
 		node.setAttribute('type', 'menu');
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
@@ -229,24 +209,21 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var role = 'navigation';
 		node.setAttribute('type', 'context');
 		node.setAttribute('role', role);
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		assert.isFalse(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
 	});
 
 	it('returns true if given element can have any role', function() {
 		axe.commons.aria.lookupTable.elementsAllowedAnyRole = ['HEADER'];
 		var node = document.createElement('header');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'link');
 		assert.isTrue(actual);
 	});
 
 	it('returns true if given element can have any role', function() {
 		var node = document.createElement('div');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'banner');
 		assert.isTrue(actual);
 	});
@@ -254,16 +231,14 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 	it('returns false if given element cannot have any role', function() {
 		axe.commons.aria.lookupTable.elementsAllowedNoRole = ['NAV'];
 		var node = document.createElement('nav');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'alert'); // changed this
 		assert.isFalse(actual);
 	});
 
 	it('returns false if given element cannot have any role', function() {
 		var node = document.createElement('track');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'banner');
 		assert.isFalse(actual);
 	});
@@ -271,8 +246,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 	it('returns false if AREA element has href', function() {
 		var node = document.createElement('area');
 		node.setAttribute('href', '#yay');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -282,8 +256,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 
 	it('returns true if AREA element does not have href', function() {
 		var node = document.createElement('area');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -305,8 +278,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		var node = document.createElement('img');
 		node.setAttribute('alt', '');
 		node.setAttribute('role', 'presentation');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -328,8 +300,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		};
 		var node = document.createElement('img');
 		node.setAttribute('role', 'presentation');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var presentationAllowed = axe.commons.aria.isAriaRoleAllowedOnElement(
 			node,
 			'presentation'
@@ -352,8 +323,7 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
 		};
 		var node = document.createElement('li');
 		node.setAttribute('role', 'menuitem');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		flatTreeSetup(node);
 		var actual = axe.commons.aria.isAriaRoleAllowedOnElement(node, 'menuitem');
 		assert.isTrue(overrideInvoked);
 		assert.isFalse(actual);


### PR DESCRIPTION
Prepare test code for #1988. It's mostly just adding `flatTreeSetup` to all the affected tests.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
