### PR TITLE
chore: Add specific homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 			"url": "http://deque.com/"
 		}
 	],
+  "homepage": "https://www.deque.com/axe/",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/dequelabs/axe-core.git"


### PR DESCRIPTION
Adds https://www.deque.com/axe as the homepage reducing the redundancy on the npm site of having both links point to Github.

Closes issue: #2026 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
