### PR TITLE
fix(unicode) detect supplementary private use area A

### DIFF
--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -135,5 +135,5 @@ function getSupplementaryPrivateUseRegExp() {
 	 * https://www.unicode.org/charts/PDF/UDC00.pdf
 	 * https://www.unicode.org/charts/PDF/UF0000.pdf
 	 */
-	return /[\uDB80-\uDBBF][\uDC00-\uDFFD]|[\u{F0000}-\u{FFFFD}]/gu;
+	return /[\uDB80-\uDBBF][\uDC00-\uDFFD]|(?:[\uDB80-\uDBBE][\uDC00-\uDFFF]|\uDBBF[\uDC00-\uDFFD])/g;
 }

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -19,7 +19,10 @@ text.hasUnicode = function hasUnicode(str, options) {
 		return axe.imports.emojiRegexText().test(str);
 	}
 	if (nonBmp) {
-		return getUnicodeNonBmpRegExp().test(str);
+		return (
+			getUnicodeNonBmpRegExp().test(str) ||
+			getSupplementaryPrivateUseRegExp().test(str)
+		);
 	}
 	if (punctuations) {
 		return getPunctuationRegExp().test(str);
@@ -93,12 +96,11 @@ function getUnicodeNonBmpRegExp() {
 	 * '\u2600-\u26FF'  Misc Symbols
 	 * '\u2700-\u27BF'  Dingbats
 	 * '\uE000-\uF8FF'  Private Use
-	 * '\u{F0000}-\u{FFFFD}' Supplementary Private Use Area A
 	 *
 	 * Note: plane '\u2000-\u206F' used for General punctuation is excluded as it is handled in -> getPunctuationRegExp
 	 */
 
-	return /[\u1D00-\u1D7F\u1D80-\u1DBF\u1DC0-\u1DFF\u20A0-\u20CF\u20D0-\u20FF\u2100-\u214F\u2150-\u218F\u2190-\u21FF\u2200-\u22FF\u2300-\u23FF\u2400-\u243F\u2440-\u245F\u2460-\u24FF\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\uE000-\uF8FF\u{F0000}-\u{FFFFD}]/gu;
+	return /[\u1D00-\u1D7F\u1D80-\u1DBF\u1DC0-\u1DFF\u20A0-\u20CF\u20D0-\u20FF\u2100-\u214F\u2150-\u218F\u2190-\u21FF\u2200-\u22FF\u2300-\u23FF\u2400-\u243F\u2440-\u245F\u2460-\u24FF\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\uE000-\uF8FF]/g;
 }
 
 /**
@@ -131,6 +133,7 @@ function getSupplementaryPrivateUseRegExp() {
 	/**
 	 * Reference: https://www.unicode.org/charts/PDF/UD800.pdf
 	 * https://www.unicode.org/charts/PDF/UDC00.pdf
+	 * https://www.unicode.org/charts/PDF/UF0000.pdf
 	 */
-	return /[\uDB80-\uDBBF][\uDC00-\uDFFD]/g;
+	return /[\uDB80-\uDBBF][\uDC00-\uDFFD]|[\u{F0000}-\u{FFFFD}]/gu;
 }

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -93,11 +93,12 @@ function getUnicodeNonBmpRegExp() {
 	 * '\u2600-\u26FF'  Misc Symbols
 	 * '\u2700-\u27BF'  Dingbats
 	 * '\uE000-\uF8FF'  Private Use
+	 * '\u{F0000}-\u{FFFFD}' Supplementary Private Use Area A
 	 *
 	 * Note: plane '\u2000-\u206F' used for General punctuation is excluded as it is handled in -> getPunctuationRegExp
 	 */
 
-	return /[\u1D00-\u1D7F\u1D80-\u1DBF\u1DC0-\u1DFF\u20A0-\u20CF\u20D0-\u20FF\u2100-\u214F\u2150-\u218F\u2190-\u21FF\u2200-\u22FF\u2300-\u23FF\u2400-\u243F\u2440-\u245F\u2460-\u24FF\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\uE000-\uF8FF]/g;
+	return /[\u1D00-\u1D7F\u1D80-\u1DBF\u1DC0-\u1DFF\u20A0-\u20CF\u20D0-\u20FF\u2100-\u214F\u2150-\u218F\u2190-\u21FF\u2200-\u22FF\u2300-\u23FF\u2400-\u243F\u2440-\u245F\u2460-\u24FF\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\uE000-\uF8FF\u{F0000}-\u{FFFFD}]/gu;
 }
 
 /**

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -130,10 +130,11 @@ function getPunctuationRegExp() {
  * @returns {RegExp}
  */
 function getSupplementaryPrivateUseRegExp() {
-	/**
-	 * Reference: https://www.unicode.org/charts/PDF/UD800.pdf
-	 * https://www.unicode.org/charts/PDF/UDC00.pdf
-	 * https://www.unicode.org/charts/PDF/UF0000.pdf
-	 */
+	// 1. High surrogate area (https://www.unicode.org/charts/PDF/UD800.pdf)
+	// 2. Low surrogate area (https://www.unicode.org/charts/PDF/UDC00.pdf)
+	// 3. Supplementary private use area A (https://www.unicode.org/charts/PDF/UF0000.pdf)
+	//
+	//             1              2                                  3
+	//      ┏━━━━━━┻━━━━━━┓┏━━━━━━┻━━━━━━┓ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 	return /[\uDB80-\uDBBF][\uDC00-\uDFFD]|(?:[\uDB80-\uDBBE][\uDC00-\uDFFF]|\uDBBF[\uDC00-\uDFFD])/g;
 }

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -71,7 +71,7 @@ describe('text.hasUnicode', function() {
 		});
 
 		it('returns true for a string with characters in supplementary private use area A', function() {
-			var actual = axe.commons.text.hasUnicode('\u{F0019}', {
+			var actual = axe.commons.text.hasUnicode('\uDB80\uDC19', {
 				nonBmp: true
 			});
 			assert.isTrue(actual);

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -69,6 +69,13 @@ describe('text.hasUnicode', function() {
 			});
 			assert.isTrue(actual);
 		});
+
+		it('returns true for a string with characters in supplementary private use area A', function() {
+			var actual = axe.commons.text.hasUnicode('\u{F0019}', {
+				nonBmp: true
+			});
+			assert.isTrue(actual);
+		});
 	});
 
 	describe('text.hasUnicode, characters of type Emoji', function() {

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -208,6 +208,13 @@ describe('text.removeUnicode', function() {
 		assert.equal(actual, '');
 	});
 
+	it('returns the string with supplementary private use area A characters removed', function() {
+		var actual = axe.commons.text.removeUnicode('\uDB80\uDC19', {
+			nonBmp: true
+		});
+		assert.equal(actual, '');
+	});
+
 	it('returns string removing combination of unicode characters', function() {
 		var actual = axe.commons.text.removeUnicode(
 			'The ☀️ is orange, the ◓ is white.',


### PR DESCRIPTION
This PR adds unicode characters in Supplementary Private Use Area-A to the `getUnicodeNonBmpRegExp` regex.

Closes issue: https://github.com/dequelabs/axe-core/issues/2101

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
