### PR TITLE
fix(commons): handle node(s) contained by SVG document when deciphering url properties

### DIFF
--- a/lib/commons/dom/url-props-from-attribute.js
+++ b/lib/commons/dom/url-props-from-attribute.js
@@ -8,7 +8,7 @@
  * @returns {Object}
  */
 dom.urlPropsFromAttribute = function urlPropsFromAttribute(node, attribute) {
-	const value = node[attribute];
+	const value = node.getAttribute(attribute);
 	if (!value) {
 		return undefined;
 	}
@@ -18,9 +18,10 @@ dom.urlPropsFromAttribute = function urlPropsFromAttribute(node, attribute) {
 
 	/**
 	 * Note:
-	 * The need to create a parser, is to keep this function generic, to be able to parse resource from element like `iframe` with `src` attribute
+	 * The need to create a parser, is to keep this function generic, to be able to parse resource from element like `iframe` with `src` attribute,
+	 * also, when `a` or `area` is nested inside an svg document, they do not have url properties as a HTML Node, hence the check for `ownerSVGElement`
 	 */
-	if (!['A', 'AREA'].includes(nodeName)) {
+	if (!['A', 'AREA'].includes(nodeName) || node.ownerSVGElement) {
 		parser = document.createElement('a');
 		parser.href = value;
 	}

--- a/test/commons/dom/url-props-from-attribute.js
+++ b/test/commons/dom/url-props-from-attribute.js
@@ -20,12 +20,20 @@ describe('dom.urlPropsFromAttribute', function() {
 		assert.isUndefined(actual);
 	});
 
-	it('returns undefined when `A` has no `HREF` attribute', function() {
+	it('returns undefined when `A` has no requested `HREF` attribute', function() {
 		var vNode = queryFixture('<a id="target">Follow us on Instagram</a>');
 		var actual = axe.commons.dom.urlPropsFromAttribute(
 			vNode.actualNode,
 			'href'
 		);
+		assert.isUndefined(actual);
+	});
+
+	it('returns undefined when `IFRAME` has no requested `SRC` attribute', function() {
+		var vNode = queryFixture(
+			'<iframe id="target" title="Welcome to Foo Bar"></iframe>'
+		);
+		var actual = axe.commons.dom.urlPropsFromAttribute(vNode.actualNode, 'src');
 		assert.isUndefined(actual);
 	});
 
@@ -46,6 +54,23 @@ describe('dom.urlPropsFromAttribute', function() {
 			vNode.actualNode,
 			'href'
 		);
+		assert.deepEqual(actual, expected);
+	});
+
+	it('returns URL properties for `IFRAME` with `SRC` (having HTTPS protocol)', function() {
+		var vNode = queryFixture(
+			'<iframe id="target" title="Facebook" src="https://facebook.com"></iframe>'
+		);
+		var expected = {
+			filename: '',
+			hash: '',
+			hostname: 'facebook.com',
+			pathname: '/',
+			port: '',
+			protocol: 'http:',
+			search: {}
+		};
+		var actual = axe.commons.dom.urlPropsFromAttribute(vNode.actualNode, 'src');
 		assert.deepEqual(actual, expected);
 	});
 
@@ -184,6 +209,28 @@ describe('dom.urlPropsFromAttribute', function() {
 	it('returns URL properties for `A` with `HREF` which has filename', function() {
 		var vNode = queryFixture(
 			'<a id="target" href="http://mysite.com/directory/widgets/calendar.html">Book tour</a>'
+		);
+		var expected = {
+			filename: 'calendar.html',
+			hash: '',
+			hostname: 'mysite.com',
+			pathname: '/directory/widgets/',
+			port: '',
+			protocol: 'http:',
+			search: {}
+		};
+		var actual = axe.commons.dom.urlPropsFromAttribute(
+			vNode.actualNode,
+			'href'
+		);
+		assert.deepEqual(actual, expected);
+	});
+
+	it('returns URL properties for `A` with `HREF` that is contained in SVG document', function() {
+		var vNode = queryFixture(
+			'<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">' +
+				'<a id="target" href="http://mysite.com/directory/widgets/calendar.html" aria-label="Book tour"><circle cx="50" cy="40" r="35" /></a>' +
+				'</svg>'
 		);
 		var expected = {
 			filename: 'calendar.html',

--- a/test/integration/rules/identical-links-same-purpose/identical-links-same-purpose.html
+++ b/test/integration/rules/identical-links-same-purpose/identical-links-same-purpose.html
@@ -99,6 +99,34 @@
 <a id="pass15" href="/home">Pass 15</a>
 <a id="pass15-identical1" href="http://localhost:9876/home">Pass 15</a>
 
+<!-- ARIA links, with same resource, where one inside svg document -->
+<a id="pass16" href="/home">Pass 16</a>
+<svg
+	viewBox="0 0 100 100"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+	<a id="pass16-identical1" href="/home" aria-label="Pass 16">
+		<circle cx="50" cy="40" r="35" />
+	</a>
+</svg>
+
+<!-- ARIA links, with same resource, both are inside svg document -->
+<svg
+	viewBox="0 0 100 100"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+	<a href="http://deque.com" aria-label="Pass 17" id="pass17">
+		<circle cx="50" cy="40" r="35" />
+	</a>
+	<a href="http://deque.com" id="pass17-identical1">
+		<text x="50" y="90" text-anchor="middle">
+			Pass 17
+		</text>
+	</a>
+</svg>
+
 <!-- incomplete -->
 <!-- Note:identical incomplete nodes are appended as relatedNodes -->
 <!-- native links with different purpose -->
@@ -189,6 +217,23 @@
 <a id="incomplete14-identical2" href="../directory-two/foo.html"
 	>Incomplete 14</a
 >
+
+<!-- link(s) inside svg document with same name bu different resource -->
+<svg
+	viewBox="0 0 100 100"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+	<a href="http://deque.com" aria-label="Incomplete 15" id="incomplete15">
+		<circle cx="50" cy="40" r="35" />
+	</a>
+
+	<a href="http://dequeuniversity.com" id="incomplete15-identical1">
+		<text x="50" y="90" text-anchor="middle">
+			Incomplete 15
+		</text>
+	</a>
+</svg>
 
 <!-- inapplicable -->
 <!-- area element has no parent map -->

--- a/test/integration/rules/identical-links-same-purpose/identical-links-same-purpose.json
+++ b/test/integration/rules/identical-links-same-purpose/identical-links-same-purpose.json
@@ -19,7 +19,9 @@
 		["#pass13"],
 		["#pass13-identical-resource-but-different-name"],
 		["#pass14"],
-		["#pass15"]
+		["#pass15"],
+		["#pass16"],
+		["#pass17"]
 	],
 	"incomplete": [
 		["#incomplete1"],
@@ -35,6 +37,7 @@
 		["#incomplete11"],
 		["#incomplete12"],
 		["#incomplete13"],
-		["#incomplete14"]
+		["#incomplete14"],
+		["#incomplete15"]
 	]
 }


### PR DESCRIPTION
Nodes contained inside SVG document were a special case when constructing url properties.

Closes issue:
- https://github.com/dequelabs/axe-core/issues/2017

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
