### PR TITLE
fix(color-contrast): improve speed and accuracy of code blocks with syntax highlighting

### DIFF
--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -140,14 +140,14 @@ color.filteredRectStack = function filteredRectStack(elm) {
  */
 color.getRectStack = function(elm) {
 	const boundingStack = axe.commons.dom.getElementStack(elm);
-	let rects = Array.from(elm.getClientRects());
-	// If the element does not have multiple rects, like for display:block, return a single stack
-	if (!rects || rects.length <= 1) {
-		return [boundingStack];
-	}
 
 	// Handle inline elements spanning multiple lines to be evaluated
-	let filteredArr = axe.commons.dom.getClientElementStack(elm);
+	const filteredArr = axe.commons.dom.getTextElementStack(elm);
+
+	// If the element does not have multiple rects, like for display:block, return a single stack
+	if (!filteredArr || filteredArr.length <= 1) {
+		return [boundingStack];
+	}
 
 	if (filteredArr.some(stack => stack === undefined)) {
 		// Can be happen when one or more of the rects sits outside the viewport

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -54,8 +54,7 @@ color.getForegroundColor = function(node, noScroll, bgColor) {
 	if (bgColor === null) {
 		const reason = axe.commons.color.incompleteData.get('bgColor');
 		axe.commons.color.incompleteData.set('fgColor', reason);
-		// TODO: revert to null after tests
-		return reason;
+		return null;
 	}
 
 	return color.flattenColors(fgColor, bgColor);

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -54,7 +54,8 @@ color.getForegroundColor = function(node, noScroll, bgColor) {
 	if (bgColor === null) {
 		const reason = axe.commons.color.incompleteData.get('bgColor');
 		axe.commons.color.incompleteData.set('fgColor', reason);
-		return null;
+		// TODO: revert to null after tests
+		return reason;
 	}
 
 	return color.flattenColors(fgColor, bgColor);

--- a/lib/commons/dom/get-element-stack.js
+++ b/lib/commons/dom/get-element-stack.js
@@ -548,7 +548,9 @@ dom.getTextElementStack = function(node) {
 				const rect = rects[i];
 
 				// filter out 0 width and height rects (newline characters)
-				if (rect.width && rect.height) {
+				// ie11 has newline characters return 0.00998, so we'll say if the
+				// line is < 1 it shouldn't be counted
+				if (rect.width >= 1 && rect.height >= 1) {
 					clientRects.push(rect);
 				}
 			}

--- a/lib/commons/dom/get-element-stack.js
+++ b/lib/commons/dom/get-element-stack.js
@@ -337,7 +337,10 @@ function addNodeToGrid(grid, vNode) {
 
 			for (let col = startCol; col <= endCol; col++) {
 				grid.cells[row][col] = grid.cells[row][col] || [];
-				grid.cells[row][col].push(vNode);
+
+				if (!grid.cells[row][col].includes(vNode)) {
+					grid.cells[row][col].push(vNode);
+				}
 			}
 		}
 	});
@@ -452,10 +455,10 @@ function getRectStack(grid, rect, recursed = false) {
 			// perform an AABB (axis-aligned bounding box) collision check for the
 			// point inside the rect
 			return (
-				x < rectX + clientRect.width &&
-				x > rectX &&
-				y < rectY + clientRect.height &&
-				y > rectY
+				x <= rectX + clientRect.width &&
+				x >= rectX &&
+				y <= rectY + clientRect.height &&
+				y >= rectY
 			);
 		});
 	});
@@ -507,12 +510,12 @@ dom.getElementStack = function(node) {
 
 /**
  * Return all elements that are at the center of each client rect of the passed in node.
- * @method getClientElementStack
+ * @method getTextElementStack
  * @memberof axe.commons.dom
  * @param {Node} node
  * @return {Array<Node[]>}
  */
-dom.getClientElementStack = function(node) {
+dom.getTextElementStack = function(node) {
 	if (!axe._cache.get('gridCreated')) {
 		createGrid();
 		axe._cache.set('gridCreated', true);
@@ -525,7 +528,33 @@ dom.getClientElementStack = function(node) {
 		return [];
 	}
 
-	const clientRects = vNode.clientRects;
+	// for code blocks that use syntax highlighting, you can get a ton of client
+	// rects (See https://github.com/dequelabs/axe-core/issues/1985). they use
+	// a mixture of text nodes and other nodes (which will contain their own text
+	// nodes), but all we care about is checking the direct text nodes as the
+	// other nodes will have their own client rects checked. doing this speeds up
+	// color contrast significantly for large syntax highlighted code blocks
+	const clientRects = [];
+	Array.from(node.childNodes).forEach(elm => {
+		if (
+			elm.nodeType === 3 &&
+			axe.commons.text.sanitize(elm.textContent) !== ''
+		) {
+			const range = document.createRange();
+			range.selectNodeContents(elm);
+			const rects = range.getClientRects();
+
+			for (let i = 0; i < rects.length; i++) {
+				const rect = rects[i];
+
+				// filter out 0 width and height rects (newline characters)
+				if (rect.width && rect.height) {
+					clientRects.push(rect);
+				}
+			}
+		}
+	});
+
 	return clientRects.map(rect => {
 		return getRectStack(grid, rect);
 	});

--- a/lib/commons/dom/get-element-stack.js
+++ b/lib/commons/dom/get-element-stack.js
@@ -509,7 +509,7 @@ dom.getElementStack = function(node) {
 };
 
 /**
- * Return all elements that are at the center of each client rect of the passed in node.
+ * Return all elements that are at the center of each text client rect of the passed in node.
  * @method getTextElementStack
  * @memberof axe.commons.dom
  * @param {Node} node

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -14,8 +14,8 @@ describe('color.getForegroundColor', function() {
 
 	it('should return the blended color if it has alpha set', function() {
 		fixture.innerHTML =
-			'<div style="height: 40px; width: 30px; background-color: #800000;">' +
-			'<div id="target" style="height: 20px; width: 15px; color: rgba(0, 0, 128, 0.5);' +
+			'<div style="height: 40px; background-color: #800000;">' +
+			'<div id="target" style="height: 40px; color: rgba(0, 0, 128, 0.5);' +
 			' background-color: rgba(0, 128, 0, 0.5);">' +
 			'This is my text' +
 			'</div></div>';
@@ -23,9 +23,6 @@ describe('color.getForegroundColor', function() {
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
 		var expected = new axe.commons.color.Color(32, 32, 64, 1);
-		if (actual === null) {
-			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
-		}
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
 		assert.closeTo(actual.blue, expected.blue, 0.8);
@@ -34,8 +31,8 @@ describe('color.getForegroundColor', function() {
 
 	it('should return the blended color if it has opacity set', function() {
 		fixture.innerHTML =
-			'<div style="height: 40px; width: 30px; background-color: #800000;">' +
-			'<div id="target" style="height: 20px; width: 15px; color: #000080;' +
+			'<div style="height: 40px; background-color: #800000;">' +
+			'<div id="target" style="height: 40px; color: #000080;' +
 			' background-color: green; opacity: 0.5;">' +
 			'This is my text' +
 			'</div></div>';
@@ -43,9 +40,6 @@ describe('color.getForegroundColor', function() {
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
 		var expected = new axe.commons.color.Color(32, 32, 64, 1);
-		if (actual === null) {
-			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
-		}
 		assert.equal(actual.red, expected.red);
 		assert.equal(actual.green, expected.green);
 		assert.equal(actual.blue, expected.blue);
@@ -55,17 +49,14 @@ describe('color.getForegroundColor', function() {
 	it('should take into account parent opacity tree', function() {
 		fixture.innerHTML =
 			'<div style="background-color: #fafafa">' +
-			'<div style="height: 40px; width: 30px; opacity: 0.6">' +
-			'<div id="target" style="height: 20px; width: 15px; color: rgba(0, 0, 0, 0.87);">' +
+			'<div style="height: 40px; opacity: 0.6">' +
+			'<div id="target" style="height: 40px; color: rgba(0, 0, 0, 0.87);">' +
 			'This is my text' +
 			'</div></div></div>';
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
 		var expected = new axe.commons.color.Color(119.5, 119.5, 119.5, 1);
-		if (actual === null) {
-			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
-		}
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
 		assert.closeTo(actual.blue, expected.blue, 0.8);
@@ -75,18 +66,15 @@ describe('color.getForegroundColor', function() {
 	it('should take into account entire parent opacity tree', function() {
 		fixture.innerHTML =
 			'<div style="background-color: #fafafa">' +
-			'<div style="height: 40px; width: 30px; opacity: 0.75">' +
-			'<div style="height: 40px; width: 30px; opacity: 0.8">' +
-			'<div id="target" style="height: 20px; width: 15px; color: rgba(0, 0, 0, 0.87);">' +
+			'<div style="height: 40px; opacity: 0.75">' +
+			'<div style="height: 40px; opacity: 0.8">' +
+			'<div id="target" style="height: 40px; color: rgba(0, 0, 0, 0.87);">' +
 			'This is my text' +
 			'</div></div></div></div>';
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
 		var expected = new axe.commons.color.Color(119.5, 119.5, 119.5, 1);
-		if (actual === null) {
-			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
-		}
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
 		assert.closeTo(actual.blue, expected.blue, 0.8);

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -22,6 +22,7 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
+		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(32, 32, 64, 1);
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
@@ -39,6 +40,7 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
+		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(32, 32, 64, 1);
 		assert.equal(actual.red, expected.red);
 		assert.equal(actual.green, expected.green);
@@ -56,6 +58,7 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
+		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(119.5, 119.5, 119.5, 1);
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
@@ -74,6 +77,7 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
+		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(119.5, 119.5, 119.5, 1);
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -22,8 +22,10 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
-		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(32, 32, 64, 1);
+		if (actual === null) {
+			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
+		}
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
 		assert.closeTo(actual.blue, expected.blue, 0.8);
@@ -40,8 +42,10 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
-		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(32, 32, 64, 1);
+		if (actual === null) {
+			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
+		}
 		assert.equal(actual.red, expected.red);
 		assert.equal(actual.green, expected.green);
 		assert.equal(actual.blue, expected.blue);
@@ -58,8 +62,10 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
-		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(119.5, 119.5, 119.5, 1);
+		if (actual === null) {
+			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
+		}
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
 		assert.closeTo(actual.blue, expected.blue, 0.8);
@@ -77,8 +83,10 @@ describe('color.getForegroundColor', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var target = fixture.querySelector('#target');
 		var actual = axe.commons.color.getForegroundColor(target);
-		assert.isObject(actual);
 		var expected = new axe.commons.color.Color(119.5, 119.5, 119.5, 1);
+		if (actual === null) {
+			assert.equal(axe.commons.color.incompleteData.get('fgColor'), 'foo');
+		}
 		assert.closeTo(actual.red, expected.red, 0.8);
 		assert.closeTo(actual.green, expected.green, 0.8);
 		assert.closeTo(actual.blue, expected.blue, 0.8);

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -3,7 +3,7 @@ describe('dom.getElementStack', function() {
 
 	var fixture = document.getElementById('fixture');
 	var getElementStack = axe.commons.dom.getElementStack;
-	var getClientElementStack = axe.commons.dom.getClientElementStack;
+	var getTextElementStack = axe.commons.dom.getTextElementStack;
 	var isIE11 = axe.testUtils.isIE11;
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 
@@ -247,7 +247,7 @@ describe('dom.getElementStack', function() {
 		it('should not return elements that do not fully cover the target', function() {
 			fixture.innerHTML =
 				'<div id="1" style="position:relative;">' +
-				'<div id="2" style="position:absolute;width:300px;height:20px;"></div>' +
+				'<div id="2" style="position:absolute;width:300px;height:19px;"></div>' +
 				'<p id="target" style="position:relative;z-index:1;width:300px;height:40px;">Text oh heyyyy <a href="#" id="target">and here\'s <br>a link</a></p>' +
 				'</div>';
 			axe.testUtils.flatTreeSetup(fixture);
@@ -491,21 +491,32 @@ describe('dom.getElementStack', function() {
 		});
 	});
 
-	describe('dom.getClientElementStack', function() {
-		it('should return array of client rects', function() {
+	describe('dom.getTextElementStack', function() {
+		it('should return array of client text rects', function() {
 			fixture.innerHTML =
 				'<main id="1">' +
 				'<span id="target">' +
-				'<span id="2">Hello</span><br/><span id="3">World</span>' +
+				'<span id="2">Hello</span><br/>World' +
 				'</span>' +
 				'</main>';
 			axe.testUtils.flatTreeSetup(fixture);
 			var target = fixture.querySelector('#target');
-			var stacks = getClientElementStack(target).map(mapToIDs);
-			assert.deepEqual(stacks, [
-				['2', 'target', '1', 'fixture'],
-				['3', 'target', '1', 'fixture']
-			]);
+			var stacks = getTextElementStack(target).map(mapToIDs);
+			assert.deepEqual(stacks, [['target', '1', 'fixture']]);
+		});
+
+		it('should ignore newline characters', function() {
+			fixture.innerHTML =
+				'<main id="1">' +
+				'<span id="target">' +
+				'<span id="2">Hello</span><br/>\n' +
+				'World' +
+				'</span>' +
+				'</main>';
+			axe.testUtils.flatTreeSetup(fixture);
+			var target = fixture.querySelector('#target');
+			var stacks = getTextElementStack(target).map(mapToIDs);
+			assert.deepEqual(stacks, [['target', '1', 'fixture']]);
 		});
 	});
 });

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -495,9 +495,9 @@ describe('dom.getElementStack', function() {
 		it('should return array of client text rects', function() {
 			fixture.innerHTML =
 				'<main id="1">' +
-				'<span id="target">' +
+				'<div id="target">' +
 				'<span id="2">Hello</span><br/>World' +
-				'</span>' +
+				'</div>' +
 				'</main>';
 			axe.testUtils.flatTreeSetup(fixture);
 			var target = fixture.querySelector('#target');
@@ -508,10 +508,10 @@ describe('dom.getElementStack', function() {
 		it('should ignore newline characters', function() {
 			fixture.innerHTML =
 				'<main id="1">' +
-				'<span id="target">' +
+				'<div id="target">' +
 				'<span id="2">Hello</span><br/>\n' +
 				'World' +
-				'</span>' +
+				'</div>' +
 				'</main>';
 			axe.testUtils.flatTreeSetup(fixture);
 			var target = fixture.querySelector('#target');

--- a/test/integration/full/contrast/code-highlighting.html
+++ b/test/integration/full/contrast/code-highlighting.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Test Page</title>
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href="/node_modules/mocha/mocha.css"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/themes/prism.min.css"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/themes/prism-okaidia.min.css"
+		/>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/axe.js"></script>
+		<script>
+			mocha.setup({
+				timeout: 10000,
+				ui: 'bdd'
+			});
+			var assert = chai.assert;
+		</script>
+		<script src="/test/integration/no-ui-reporter.js"></script>
+		<style></style>
+	</head>
+
+	<body>
+		<div id="fixture">
+			<pre>
+        <code class="language-html">&lt;!DOCTYPE html&gt;
+          &lt;html lang="en"&gt;
+            &lt;head&gt;
+              &lt;title&gt;Test Page&lt;/title&gt;
+              &lt;link
+                rel="stylesheet"
+                type="text/css"
+                href="/node_modules/mocha/mocha.css"
+              /&gt;
+              &lt;script src="/node_modules/mocha/mocha.js"&gt;&lt;/script&gt;
+              &lt;script src="/node_modules/chai/chai.js"&gt;&lt;/script&gt;
+              &lt;script src="/axe.js"&gt;&lt;/script&gt;
+              &lt;script&gt;
+                mocha.setup({
+                  timeout: 10000,
+                  ui: 'bdd'
+                });
+                var assert = chai.assert;
+              &lt;/script&gt;
+              &lt;script src="/test/integration/no-ui-reporter.js"&gt;&lt;/script&gt;
+              &lt;style&gt;&lt;/style&gt;
+            &lt;/head&gt;
+
+            &lt;body&gt;
+              &lt;pre&gt;
+                &lt;code&gt;
+
+                &lt;/code&gt;
+              &lt;/pre&gt;
+              &lt;script src="/test/testutils.js"&gt;&lt;/script&gt;
+              &lt;script src="code-highlighting.js"&gt;&lt;/script&gt;
+              &lt;script src="/test/integration/adapter.js"&gt;&lt;/script&gt;
+            &lt;/body&gt;
+          &lt;/html&gt;</code>
+      </pre>
+		</div>
+		<script src="/test/testutils.js"></script>
+		<script src="code-highlighting.js"></script>
+		<script src="/test/integration/adapter.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/prism.min.js"></script>
+	</body>
+</html>

--- a/test/integration/full/contrast/code-highlighting.js
+++ b/test/integration/full/contrast/code-highlighting.js
@@ -1,0 +1,52 @@
+describe('color-contrast code highlighting test', function() {
+	'use strict';
+
+	describe('violations', function() {
+		it('should find issues', function(done) {
+			axe.run(
+				'#fixture',
+				{ runOnly: { type: 'rule', values: ['color-contrast'] } },
+				function(err, results) {
+					assert.isNull(err);
+					assert.lengthOf(results.violations, 1);
+					assert.lengthOf(results.violations[0].nodes, 32);
+					done();
+				}
+			);
+		});
+	});
+
+	describe('passes', function() {
+		it('should find passes', function(done) {
+			axe.run(
+				'#fixture',
+				{ runOnly: { type: 'rule', values: ['color-contrast'] } },
+				function(err, results) {
+					assert.isNull(err);
+					assert.lengthOf(results.passes, 1);
+					assert.lengthOf(results.passes[0].nodes, 27);
+					done();
+				}
+			);
+		});
+	});
+
+	describe('incomplete', function() {
+		it('should find just the code block', function(done) {
+			axe.run(
+				'#fixture',
+				{ runOnly: { type: 'rule', values: ['color-contrast'] } },
+				function(err, results) {
+					assert.isNull(err);
+					assert.lengthOf(results.incomplete, 1);
+					assert.lengthOf(results.incomplete[0].nodes, 1);
+					assert.equal(
+						results.incomplete[0].nodes[0].html,
+						'<code class=" language-html">'
+					);
+					done();
+				}
+			);
+		});
+	});
+});


### PR DESCRIPTION
Code blocks with syntax highlighting could have large amounts of client rects, which would then cause it to take a few seconds each to process. Code blocks could also cause us lots of incomplete results with "partially obscured by another element." 

The code changes fix the speed by focusing only on the client rects of the text nodes of the element rather than all client rects. Since each of the child nodes that have text nodes will be checked individually, there is no need for the main parent to also check those nodes as well. This reduced the large code block from 2000+ client rects to just <20, taking color contrast from running in 10+ seconds to <1 seconds. 

It also adjusts the collision check to account for elements which lie exactly on the middle of the element being checked. This solved all the incomplete issues and they now return as proper pass/fail.

Closes issue: #1985

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
