### PR TITLE
fix(region-rule): allow live regions with explicit roles

### DIFF
--- a/lib/checks/navigation/region.js
+++ b/lib/checks/navigation/region.js
@@ -12,12 +12,13 @@ function isRegion(virtualNode) {
 	const explicitRole = axe.commons.aria.getRole(node, { noImplicit: true });
 	const ariaLive = (node.getAttribute('aria-live') || '').toLowerCase().trim();
 
-	if (explicitRole) {
-		return explicitRole === 'dialog' || landmarkRoles.includes(explicitRole);
-	}
 	// Ignore content inside of aria-live
 	if (['assertive', 'polite'].includes(ariaLive)) {
 		return true;
+	}
+
+	if (explicitRole) {
+		return explicitRole === 'dialog' || landmarkRoles.includes(explicitRole);
 	}
 
 	// Check if the node matches any of the CSS selectors of implicit landmarks

--- a/test/checks/navigation/region.js
+++ b/test/checks/navigation/region.js
@@ -241,6 +241,20 @@ describe('region', function() {
 		assert.isFalse(checks.region.evaluate.apply(checkContext, checkArgs));
 	});
 
+	it('allows content in aria-live=assertive with explicit role set', function() {
+		var checkArgs = checkSetup(
+			'<div aria-live="assertive" role="alert" id="target"><p>This is random content.</p></div>'
+		);
+		assert.isTrue(checks.region.evaluate.apply(checkContext, checkArgs));
+	});
+
+	it('allows content in aria-live=polite with explicit role set', function() {
+		var checkArgs = checkSetup(
+			'<div aria-live="polite" role="status" id="target"><p>This is random content.</p></div>'
+		);
+		assert.isTrue(checks.region.evaluate.apply(checkContext, checkArgs));
+	});
+
 	it('treats role=dialog elements as regions', function() {
 		var checkArgs = checkSetup(
 			'<div role="dialog" id="target"><p>This is random content.</p></div>'


### PR DESCRIPTION
The region rule should always allow content in an ARIA live region. The current code fails the rule based on role before it gets to the `aria-live` check. This fix moves that check up so a region with `role="alert"` and `aria-live` is allowed.

Closes issue: #1992 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
