### PR TITLE
fix(respondable): ignore reflected messages from iframes

### DIFF
--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -83,6 +83,7 @@
 			error: error,
 			_respondable: true,
 			_source: _getSource(),
+			_axeuuid: axe._uuid,
 			_keepalive: keepalive
 		};
 
@@ -213,7 +214,7 @@
 			'message',
 			function(e) {
 				var data = parseMessage(e.data);
-				if (!data) {
+				if (!data || !data._axeuuid) {
 					return;
 				}
 
@@ -221,13 +222,13 @@
 
 				/**
 				 * NOTE: messages from other contexts (frames) in response
-				 * to a message should not contain a topic. We ignore these
-				 * messages to prevent rogue postMessage handlers reflecting
-				 * our messages.
+				 * to a message should not contain the same axe._uuid. We
+				 * ignore these messages to prevent rogue postMessage
+				 * handlers reflecting our messages.
 				 * @see https://github.com/dequelabs/axe-core/issues/1754
 				 */
 				var axeRespondables = axe._cache.get('axeRespondables') || {};
-				if (axeRespondables[uuid] && data.topic && e.source !== window) {
+				if (axeRespondables[uuid] && data._axeuuid === axe._uuid) {
 					return;
 				}
 

--- a/lib/core/utils/uuid.js
+++ b/lib/core/utils/uuid.js
@@ -238,4 +238,7 @@ var uuid;
 	uuid.parse = parse;
 	uuid.unparse = unparse;
 	uuid.BufferClass = BufferClass;
+
+	// assign a unique id to this axe instance
+	axe._uuid = v1();
 })(window);

--- a/test/core/utils/respondable.js
+++ b/test/core/utils/respondable.js
@@ -119,7 +119,8 @@ describe('axe.utils.respondable', function() {
 			_respondable: true,
 			_source: 'axeAPI.2.0.0',
 			message: 'Help us Obi-Wan',
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -140,7 +141,8 @@ describe('axe.utils.respondable', function() {
 			_respondable: true,
 			_source: 'axeAPI.x.y.z',
 			message: 'Help us Obi-Wan',
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -163,7 +165,8 @@ describe('axe.utils.respondable', function() {
 			_respondable: true,
 			_source: 'axeAPI.2.0.0',
 			message: 'Help us Obi-Wan',
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -187,7 +190,8 @@ describe('axe.utils.respondable', function() {
 			_respondable: true,
 			_source: 'axeAPI.2.0.0',
 			message: 'Help us Obi-Wan',
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -206,7 +210,8 @@ describe('axe.utils.respondable', function() {
 		event.initEvent('message', true, true);
 		event.data = {
 			_respondable: true,
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		};
 		event.source = window;
 
@@ -225,7 +230,8 @@ describe('axe.utils.respondable', function() {
 		event.data =
 			JSON.stringify({
 				_respondable: true,
-				uuid: mockUUID
+				uuid: mockUUID,
+				_axeuuid: 'otherAxe'
 			}) + 'joker tricks!';
 		event.source = window;
 
@@ -243,7 +249,8 @@ describe('axe.utils.respondable', function() {
 		event.initEvent('message', true, true);
 		event.data = '{ "_respondable": true, "topic": "batman" }';
 		event.data = JSON.stringify({
-			_respondable: true
+			_respondable: true,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -262,7 +269,8 @@ describe('axe.utils.respondable', function() {
 		event.data = '{ "_respondable": true, "topic": "batman", "uuid": "12" }';
 		event.data = JSON.stringify({
 			_respondable: true,
-			uuid: 'not-' + mockUUID
+			uuid: 'not-' + mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -280,7 +288,8 @@ describe('axe.utils.respondable', function() {
 		event.initEvent('message', true, true);
 		event.data = '{ "uuid": "48", "topic": "batman" }';
 		event.data = JSON.stringify({
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -304,7 +313,8 @@ describe('axe.utils.respondable', function() {
 				message: 'The exhaust port is open!',
 				trail: '... boom'
 			},
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -332,7 +342,8 @@ describe('axe.utils.respondable', function() {
 				message: 'The exhaust port is open!',
 				trail: '... boom'
 			},
-			uuid: mockUUID
+			uuid: mockUUID,
+			_axeuuid: 'otherAxe'
 		});
 		event.source = window;
 
@@ -363,6 +374,26 @@ describe('axe.utils.respondable', function() {
 	});
 
 	describe('subscribe', function() {
+		var origAxeUUID = axe._uuid;
+		var counter = 0;
+
+		before(function() {
+			// assign axe a new uuid every time it's requested to trick
+			// the code that each respondable was called from a different
+			// context
+			Object.defineProperty(axe, '_uuid', {
+				get: function() {
+					return ++counter;
+				}
+			});
+		});
+
+		after(function() {
+			Object.defineProperty(axe, '_uuid', {
+				value: origAxeUUID
+			});
+		});
+
 		it('should be a function', function() {
 			assert.isFunction(axe.utils.respondable.subscribe);
 		});

--- a/test/mock/frames/responder.html
+++ b/test/mock/frames/responder.html
@@ -4,13 +4,13 @@
 		<title>Double responding frame</title>
 	</head>
 	<body>
-		<script src="../../../lib/core/utils/uuid.js"></script>
 		<script>
 			var utils = {};
 			var axe = {
 				version: '2.0.0'
 			};
 		</script>
+		<script src="../../../lib/core/utils/uuid.js"></script>
 		<script src="../../../tmp/core/base/cache.js"></script>
 		<script src="../../../lib/core/utils/respondable.js"></script>
 

--- a/test/mock/frames/results-timeout.html
+++ b/test/mock/frames/results-timeout.html
@@ -4,13 +4,13 @@
 		<title>Message Iframe Fixture</title>
 	</head>
 	<body>
-		<script src="../../../lib/core/utils/uuid.js"></script>
 		<script>
 			var utils = {};
 			var axe = {
 				version: '2.0.0'
 			};
 		</script>
+		<script src="../../../lib/core/utils/uuid.js"></script>
 		<script src="../../../tmp/core/base/cache.js"></script>
 		<script src="../../../lib/core/utils/respondable.js"></script>
 

--- a/test/mock/frames/throwing.html
+++ b/test/mock/frames/throwing.html
@@ -4,13 +4,13 @@
 		<title>Error returning frame frame</title>
 	</head>
 	<body>
-		<script src="../../../lib/core/utils/uuid.js"></script>
 		<script>
 			var utils = {};
 			var axe = {
 				version: '2.0.0'
 			};
 		</script>
+		<script src="../../../lib/core/utils/uuid.js"></script>
 		<script src="../../../tmp/core/base/cache.js"></script>
 		<script src="../../../lib/core/utils/respondable.js"></script>
 


### PR DESCRIPTION
The code wasn't ignoring errant iframes from responding to our post messages with data we weren't expecting or to reflected messages. So to ensure we ignored these messages I assigned a unique id to each axe instance. When we receive a message we look to make sure the messages came from a different axe instance than the one listening to the event. That way we are guaranteed to only respond to messages sent from an axe instance inside an iframe.

Closes issue: #2127

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
