### PR TITLE
fix(page-no-duplicate-contentinfo): do not fail when first element is inside landmark

### DIFF
--- a/lib/checks/keyboard/page-no-duplicate.js
+++ b/lib/checks/keyboard/page-no-duplicate.js
@@ -15,7 +15,7 @@ axe._cache.set(key, true);
 let elms = axe.utils.querySelectorAllFilter(
 	axe._tree[0],
 	options.selector,
-	elm => elm !== virtualNode && axe.commons.dom.isVisible(elm.actualNode)
+	elm => axe.commons.dom.isVisible(elm.actualNode)
 );
 
 // Filter elements that, within certain contexts, don't map their role.
@@ -29,6 +29,8 @@ if (typeof options.nativeScopeFilter === 'string') {
 	});
 }
 
-this.relatedNodes(elms.map(elm => elm.actualNode));
+this.relatedNodes(
+	elms.filter(elm => elm !== virtualNode).map(elm => elm.actualNode)
+);
 
-return elms.length === 0;
+return elms.length <= 1;

--- a/test/checks/keyboard/page-no-duplicate.js
+++ b/test/checks/keyboard/page-no-duplicate.js
@@ -112,7 +112,20 @@ describe('page-no-duplicate', function() {
 			assert.isFalse(check.evaluate.apply(checkContext, params));
 		});
 
-		(shadowSupported ? it : xit)(
+		it('should pass when there are two elements and the first is contained within a nativeSccopeFilter', function() {
+			var options = {
+				selector: 'footer, [role="contentinfo"]',
+				nativeScopeFilter: 'article'
+			};
+			var params = checkSetup(
+				'<article>' +
+					'<footer id="target">Article footer</footer>' +
+					'</article>' +
+					'<footer>Body footer</footer>',
+				options
+			);
+			assert.isTrue(check.evaluate.apply(checkContext, params));
+		})(shadowSupported ? it : xit)(
 			'elements if its ancestor is outside the shadow DOM tree',
 			function() {
 				var options = {

--- a/test/checks/keyboard/page-no-duplicate.js
+++ b/test/checks/keyboard/page-no-duplicate.js
@@ -125,7 +125,9 @@ describe('page-no-duplicate', function() {
 				options
 			);
 			assert.isTrue(check.evaluate.apply(checkContext, params));
-		})(shadowSupported ? it : xit)(
+		});
+
+		(shadowSupported ? it : xit)(
 			'elements if its ancestor is outside the shadow DOM tree',
 			function() {
 				var options = {


### PR DESCRIPTION
The changes in [this pr](https://github.com/dequelabs/axe-core/pull/1949) modified the code in such a way that the first element passed to the check is not filtered based on the `nativeScopeFilter` option. This caused the bug in #2081

Closes issue: #2081

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
