### PR TITLE
fix(no-autoplay-audio): remove `Number.isNaN` check for node duration

### DIFF
--- a/lib/checks/media/no-autoplay-audio.js
+++ b/lib/checks/media/no-autoplay-audio.js
@@ -1,7 +1,7 @@
 /**
  * if duration cannot be read, this means `preloadMedia` has failed
  */
-if (!node.duration || Number.isNaN(node.duration)) {
+if (!node.duration) {
 	console.warn(`axe.utils.preloadMedia did not load metadata`);
 	return undefined;
 }


### PR DESCRIPTION
Identified that `Number.isNaN` fails in IE11. Also it is a redundant check as we already check if `!node.duration`.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
