### PR TITLE
fix(preload): reject promise `axe.utils.preload` when XHR fails

### DIFF
--- a/lib/core/utils/preload.js
+++ b/lib/core/utils/preload.js
@@ -66,7 +66,7 @@ axe.utils.getPreloadConfig = function getPreloadConfig(options) {
 	if (
 		options.preload.timeout &&
 		typeof options.preload.timeout === 'number' &&
-		!Number.isNaN(options.preload.timeout)
+		!isNaN(options.preload.timeout)
 	) {
 		config.timeout = options.preload.timeout;
 	}

--- a/lib/core/utils/preload.js
+++ b/lib/core/utils/preload.js
@@ -97,10 +97,10 @@ axe.utils.preload = function preload(options) {
 		 * Start `timeout` timer for preloading assets
 		 * -> reject if allowed time expires.
 		 */
-		const preloadTimeout = setTimeout(() => {
-			clearTimeout(preloadTimeout);
-			reject(new Error(`Preload assets timed out.`));
-		}, timeout);
+		const preloadTimeout = setTimeout(
+			() => reject(new Error(`Preload assets timed out.`)),
+			timeout
+		);
 
 		/**
 		 * Fetch requested `assets`

--- a/lib/core/utils/preload.js
+++ b/lib/core/utils/preload.js
@@ -97,12 +97,14 @@ axe.utils.preload = function preload(options) {
 		 * Start `timeout` timer for preloading assets
 		 * -> reject if allowed time expires.
 		 */
-		setTimeout(() => reject(`Preload assets timed out.`), timeout);
+		const preloadTimeout = setTimeout(() => {
+			clearTimeout(preloadTimeout);
+			reject(new Error(`Preload assets timed out.`));
+		}, timeout);
 
 		/**
 		 * Fetch requested `assets`
 		 */
-
 		Promise.all(
 			assets.map(asset =>
 				preloadFunctionsMap[asset](options).then(results => {
@@ -111,26 +113,32 @@ axe.utils.preload = function preload(options) {
 					};
 				})
 			)
-		).then(results => {
-			/**
-			 * Combine array of results into an object map
-			 *
-			 * From ->
-			 * 	[{cssom: [...], aom: [...]}]
-			 * To ->
-			 * 	{
-			 * 		cssom: [...]
-			 * 	 	aom: [...]
-			 * 	}
-			 */
-			const preloadAssets = results.reduce((out, result) => {
-				return {
-					...out,
-					...result
-				};
-			}, {});
+		)
+			.then(results => {
+				/**
+				 * Combine array of results into an object map
+				 *
+				 * From ->
+				 * 	[{cssom: [...], aom: [...]}]
+				 * To ->
+				 * 	{
+				 * 		cssom: [...]
+				 * 	 	aom: [...]
+				 * 	}
+				 */
+				const preloadAssets = results.reduce((out, result) => {
+					return {
+						...out,
+						...result
+					};
+				}, {});
 
-			resolve(preloadAssets);
-		});
+				clearTimeout(preloadTimeout);
+				resolve(preloadAssets);
+			})
+			.catch(err => {
+				clearTimeout(preloadTimeout);
+				reject(err);
+			});
 	});
 };

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -74,17 +74,19 @@ describe('axe.utils.preload integration test', function() {
 			if (err) {
 				done(err);
 			}
-			getPreload().then(function(preloadedAssets) {
-				assert.property(preloadedAssets, 'cssom');
-				assert.lengthOf(preloadedAssets.cssom, 1);
-				var sheetData = preloadedAssets.cssom[0].sheet;
-				axe.testUtils.assertStylesheet(
-					sheetData,
-					'.inline-css-test',
-					stylesForPage[0].text
-				);
-				done();
-			});
+			getPreload()
+				.then(function(preloadedAssets) {
+					assert.property(preloadedAssets, 'cssom');
+					assert.lengthOf(preloadedAssets.cssom, 1);
+					var sheetData = preloadedAssets.cssom[0].sheet;
+					axe.testUtils.assertStylesheet(
+						sheetData,
+						'.inline-css-test',
+						stylesForPage[0].text
+					);
+					done();
+				})
+				.catch(done);
 		});
 	});
 
@@ -94,11 +96,13 @@ describe('axe.utils.preload integration test', function() {
 			if (err) {
 				done(err);
 			}
-			getPreload().then(function(preloadedAssets) {
-				assert.property(preloadedAssets, 'cssom');
-				assert.lengthOf(preloadedAssets.cssom, 0);
-				done();
-			});
+			getPreload()
+				.then(function(preloadedAssets) {
+					assert.property(preloadedAssets, 'cssom');
+					assert.lengthOf(preloadedAssets.cssom, 0);
+					done();
+				})
+				.catch(done);
 		});
 	});
 
@@ -116,7 +120,8 @@ describe('axe.utils.preload integration test', function() {
 					assert.isNotNull(err);
 					assert.isTrue(!err.message.includes('Preload assets timed out'));
 					done();
-				});
+				})
+				.catch(done);
 		});
 	});
 
