### PR TITLE
fix(region): ignore direct child text nodes of body

### DIFF
--- a/lib/checks/navigation/region.js
+++ b/lib/checks/navigation/region.js
@@ -66,8 +66,13 @@ function findRegionlessElms(virtualNode) {
 
 		return [];
 
-		// Return the node is a content element
-	} else if (dom.hasContent(node, /* noRecursion: */ true)) {
+		// Return the node is a content element. Ignore any direct text children
+		// of body so we don't report body as being outside of a landmark.
+		// @see https://github.com/dequelabs/axe-core/issues/2049
+	} else if (
+		node !== document.body &&
+		dom.hasContent(node, /* noRecursion: */ true)
+	) {
 		return [virtualNode];
 
 		// Recursively look at all child elements

--- a/test/integration/full/region/region-fail.html
+++ b/test/integration/full/region/region-fail.html
@@ -37,6 +37,8 @@
 			</section>
 		</div>
 
+		This should be ignored
+
 		<main id="mocha"></main>
 		<script src="region-fail.js"></script>
 		<script src="/test/integration/adapter.js"></script>


### PR DESCRIPTION
We should ignore text nodes that are direct children of body since we cannot target the text node itself and saying "body must be contained within a landmark" doesn't make sense.

Closes issue: #2049

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
