### PR TITLE
fix(color-contrast): support IE extension context

### DIFF
--- a/lib/commons/dom/shadow-elements-from-point.js
+++ b/lib/commons/dom/shadow-elements-from-point.js
@@ -14,7 +14,8 @@ dom.shadowElementsFromPoint = function(nodeX, nodeY, root = document, i = 0) {
 		throw new Error('Infinite loop detected');
 	}
 	return (
-		Array.from(root.elementsFromPoint(nodeX, nodeY))
+		// IE can return null when there are no elements
+		Array.from(root.elementsFromPoint(nodeX, nodeY) || [])
 			// As of Chrome 66, elementFromPoint will return elements from parent trees.
 			// We only want to touch each tree once, so we're filtering out nodes on other trees.
 			.filter(nodes => dom.getRootNode(nodes) === root)

--- a/test/commons/dom/shadow-elements-from-point.js
+++ b/test/commons/dom/shadow-elements-from-point.js
@@ -44,4 +44,17 @@ describe('dom.shadowElementsFromPoint', function() {
 			assert.notInclude(result2, shadowSpan);
 		}
 	);
+
+	it('does not throw when elementsFromPoints returns null', function() {
+		var mockDocument = {
+			elementsFromPoint: function() {
+				return null;
+			}
+		};
+		var out;
+		assert.doesNotThrow(function() {
+			out = axe.commons.dom.shadowElementsFromPoint(10, 10, mockDocument);
+		});
+		assert.deepEqual(out, []);
+	});
 });


### PR DESCRIPTION
`msElementsFromPoint` in IE extensions can return null instead of an empty array where the point is outside the viewport. This ensures such a scenario doesn't cause color-contrast to bail.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
