### PR TITLE
feat(closest): VirtualNode implementation of Element.closest. Deprecate commons.dom.findUp and commons.dom.findUpVirtual

### DIFF
--- a/lib/commons/dom/find-up.js
+++ b/lib/commons/dom/find-up.js
@@ -6,6 +6,7 @@
  * @method findUp
  * @memberof axe.commons.dom
  * @instance
+ * @deprecated use axe.utils.closest
  * @param {HTMLElement} element The starting HTMLElement
  * @param {String} target The selector for the HTMLElement
  * @return {HTMLElement|null} Either the matching HTMLElement or `null` if there was no match
@@ -21,6 +22,7 @@ dom.findUp = function(element, target) {
  * @method findUpVirtual
  * @memberof axe.commons.dom
  * @instance
+ * @deprecated use axe.utils.closest
  * @param {VirtualNode} element The starting virtualNode
  * @param {String} target The selector for the HTMLElement
  * @return {HTMLElement|null} Either the matching HTMLElement or `null` if there was no match

--- a/lib/core/utils/closest.js
+++ b/lib/core/utils/closest.js
@@ -1,0 +1,20 @@
+/**
+ * closest implementation that operates on a VirtualNode
+ *
+ * @method closest
+ * @memberof axe.utils
+ * @param {VirtualNode} vNode VirtualNode to match
+ * @param {String} selector CSS selector string
+ * @return {Boolean}
+ */
+axe.utils.closest = function closest(vNode, selector) {
+	while (vNode) {
+		if (axe.utils.matches(vNode, selector)) {
+			return vNode;
+		}
+
+		vNode = vNode.parent;
+	}
+
+	return null;
+};

--- a/test/core/utils/closest.js
+++ b/test/core/utils/closest.js
@@ -2,6 +2,7 @@ describe('utils.closest', function() {
 	var closest = axe.utils.closest;
 	var fixture = document.querySelector('#fixture');
 	var queryFixture = axe.testUtils.queryFixture;
+	var shadowSupported = axe.testUtils.shadowSupport.v1;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
@@ -39,5 +40,20 @@ describe('utils.closest', function() {
 		);
 		var closestNode = closest(virtualNode, 'h1');
 		assert.isNull(closestNode);
+	});
+
+	(shadowSupported ? it : xit)('should support shadow dom', function() {
+		fixture.innerHTML = '<div id="parent"></div>';
+
+		var root = fixture.firstChild.attachShadow({ mode: 'open' });
+		var slotted = document.createElement('span');
+		slotted.innerHTML = '<span id="target">foo</span>';
+		root.appendChild(slotted);
+		axe.utils.getFlattenedTree(fixture.firstChild);
+
+		var virtualNode = axe.utils.getNodeFromTree(slotted.firstChild);
+		var parent = fixture.querySelector('#parent');
+		var closestNode = closest(virtualNode, 'div');
+		assert.equal(closestNode, axe.utils.getNodeFromTree(parent));
 	});
 });

--- a/test/core/utils/closest.js
+++ b/test/core/utils/closest.js
@@ -1,0 +1,43 @@
+describe('utils.closest', function() {
+	var closest = axe.utils.closest;
+	var fixture = document.querySelector('#fixture');
+	var queryFixture = axe.testUtils.queryFixture;
+
+	afterEach(function() {
+		fixture.innerHTML = '';
+	});
+
+	it('should find the current node', function() {
+		var virtualNode = queryFixture(
+			'<div id="parent"><div id="target">foo</div></div>'
+		);
+		var closestNode = closest(virtualNode, 'div');
+		assert.equal(closestNode, virtualNode);
+	});
+
+	it('should find a parent node', function() {
+		var virtualNode = queryFixture(
+			'<div id="parent"><span id="target">foo</span></div>'
+		);
+		var closestNode = closest(virtualNode, 'div');
+		var parent = fixture.querySelector('#parent');
+		assert.equal(closestNode, axe.utils.getNodeFromTree(parent));
+	});
+
+	it('should find an ancestor node', function() {
+		var virtualNode = queryFixture(
+			'<div id="parent"><span><span><span><span id="target">foo</span></span></span></div>'
+		);
+		var closestNode = closest(virtualNode, 'div');
+		var parent = fixture.querySelector('#parent');
+		assert.equal(closestNode, axe.utils.getNodeFromTree(parent));
+	});
+
+	it('should return null if no ancestor is found', function() {
+		var virtualNode = queryFixture(
+			'<div id="parent"><div id="target">foo</div></div>'
+		);
+		var closestNode = closest(virtualNode, 'h1');
+		assert.isNull(closestNode);
+	});
+});


### PR DESCRIPTION
Noticed a bug in our `findUpVirtual` code. 

`findUpVirtual` uses `Element.closest` if it's available and uses the passed in node. If it's not available it walks up the parent tree looking for a matching node. However, `closest` will return the current node while our tree walk code always starts at the parent node. This means that in IE11 you get a different result than the other browsers:

```html
<div id="1">
  <div id="2">Hi</div>
</div>

<script>
const node = document.getElementById('2');
const upNode = axe.commons.dom.findUp(node, '[id]');

// in IE11 this returns "#1" but in everything else it's #2
console.log(upNode);
</script>
```

Talking to Wilco, he suggested we create a virtual node implementation of `closest` as we have done for `matches`. `findUpVirtual` is also odd in that it takes a virtual node but returns an HTML element. This code should be used instead of `findUp` and `findUpVirtual` so we are deprecating those two functions.

Fixes the issue in https://github.com/dequelabs/axe-core/pull/2133

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
