### PR TITLE
fix(color-contrast): properly pass options to check

### DIFF
--- a/lib/checks/color/color-contrast.js
+++ b/lib/checks/color/color-contrast.js
@@ -6,13 +6,15 @@ if (!dom.isVisible(node, false)) {
 
 const visibleText = text.visibleVirtual(virtualNode, false, true);
 const ignoreUnicode = !!(options || {}).ignoreUnicode;
-const textContainsOnlyUnicode = !text.sanitize(
-	text.removeUnicode(visibleText, {
-		emoji: false,
-		nonBmp: true,
-		punctuations: false
-	})
-).length;
+const textContainsOnlyUnicode =
+	text.hasUnicode(visibleText, {
+		nonBmp: true
+	}) &&
+	text.sanitize(
+		text.removeUnicode(visibleText, {
+			nonBmp: true
+		})
+	) === '';
 
 if (textContainsOnlyUnicode && ignoreUnicode) {
 	this.data({ messageKey: 'nonBmp' });

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -1,13 +1,13 @@
 {
 	"id": "color-contrast",
 	"evaluate": "color-contrast.js",
+	"options": {
+		"noScroll": false,
+		"ignoreUnicode": true,
+		"ignoreLength": false
+	},
 	"metadata": {
 		"impact": "serious",
-		"options": {
-			"noScroll": false,
-			"ignoreUnicode": true,
-			"ignoreLength": false
-		},
 		"messages": {
 			"pass": "Element has sufficient color contrast of ${data.contrastRatio}",
 			"fail": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",

--- a/lib/rules/color-contrast.json
+++ b/lib/rules/color-contrast.json
@@ -2,11 +2,6 @@
 	"id": "color-contrast",
 	"matches": "color-contrast-matches.js",
 	"excludeHidden": false,
-	"options": {
-		"noScroll": false,
-		"ignoreUnicode": true,
-		"ignoreLength": false
-	},
 	"tags": ["cat.color", "wcag2aa", "wcag143"],
 	"metadata": {
 		"description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -219,3 +219,9 @@
 		Hi
 	</div>
 </div>
+
+<div style="background-color: #FFF;">
+	<div id="canttell20" style="color:#DDD;">
+		&#x20A0; &#x20A1; &#x20A2; &#x20A3;
+	</div>
+</div>

--- a/test/integration/rules/color-contrast/color-contrast.json
+++ b/test/integration/rules/color-contrast/color-contrast.json
@@ -30,6 +30,7 @@
 		["#canttell16"],
 		["#canttell17"],
 		["#canttell18"],
-		["#canttell19"]
+		["#canttell19"],
+		["#canttell20"]
 	]
 }


### PR DESCRIPTION
The check options were not being passed to the check as it was in the wrong place in the JSON file. Moving it to the correct place caused a bug in our [integration test](https://github.com/dequelabs/axe-core/blob/develop/test/integration/rules/color-contrast/color-contrast.html#L27-L32) in that a text field would return as undefined as it's visible text was empty, so we returned `undefined` instead of passing it as the [code assumed any empty text was due to unicodes](https://github.com/dequelabs/axe-core/blob/develop/lib/checks/color/color-contrast.js#L7-L20).

So I had to fix that by ensuring the visible text actually contained unicode characters before checking if it was empty due to removed unicode characters.

Closes issue: #1993

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
