### PR TITLE
fix: check `invaildrole` fails only when all roles are invalid

### DIFF
--- a/lib/checks/aria/invalidrole.js
+++ b/lib/checks/aria/invalidrole.js
@@ -10,7 +10,7 @@ const allInvalid = allRoles.every(
  * Only fail when all the roles are invalid
  */
 if (allInvalid) {
-	this.data(invalidRoles);
+	this.data(allRoles);
 	return true;
 }
 

--- a/lib/checks/aria/invalidrole.js
+++ b/lib/checks/aria/invalidrole.js
@@ -1,12 +1,15 @@
-const invalidRoles = axe.utils
-	.tokenList(virtualNode.attr('role'))
-	.filter(role => {
-		return !axe.commons.aria.isValidRole(role, {
-			allowAbstract: true
-		});
-	});
+const { tokenList } = axe.utils;
+const { aria } = axe.commons;
 
-if (invalidRoles.length > 0) {
+const allRoles = tokenList(virtualNode.attr('role'));
+const invalidRoles = allRoles.filter(
+	role => !aria.isValidRole(role, { allowAbstract: true })
+);
+
+/**
+ * Only fail when all the roles are invalid
+ */
+if (invalidRoles.length > 0 && invalidRoles.length === allRoles.length) {
 	this.data(invalidRoles);
 	return true;
 }

--- a/lib/checks/aria/invalidrole.js
+++ b/lib/checks/aria/invalidrole.js
@@ -2,14 +2,14 @@ const { tokenList } = axe.utils;
 const { aria } = axe.commons;
 
 const allRoles = tokenList(virtualNode.attr('role'));
-const invalidRoles = allRoles.filter(
+const allInvalid = allRoles.every(
 	role => !aria.isValidRole(role, { allowAbstract: true })
 );
 
 /**
  * Only fail when all the roles are invalid
  */
-if (invalidRoles.length > 0 && invalidRoles.length === allRoles.length) {
+if (allInvalid) {
 	this.data(invalidRoles);
 	return true;
 }

--- a/test/checks/shared/invalidrole.js
+++ b/test/checks/shared/invalidrole.js
@@ -83,9 +83,23 @@ describe('invalidrole', function() {
 		assert.isNull(checkContext._data);
 	});
 
-	it('should return true if applied to at least one nonsensical role', function() {
+	it('should return false if atleast one role is valid', function() {
 		var virtualNode = queryFixture(
 			'<div id="target" role="alert button foo bar">Contents</div>'
+		);
+		assert.isFalse(
+			checks.invalidrole.evaluate.call(
+				checkContext,
+				virtualNode.actualNode,
+				null,
+				virtualNode
+			)
+		);
+	});
+
+	it('should return true if all roles are invalid', function() {
+		var virtualNode = queryFixture(
+			'<div id="target" role="foo bar">Contents</div>'
 		);
 		assert.isTrue(
 			checks.invalidrole.evaluate.call(


### PR DESCRIPTION
`invalidrole` should fail only when all roles on a given element are invalid.

Closes issue:
- https://github.com/dequelabs/axe-core/issues/2073

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
