### PR TITLE
fix(aria-allowed-role): allow role=spinbutton on input[type=tel]

### DIFF
--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -1806,7 +1806,7 @@ lookupTable.role = {
 		allowedElements: {
 			nodeName: 'input',
 			properties: {
-				type: 'text'
+				type: ['text', 'tel']
 			}
 		}
 	},
@@ -2341,6 +2341,7 @@ lookupTable.evaluateRoleForElement = {
 					role === 'combobox' || role === 'searchbox' || role === 'spinbutton'
 				);
 			case 'tel':
+				return role === 'combobox' || role === 'spinbutton';
 			case 'url':
 			case 'search':
 			case 'email':

--- a/test/checks/aria/aria-allowed-role.js
+++ b/test/checks/aria/aria-allowed-role.js
@@ -232,6 +232,28 @@ describe('aria-allowed-role', function() {
 		);
 	});
 
+	it('returns true when INPUT type is number with role spinbutton', function() {
+		var node = document.createElement('input');
+		node.setAttribute('type', 'number');
+		node.setAttribute('role', 'spinbutton');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
+		assert.isTrue(
+			checks['aria-allowed-role'].evaluate.call(checkContext, node)
+		);
+	});
+
+	it('returns true when INPUT type is tel with role spinbutton', function() {
+		var node = document.createElement('input');
+		node.setAttribute('type', 'tel');
+		node.setAttribute('role', 'spinbutton');
+		fixture.appendChild(node);
+		flatTreeSetup(fixture);
+		assert.isTrue(
+			checks['aria-allowed-role'].evaluate.call(checkContext, node)
+		);
+	});
+
 	it('returns true when INPUT type is text with role searchbox', function() {
 		var node = document.createElement('input');
 		node.setAttribute('type', 'text');

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -107,6 +107,24 @@
 	aria-expanded="true"
 	id="pass-input-text-role-spinbutton"
 />
+<input
+	aria-autocomplete="list"
+	aria-label="some label"
+	autocomplete="off"
+	role="spinbutton"
+	type="number"
+	aria-expanded="true"
+	id="pass-input-number-role-spinbutton"
+/>
+<input
+	aria-autocomplete="list"
+	aria-label="some label"
+	autocomplete="off"
+	role="spinbutton"
+	type="tel"
+	aria-expanded="true"
+	id="pass-input-tel-role-spinbutton"
+/>
 <input type="image" role="link" id="pass-input-image-valid-role" />
 <input
 	type="checkbox"

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.json
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.json
@@ -41,6 +41,8 @@
 		["#pass-input-url-role-combobox"],
 		["#pass-input-email-role-combobox"],
 		["#pass-input-text-role-spinbutton"],
+		["#pass-input-number-role-spinbutton"],
+		["#pass-input-tel-role-spinbutton"],
 		["#pass-input-image-valid-role"],
 		["#pass-input-checkbox-valid-role"],
 		["#pass-h1-valid-role"],


### PR DESCRIPTION
Added input with a type of tel as an element that should allow the aria role of spinbutton.

Closes issue: #1928 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
