### PR TITLE
fix(definition-list): Mention <div> is allowed to group content in <dl>

### DIFF
--- a/lib/rules/definition-list.json
+++ b/lib/rules/definition-list.json
@@ -5,7 +5,7 @@
 	"tags": ["cat.structure", "wcag2a", "wcag131"],
 	"metadata": {
 		"description": "Ensures <dl> elements are structured correctly",
-		"help": "<dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script> or <template> elements"
+		"help": "<dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script>, <template> or <div> elements"
 	},
 	"all": [],
 	"any": [],


### PR DESCRIPTION
Add mention that `<div>` is allowed to group content in `<dl>`, reference:  https://github.com/dequelabs/axe-core/pull/1076.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security