### PR TITLE
docs: nest sublist in context parameter <ol />

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -268,13 +268,10 @@ axe.run(context, options, (err, results) => {
 By default, `axe.run` will test the entire document. The context object is an optional parameter that can be used to specify which element should and which should not be tested. It can be passed one of the following:
 
 1. An element reference that represents the portion of the document that must be analyzed
-
     - Example: To limit analysis to the `<div id="content">` element: `document.getElementById("content")`
-
-2. A NodeList such as returned by `document.querySelectorAll`.
-3. A [CSS selector](./developer-guide.md#supported-css-selectors) that selects the portion(s) of the document that must be analyzed.
-
-4. An include-exclude object (see below)
+1. A NodeList such as returned by `document.querySelectorAll`.
+1. A [CSS selector](./developer-guide.md#supported-css-selectors) that selects the portion(s) of the document that must be analyzed.
+1. An include-exclude object (see below)
 
 ###### Include-Exclude Object
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -269,7 +269,7 @@ By default, `axe.run` will test the entire document. The context object is an op
 
 1. An element reference that represents the portion of the document that must be analyzed
 
-- Example: To limit analysis to the `<div id="content">` element: `document.getElementById("content")`
+    - Example: To limit analysis to the `<div id="content">` element: `document.getElementById("content")`
 
 2. A NodeList such as returned by `document.querySelectorAll`.
 3. A [CSS selector](./developer-guide.md#supported-css-selectors) that selects the portion(s) of the document that must be analyzed.


### PR DESCRIPTION
The output contains 2 separate `<ol />` elements instead of just 1 (which I assume was the intent). This only visually worked because we previously hard-coded the numbers in the `<li />`s 

Closes issue: n/a

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
