### PR TITLE
fix(aria-valid-attr-value): mark as needs review for aria-current with invalid value

### DIFF
--- a/lib/checks/aria/valid-attr-value.js
+++ b/lib/checks/aria/valid-attr-value.js
@@ -1,6 +1,7 @@
 options = Array.isArray(options) ? options : [];
 
-const needsReview = [];
+let needsReview = '';
+let messageKey = '';
 const invalid = [];
 const aria = /^aria-/;
 const attrs = axe.utils.getNodeAttributes(node);
@@ -11,26 +12,37 @@ const preChecks = {
 	// aria-controls should only check if element exists if the element
 	// doesn't have aria-expanded=false or aria-selected=false (tabs)
 	// @see https://github.com/dequelabs/axe-core/issues/1463
-	'aria-controls': function() {
+	'aria-controls': () => {
 		return (
 			node.getAttribute('aria-expanded') !== 'false' &&
 			node.getAttribute('aria-selected') !== 'false'
 		);
 	},
+	// aria-current should mark as needs review if any value is used that is
+	// not one of the valid values (since any value is treated as "true")
+	'aria-current': () => {
+		if (!axe.commons.aria.validateAttrValue(node, 'aria-current')) {
+			needsReview = `aria-current="${node.getAttribute('aria-current')}"`;
+			messageKey = 'ariaCurrent';
+		}
+
+		return;
+	},
 	// aria-owns should only check if element exists if the element
 	// doesn't have aria-expanded=false (combobox)
 	// @see https://github.com/dequelabs/axe-core/issues/1524
-	'aria-owns': function() {
+	'aria-owns': () => {
 		return node.getAttribute('aria-expanded') !== 'false';
 	},
 	// aria-describedby should not mark missing element as violation but
 	// instead as needs review
 	// @see https://github.com/dequelabs/axe-core/issues/1151
-	'aria-describedby': function() {
+	'aria-describedby': () => {
 		if (!axe.commons.aria.validateAttrValue(node, 'aria-describedby')) {
-			needsReview.push(
-				`aria-describedby="${node.getAttribute('aria-describedby')}"`
-			);
+			needsReview = `aria-describedby="${node.getAttribute(
+				'aria-describedby'
+			)}"`;
+			messageKey = 'noId';
 		}
 
 		return;
@@ -52,8 +64,11 @@ for (let i = 0, l = attrs.length; i < l; i++) {
 	}
 }
 
-if (needsReview.length) {
-	this.data(needsReview);
+if (needsReview) {
+	this.data({
+		messageKey,
+		needsReview
+	});
 	return undefined;
 }
 

--- a/lib/checks/aria/valid-attr-value.json
+++ b/lib/checks/aria/valid-attr-value.json
@@ -11,8 +11,8 @@
 				"plural": "Invalid ARIA attribute values: ${data.values}"
 			},
 			"incomplete": {
-				"singular": "ARIA attribute element ID does not exist on the page: ${data.values}",
-				"plural": "ARIA attributes element ID does not exist on the page: ${data.values}"
+				"noId": "ARIA attribute element ID does not exist on the page: ${data.needsReview}",
+				"ariaCurrent": "ARIA attribute value is invalid and will be treated as \"aria-current=true\": ${data.needsReview}"
 			}
 		}
 	}

--- a/lib/checks/keyboard/page-has-main.json
+++ b/lib/checks/keyboard/page-has-main.json
@@ -2,9 +2,6 @@
 	"id": "page-has-main",
 	"evaluate": "page-has-elm.js",
 	"after": "page-has-elm-after.js",
-	"options": {
-		"selector": "main:not([role]), [role='main']"
-	},
 	"metadata": {
 		"impact": "moderate",
 		"messages": {

--- a/lib/checks/keyboard/page-has-main.json
+++ b/lib/checks/keyboard/page-has-main.json
@@ -2,6 +2,9 @@
 	"id": "page-has-main",
 	"evaluate": "page-has-elm.js",
 	"after": "page-has-elm-after.js",
+	"options": {
+		"selector": "main:not([role]), [role='main']"
+	},
 	"metadata": {
 		"impact": "moderate",
 		"messages": {

--- a/test/checks/aria/valid-attr-value.js
+++ b/test/checks/aria/valid-attr-value.js
@@ -213,6 +213,14 @@ describe('aria-valid-attr-value', function() {
 		);
 	});
 
+	it('should return undefined on aria-current with invalid value', function() {
+		fixtureSetup('<button aria-current="test">Button</button>');
+		var undefined1 = fixture.querySelector('button');
+		assert.isUndefined(
+			checks['aria-valid-attr-value'].evaluate.call(checkContext, undefined1)
+		);
+	});
+
 	describe('options', function() {
 		it('should exclude supplied attributes', function() {
 			fixture.innerHTML =

--- a/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.html
+++ b/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.html
@@ -11,7 +11,6 @@
 
 	<div aria-checked="stuff" id="violation6">hi</div>
 	<div aria-controls="stuff" id="violation7">hi</div>
-	<div aria-current="stage" id="violation8">hi</div>
 	<div aria-disabled="stuff" id="violation10">hi</div>
 	<div aria-dropeffect="stuff" id="violation11">hi</div>
 	<div aria-expanded="stuff" id="violation12">hi</div>
@@ -270,4 +269,5 @@
 	<div id="ref2">Hi2</div>
 
 	<div aria-describedby="stuff" id="incomplete1">hi</div>
+	<div aria-current="stage" id="incomplete2">hi</div>
 </div>

--- a/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.json
+++ b/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.json
@@ -9,7 +9,6 @@
 		["#violation5"],
 		["#violation6"],
 		["#violation7"],
-		["#violation8"],
 		["#violation10"],
 		["#violation11"],
 		["#violation12"],
@@ -224,5 +223,5 @@
 		["#pass183"],
 		["#pass184"]
 	],
-	"incomplete": [["#incomplete1"]]
+	"incomplete": [["#incomplete1"], ["#incomplete2"]]
 }


### PR DESCRIPTION
Aria-current with an invalid value is [just treated as "aria-current=true."](https://www.w3.org/TR/wai-aria-1.1/#aria-current) 

With another value needing to be marked as incomplete we needed to have different remediation messages for each one (aria-describedby for missing id and aria-current for invalid value). Because of this we couldn't return an array of values since we needed to set the `messageKey` property of the data. 

What this all means is that only one needs review item can be marked on an element at a time due to the need of different need review messages.

Closes issue: #1773

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
