### PR TITLE
chore: simplify the regex getting supplementary private use characters

### DIFF
--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -134,6 +134,10 @@ function getSupplementaryPrivateUseRegExp() {
 	// characters between F0000 and FFFFF. Because ES5 doesn't have a syntax for regular expressions
 	// of such characters, search instead for the corresponding surrogate pairs.
 	//
+	// Code points FFFFD and FFFFF are "noncharacters", but the regex still matches them, because its
+	// intent is to match things we don't want to check color contrast for. This is why the low
+	// surrogate range in the regex ends at DFFF, not DFFD.
+	//
 	// 1. High surrogate area (https://www.unicode.org/charts/PDF/UD800.pdf)
 	// 2. Low surrogate area (https://www.unicode.org/charts/PDF/UDC00.pdf)
 	//

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -130,11 +130,14 @@ function getPunctuationRegExp() {
  * @returns {RegExp}
  */
 function getSupplementaryPrivateUseRegExp() {
+	// Supplementary private use area A (https://www.unicode.org/charts/PDF/UF0000.pdf) contains
+	// characters between F0000 and FFFFF. Because ES5 doesn't have a syntax for regular expressions
+	// of such characters, search instead for the corresponding surrogate pairs.
+	//
 	// 1. High surrogate area (https://www.unicode.org/charts/PDF/UD800.pdf)
 	// 2. Low surrogate area (https://www.unicode.org/charts/PDF/UDC00.pdf)
-	// 3. Supplementary private use area A (https://www.unicode.org/charts/PDF/UF0000.pdf)
 	//
-	//             1              2                                  3
-	//      ┏━━━━━━┻━━━━━━┓┏━━━━━━┻━━━━━━┓ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-	return /[\uDB80-\uDBBF][\uDC00-\uDFFD]|(?:[\uDB80-\uDBBE][\uDC00-\uDFFF]|\uDBBF[\uDC00-\uDFFD])/g;
+	//             1              2
+	//      ┏━━━━━━┻━━━━━━┓┏━━━━━━┻━━━━━━┓
+	return /[\uDB80-\uDBBF][\uDC00-\uDFFF]/g;
 }

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -71,7 +71,7 @@ describe('text.hasUnicode', function() {
 		});
 
 		it('returns true for a string with characters in supplementary private use area A', function() {
-			var actual = axe.commons.text.hasUnicode('\uDB80\uDC19', {
+			var actual = axe.commons.text.hasUnicode('\uDB80\uDFFE', {
 				nonBmp: true
 			});
 			assert.isTrue(actual);
@@ -209,7 +209,7 @@ describe('text.removeUnicode', function() {
 	});
 
 	it('returns the string with supplementary private use area A characters removed', function() {
-		var actual = axe.commons.text.removeUnicode('\uDB80\uDC19', {
+		var actual = axe.commons.text.removeUnicode('\uDB80\uDFFE', {
 			nonBmp: true
 		});
 		assert.equal(actual, '');


### PR DESCRIPTION
I added an additional range to the regex in #2102. The purpose of it was to match unicode characters in Supplementary Private Use Area A, and I got the regex itself from https://apps.timwhitlock.info/js/regex.

However, it randomly occurred to me that the part of the regex I added is actually a superset of what was already there. And the real fix to #2101 was not the addition to the regex, but was solely due to [adding `getSupplementaryPrivateUseRegExp` to `hasUnicode`](https://github.com/dequelabs/axe-core/pull/2102/files#diff-e46b3ba4cd0e3b35ba002d5305ee074b) 🤦‍♂.

The existing part was:

```regex
[\uDB80-\uDBBF][\uDC00-\uDFFD]
```

The part I previously added (with an "or") was:

``` regex
[\uDB80-\uDBBE][\uDC00-\uDFFF]|\uDBBF[\uDC00-\uDFFD]
```

Note the overlap in the ranges. In fact, as far as I can tell, they're equivalent, except the previous one excluded anything where the low surrogate was DFFE or DFFF.

I've gone ahead and:
1. Removed the part of the regex I added
2. Expanded the range of the low surrogate to include DFFE and DFFF

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