@@ -134,7 +139,8 @@ describe('axe.utils.preload integration test', function() {
 					assert.isNotNull(err);
 					assert.isTrue(err.message.includes('Preload assets timed out'));
 					done();
-				});
+				})
+				.catch(done);
 		});
 	});
 

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -9,8 +9,8 @@ describe('axe.utils.preload integration test', function() {
 			href: 'https://unpkg.com/gutenberg-css@0.4'
 		},
 		crossOriginDoesNotExist: {
-			id: 'crossOriginDoesNotExist',
-			href: 'https://i-do-not-exist.css'
+			id: 'styleTag',
+			text: '@import "https://i-do-not-exist.css"'
 		},
 		crossOriginLinkHrefMediaPrint: {
 			id: 'crossOriginLinkHrefMediaPrint',

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -8,6 +8,11 @@ describe('axe.utils.preload integration test', function() {
 			id: 'crossOriginLinkHref',
 			href: 'https://unpkg.com/gutenberg-css@0.4'
 		},
+		crossOriginLinkHrefThatWillFailBecauseOfCors: {
+			id: 'crossOriginLinkHrefThatWillFailBecauseOfCors',
+			href:
+				'https://qkadxq0tba-flywheel.netdna-ssl.com/wp-content/plugins/deque-hubspot/assets/css/deque-forms.css?ver=1.2.4'
+		},
 		crossOriginLinkHrefMediaPrint: {
 			id: 'crossOriginLinkHrefMediaPrint',
 			href:
@@ -98,16 +103,39 @@ describe('axe.utils.preload integration test', function() {
 		});
 	});
 
+	it('returns NO preloaded CSSOM assets when requested stylesheets has been blocked by CORS policy: No `Access-Control-Allow-Origin`', function(done) {
+		stylesForPage = [styleSheets.crossOriginLinkHrefThatWillFailBecauseOfCors];
+		attachStylesheets({ styles: stylesForPage }, function(err) {
+			if (err) {
+				done(err);
+			}
+			getPreload()
+				.then(function() {
+					done(new Error('Not expecting to complete the promise'));
+				})
+				.catch(function(err) {
+					assert.isNotNull(err);
+					assert.isTrue(!err.message.includes('Preload assets timed out'));
+					done();
+				});
+		});
+	});
+
 	it('rejects preload function when timed out before fetching assets', function(done) {
 		stylesForPage = [styleSheets.crossOriginLinkHref];
 		attachStylesheets({ styles: stylesForPage }, function(err) {
 			if (err) {
 				done(err);
 			}
-			getPreload(1).catch(function(err) {
-				assert.isNotNull(err);
-				done();
-			});
+			getPreload(1)
+				.then(function() {
+					done(new Error('Not expecting to complete the promise'));
+				})
+				.catch(function(err) {
+					assert.isNotNull(err);
+					assert.isTrue(err.message.includes('Preload assets timed out'));
+					done();
+				});
 		});
 	});
 

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -8,10 +8,9 @@ describe('axe.utils.preload integration test', function() {
 			id: 'crossOriginLinkHref',
 			href: 'https://unpkg.com/gutenberg-css@0.4'
 		},
-		crossOriginLinkHrefThatWillFailBecauseOfCors: {
-			id: 'crossOriginLinkHrefThatWillFailBecauseOfCors',
-			href:
-				'https://qkadxq0tba-flywheel.netdna-ssl.com/wp-content/plugins/deque-hubspot/assets/css/deque-forms.css?ver=1.2.4'
+		crossOriginDoesNotExist: {
+			id: 'crossOriginDoesNotExist',
+			href: 'https://i-do-not-exist.css'
 		},
 		crossOriginLinkHrefMediaPrint: {
 			id: 'crossOriginLinkHrefMediaPrint',
@@ -103,8 +102,8 @@ describe('axe.utils.preload integration test', function() {
 		});
 	});
 
-	it('returns NO preloaded CSSOM assets when requested stylesheets has been blocked by CORS policy: No `Access-Control-Allow-Origin`', function(done) {
-		stylesForPage = [styleSheets.crossOriginLinkHrefThatWillFailBecauseOfCors];
+	it('returns NO preloaded CSSOM assets when requested stylesheet does not exist`', function(done) {
+		stylesForPage = [styleSheets.crossOriginDoesNotExist];
 		attachStylesheets({ styles: stylesForPage }, function(err) {
 			if (err) {
 				done(err);

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -1,4 +1,5 @@
-/* global axe */
+/* global axe, Promise */
+
 describe('axe.utils.preload integration test', function() {
 	'use strict';
 
@@ -127,6 +128,16 @@ describe('axe.utils.preload integration test', function() {
 
 	it('rejects preload function when timed out before fetching assets', function(done) {
 		stylesForPage = [styleSheets.crossOriginLinkHref];
+
+		var origPreloadCssom = axe.utils.preloadCssom;
+		axe.utils.preloadCssom = function() {
+			return new Promise(function(res) {
+				setTimeout(function() {
+					res(true);
+				}, 2000);
+			});
+		};
+
 		attachStylesheets({ styles: stylesForPage }, function(err) {
 			if (err) {
 				done(err);
@@ -138,9 +149,13 @@ describe('axe.utils.preload integration test', function() {
 				.catch(function(err) {
 					assert.isNotNull(err);
 					assert.isTrue(err.message.includes('Preload assets timed out'));
+
 					done();
 				})
-				.catch(done);
+				.catch(done)
+				.finally(function() {
+					axe.utils.preloadCssom = origPreloadCssom;
+				});
 		});
 	});
 


### PR DESCRIPTION
Preload assets did not reject with `axios.get` failed.
This meant that before this fix, axe.run waited till preload timeout kicked in.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
