### PR TITLE
fix(commons): avoid unicode regex encoding in axe.min.js

### DIFF
--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -71,31 +71,35 @@ function getUnicodeNonBmpRegExp() {
 	 * Regex for matching astral plane unicode
 	 * - http://kourge.net/projects/regexp-unicode-block
 	 */
-	return new RegExp(
-		'[' +
-		'\u1D00-\u1D7F' + // Phonetic Extensions
-		'\u1D80-\u1DBF' + // Phonetic Extensions Supplement
-		'\u1DC0-\u1DFF' + // Combining Diacritical Marks Supplement
-		// '\u2000-\u206F' + // General punctuation - handled in -> getPunctuationRegExp
-		'\u20A0-\u20CF' + // Currency symbols
-		'\u20D0-\u20FF' + // Combining Diacritical Marks for Symbols
-		'\u2100-\u214F' + // Letter like symbols
-		'\u2150-\u218F' + // Number forms (eg: Roman numbers)
-		'\u2190-\u21FF' + // Arrows
-		'\u2200-\u22FF' + // Mathematical operators
-		'\u2300-\u23FF' + // Misc Technical
-		'\u2400-\u243F' + // Control pictures
-		'\u2440-\u245F' + // OCR
-		'\u2460-\u24FF' + // Enclosed alpha numerics
-		'\u2500-\u257F' + // Box Drawing
-		'\u2580-\u259F' + // Block Elements
-		'\u25A0-\u25FF' + // Geometric Shapes
-		'\u2600-\u26FF' + // Misc Symbols
-		'\u2700-\u27BF' + // Dingbats
-		'\uE000-\uF8FF' + // Private Use
-			']',
-		'g'
-	);
+
+
+	/**
+	 * Notes on various unicode planes being used in the regex below:
+*		'\u1D00-\u1D7F'  Phonetic Extensions
+*		'\u1D80-\u1DBF'  Phonetic Extensions Supplement
+*		'\u1DC0-\u1DFF'  Combining Diacritical Marks Supplement
+*
+*'\u20A0-\u20CF'  Currency symbols
+*'\u20D0-\u20FF'  Combining Diacritical Marks for Symbols
+*'\u2100-\u214F'  Letter like symbols
+*'\u2150-\u218F'  Number forms (eg: Roman numbers)
+*'\u2190-\u21FF'  Arrows
+*'\u2200-\u22FF'  Mathematical operators
+*'\u2300-\u23FF'  Misc Technical
+*'\u2400-\u243F'  Control pictures
+*'\u2440-\u245F'  OCR
+*'\u2460-\u24FF'  Enclosed alpha numerics
+*'\u2500-\u257F'  Box Drawing
+*'\u2580-\u259F'  Block Elements
+*'\u25A0-\u25FF'  Geometric Shapes
+*'\u2600-\u26FF'  Misc Symbols
+*'\u2700-\u27BF'  Dingbats
+*'\uE000-\uF8FF'  Private Use
+*
+* Note: plane '\u2000-\u206F' used for General punctuation is excluded as it is handled in -> getPunctuationRegExp
+	 */
+
+	return /[\u1D00-\u1D7F\u1D80-\u1DBF\u1DC0-\u1DFF\u20A0-\u20CF\u20D0-\u20FF\u2100-\u214F\u2150-\u218F\u2190-\u21FF\u2200-\u22FF\u2300-\u23FF\u2400-\u243F\u2440-\u245F\u2460-\u24FF\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\uE000-\uF8FF]/g
 }
 
 /**

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -72,34 +72,33 @@ function getUnicodeNonBmpRegExp() {
 	 * - http://kourge.net/projects/regexp-unicode-block
 	 */
 
-
 	/**
 	 * Notes on various unicode planes being used in the regex below:
-*		'\u1D00-\u1D7F'  Phonetic Extensions
-*		'\u1D80-\u1DBF'  Phonetic Extensions Supplement
-*		'\u1DC0-\u1DFF'  Combining Diacritical Marks Supplement
-*
-*'\u20A0-\u20CF'  Currency symbols
-*'\u20D0-\u20FF'  Combining Diacritical Marks for Symbols
-*'\u2100-\u214F'  Letter like symbols
-*'\u2150-\u218F'  Number forms (eg: Roman numbers)
-*'\u2190-\u21FF'  Arrows
-*'\u2200-\u22FF'  Mathematical operators
-*'\u2300-\u23FF'  Misc Technical
-*'\u2400-\u243F'  Control pictures
-*'\u2440-\u245F'  OCR
-*'\u2460-\u24FF'  Enclosed alpha numerics
-*'\u2500-\u257F'  Box Drawing
-*'\u2580-\u259F'  Block Elements
-*'\u25A0-\u25FF'  Geometric Shapes
-*'\u2600-\u26FF'  Misc Symbols
-*'\u2700-\u27BF'  Dingbats
-*'\uE000-\uF8FF'  Private Use
-*
-* Note: plane '\u2000-\u206F' used for General punctuation is excluded as it is handled in -> getPunctuationRegExp
+	 *		'\u1D00-\u1D7F'  Phonetic Extensions
+	 *		'\u1D80-\u1DBF'  Phonetic Extensions Supplement
+	 *		'\u1DC0-\u1DFF'  Combining Diacritical Marks Supplement
+	 *
+	 *'\u20A0-\u20CF'  Currency symbols
+	 *'\u20D0-\u20FF'  Combining Diacritical Marks for Symbols
+	 *'\u2100-\u214F'  Letter like symbols
+	 *'\u2150-\u218F'  Number forms (eg: Roman numbers)
+	 *'\u2190-\u21FF'  Arrows
+	 *'\u2200-\u22FF'  Mathematical operators
+	 *'\u2300-\u23FF'  Misc Technical
+	 *'\u2400-\u243F'  Control pictures
+	 *'\u2440-\u245F'  OCR
+	 *'\u2460-\u24FF'  Enclosed alpha numerics
+	 *'\u2500-\u257F'  Box Drawing
+	 *'\u2580-\u259F'  Block Elements
+	 *'\u25A0-\u25FF'  Geometric Shapes
+	 *'\u2600-\u26FF'  Misc Symbols
+	 *'\u2700-\u27BF'  Dingbats
+	 *'\uE000-\uF8FF'  Private Use
+	 *
+	 * Note: plane '\u2000-\u206F' used for General punctuation is excluded as it is handled in -> getPunctuationRegExp
 	 */
 
