### PR TITLE
chore: convert commons.matches to ES Modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -75,6 +75,7 @@
     {
       "files": [
         "lib/commons/forms/*.js",
+        "lib/commons/matches/*.js",
         "lib/commons/utils/*.js"
       ],
       "parserOptions":{

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -155,6 +155,7 @@ module.exports = function(grunt) {
 
 					// directories we've converted to ES Modules
 					'!lib/commons/forms/*.js',
+					'!lib/commons/matches/*.js',
 					'!lib/commons/utils/*.js',
 
 					// output of webpack directories
@@ -173,6 +174,10 @@ module.exports = function(grunt) {
 			commonsForms: createWebpackConfig(
 				'lib/commons/forms/index.js',
 				'tmp/commons/forms'
+			),
+			commonsMatches: createWebpackConfig(
+				'lib/commons/matches/index.js',
+				'tmp/commons/matches'
 			)
 		},
 		'aria-supported': {

--- a/lib/commons/index.js
+++ b/lib/commons/index.js
@@ -9,3 +9,4 @@
  */
 
 var commons = {};
+var matches;

--- a/lib/commons/matches/attributes.js
+++ b/lib/commons/matches/attributes.js
@@ -1,4 +1,5 @@
-/* global matches */
+import fromFunction from './from-function';
+
 /**
  * Check if a virtual node matches some attribute(s)
  *
@@ -19,9 +20,13 @@
  * @param {Object} Attribute matcher
  * @returns {Boolean}
  */
-matches.attributes = function matchesAttributes(vNode, matcher) {
+function attributes(vNode, matcher) {
+	// TODO: es-module-AbstractVirtualNode
 	if (!(vNode instanceof axe.AbstractVirtualNode)) {
+		// TODO: es-module-utils.getNodeFromTree
 		vNode = axe.utils.getNodeFromTree(vNode);
 	}
-	return matches.fromFunction(attrName => vNode.attr(attrName), matcher);
-};
+	return fromFunction(attrName => vNode.attr(attrName), matcher);
+}
+
+export default attributes;

--- a/lib/commons/matches/condition.js
+++ b/lib/commons/matches/condition.js
@@ -1,4 +1,3 @@
-/* global matches */
 /**
  * Check if a "thing" is truthy according to a "condition"
  *
@@ -14,6 +13,8 @@
  * @param {Function|Null|undefined} condition
  * @returns {Boolean}
  */
-matches.condition = function(arg, condition) {
+function condition(arg, condition) {
 	return !!condition(arg);
-};
+}
+
+export default condition;

--- a/lib/commons/matches/from-definition.js
+++ b/lib/commons/matches/from-definition.js
@@ -1,5 +1,15 @@
-/* global matches */
-const matchers = ['nodeName', 'attributes', 'properties', 'condition'];
+import attributes from './attributes';
+import condition from './condition';
+import nodeName from './node-name';
+import properties from './properties';
+import matches from './matches';
+
+const matchers = {
+	attributes,
+	condition,
+	nodeName,
+	properties
+};
 
 /**
  * Check if a virtual node matches some definition
@@ -24,8 +34,10 @@ const matchers = ['nodeName', 'attributes', 'properties', 'condition'];
  * @param {Object|Array<Object>} definition
  * @returns {Boolean}
  */
-matches.fromDefinition = function matchFromDefinition(vNode, definition) {
+function fromDefinition(vNode, definition) {
+	// TODO: es-module-AbstractVirtualNode
 	if (!(vNode instanceof axe.AbstractVirtualNode)) {
+		// TODO: es-module-utils.getNodeFromTree
 		vNode = axe.utils.getNodeFromTree(vNode);
 	}
 
@@ -33,20 +45,23 @@ matches.fromDefinition = function matchFromDefinition(vNode, definition) {
 		return definition.some(definitionItem => matches(vNode, definitionItem));
 	}
 	if (typeof definition === 'string') {
+		// TODO: es-module-utils.matches
 		return axe.utils.matches(vNode, definition);
 	}
 
 	return Object.keys(definition).every(matcherName => {
-		if (!matchers.includes(matcherName)) {
+		if (!matchers[matcherName]) {
 			throw new Error(`Unknown matcher type "${matcherName}"`);
 		}
 		// Find the specific matches method to.
 		// matches.attributes, matches.nodeName, matches.properties, etc.
-		const matchMethod = matches[matcherName];
+		const matchMethod = matchers[matcherName];
 
 		// Find the matcher that goes into the matches method.
 		// 'div', /^div$/, (str) => str === 'div', etc.
 		const matcher = definition[matcherName];
 		return matchMethod(vNode, matcher);
 	});
-};
+}
+
+export default fromDefinition;

--- a/lib/commons/matches/from-function.js
+++ b/lib/commons/matches/from-function.js
@@ -1,4 +1,4 @@
-/* global matches */
+import fromPrimative from './from-primative';
 
 /**
  * Check if the value from a function matches some condition
@@ -21,7 +21,7 @@
  * @param {Object} matcher matcher
  * @returns {Boolean}
  */
-matches.fromFunction = function matchFromFunction(getValue, matcher) {
+function fromFunction(getValue, matcher) {
 	const matcherType = typeof matcher;
 	if (
 		matcherType !== 'object' ||
@@ -33,6 +33,8 @@ matches.fromFunction = function matchFromFunction(getValue, matcher) {
 
 	// Check that the property has all the expected values
 	return Object.keys(matcher).every(propName => {
-		return matches.fromPrimative(getValue(propName), matcher[propName]);
+		return fromPrimative(getValue(propName), matcher[propName]);
 	});
-};
+}
+
+export default fromFunction;

--- a/lib/commons/matches/from-primative.js
+++ b/lib/commons/matches/from-primative.js
@@ -1,5 +1,3 @@
-/* global matches */
-
 /**
  * Check if some value matches
  *
@@ -15,7 +13,7 @@
  * @param {String|RegExp|Function|Array<String>|Null|Undefined} matcher
  * @returns {Boolean}
  */
-matches.fromPrimative = function matchFromPrimative(someString, matcher) {
+function fromPrimative(someString, matcher) {
 	const matcherType = typeof matcher;
 	if (Array.isArray(matcher) && typeof someString !== 'undefined') {
 		return matcher.includes(someString);
@@ -27,4 +25,6 @@ matches.fromPrimative = function matchFromPrimative(someString, matcher) {
 		return matcher.test(someString);
 	}
 	return matcher === someString;
-};
+}
+
+export default fromPrimative;

--- a/lib/commons/matches/index.js
+++ b/lib/commons/matches/index.js
@@ -1,39 +1,31 @@
-/* exported matches */
+/* global matches */
 
 /**
- * Check if a virtual node matches a definition
- *
- * Example:
- * ```js
- * // Match a single nodeName:
- * axe.commons.matches(vNode, 'div')
- *
- * // Match one of multiple nodeNames:
- * axe.commons.matches(vNode, ['ul', 'ol'])
- *
- * // Match a node with nodeName 'button' and with aria-hidden: true:
- * axe.commons.matches(vNode, {
- * 	 nodeName: 'button',
- * 	 attributes: { 'aria-hidden': 'true' }
- * })
- *
- * // Mixed input. Match button nodeName, input[type=button] and input[type=reset]
- * axe.commons.matches(vNode, ['button', {
- * 	nodeName: 'input', // nodeName match isn't case sensitive
- * 	properties: { type: ['button', 'reset'] }
- * }])
- * ```
- *
- * @deprecated HTMLElement is deprecated, use VirtualNode instead
- *
- * @namespace matches
- * @memberof axe.commons
- * @param {HTMLElement|VirtualNode} vNode virtual node to verify attributes against constraints
- * @param {Array<ElementDefinition>|String|Object|Function|Regex} definition
- * @return {Boolean} true/ false based on if vNode passes the constraints expected
+ * Namespace for matching utilities.
+ * @namespace commons.matches
+ * @memberof axe
  */
-function matches(vNode, definition) {
-	return matches.fromDefinition(vNode, definition);
-}
+import attributes from './attributes';
+import condition from './condition';
+import fromDefinition from './from-definition';
+import fromFunction from './from-function';
+import fromPrimative from './from-primative';
+// TODO: es-module-commons. change to:
+// import matches from './matches'
+import matchesFn from './matches';
+import nodeName from './node-name';
+import properties from './properties';
 
-commons.matches = matches;
+// TODO: es-module-commons. remove matches setter
+matches = matchesFn;
+matches.attributes = attributes;
+matches.condition = condition;
+matches.fromDefinition = fromDefinition;
+matches.fromFunction = fromFunction;
+matches.fromPrimative = fromPrimative;
+matches.nodeName = nodeName;
+matches.properties = properties;
+
+// TODO: es-module-commons. convert to:
+// export default matches
+commons.matches = matchesFn;

--- a/lib/commons/matches/matches.js
+++ b/lib/commons/matches/matches.js
@@ -1,0 +1,39 @@
+import fromDefinition from './from-definition';
+
+/**
+ * Check if a virtual node matches a definition
+ *
+ * Example:
+ * ```js
+ * // Match a single nodeName:
+ * axe.commons.matches(vNode, 'div')
+ *
+ * // Match one of multiple nodeNames:
+ * axe.commons.matches(vNode, ['ul', 'ol'])
+ *
+ * // Match a node with nodeName 'button' and with aria-hidden: true:
+ * axe.commons.matches(vNode, {
+ *   nodeName: 'button',
+ *   attributes: { 'aria-hidden': 'true' }
+ * })
+ *
+ * // Mixed input. Match button nodeName, input[type=button] and input[type=reset]
+ * axe.commons.matches(vNode, ['button', {
+ *  nodeName: 'input', // nodeName match isn't case sensitive
+ *  properties: { type: ['button', 'reset'] }
+ * }])
+ * ```
+ *
+ * @deprecated HTMLElement is deprecated, use VirtualNode instead
+ *
+ * @namespace matches
+ * @memberof axe.commons
+ * @param {HTMLElement|VirtualNode} vNode virtual node to verify attributes against constraints
+ * @param {Array<ElementDefinition>|String|Object|Function|Regex} definition
+ * @return {Boolean} true/ false based on if vNode passes the constraints expected
+ */
+function matches(vNode, definition) {
+	return fromDefinition(vNode, definition);
+}
+
+export default matches;

--- a/lib/commons/matches/node-name.js
+++ b/lib/commons/matches/node-name.js
@@ -1,4 +1,5 @@
-/* global matches */
+import fromPrimative from './from-primative';
+
 /**
  * Check if the nodeName of a virtual node matches some value.
  *
@@ -16,9 +17,13 @@
  * @param {Object} Attribute matcher
  * @returns {Boolean}
  */
-matches.nodeName = function matchNodeName(vNode, matcher) {
+function nodeName(vNode, matcher) {
+	// TODO: es-module-AbstractVirtualNode
 	if (!(vNode instanceof axe.AbstractVirtualNode)) {
+		// TODO: es-module-utils.getNodeFromTree
 		vNode = axe.utils.getNodeFromTree(vNode);
 	}
-	return matches.fromPrimative(vNode.props.nodeName, matcher);
-};
+	return fromPrimative(vNode.props.nodeName, matcher);
+}
+
+export default nodeName;

--- a/lib/commons/matches/properties.js
+++ b/lib/commons/matches/properties.js
@@ -1,4 +1,4 @@
-/* global matches */
+import fromFunction from './from-function';
 
 /**
  * Check if a virtual node matches some attribute(s)
@@ -20,9 +20,13 @@
  * @param {Object} matcher
  * @returns {Boolean}
  */
-matches.properties = function matchesProperties(vNode, matcher) {
+function properties(vNode, matcher) {
+	// TODO: es-module-AbstractVirtualNode
 	if (!(vNode instanceof axe.AbstractVirtualNode)) {
+		// TODO: es-module-utils.getNodeFromTree
 		vNode = axe.utils.getNodeFromTree(vNode);
 	}
-	return matches.fromFunction(propName => vNode.props[propName], matcher);
-};
+	return fromFunction(propName => vNode.props[propName], matcher);
+}
+
+export default properties;


### PR DESCRIPTION
`commons/matches` is an odd group as everything is added off of the main `matches` function instead of an object. Also, there is a lot of code that accesses just `matches` instead of `commons.matches` so I had to make a global variable and add things to that. Will have to clean up when everything is converted.

Closes issue: #2114 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
