### PR TITLE
fix(unicode): stop parsing escaped unicode strings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -207,6 +207,7 @@ module.exports = function(grunt) {
 					compress: false,
 					beautify: {
 						beautify: true,
+						ascii_only: true,
 						indent_level: 2,
 						braces: true,
 						quote_style: 1


### PR DESCRIPTION
The uglify/beautify script was parsing our escaped unicode regex strings. This turned

```js
function getUnicodeNonBmpRegExp() {
	/**
	 * Regex for matching astral plane unicode
	 * - http://kourge.net/projects/regexp-unicode-block
	 */
	return new RegExp(
		'[' +
		'\u1D00-\u1D7F' + // Phonetic Extensions
		'\u1D80-\u1DBF' + // Phonetic Extensions Supplement
		'\u1DC0-\u1DFF' + // Combining Diacritical Marks Supplement
		// '\u2000-\u206F' + // General punctuation - handled in -> getPunctuationRegExp
		'\u20A0-\u20CF' + // Currency symbols
		'\u20D0-\u20FF' + // Combining Diacritical Marks for Symbols
		'\u2100-\u214F' + // Letter like symbols
		'\u2150-\u218F' + // Number forms (eg: Roman numbers)
		'\u2190-\u21FF' + // Arrows
		'\u2200-\u22FF' + // Mathematical operators
		'\u2300-\u23FF' + // Misc Technical
		'\u2400-\u243F' + // Control pictures
		'\u2440-\u245F' + // OCR
		'\u2460-\u24FF' + // Enclosed alpha numerics
		'\u2500-\u257F' + // Box Drawing
		'\u2580-\u259F' + // Block Elements
		'\u25A0-\u25FF' + // Geometric Shapes
		'\u2600-\u26FF' + // Misc Symbols
		'\u2700-\u27BF' + // Dingbats
		'\uE000-\uF8FF' + // Private Use
			']'
	);
}
```

into 

```js
function getUnicodeNonBmpRegExp() {
        return new RegExp('[' + 'ᴀ-ᵿ' + 'ᶀ-ᶿ' + '᷀-᷿' + '₠-⃏' + '⃐-⃿' + '℀-⅏' + '⅐-↏' + '←-⇿' + '∀-⋿' + '⌀-⏿' + '␀-␿' + '⑀-⑟' + '①-⓿' + '─-╿' + '▀-▟' + '■-◿' + '☀-⛿' + '✀-➿' + '-' + ']');
      }
``` 

This caused IE extension context to not be able to parse them. The `ascii_only` option will keep the strings as is which we know works in the extension context. See https://github.com/mishoo/UglifyJS2/issues/2569

Closes issue: #1994

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
