### PR TITLE
docs(readme): use axe.run() promise API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ Now include the javascript file in each of your iframes in your fixtures or test
 Now insert calls at each point in your tests where a new piece of UI becomes visible or exposed:
 
 ```js
-axe.run().then(results => {
-  assert.isEmpty(results.violations, 'Has no accessibility issues');
-}).catch(done);
+axe.run()
+  .then(results => {
+    if (results.violations.length) {
+      throw new Error('Accessibility issues found')
+    }
+  })
+  .catch(err => {
+    console.error('Something bad happened:', err.message)
+  })
 ```
 
 ## Supported Browsers

--- a/README.md
+++ b/README.md
@@ -50,12 +50,9 @@ Now include the javascript file in each of your iframes in your fixtures or test
 Now insert calls at each point in your tests where a new piece of UI becomes visible or exposed:
 
 ```js
-axe.run(function (err, results) {
-  if (err) throw err;
-    ok(results.violations.length === 0, 'Should be no accessibility issues');
-    // complete the async call
-    ...
-});
+axe.run().then(results => {
+  assert.isEmpty(results.violations, 'Has no accessibility issues');
+}).catch(done);
 ```
 
 ## Supported Browsers


### PR DESCRIPTION
I noticed in a recent article someone was using the callback API instead of the promise API. The promise API is the preferred way to run axe, so it doesn't make sense that we use the callback API in the readme.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