-	return /[\u1D00-\u1D7F\u1D80-\u1DBF\u1DC0-\u1DFF\u20A0-\u20CF\u20D0-\u20FF\u2100-\u214F\u2150-\u218F\u2190-\u21FF\u2200-\u22FF\u2300-\u23FF\u2400-\u243F\u2440-\u245F\u2460-\u24FF\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\uE000-\uF8FF]/g
+	return /[\u1D00-\u1D7F\u1D80-\u1DBF\u1DC0-\u1DFF\u20A0-\u20CF\u20D0-\u20FF\u2100-\u214F\u2150-\u218F\u2190-\u21FF\u2200-\u22FF\u2300-\u23FF\u2400-\u243F\u2440-\u245F\u2460-\u24FF\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\uE000-\uF8FF]/g;
 }
 
 /**

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -74,26 +74,25 @@ function getUnicodeNonBmpRegExp() {
 
 	/**
 	 * Notes on various unicode planes being used in the regex below:
-	 *		'\u1D00-\u1D7F'  Phonetic Extensions
-	 *		'\u1D80-\u1DBF'  Phonetic Extensions Supplement
-	 *		'\u1DC0-\u1DFF'  Combining Diacritical Marks Supplement
-	 *
-	 *'\u20A0-\u20CF'  Currency symbols
-	 *'\u20D0-\u20FF'  Combining Diacritical Marks for Symbols
-	 *'\u2100-\u214F'  Letter like symbols
-	 *'\u2150-\u218F'  Number forms (eg: Roman numbers)
-	 *'\u2190-\u21FF'  Arrows
-	 *'\u2200-\u22FF'  Mathematical operators
-	 *'\u2300-\u23FF'  Misc Technical
-	 *'\u2400-\u243F'  Control pictures
-	 *'\u2440-\u245F'  OCR
-	 *'\u2460-\u24FF'  Enclosed alpha numerics
-	 *'\u2500-\u257F'  Box Drawing
-	 *'\u2580-\u259F'  Block Elements
-	 *'\u25A0-\u25FF'  Geometric Shapes
-	 *'\u2600-\u26FF'  Misc Symbols
-	 *'\u2700-\u27BF'  Dingbats
-	 *'\uE000-\uF8FF'  Private Use
+	 * '\u1D00-\u1D7F'  Phonetic Extensions
+	 * '\u1D80-\u1DBF'  Phonetic Extensions Supplement
+	 * '\u1DC0-\u1DFF'  Combining Diacritical Marks Supplement
+	 * '\u20A0-\u20CF'  Currency symbols
+	 * '\u20D0-\u20FF'  Combining Diacritical Marks for Symbols
+	 * '\u2100-\u214F'  Letter like symbols
+	 * '\u2150-\u218F'  Number forms (eg: Roman numbers)
+	 * '\u2190-\u21FF'  Arrows
+	 * '\u2200-\u22FF'  Mathematical operators
+	 * '\u2300-\u23FF'  Misc Technical
+	 * '\u2400-\u243F'  Control pictures
+	 * '\u2440-\u245F'  OCR
+	 * '\u2460-\u24FF'  Enclosed alpha numerics
+	 * '\u2500-\u257F'  Box Drawing
+	 * '\u2580-\u259F'  Block Elements
+	 * '\u25A0-\u25FF'  Geometric Shapes
+	 * '\u2600-\u26FF'  Misc Symbols
+	 * '\u2700-\u27BF'  Dingbats
+	 * '\uE000-\uF8FF'  Private Use
 	 *
 	 * Note: plane '\u2000-\u206F' used for General punctuation is excluded as it is handled in -> getPunctuationRegExp
 	 */


### PR DESCRIPTION
> Street creds for @AdnoC for pairing on this :)

See related issue - https://github.com/dequelabs/axe-core/issues/2023 for description.

In this fix, we create a `RegExp` literal instead of creating a RegExp from a string, which changes uglify behaviour.

This issue is not currently tested by any of the test coverage we have, because all of them use `axe.js` over a the minified `axe.min.js`. This issue was identified under windows ecosystem when executing axe from attest-java using the minified source.

Closes issue:
- https://github.com/dequelabs/axe-core/issues/2023

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
