### PR TITLE
fix(td-has-headers): don't fail for empty headers attribute

### DIFF
--- a/lib/commons/table/get-headers.js
+++ b/lib/commons/table/get-headers.js
@@ -57,7 +57,7 @@ function traverseForHeaders(headerType, position, tableGrid) {
  * @return {Array<HTMLTableCellElement>} Array of headers associated to the table cell
  */
 table.getHeaders = function(cell, tableGrid) {
-	if (cell.hasAttribute('headers')) {
+	if (cell.getAttribute('headers')) {
 		return commons.dom.idrefs(cell, 'headers');
 	}
 	if (!tableGrid) {

--- a/lib/commons/table/get-headers.js
+++ b/lib/commons/table/get-headers.js
@@ -58,7 +58,13 @@ function traverseForHeaders(headerType, position, tableGrid) {
  */
 table.getHeaders = function(cell, tableGrid) {
 	if (cell.getAttribute('headers')) {
-		return commons.dom.idrefs(cell, 'headers');
+		const headers = commons.dom.idrefs(cell, 'headers');
+
+		// testing has shown that if the headers attribute is incorrect the browser
+		// will default to the table row/column headers
+		if (headers.filter(header => header).length) {
+			return headers;
+		}
 	}
 	if (!tableGrid) {
 		tableGrid = commons.table.toGrid(commons.dom.findUp(cell, 'table'));

--- a/test/checks/tables/td-has-header.js
+++ b/test/checks/tables/td-has-header.js
@@ -159,7 +159,7 @@ describe('td-has-header', function() {
 		]);
 	});
 
-	it('should return false if the headers element is empty', function() {
+	it('should return true if the headers element is empty', function() {
 		fixture.innerHTML =
 			'<table>' +
 			'  <tr> <th>Hello</th> <td headers="">goodbye</td> </tr>' +
@@ -168,7 +168,7 @@ describe('td-has-header', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var node = fixture.querySelector('table');
 
-		assert.isFalse(checks['td-has-header'].evaluate.call(checkContext, node));
+		assert.isTrue(checks['td-has-header'].evaluate.call(checkContext, node));
 	});
 
 	it('should return false if the headers element refers to non-existing elements', function() {

--- a/test/checks/tables/td-has-header.js
+++ b/test/checks/tables/td-has-header.js
@@ -171,7 +171,7 @@ describe('td-has-header', function() {
 		assert.isTrue(checks['td-has-header'].evaluate.call(checkContext, node));
 	});
 
-	it('should return false if the headers element refers to non-existing elements', function() {
+	it('should return true if the headers element refers to non-existing elements', function() {
 		fixture.innerHTML =
 			'<table>' +
 			'  <tr> <th>Hello</th> <td headers="beatles">goodbye</td> </tr>' +
@@ -180,7 +180,7 @@ describe('td-has-header', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 		var node = fixture.querySelector('table');
 
-		assert.isFalse(checks['td-has-header'].evaluate.call(checkContext, node));
+		assert.isTrue(checks['td-has-header'].evaluate.call(checkContext, node));
 	});
 
 	it('should return false if all headers are empty', function() {

--- a/test/commons/table/get-headers.js
+++ b/test/commons/table/get-headers.js
@@ -128,6 +128,25 @@ describe('table.getHeaders', function() {
 		]);
 	});
 
+	it('should handle empty headers attribute', function() {
+		fixture.innerHTML =
+			'<table>' +
+			'<tr>' +
+			'<th scope="col" id="t1">Projects</th>' +
+			'<th scope="col" id="t2">Progress</th>' +
+			'</tr>' +
+			'<tr>' +
+			'<td headers="" id="target">My Project</td>' +
+			'<td>15%</td>' +
+			'</tr>' +
+			'</table>';
+
+		var target = $id('target');
+
+		axe.testUtils.flatTreeSetup(fixture.firstChild);
+		assert.deepEqual(axe.commons.table.getHeaders(target), [$id('t1')]);
+	});
+
 	it('should work with tables that have inconsistent columns', function() {
 		fixture.innerHTML =
 			'<table>' +

--- a/test/commons/table/get-headers.js
+++ b/test/commons/table/get-headers.js
@@ -147,6 +147,25 @@ describe('table.getHeaders', function() {
 		assert.deepEqual(axe.commons.table.getHeaders(target), [$id('t1')]);
 	});
 
+	it('should handle non-existent headers attribute', function() {
+		fixture.innerHTML =
+			'<table>' +
+			'<tr>' +
+			'<th scope="col" id="t1">Projects</th>' +
+			'<th scope="col" id="t2">Progress</th>' +
+			'</tr>' +
+			'<tr>' +
+			'<td headers="non-existent" id="target">My Project</td>' +
+			'<td>15%</td>' +
+			'</tr>' +
+			'</table>';
+
+		var target = $id('target');
+
+		axe.testUtils.flatTreeSetup(fixture.firstChild);
+		assert.deepEqual(axe.commons.table.getHeaders(target), [$id('t1')]);
+	});
+
 	it('should work with tables that have inconsistent columns', function() {
 		fixture.innerHTML =
 			'<table>' +


### PR DESCRIPTION
Part 1 of 2 (part 2: https://github.com/dequelabs/axe-core/pull/2096)

Partially closes issue: #2039

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
