### PR TITLE
fix(getCheckMessage): add API to return check message

### DIFF
--- a/lib/core/utils/get-check-message.js
+++ b/lib/core/utils/get-check-message.js
@@ -1,0 +1,18 @@
+/* global axe*/
+
+/**
+ * Get the pass, fail, or incomplete message for a check.
+ * @param {String} checkId The check id
+ * @param {String} type The message type ('pass', 'fail', or 'incomplete')
+ * @param {Object} [data] The check data
+ * @return {String}
+ */
+axe.utils.getCheckMessage = function getCheckMessage(checkId, type, data) {
+	const check = axe._audit.data.checks[checkId];
+
+	if (!check || !check.messages[type]) {
+		return '';
+	}
+
+	return axe.utils.processMessage(check.messages[type], data);
+};

--- a/lib/core/utils/get-check-message.js
+++ b/lib/core/utils/get-check-message.js
@@ -10,8 +10,11 @@
 axe.utils.getCheckMessage = function getCheckMessage(checkId, type, data) {
 	const check = axe._audit.data.checks[checkId];
 
-	if (!check || !check.messages[type]) {
-		return '';
+	if (!check) {
+		throw new Error(`Cannot get message for unknown check: ${checkId}.`);
+	}
+	if (!check.messages[type]) {
+		throw new Error(`Check "${checkId}"" does not have a "${type}" message.`);
 	}
 
 	return axe.utils.processMessage(check.messages[type], data);

--- a/test/core/utils/get-check-message.js
+++ b/test/core/utils/get-check-message.js
@@ -1,0 +1,55 @@
+describe('axe.utils.getCheckMessage', function() {
+	var getCheckMessage = axe.utils.getCheckMessage;
+
+	beforeEach(function() {
+		axe._audit = {
+			data: {
+				checks: {
+					'my-check': {
+						messages: {
+							pass: 'Pass message',
+							fail: 'Fail message',
+							incomplete: 'Incomplete message'
+						}
+					}
+				}
+			}
+		};
+	});
+
+	afterEach(function() {
+		axe._audit = undefined;
+	});
+
+	it('should return the pass message', function() {
+		assert.equal(getCheckMessage('my-check', 'pass'), 'Pass message');
+	});
+
+	it('should return the fail message', function() {
+		assert.equal(getCheckMessage('my-check', 'fail'), 'Fail message');
+	});
+
+	it('should return the incomplete message', function() {
+		assert.equal(
+			getCheckMessage('my-check', 'incomplete'),
+			'Incomplete message'
+		);
+	});
+
+	it('should handle data', function() {
+		axe._audit.data.checks['my-check'].messages.pass =
+			'Pass message with ${data.message}';
+		assert.equal(
+			getCheckMessage('my-check', 'pass', { message: 'hello world!' }),
+			'Pass message with hello world!'
+		);
+	});
+
+	it('returns empty string when check does not exist', function() {
+		assert.equal(getCheckMessage('invalid-check', 'pass'), '');
+	});
+
+	it('returns empty string when check message does not exist', function() {
+		assert.equal(getCheckMessage('invalid-check', 'invalid'), '');
+	});
+});

--- a/test/core/utils/get-check-message.js
+++ b/test/core/utils/get-check-message.js
@@ -45,11 +45,15 @@ describe('axe.utils.getCheckMessage', function() {
 		);
 	});
 
-	it('returns empty string when check does not exist', function() {
-		assert.equal(getCheckMessage('invalid-check', 'pass'), '');
+	it('should error when check does not exist', function() {
+		assert.throws(function() {
+			getCheckMessage('invalid-check', 'pass');
+		});
 	});
 
-	it('returns empty string when check message does not exist', function() {
-		assert.equal(getCheckMessage('invalid-check', 'invalid'), '');
+	it('should error when check message does not exist', function() {
+		assert.throws(function() {
+			getCheckMessage('invalid-check', 'invalid');
+		});
 	});
 });


### PR DESCRIPTION
Technically this is a `feat`, but we had a breaking change for 3.5.1 that broke eslint-plugin-jsx-a11y, so we need to release this as a patch release so we don't go to 3.6.0. 

With this, they can use a public API rather than accessing a private interface:

```js
export function axeFailMessage(checkId, data) {
  return axe.utils.getCheckMessage(checkId, 'fail', data);
}
```

Closes issue: #2060 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
