### PR TITLE
fix(page-has-main): ignore hidden elements

### DIFF
--- a/lib/checks/keyboard/page-has-elm.js
+++ b/lib/checks/keyboard/page-has-elm.js
@@ -4,6 +4,10 @@ if (!options || !options.selector || typeof options.selector !== 'string') {
 	);
 }
 
-const matchingElms = axe.utils.querySelectorAll(virtualNode, options.selector);
+const matchingElms = axe.utils.querySelectorAllFilter(
+	virtualNode,
+	options.selector,
+	vNode => axe.commons.dom.isVisible(vNode.actualNode)
+);
 this.relatedNodes(matchingElms.map(vNode => vNode.actualNode));
 return matchingElms.length > 0;

--- a/test/checks/keyboard/page-has-elm.js
+++ b/test/checks/keyboard/page-has-elm.js
@@ -45,6 +45,15 @@ describe('page-has-*', function() {
 			var params = checkSetup('<div id="target"><b>No role</b></div>', options);
 			assert.isFalse(evaluate.apply(checkContext, params));
 		});
+
+		it('does not find hidden elements', function() {
+			var options = { selector: 'b' };
+			var params = checkSetup(
+				'<div id="target"><b style="display: none;">No role</b></div>',
+				options
+			);
+			assert.isFalse(evaluate.apply(checkContext, params));
+		});
 	});
 
 	describe('after', function() {


### PR DESCRIPTION
In the same vain as #1973, if a page has a main or h1 element but it is not visible, it shouldn't pass the check.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
