### PR TITLE
fix(package-lock): change @deque/doT from agora to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "axe-core",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -886,8 +886,8 @@
 		},
 		"@deque/dot": {
 			"version": "1.1.5",
-			"resolved": "https://agora.dequecloud.com/artifactory/api/npm/attest-virtual/@deque/dot/-/dot-1.1.5.tgz",
-			"integrity": "sha1-zMUCWgC+JVGrfJVdsPpnNVVMloE=",
+			"resolved": "https://registry.npmjs.org/@deque/dot/-/dot-1.1.5.tgz",
+			"integrity": "sha512-8lvvd+qQrPQ/wRaYav/vpbx9qBwFTZydMQQmKYJGcso6nUnVjTA0EqZl4Z0VVQPwozepLyXD7oksxdwNeYv6dg==",
 			"dev": true
 		},
 		"@nodelib/fs.scandir": {
@@ -926,9 +926,9 @@
 			}
 		},
 		"@sinonjs/commons": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
-			"integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+			"integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
@@ -997,9 +997,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.7.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-			"integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
+			"version": "13.7.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
+			"integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -1066,9 +1066,9 @@
 			}
 		},
 		"acorn-walk": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
-			"integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+			"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
 			"dev": true
 		},
 		"add-stream": {
@@ -1574,14 +1574,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.8.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
-			"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
+			"version": "4.8.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.7.tgz",
+			"integrity": "sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001023",
-				"electron-to-chromium": "^1.3.341",
-				"node-releases": "^1.1.47"
+				"caniuse-lite": "^1.0.30001027",
+				"electron-to-chromium": "^1.3.349",
+				"node-releases": "^1.1.49"
 			}
 		},
 		"buffer": {
@@ -1681,9 +1681,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001025",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-			"integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+			"version": "1.0.30001028",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001028.tgz",
+			"integrity": "sha512-Vnrq+XMSHpT7E+LWoIYhs3Sne8h9lx9YJV3acH3THNCwU/9zV93/ta4xVfzTtnqd3rvnuVpVjE3DFqf56tr3aQ==",
 			"dev": true
 		},
 		"catharsis": {
@@ -2935,9 +2935,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -3274,9 +3274,9 @@
 			},
 			"dependencies": {
 				"rimraf": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-					"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -3500,9 +3500,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.345",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-			"integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
+			"version": "1.3.355",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz",
+			"integrity": "sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -3860,9 +3860,9 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
@@ -4127,9 +4127,9 @@
 			}
 		},
 		"figures": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-			"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -4885,13 +4885,13 @@
 			}
 		},
 		"globule": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
-			"integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+			"integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
+				"lodash": "~4.17.12",
 				"minimatch": "~3.0.2"
 			}
 		},
@@ -5270,6 +5270,12 @@
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
 			}
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -5688,13 +5694,10 @@
 			"dev": true
 		},
 		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
@@ -5889,15 +5892,6 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
 					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 					"dev": true
-				},
-				"klaw": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-					"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.9"
-					}
 				}
 			}
 		},
@@ -5987,6 +5981,15 @@
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
 			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
+		},
+		"klaw": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.9"
+			}
 		},
 		"labeled-stream-splicer": {
 			"version": "2.0.2",
@@ -6461,9 +6464,9 @@
 			}
 		},
 		"make-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-			"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+			"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
@@ -6830,12 +6833,6 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
-				},
-				"he": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-					"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
@@ -7236,9 +7233,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.48",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
-			"integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
+			"version": "1.1.49",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
+			"integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.3.0"
@@ -8049,9 +8046,9 @@
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
-			"integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.3.tgz",
+			"integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -8614,6 +8611,15 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"figures": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+					"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
 				"find-up": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -8767,9 +8773,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -9188,9 +9194,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.7.tgz",
-			"integrity": "sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+			"integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
 			"dev": true,
 			"requires": {
 				"commander": "~2.20.3",


### PR DESCRIPTION
When we created the package-lock.json, @deqeue/doT.js was resolved to use agora rather than npm.

Thanks to @scurker for finding this.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
