### PR TITLE
chore(fr.json): fix typo in incomplete fallback

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -838,5 +838,5 @@
 			"failureMessage": "Corriger tous les éléments suivants : {{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "axee n'a pu en déterminr la raison. Il est temps de sortir l'inspecteur d'éléments!"
+  "incompleteFallbackMessage": "axe n'a pu en déterminer la raison. Il est temps de sortir l'inspecteur d'éléments!"
 }


### PR DESCRIPTION
Fixes a typo I noticed in fr.json

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
