### PR TITLE
fix(color-contrast): mark as needs review for text that contains only non-BMP characters

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -6,14 +6,17 @@ if (!dom.isVisible(node, false)) {
 
 const visibleText = text.visibleVirtual(virtualNode, false, true);
 const ignoreUnicode = !!(options || {}).ignoreUnicode;
-const textContainsOnlyUnicode = !text.removeUnicode(visibleText, {
-	emoji: false,
-	nonBmp: true,
-	punctuations: false
-}).length;
+const textContainsOnlyUnicode = !text.sanitize(
+	text.removeUnicode(visibleText, {
+		emoji: false,
+		nonBmp: true,
+		punctuations: false
+	})
+).length;
 
 if (textContainsOnlyUnicode && ignoreUnicode) {
-	return true;
+	this.data({ messageKey: 'nonBmp' });
+	return undefined;
 }
 
 const noScroll = !!(options || {}).noScroll;

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -23,7 +23,7 @@
 				"outsideViewport": "Element's background color could not be determined because it's outside the viewport",
 				"equalRatio": "Element has a 1:1 contrast ratio with the background",
 				"shortTextContent": "Element content is too short to determine if it is actual text content",
-				"nonBmp": "Element content contains only non-BMP unicode characters"
+				"nonBmp": "Element content contains only non-text characters"
 			}
 		}
 	}

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -22,7 +22,8 @@
 				"elmPartiallyObscuring": "Element's background color could not be determined because it partially overlaps other elements",
 				"outsideViewport": "Element's background color could not be determined because it's outside the viewport",
 				"equalRatio": "Element has a 1:1 contrast ratio with the background",
-				"shortTextContent": "Element content is too short to determine if it is actual text content"
+				"shortTextContent": "Element content is too short to determine if it is actual text content",
+				"nonBmp": "Element content contains only non-BMP unicode characters"
 			}
 		}
 	}

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -93,7 +93,8 @@ function getUnicodeNonBmpRegExp() {
 		'\u2600-\u26FF' + // Misc Symbols
 		'\u2700-\u27BF' + // Dingbats
 		'\uE000-\uF8FF' + // Private Use
-			']'
+			']',
+		'g'
 	);
 }
 

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -328,16 +328,19 @@ describe('color-contrast', function() {
 		assert.equal(checkContext._data.messageKey, 'shortTextContent');
 	});
 
-	it('should return undefined when the text only contains nonBmp unicode by default', function() {
+	it('should return undefined when the text only contains nonBmp unicode when the ignoreUnicode option is true', function() {
 		var params = checkSetup(
 			'<div style="background-color: #FFF;">' +
-				'<div style="color:#DDD;" id="target">◓</div>' +
-				'</div>'
+				'<div style="color:#DDD;" id="target">&#x20A0; &#x20A1; &#x20A2; &#x20A3;</div>' +
+				'</div>',
+			{
+				ignoreUnicode: true
+			}
 		);
 
 		var actual = contrastEvaluate.apply(checkContext, params);
 		assert.isUndefined(actual);
-		assert.equal(checkContext._data.messageKey, 'shortTextContent');
+		assert.equal(checkContext._data.messageKey, 'nonBmp');
 	});
 
 	it('should return true when the text only contains nonBmp unicode when the ignoreUnicode option is false, and there is sufficient contrast', function() {

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -160,7 +160,7 @@ describe('text.hasUnicode', function() {
 
 describe('text.removeUnicode', function() {
 	it('returns string by removing non BMP unicode ', function() {
-		var actual = axe.commons.text.removeUnicode('₨20000', {
+		var actual = axe.commons.text.removeUnicode('₨₨20000₨₨', {
 			nonBmp: true
 		});
 		assert.equal(actual, '20000');


### PR DESCRIPTION
The test for non-BMP characters was actually broken as it was returning `undefined` because of short text content and not because of the non-BMP characters. Also fixed the non-BMP regex to globally ignore characters.

Closes issue: #1993

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
