### PR TITLE
chore: convert commons.text to ES Modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -77,6 +77,7 @@
         "lib/commons/aria/*.js",
         "lib/commons/forms/*.js",
         "lib/commons/matches/*.js",
+        "lib/commons/text/*.js",
         "lib/commons/utils/*.js"
       ],
       "parserOptions":{

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,6 +157,7 @@ module.exports = function(grunt) {
 					'!lib/commons/aria/*.js',
 					'!lib/commons/forms/*.js',
 					'!lib/commons/matches/*.js',
+					'!lib/commons/text/*.js',
 					'!lib/commons/utils/*.js',
 
 					// output of webpack directories
@@ -183,6 +184,10 @@ module.exports = function(grunt) {
 			commonsMatches: createWebpackConfig(
 				'lib/commons/matches/index.js',
 				'tmp/commons/matches'
+			),
+			commonsText: createWebpackConfig(
+				'lib/commons/text/index.js',
+				'tmp/commons/text'
 			)
 		},
 		'aria-supported': {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-parallel');
 	grunt.loadNpmTasks('grunt-run');
 	grunt.loadNpmTasks('grunt-webpack');
+	grunt.loadNpmTasks('grunt-rollup');
 	grunt.loadTasks('build/tasks');
 
 	var langs;
@@ -167,6 +168,15 @@ module.exports = function(grunt) {
 				],
 				dest: 'tmp/commons.js'
 			}
+		},
+		rollup: {
+			options: {
+				format: 'iife'
+			},
+			'tmp/commons/aria/index.js': 'lib/commons/aria/index.js',
+			'tmp/commons/forms/index.js': 'lib/commons/forms/index.js',
+			'tmp/commons/matches/index.js': 'lib/commons/matches/index.js',
+			'tmp/commons/text/index.js': 'lib/commons/text/index.js'
 		},
 		webpack: {
 			commonsUtils: createWebpackConfig(

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,6 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-parallel');
 	grunt.loadNpmTasks('grunt-run');
 	grunt.loadNpmTasks('grunt-webpack');
-	grunt.loadNpmTasks('grunt-rollup');
 	grunt.loadTasks('build/tasks');
 
 	var langs;
@@ -168,15 +167,6 @@ module.exports = function(grunt) {
 				],
 				dest: 'tmp/commons.js'
 			}
-		},
-		rollup: {
-			options: {
-				format: 'iife'
-			},
-			'tmp/commons/aria/index.js': 'lib/commons/aria/index.js',
-			'tmp/commons/forms/index.js': 'lib/commons/forms/index.js',
-			'tmp/commons/matches/index.js': 'lib/commons/matches/index.js',
-			'tmp/commons/text/index.js': 'lib/commons/text/index.js'
 		},
 		webpack: {
 			commonsUtils: createWebpackConfig(

--- a/lib/commons/aria/is-aria-role-allowed-on-element.js
+++ b/lib/commons/aria/is-aria-role-allowed-on-element.js
@@ -1,5 +1,5 @@
 import lookupTable from './lookup-table';
-import matches from '../matches';
+import matches from '../matches/matches';
 
 /**
  * @description validate if a given role is an allowed ARIA role for the supplied node

--- a/lib/commons/index.js
+++ b/lib/commons/index.js
@@ -10,4 +10,5 @@
 
 var commons = {};
 var aria = {};
+var text = {};
 var matches;

--- a/lib/commons/matches/from-definition.js
+++ b/lib/commons/matches/from-definition.js
@@ -2,7 +2,6 @@ import attributes from './attributes';
 import condition from './condition';
 import nodeName from './node-name';
 import properties from './properties';
-import matches from './matches';
 
 const matchers = {
 	attributes,
@@ -42,7 +41,9 @@ function fromDefinition(vNode, definition) {
 	}
 
 	if (Array.isArray(definition)) {
-		return definition.some(definitionItem => matches(vNode, definitionItem));
+		return definition.some(definitionItem =>
+			fromDefinition(vNode, definitionItem)
+		);
 	}
 	if (typeof definition === 'string') {
 		// TODO: es-module-utils.matches

--- a/lib/commons/matches/index.js
+++ b/lib/commons/matches/index.js
@@ -28,5 +28,3 @@ matches.properties = properties;
 
 // TODO: es-module-commons. remove
 commons.matches = matchesFn;
-
-export default matches;

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -1,4 +1,11 @@
-/* global text, dom, aria, axe */
+/* global dom */
+import arialabelledbyText from '../aria/arialabelledby-text';
+import arialabelText from '../aria/arialabel-text';
+import nativeTextAlternative from './native-text-alternative';
+import formControlValue from './form-control-value';
+import subtreeText from './subtree-text';
+import titleText from './title-text';
+import sanitize from './sanitize';
 
 /**
  * Finds virtual node and calls accessibleTextVirtual()
@@ -10,25 +17,7 @@
  * @property {Bool} inLabelledByContext
  * @return {string}
  */
-text.accessibleText = function accessibleText(element, context) {
-	const virtualNode = axe.utils.getNodeFromTree(element); // throws an exception on purpose if axe._tree not correct
-	return text.accessibleTextVirtual(virtualNode, context);
-};
-
-/**
- * Finds virtual node and calls accessibleTextVirtual()
- * IMPORTANT: This method requires the composed tree at axe._tree
- *
- * @param {HTMLElement} element The HTMLElement
- * @param {Object} context
- * @property {Bool} inControlContext
- * @property {Bool} inLabelledByContext
- * @return {string}
- */
-text.accessibleTextVirtual = function accessibleTextVirtual(
-	virtualNode,
-	context = {}
-) {
+function accessibleTextVirtual(virtualNode, context = {}) {
 	const { actualNode } = virtualNode;
 	context = prepareContext(virtualNode, context);
 
@@ -38,19 +27,19 @@ text.accessibleTextVirtual = function accessibleTextVirtual(
 	}
 
 	const computationSteps = [
-		aria.arialabelledbyText, // Step 2B.1
-		aria.arialabelText, // Step 2C
-		text.nativeTextAlternative, // Step 2D
-		text.formControlValue, // Step 2E
-		text.subtreeText, // Step 2F + Step 2H
+		arialabelledbyText, // Step 2B.1
+		arialabelText, // Step 2C
+		nativeTextAlternative, // Step 2D
+		formControlValue, // Step 2E
+		subtreeText, // Step 2F + Step 2H
 		textNodeContent, // Step 2G (order with 2H does not matter)
-		text.titleText // Step 2I
+		titleText // Step 2I
 	];
 
 	// Find the first step that returns a non-empty string
 	let accName = computationSteps.reduce((accName, step) => {
 		if (context.startNode === virtualNode) {
-			accName = text.sanitize(accName);
+			accName = sanitize(accName);
 		}
 
 		if (accName !== '') {
@@ -64,7 +53,7 @@ text.accessibleTextVirtual = function accessibleTextVirtual(
 		axe.log(accName || '{empty-value}', actualNode, context);
 	}
 	return accName;
-};
+}
 
 /**
  * Return the textContent of a node
@@ -95,6 +84,7 @@ function shouldIgnoreHidden({ actualNode }, context) {
 		return false;
 	}
 
+	// TODO: es-module-dom.isVisible
 	return !dom.isVisible(actualNode, true);
 }
 
@@ -124,6 +114,7 @@ function prepareContext(virtualNode, context) {
 		context.includeHidden === undefined
 	) {
 		context = {
+			// TODO: es-module-dom.isVisible
 			includeHidden: !dom.isVisible(actualNode, true),
 			...context
 		};
@@ -138,7 +129,7 @@ function prepareContext(virtualNode, context) {
  * @property {VirtualNode[]} processed
  * @return {Boolean}
  */
-text.accessibleTextVirtual.alreadyProcessed = function alreadyProcessed(
+accessibleTextVirtual.alreadyProcessed = function alreadyProcessed(
 	virtualnode,
 	context
 ) {
@@ -150,3 +141,5 @@ text.accessibleTextVirtual.alreadyProcessed = function alreadyProcessed(
 	context.processed.push(virtualnode);
 	return false;
 };
+
+export default accessibleTextVirtual;

--- a/lib/commons/text/accessible-text.js
+++ b/lib/commons/text/accessible-text.js
@@ -1,0 +1,19 @@
+import accessibleTextVirtual from './accessible-text-virtual';
+
+/**
+ * Finds virtual node and calls accessibleTextVirtual()
+ * IMPORTANT: This method requires the composed tree at axe._tree
+ *
+ * @param {HTMLElement} element The HTMLElement
+ * @param {Object} context
+ * @property {Bool} inControlContext
+ * @property {Bool} inLabelledByContext
+ * @return {string}
+ */
+function accessibleText(element, context) {
+	// TODO: es-module-utils.getNodeFromTree
+	const virtualNode = axe.utils.getNodeFromTree(element); // throws an exception on purpose if axe._tree not correct
+	return accessibleTextVirtual(virtualNode, context);
+}
+
+export default accessibleText;

--- a/lib/commons/text/form-control-value.js
+++ b/lib/commons/text/form-control-value.js
@@ -1,4 +1,16 @@
-/* global text, aria, dom */
+/* global dom */
+import getRole from '../aria/get-role';
+import unsupported from './unsupported';
+import visibleVirtual from './visible-virtual';
+import accessibleTextVirtual from './accessible-text-virtual';
+import isNativeTextbox from '../forms/is-native-textbox';
+import isNativeSelect from '../forms/is-native-select';
+import isAriaTextbox from '../forms/is-aria-textbox';
+import isAriaListbox from '../forms/is-aria-listbox';
+import isAriaCombobox from '../forms/is-aria-combobox';
+import isAriaRange from '../forms/is-aria-range';
+import getOwnedVirtual from '../aria/get-owned/virtual';
+
 const controlValueRoles = [
 	'textbox',
 	'progressbar',
@@ -9,7 +21,7 @@ const controlValueRoles = [
 	'listbox'
 ];
 
-text.formControlValueMethods = {
+export const formControlValueMethods = {
 	nativeTextboxValue,
 	nativeSelectValue,
 	ariaTextboxValue,
@@ -28,10 +40,10 @@ text.formControlValueMethods = {
  * @property {Bool} debug Enable logging for formControlValue
  * @return {string} The calculated value
  */
-text.formControlValue = function formControlValue(virtualNode, context = {}) {
+function formControlValue(virtualNode, context = {}) {
 	const { actualNode } = virtualNode;
-	const unsupported = text.unsupported.accessibleNameFromFieldValue || [];
-	const role = aria.getRole(actualNode);
+	const unsupportedRoles = unsupported.accessibleNameFromFieldValue || [];
+	const role = getRole(actualNode);
 
 	if (
 		// For the targeted node, the accessible name is never the value:
@@ -39,14 +51,14 @@ text.formControlValue = function formControlValue(virtualNode, context = {}) {
 		// Only elements with a certain role can return their value
 		!controlValueRoles.includes(role) ||
 		// Skip unsupported roles
-		unsupported.includes(role)
+		unsupportedRoles.includes(role)
 	) {
 		return '';
 	}
 
 	// Object.values:
-	const valueMethods = Object.keys(text.formControlValueMethods).map(
-		name => text.formControlValueMethods[name]
+	const valueMethods = Object.keys(formControlValueMethods).map(
+		name => formControlValueMethods[name]
 	);
 
 	// Return the value of the first step that returns with text
@@ -55,10 +67,11 @@ text.formControlValue = function formControlValue(virtualNode, context = {}) {
 	}, '');
 
 	if (context.debug) {
+		// TODO: es-module-log
 		axe.log(valueString || '{empty-value}', actualNode, context);
 	}
 	return valueString;
-};
+}
 
 /**
  * Calculate value of a native textbox element (input and textarea)
@@ -68,7 +81,7 @@ text.formControlValue = function formControlValue(virtualNode, context = {}) {
  */
 function nativeTextboxValue(node) {
 	node = node.actualNode || node;
-	if (axe.commons.forms.isNativeTextbox(node)) {
+	if (isNativeTextbox(node)) {
 		return node.value || '';
 	}
 	return '';
@@ -82,7 +95,7 @@ function nativeTextboxValue(node) {
  */
 function nativeSelectValue(node) {
 	node = node.actualNode || node;
-	if (!axe.commons.forms.isNativeSelect(node)) {
+	if (!isNativeSelect(node)) {
 		return '';
 	}
 	return (
@@ -101,11 +114,12 @@ function nativeSelectValue(node) {
  */
 function ariaTextboxValue(virtualNode) {
 	const { actualNode } = virtualNode;
-	if (!axe.commons.forms.isAriaTextbox(actualNode)) {
+	if (!isAriaTextbox(actualNode)) {
 		return '';
 	}
+	// TODO: es-module-dom.isHiddenWithCSS
 	if (!dom.isHiddenWithCSS(actualNode)) {
-		return text.visibleVirtual(virtualNode, true);
+		return visibleVirtual(virtualNode, true);
 	} else {
 		return actualNode.textContent;
 	}
@@ -123,17 +137,15 @@ function ariaTextboxValue(virtualNode) {
  */
 function ariaListboxValue(virtualNode, context) {
 	const { actualNode } = virtualNode;
-	if (!axe.commons.forms.isAriaListbox(actualNode)) {
+	if (!isAriaListbox(actualNode)) {
 		return '';
 	}
 
-	const selected = aria
-		.getOwnedVirtual(virtualNode)
-		.filter(
-			owned =>
-				aria.getRole(owned) === 'option' &&
-				owned.actualNode.getAttribute('aria-selected') === 'true'
-		);
+	const selected = getOwnedVirtual(virtualNode).filter(
+		owned =>
+			getRole(owned) === 'option' &&
+			owned.actualNode.getAttribute('aria-selected') === 'true'
+	);
 
 	if (selected.length === 0) {
 		return '';
@@ -141,7 +153,7 @@ function ariaListboxValue(virtualNode, context) {
 	// Note: Even with aria-multiselectable, only the first value will be used
 	// in the accessible name. This isn't spec'ed out, but seems to be how all
 	// browser behave.
-	return axe.commons.text.accessibleTextVirtual(selected[0], context);
+	return accessibleTextVirtual(selected[0], context);
 }
 
 /**
@@ -159,16 +171,14 @@ function ariaComboboxValue(virtualNode, context) {
 	let listbox;
 
 	// For combobox, find the first owned listbox:
-	if (!axe.commons.forms.isAriaCombobox(actualNode)) {
+	if (!isAriaCombobox(actualNode)) {
 		return '';
 	}
-	listbox = aria
-		.getOwnedVirtual(virtualNode)
-		.filter(elm => aria.getRole(elm) === 'listbox')[0];
+	listbox = getOwnedVirtual(virtualNode).filter(
+		elm => getRole(elm) === 'listbox'
+	)[0];
 
-	return listbox
-		? text.formControlValueMethods.ariaListboxValue(listbox, context)
-		: '';
+	return listbox ? ariaListboxValue(listbox, context) : '';
 }
 
 /**
@@ -179,10 +189,7 @@ function ariaComboboxValue(virtualNode, context) {
  */
 function ariaRangeValue(node) {
 	node = node.actualNode || node;
-	if (
-		!axe.commons.forms.isAriaRange(node) ||
-		!node.hasAttribute('aria-valuenow')
-	) {
+	if (!isAriaRange(node) || !node.hasAttribute('aria-valuenow')) {
 		return '';
 	}
 	// Validate the number, if not, return 0.
@@ -190,3 +197,5 @@ function ariaRangeValue(node) {
 	const valueNow = +node.getAttribute('aria-valuenow');
 	return !isNaN(valueNow) ? String(valueNow) : '0';
 }
+
+export default formControlValue;

--- a/lib/commons/text/form-control-value.js
+++ b/lib/commons/text/form-control-value.js
@@ -9,7 +9,7 @@ import isAriaTextbox from '../forms/is-aria-textbox';
 import isAriaListbox from '../forms/is-aria-listbox';
 import isAriaCombobox from '../forms/is-aria-combobox';
 import isAriaRange from '../forms/is-aria-range';
-import getOwnedVirtual from '../aria/get-owned/virtual';
+import getOwnedVirtual from '../aria/get-owned-virtual';
 
 const controlValueRoles = [
 	'textbox',

--- a/lib/commons/text/has-unicode.js
+++ b/lib/commons/text/has-unicode.js
@@ -2,7 +2,7 @@ import {
 	getUnicodeNonBmpRegExp,
 	getSupplementaryPrivateUseRegExp,
 	getPunctuationRegExp
-} from './unicode.js';
+} from './unicode';
 
 /**
  * Determine if a given string contains unicode characters, specified in options

--- a/lib/commons/text/has-unicode.js
+++ b/lib/commons/text/has-unicode.js
@@ -1,0 +1,38 @@
+import {
+	getUnicodeNonBmpRegExp,
+	getSupplementaryPrivateUseRegExp,
+	getPunctuationRegExp
+} from './unicode.js';
+
+/**
+ * Determine if a given string contains unicode characters, specified in options
+ *
+ * @method hasUnicode
+ * @memberof axe.commons.text
+ * @instance
+ * @param {String} str string to verify
+ * @param {Object} options config containing which unicode character sets to verify
+ * @property {Boolean} options.emoji verify emoji unicode
+ * @property {Boolean} options.nonBmp verify nonBmp unicode
+ * @property {Boolean} options.punctuations verify punctuations unicode
+ * @returns {Boolean}
+ */
+function hasUnicode(str, options) {
+	const { emoji, nonBmp, punctuations } = options;
+	if (emoji) {
+		// TODO: es-module-imports.emojiRegexText
+		return axe.imports.emojiRegexText().test(str);
+	}
+	if (nonBmp) {
+		return (
+			getUnicodeNonBmpRegExp().test(str) ||
+			getSupplementaryPrivateUseRegExp().test(str)
+		);
+	}
+	if (punctuations) {
+		return getPunctuationRegExp().test(str);
+	}
+	return false;
+}
+
+export default hasUnicode;

--- a/lib/commons/text/index.js
+++ b/lib/commons/text/index.js
@@ -1,8 +1,60 @@
-/* exported text */
-/*eslint no-unused-vars: 0*/
+/* global text */
+
+// TODO: es-module-commons. convert to:
+// export { default as isAriaCombobox } from 'path'
+import accessibleTextVirtual from './accessible-text-virtual';
+import accessibleText from './accessible-text';
+import formControlValue, {
+	formControlValueMethods
+} from './form-control-value';
+import hasUnicode from './has-unicode';
+import isHumanInterpretable from './is-human-interpretable';
+import isIconLigature from './is-icon-ligature';
+import isValidAutocomplete, { autocomplete } from './is-valid-autocomplete';
+import labelText from './label-text';
+import labelVirtual from './label-virtual';
+import label from './label';
+import nativeElementType from './native-element-type';
+import nativeTextAlternative from './native-text-alternative';
+import nativeTextMethods from './native-text-methods';
+import removeUnicode from './remove-unicode';
+import sanitize from './sanitize';
+import subtreeText from './subtree-text';
+import titleText from './title-text';
+import unsupported from './unsupported';
+import visibleTextNodes from './visible-text-nodes';
+import visibleVirtual from './visible-virtual';
+import visible from './visible';
+
 /**
  * Namespace for text-related utilities.
  * @namespace text
  * @memberof axe.commons
  */
-var text = (commons.text = { EdgeFormDefaults: {} });
+// TODO: es-module-commons. don't rely on global
+text = {
+	accessibleTextVirtual,
+	accessibleText,
+	formControlValue,
+	formControlValueMethods,
+	hasUnicode,
+	isHumanInterpretable,
+	isIconLigature,
+	isValidAutocomplete,
+	autocomplete,
+	labelText,
+	labelVirtual,
+	label,
+	nativeElementType,
+	nativeTextAlternative,
+	nativeTextMethods,
+	removeUnicode,
+	sanitize,
+	subtreeText,
+	titleText,
+	unsupported,
+	visibleTextNodes,
+	visibleVirtual,
+	visible
+};
+commons.text = text;

--- a/lib/commons/text/index.js
+++ b/lib/commons/text/index.js
@@ -14,18 +14,14 @@ import isValidAutocomplete, { autocomplete } from './is-valid-autocomplete';
 import labelText from './label-text';
 import labelVirtual from './label-virtual';
 import label from './label';
-import nativeElementType, {
-	__stubNativeElementType
-} from './native-element-type';
+import nativeElementType from './native-element-type';
 import nativeTextAlternative from './native-text-alternative';
-import nativeTextMethods, {
-	__stubNativeTextMethods
-} from './native-text-methods';
+import nativeTextMethods from './native-text-methods';
 import removeUnicode from './remove-unicode';
 import sanitize from './sanitize';
 import subtreeText from './subtree-text';
 import titleText from './title-text';
-import unsupported from './unsupported';
+import unsupported, { setUnsupported } from './unsupported';
 import visibleTextNodes from './visible-text-nodes';
 import visibleVirtual from './visible-virtual';
 import visible from './visible';
@@ -61,8 +57,7 @@ text = {
 	visibleVirtual,
 	visible,
 
-	// test functions
-	__stubNativeElementType,
-	__stubNativeTextMethods
+	// set as private for now
+	_setUnsupported: setUnsupported
 };
 commons.text = text;

--- a/lib/commons/text/index.js
+++ b/lib/commons/text/index.js
@@ -21,7 +21,7 @@ import removeUnicode from './remove-unicode';
 import sanitize from './sanitize';
 import subtreeText from './subtree-text';
 import titleText from './title-text';
-import unsupported, { setUnsupported } from './unsupported';
+import unsupported from './unsupported';
 import visibleTextNodes from './visible-text-nodes';
 import visibleVirtual from './visible-virtual';
 import visible from './visible';
@@ -55,9 +55,6 @@ text = {
 	unsupported,
 	visibleTextNodes,
 	visibleVirtual,
-	visible,
-
-	// set as private for now
-	_setUnsupported: setUnsupported
+	visible
 };
 commons.text = text;

--- a/lib/commons/text/index.js
+++ b/lib/commons/text/index.js
@@ -14,9 +14,13 @@ import isValidAutocomplete, { autocomplete } from './is-valid-autocomplete';
 import labelText from './label-text';
 import labelVirtual from './label-virtual';
 import label from './label';
-import nativeElementType from './native-element-type';
+import nativeElementType, {
+	__stubNativeElementType
+} from './native-element-type';
 import nativeTextAlternative from './native-text-alternative';
-import nativeTextMethods from './native-text-methods';
+import nativeTextMethods, {
+	__stubNativeTextMethods
+} from './native-text-methods';
 import removeUnicode from './remove-unicode';
 import sanitize from './sanitize';
 import subtreeText from './subtree-text';
@@ -55,6 +59,10 @@ text = {
 	unsupported,
 	visibleTextNodes,
 	visibleVirtual,
-	visible
+	visible,
+
+	// test functions
+	__stubNativeElementType,
+	__stubNativeTextMethods
 };
 commons.text = text;

--- a/lib/commons/text/is-human-interpretable.js
+++ b/lib/commons/text/is-human-interpretable.js
@@ -1,4 +1,5 @@
-/* global text */
+import removeUnicode from './remove-unicode';
+import sanitize from './sanitize';
 
 /**
  * Determines if a given text is human friendly and interpretable
@@ -9,7 +10,7 @@
  * @param  {String} str text to be validated
  * @returns {Number} Between 0 and 1, (0 -> not interpretable, 1 -> interpretable)
  */
-text.isHumanInterpretable = function(str) {
+function isHumanInterpretable(str) {
 	/**
 	 * Steps:
 	 * 1) Check for single character edge cases
@@ -38,14 +39,16 @@ text.isHumanInterpretable = function(str) {
 	}
 
 	// Step 2
-	const noUnicodeStr = text.removeUnicode(str, {
+	const noUnicodeStr = removeUnicode(str, {
 		emoji: true,
 		nonBmp: true,
 		punctuations: true
 	});
-	if (!text.sanitize(noUnicodeStr)) {
+	if (!sanitize(noUnicodeStr)) {
 		return 0;
 	}
 
 	return 1;
-};
+}
+
+export default isHumanInterpretable;

--- a/lib/commons/text/is-icon-ligature.js
+++ b/lib/commons/text/is-icon-ligature.js
@@ -1,4 +1,5 @@
-/* global text */
+import sanitize from './sanitize';
+import hasUnicode from './has-unicode';
 
 /**
  * Determines if a given text node is an icon ligature
@@ -11,7 +12,7 @@
  * @param {Number} differenceThreshold Percent of differences in pixel data or pixel width needed to determine if a font is a ligature font
  * @return {Boolean}
  */
-text.isIconLigature = function(
+function isIconLigature(
 	textVNode,
 	differenceThreshold = 0.15,
 	occuranceThreshold = 3
@@ -76,12 +77,13 @@ text.isIconLigature = function(
 
 	// text with unicode or non-bmp letters cannot be ligature icons
 	if (
-		!text.sanitize(nodeValue) ||
-		text.hasUnicode(nodeValue, { emoji: true, nonBmp: true })
+		!sanitize(nodeValue) ||
+		hasUnicode(nodeValue, { emoji: true, nonBmp: true })
 	) {
 		return false;
 	}
 
+	// TODO: es-module-_cache
 	if (!axe._cache.get('canvasContext')) {
 		axe._cache.set(
 			'canvasContext',
@@ -93,6 +95,7 @@ text.isIconLigature = function(
 
 	// keep track of each font encountered and the number of times it shows up
 	// as a ligature.
+	// TODO: es-module-_cache
 	if (!axe._cache.get('fonts')) {
 		axe._cache.set('fonts', {});
 	}
@@ -207,4 +210,6 @@ text.isIconLigature = function(
 	}
 
 	return false;
-};
+}
+
+export default isIconLigature;

--- a/lib/commons/text/is-valid-autocomplete.js
+++ b/lib/commons/text/is-valid-autocomplete.js
@@ -62,7 +62,7 @@ export const autocomplete = {
 };
 
 function isValidAutocomplete(
-	autocomplete,
+	autocompleteValue,
 	{
 		looseTyped = false,
 		stateTerms = [],
@@ -72,9 +72,9 @@ function isValidAutocomplete(
 		qualifiedTerms = []
 	} = {}
 ) {
-	autocomplete = autocomplete.toLowerCase().trim();
+	autocompleteValue = autocompleteValue.toLowerCase().trim();
 	stateTerms = stateTerms.concat(autocomplete.stateTerms);
-	if (stateTerms.includes(autocomplete) || autocomplete === '') {
+	if (stateTerms.includes(autocompleteValue) || autocompleteValue === '') {
 		return true;
 	}
 
@@ -83,7 +83,7 @@ function isValidAutocomplete(
 	standaloneTerms = standaloneTerms.concat(autocomplete.standaloneTerms);
 	qualifiedTerms = qualifiedTerms.concat(autocomplete.qualifiedTerms);
 
-	const autocompleteTerms = autocomplete.split(/\s+/g);
+	const autocompleteTerms = autocompleteValue.split(/\s+/g);
 	if (!looseTyped) {
 		if (
 			autocompleteTerms[0].length > 8 &&

--- a/lib/commons/text/is-valid-autocomplete.js
+++ b/lib/commons/text/is-valid-autocomplete.js
@@ -1,5 +1,4 @@
-/* global text */
-const autocomplete = {
+export const autocomplete = {
 	stateTerms: ['on', 'off'],
 	standaloneTerms: [
 		'name',
@@ -61,9 +60,8 @@ const autocomplete = {
 	],
 	locations: ['billing', 'shipping']
 };
-text.autocomplete = autocomplete;
 
-text.isValidAutocomplete = function isValidAutocomplete(
+function isValidAutocomplete(
 	autocomplete,
 	{
 		looseTyped = false,
@@ -75,15 +73,15 @@ text.isValidAutocomplete = function isValidAutocomplete(
 	} = {}
 ) {
 	autocomplete = autocomplete.toLowerCase().trim();
-	stateTerms = stateTerms.concat(text.autocomplete.stateTerms);
+	stateTerms = stateTerms.concat(autocomplete.stateTerms);
 	if (stateTerms.includes(autocomplete) || autocomplete === '') {
 		return true;
 	}
 
-	qualifiers = qualifiers.concat(text.autocomplete.qualifiers);
-	locations = locations.concat(text.autocomplete.locations);
-	standaloneTerms = standaloneTerms.concat(text.autocomplete.standaloneTerms);
-	qualifiedTerms = qualifiedTerms.concat(text.autocomplete.qualifiedTerms);
+	qualifiers = qualifiers.concat(autocomplete.qualifiers);
+	locations = locations.concat(autocomplete.locations);
+	standaloneTerms = standaloneTerms.concat(autocomplete.standaloneTerms);
+	qualifiedTerms = qualifiedTerms.concat(autocomplete.qualifiedTerms);
 
 	const autocompleteTerms = autocomplete.split(/\s+/g);
 	if (!looseTyped) {
@@ -114,4 +112,6 @@ text.isValidAutocomplete = function isValidAutocomplete(
 		standaloneTerms.includes(purposeTerm) ||
 		qualifiedTerms.includes(purposeTerm)
 	);
-};
+}
+
+export default isValidAutocomplete;

--- a/lib/commons/text/label-text.js
+++ b/lib/commons/text/label-text.js
@@ -1,4 +1,6 @@
-/* global dom, text */
+/* global dom */
+import accessibleTextVirtual from './accessible-text-virtual';
+import accessibleText from './accessible-text';
 
 /**
  * Return accessible text for an implicit and/or explicit HTML label element
@@ -8,8 +10,8 @@
  * @property {Bool} inLabelledByContext
  * @return {String} Label text
  */
-text.labelText = function labelText(virtualNode, context = {}) {
-	const { alreadyProcessed } = text.accessibleTextVirtual;
+function labelText(virtualNode, context = {}) {
+	const { alreadyProcessed } = accessibleTextVirtual;
 	if (
 		context.inControlContext ||
 		context.inLabelledByContext ||
@@ -23,21 +25,23 @@ text.labelText = function labelText(virtualNode, context = {}) {
 
 	const labelContext = { inControlContext: true, ...context };
 	const explicitLabels = getExplicitLabels(virtualNode);
+	// TODO: es-module-dom.findUpVirtual
 	const implicitLabel = dom.findUpVirtual(virtualNode, 'label');
 
 	let labels;
 	if (implicitLabel) {
 		labels = [...explicitLabels, implicitLabel];
+		// TODO: es-module-utils.nodeSorter
 		labels.sort(axe.utils.nodeSorter);
 	} else {
 		labels = explicitLabels;
 	}
 
 	return labels
-		.map(label => text.accessibleText(label, labelContext))
+		.map(label => accessibleText(label, labelContext))
 		.filter(text => text !== '')
 		.join(' ');
-};
+}
 
 /**
  * Find a non-ARIA label for an element
@@ -49,6 +53,7 @@ function getExplicitLabels({ actualNode }) {
 	if (!actualNode.id) {
 		return [];
 	}
+	// TODO: es-module-dom.findElmsInContext
 	return dom.findElmsInContext({
 		elm: 'label',
 		attr: 'for',
@@ -56,3 +61,5 @@ function getExplicitLabels({ actualNode }) {
 		context: actualNode
 	});
 }
+
+export default labelText;

--- a/lib/commons/text/label-virtual.js
+++ b/lib/commons/text/label-virtual.js
@@ -1,4 +1,6 @@
-/* global text, dom, axe, aria */
+/* global dom */
+import ariaLabelVirtual from '../aria/label-virtual';
+import visible from './visible';
 
 /**
  * Gets the visible text of a label for a given input
@@ -9,45 +11,35 @@
  * @param  {VirtualNode} node The virtual node mapping to the input to test
  * @return {Mixed} String of visible text, or `null` if no label is found
  */
-text.labelVirtual = function(node) {
+function labelVirtual(node) {
 	var ref, candidate, doc;
 
-	candidate = aria.labelVirtual(node);
+	candidate = ariaLabelVirtual(node);
 	if (candidate) {
 		return candidate;
 	}
 
 	// explicit label
 	if (node.actualNode.id) {
+		// TODO: es-module-utils.escapeSelector
 		const id = axe.utils.escapeSelector(node.actualNode.getAttribute('id'));
+		// TODO: es-module-dom.getRootNode
 		doc = axe.commons.dom.getRootNode(node.actualNode);
 		ref = doc.querySelector('label[for="' + id + '"]');
-		candidate = ref && text.visible(ref, true);
+		candidate = ref && visible(ref, true);
 		if (candidate) {
 			return candidate;
 		}
 	}
 
+	// TODO: es-module-dom.findUpVirtual
 	ref = dom.findUpVirtual(node, 'label');
-	candidate = ref && text.visible(ref, true);
+	candidate = ref && visible(ref, true);
 	if (candidate) {
 		return candidate;
 	}
 
 	return null;
-};
+}
 
-/**
- * Finds virtual node and calls labelVirtual()
- * IMPORTANT: This method requires the composed tree at axe._tree
- * @see axe.commons.text.virtualLabel
- * @method label
- * @memberof axe.commons.text
- * @instance
- * @param  {Element} node The virtual node mapping to the input to test
- * @return {Mixed} String of visible text, or `null` if no label is found
- */
-text.label = function(node) {
-	node = axe.utils.getNodeFromTree(node);
-	return text.labelVirtual(node);
-};
+export default labelVirtual;

--- a/lib/commons/text/label.js
+++ b/lib/commons/text/label.js
@@ -1,0 +1,19 @@
+import labelVirtual from './label-virtual';
+
+/**
+ * Finds virtual node and calls labelVirtual()
+ * IMPORTANT: This method requires the composed tree at axe._tree
+ * @see axe.commons.text.virtualLabel
+ * @method label
+ * @memberof axe.commons.text
+ * @instance
+ * @param  {Element} node The virtual node mapping to the input to test
+ * @return {Mixed} String of visible text, or `null` if no label is found
+ */
+function label(node) {
+	// TODO: es-module-utils.getNodeFromTree
+	node = axe.utils.getNodeFromTree(node);
+	return labelVirtual(node);
+}
+
+export default label;

--- a/lib/commons/text/native-element-type.js
+++ b/lib/commons/text/native-element-type.js
@@ -1,5 +1,4 @@
-/* global text */
-text.nativeElementType = [
+const nativeElementType = [
 	{
 		// 5.1 input type="text", input type="password", input type="search", input type="tel", input type="url" and textarea Element
 		matches: [
@@ -98,3 +97,5 @@ text.nativeElementType = [
 	}
 	// All else defaults to just title
 ];
+
+export default nativeElementType;

--- a/lib/commons/text/native-element-type.js
+++ b/lib/commons/text/native-element-type.js
@@ -1,4 +1,4 @@
-let nativeElementType = [
+const nativeElementType = [
 	{
 		// 5.1 input type="text", input type="password", input type="search", input type="tel", input type="url" and textarea Element
 		matches: [

--- a/lib/commons/text/native-element-type.js
+++ b/lib/commons/text/native-element-type.js
@@ -1,4 +1,4 @@
-const nativeElementType = [
+let nativeElementType = [
 	{
 		// 5.1 input type="text", input type="password", input type="search", input type="tel", input type="url" and textarea Element
 		matches: [

--- a/lib/commons/text/native-text-alternative.js
+++ b/lib/commons/text/native-text-alternative.js
@@ -1,5 +1,5 @@
 import getRole from '../aria/get-role';
-import matches from '../matches';
+import matches from '../matches/matches';
 import nativeElementType from './native-element-type';
 import nativeTextMethods from './native-text-methods';
 

--- a/lib/commons/text/native-text-alternative.js
+++ b/lib/commons/text/native-text-alternative.js
@@ -1,4 +1,7 @@
-/* global text, aria */
+import getRole from '../aria/get-role';
+import matches from '../matches';
+import nativeElementType from './native-element-type';
+import nativeTextMethods from './native-text-methods';
 
 /**
  * Get the accessible text using native HTML methods only
@@ -7,14 +10,11 @@
  * @property {Bool} debug Enable logging for formControlValue
  * @return {String} Accessible text
  */
-text.nativeTextAlternative = function nativeTextAlternative(
-	virtualNode,
-	context = {}
-) {
+function nativeTextAlternative(virtualNode, context = {}) {
 	const { actualNode } = virtualNode;
 	if (
 		actualNode.nodeType !== 1 ||
-		['presentation', 'none'].includes(aria.getRole(actualNode))
+		['presentation', 'none'].includes(getRole(actualNode))
 	) {
 		return '';
 	}
@@ -29,7 +29,7 @@ text.nativeTextAlternative = function nativeTextAlternative(
 		axe.log(accName || '{empty-value}', actualNode, context);
 	}
 	return accName;
-};
+}
 
 /**
  * Get accessible text functions for a specific native HTML element
@@ -38,9 +38,8 @@ text.nativeTextAlternative = function nativeTextAlternative(
  * @return {Function[]} Array of native accessible name computation methods
  */
 function findTextMethods(virtualNode) {
-	const { nativeElementType, nativeTextMethods } = text;
-	const nativeType = nativeElementType.find(({ matches }) => {
-		return axe.commons.matches(virtualNode, matches);
+	const nativeType = nativeElementType.find(type => {
+		return matches(virtualNode, type.matches);
 	});
 
 	// Use concat because namingMethods can be a string or an array of strings
@@ -48,3 +47,5 @@ function findTextMethods(virtualNode) {
 
 	return methods.map(methodName => nativeTextMethods[methodName]);
 }
+
+export default nativeTextAlternative;

--- a/lib/commons/text/native-text-methods.js
+++ b/lib/commons/text/native-text-methods.js
@@ -10,7 +10,7 @@ const defaultButtonValues = {
 	button: '' // No default for "button"
 };
 
-let nativeTextMethods = {
+const nativeTextMethods = {
 	/**
 	 * Return the value of a DOM node
 	 * @param {VirtualNode} element

--- a/lib/commons/text/native-text-methods.js
+++ b/lib/commons/text/native-text-methods.js
@@ -1,4 +1,7 @@
-/* global text */
+import getTitleText from './title-text';
+import getSubtreeText from './subtree-text';
+import getLabelText from './label-text';
+import accessibleText from './accessible-text';
 
 const defaultButtonValues = {
 	submit: 'Submit',
@@ -7,7 +10,7 @@ const defaultButtonValues = {
 	button: '' // No default for "button"
 };
 
-text.nativeTextMethods = {
+const nativeTextMethods = {
 	/**
 	 * Return the value of a DOM node
 	 * @param {VirtualNode} element
@@ -67,7 +70,7 @@ text.nativeTextMethods = {
 	 * @return {String} title text
 	 */
 	titleText: function titleText(virtualNode, context) {
-		return text.titleText(virtualNode, context);
+		return getTitleText(virtualNode, context);
 	},
 
 	/**
@@ -77,7 +80,7 @@ text.nativeTextMethods = {
 	 * @return {String} Subtree text
 	 */
 	subtreeText: function subtreeText(virtualNode, context) {
-		return text.subtreeText(virtualNode, context);
+		return getSubtreeText(virtualNode, context);
 	},
 
 	/**
@@ -87,7 +90,7 @@ text.nativeTextMethods = {
 	 * @return {String} Label text
 	 */
 	labelText: function labelText(virtualNode, context) {
-		return text.labelText(virtualNode, context);
+		return getLabelText(virtualNode, context);
 	},
 
 	/**
@@ -118,5 +121,7 @@ function descendantText(nodeName, { actualNode }, context) {
 	if (!candidate || candidate.nodeName.toLowerCase() !== nodeName) {
 		return '';
 	}
-	return text.accessibleText(candidate, context);
+	return accessibleText(candidate, context);
 }
+
+export default nativeTextMethods;

--- a/lib/commons/text/native-text-methods.js
+++ b/lib/commons/text/native-text-methods.js
@@ -1,6 +1,6 @@
-import getTitleText from './title-text';
-import getSubtreeText from './subtree-text';
-import getLabelText from './label-text';
+import titleText from './title-text';
+import subtreeText from './subtree-text';
+import labelText from './label-text';
 import accessibleText from './accessible-text';
 
 const defaultButtonValues = {
@@ -10,7 +10,7 @@ const defaultButtonValues = {
 	button: '' // No default for "button"
 };
 
-const nativeTextMethods = {
+let nativeTextMethods = {
 	/**
 	 * Return the value of a DOM node
 	 * @param {VirtualNode} element
@@ -69,9 +69,7 @@ const nativeTextMethods = {
 	 * @param {VirtualNode} element
 	 * @return {String} title text
 	 */
-	titleText: function titleText(virtualNode, context) {
-		return getTitleText(virtualNode, context);
-	},
+	titleText,
 
 	/**
 	 * Return accessible text of the subtree
@@ -79,9 +77,7 @@ const nativeTextMethods = {
 	 * @param {Object} context
 	 * @return {String} Subtree text
 	 */
-	subtreeText: function subtreeText(virtualNode, context) {
-		return getSubtreeText(virtualNode, context);
-	},
+	subtreeText,
 
 	/**
 	 * Return accessible text for an implicit and/or explicit HTML label element
@@ -89,9 +85,7 @@ const nativeTextMethods = {
 	 * @param {Object} context
 	 * @return {String} Label text
 	 */
-	labelText: function labelText(virtualNode, context) {
-		return getLabelText(virtualNode, context);
-	},
+	labelText,
 
 	/**
 	 * Return a single space

--- a/lib/commons/text/remove-unicode.js
+++ b/lib/commons/text/remove-unicode.js
@@ -1,0 +1,38 @@
+import {
+	getUnicodeNonBmpRegExp,
+	getSupplementaryPrivateUseRegExp,
+	getPunctuationRegExp
+} from './unicode.js';
+
+/**
+ * Remove specified type(s) unicode characters
+ *
+ * @method removeUnicode
+ * @memberof axe.commons.text
+ * @instance
+ * @param {String} str string to operate on
+ * @param {Object} options config containing which unicode character sets to remove
+ * @property {Boolean} options.emoji remove emoji unicode
+ * @property {Boolean} options.nonBmp remove nonBmp unicode
+ * @property {Boolean} options.punctuations remove punctuations unicode
+ * @returns {String}
+ */
+function removeUnicode(str, options) {
+	const { emoji, nonBmp, punctuations } = options;
+
+	if (emoji) {
+		// TODO: es-module-imports.emojiRegexText
+		str = str.replace(axe.imports.emojiRegexText(), '');
+	}
+	if (nonBmp) {
+		str = str.replace(getUnicodeNonBmpRegExp(), '');
+		str = str.replace(getSupplementaryPrivateUseRegExp(), '');
+	}
+	if (punctuations) {
+		str = str.replace(getPunctuationRegExp(), '');
+	}
+
+	return str;
+}
+
+export default removeUnicode;

--- a/lib/commons/text/sanitize.js
+++ b/lib/commons/text/sanitize.js
@@ -1,5 +1,3 @@
-/* global text */
-
 /**
  * Removes carriage returns, newline characters, tabs, non-breaking spaces, and trailing spaces from string
  * @method sanitize
@@ -8,11 +6,13 @@
  * @param  {String} str String to be cleaned
  * @return {String} Sanitized string
  */
-text.sanitize = function(str) {
+function sanitize(str) {
 	'use strict';
 	return str
 		.replace(/\r\n/g, '\n')
 		.replace(/\u00A0/g, ' ')
 		.replace(/[\s]{2,}/g, ' ')
 		.trim();
-};
+}
+
+export default sanitize;

--- a/lib/commons/text/subtree-text.js
+++ b/lib/commons/text/subtree-text.js
@@ -1,4 +1,7 @@
-/* global text, aria */
+import accessibleTextVirtual from './accessible-text-virtual';
+import namedFromContents from '../aria/named-from-contents';
+import getOwnedVirtual from '../aria/get-owned-virtual';
+
 /**
  * Get the accessible text for an element that can get its name from content
  *
@@ -7,21 +10,21 @@
  * @property {Bool} strict Should the name computation strictly follow AccName 1.1
  * @return {String} Accessible text
  */
-text.subtreeText = function subtreeText(virtualNode, context = {}) {
-	const { alreadyProcessed } = text.accessibleTextVirtual;
+function subtreeText(virtualNode, context = {}) {
+	const { alreadyProcessed } = accessibleTextVirtual;
 	context.startNode = context.startNode || virtualNode;
 	const { strict } = context;
 	if (
 		alreadyProcessed(virtualNode, context) ||
-		!aria.namedFromContents(virtualNode, { strict })
+		!namedFromContents(virtualNode, { strict })
 	) {
 		return '';
 	}
 
-	return aria.getOwnedVirtual(virtualNode).reduce((contentText, child) => {
+	return getOwnedVirtual(virtualNode).reduce((contentText, child) => {
 		return appendAccessibleText(contentText, child, context);
 	}, '');
-};
+}
 
 // TODO: Could do with an "HTML" lookup table, similar to ARIA,
 //  where this sort of stuff can live.
@@ -70,7 +73,7 @@ const phrasingElements = [
 
 function appendAccessibleText(contentText, virtualNode, context) {
 	const nodeName = virtualNode.actualNode.nodeName.toUpperCase();
-	let contentTextAdd = text.accessibleTextVirtual(virtualNode, context);
+	let contentTextAdd = accessibleTextVirtual(virtualNode, context);
 	if (!contentTextAdd) {
 		return contentText;
 	}
@@ -87,3 +90,5 @@ function appendAccessibleText(contentText, virtualNode, context) {
 	}
 	return contentText + contentTextAdd;
 }
+
+export default subtreeText;

--- a/lib/commons/text/title-text.js
+++ b/lib/commons/text/title-text.js
@@ -1,4 +1,6 @@
-/* global text, aria */
+import matches from '../matches';
+import getRole from '../aria/get-role';
+
 const alwaysTitleElements = [
 	'button',
 	'iframe',
@@ -14,7 +16,7 @@ const alwaysTitleElements = [
  * @param {HTMLElement}node the node to verify
  * @return {String}
  */
-text.titleText = function titleText(node) {
+function titleText(node) {
 	node = node.actualNode || node;
 	if (node.nodeType !== 1 || !node.hasAttribute('title')) {
 		return '';
@@ -23,11 +25,13 @@ text.titleText = function titleText(node) {
 	// Some elements return the title even with role=presentation
 	// This does appear in any spec, but its remarkably consistent
 	if (
-		!axe.commons.matches(node, alwaysTitleElements) &&
-		['none', 'presentation'].includes(aria.getRole(node))
+		!matches(node, alwaysTitleElements) &&
+		['none', 'presentation'].includes(getRole(node))
 	) {
 		return '';
 	}
 
 	return node.getAttribute('title');
-};
+}
+
+export default titleText;

--- a/lib/commons/text/title-text.js
+++ b/lib/commons/text/title-text.js
@@ -1,4 +1,4 @@
-import matches from '../matches';
+import matches from '../matches/matches';
 import getRole from '../aria/get-role';
 
 const alwaysTitleElements = [

--- a/lib/commons/text/unicode.js
+++ b/lib/commons/text/unicode.js
@@ -1,65 +1,3 @@
-/* global text */
-
-/**
- * Determine if a given string contains unicode characters, specified in options
- *
- * @method hasUnicode
- * @memberof axe.commons.text
- * @instance
- * @param {String} str string to verify
- * @param {Object} options config containing which unicode character sets to verify
- * @property {Boolean} options.emoji verify emoji unicode
- * @property {Boolean} options.nonBmp verify nonBmp unicode
- * @property {Boolean} options.punctuations verify punctuations unicode
- * @returns {Boolean}
- */
-text.hasUnicode = function hasUnicode(str, options) {
-	const { emoji, nonBmp, punctuations } = options;
-	if (emoji) {
-		return axe.imports.emojiRegexText().test(str);
-	}
-	if (nonBmp) {
-		return (
-			getUnicodeNonBmpRegExp().test(str) ||
-			getSupplementaryPrivateUseRegExp().test(str)
-		);
-	}
-	if (punctuations) {
-		return getPunctuationRegExp().test(str);
-	}
-	return false;
-};
-
-/**
- * Remove specified type(s) unicode characters
- *
- * @method removeUnicode
- * @memberof axe.commons.text
- * @instance
- * @param {String} str string to operate on
- * @param {Object} options config containing which unicode character sets to remove
- * @property {Boolean} options.emoji remove emoji unicode
- * @property {Boolean} options.nonBmp remove nonBmp unicode
- * @property {Boolean} options.punctuations remove punctuations unicode
- * @returns {String}
- */
-text.removeUnicode = function removeUnicode(str, options) {
-	const { emoji, nonBmp, punctuations } = options;
-
-	if (emoji) {
-		str = str.replace(axe.imports.emojiRegexText(), '');
-	}
-	if (nonBmp) {
-		str = str.replace(getUnicodeNonBmpRegExp(), '');
-		str = str.replace(getSupplementaryPrivateUseRegExp(), '');
-	}
-	if (punctuations) {
-		str = str.replace(getPunctuationRegExp(), '');
-	}
-
-	return str;
-};
-
 /**
  * Regex for matching unicode values out of Basic Multilingual Plane (BMP)
  * Reference:
@@ -69,7 +7,7 @@ text.removeUnicode = function removeUnicode(str, options) {
  *
  * @returns {RegExp}
  */
-function getUnicodeNonBmpRegExp() {
+export function getUnicodeNonBmpRegExp() {
 	/**
 	 * Regex for matching astral plane unicode
 	 * - http://kourge.net/projects/regexp-unicode-block
@@ -108,7 +46,7 @@ function getUnicodeNonBmpRegExp() {
  *
  * @returns {RegExp}
  */
-function getPunctuationRegExp() {
+export function getPunctuationRegExp() {
 	/**
 	 * Reference: http://kunststube.net/encoding/
 	 * US-ASCII
@@ -129,7 +67,7 @@ function getPunctuationRegExp() {
  *
  * @returns {RegExp}
  */
-function getSupplementaryPrivateUseRegExp() {
+export function getSupplementaryPrivateUseRegExp() {
 	// Supplementary private use area A (https://www.unicode.org/charts/PDF/UF0000.pdf) contains
 	// characters between F0000 and FFFFF. Because ES5 doesn't have a syntax for regular expressions
 	// of such characters, search instead for the corresponding surrogate pairs.

--- a/lib/commons/text/unsupported.js
+++ b/lib/commons/text/unsupported.js
@@ -1,5 +1,5 @@
-/* global text */
-
-text.unsupported = {
+const unsupported = {
 	accessibleNameFromFieldValue: ['combobox', 'listbox', 'progressbar']
 };
+
+export default unsupported;

--- a/lib/commons/text/unsupported.js
+++ b/lib/commons/text/unsupported.js
@@ -1,5 +1,13 @@
 const unsupported = {
-	accessibleNameFromFieldValue: ['combobox', 'listbox', 'progressbar']
+	accessibleNameFromFieldValue: ['combobox', 'listbox', 'progressbar'],
+
+	// for the acceptance tests of accessible-text.js we need to have the
+	// unsupported array be settable. this function will also be used
+	// later (v4.0) when we add these hard coded values as global
+	// configuration options (set as private for now)
+	_set(value) {
+		this.accessibleNameFromFieldValue = value;
+	}
 };
 
 export default unsupported;

--- a/lib/commons/text/unsupported.js
+++ b/lib/commons/text/unsupported.js
@@ -1,13 +1,5 @@
 const unsupported = {
-	accessibleNameFromFieldValue: ['combobox', 'listbox', 'progressbar'],
-
-	// for the acceptance tests of accessible-text.js we need to have the
-	// unsupported array be settable. this function will also be used
-	// later (v4.0) when we add these hard coded values as global
-	// configuration options (set as private for now)
-	_set(value) {
-		this.accessibleNameFromFieldValue = value;
-	}
+	accessibleNameFromFieldValue: ['combobox', 'listbox', 'progressbar']
 };
 
 export default unsupported;

--- a/lib/commons/text/visible-text-nodes.js
+++ b/lib/commons/text/visible-text-nodes.js
@@ -1,15 +1,14 @@
-/* global text */
-
 /**
  * Returns an array of visible text virtual nodes
-
+ *
  * @method visibleTextNodes
  * @memberof axe.commons.text
  * @instance
  * @param {VirtualNode} vNode
  * @return {VitrualNode[]}
  */
-text.visibleTextNodes = function(vNode) {
+function visibleTextNodes(vNode) {
+	// TODO: es-module-dom.isVisible
 	const parentVisible = axe.commons.dom.isVisible(vNode.actualNode);
 	let nodes = [];
 	vNode.children.forEach(child => {
@@ -18,8 +17,10 @@ text.visibleTextNodes = function(vNode) {
 				nodes.push(child);
 			}
 		} else {
-			nodes = nodes.concat(text.visibleTextNodes(child));
+			nodes = nodes.concat(visibleTextNodes(child));
 		}
 	});
 	return nodes;
-};
+}
+
+export default visibleTextNodes;

--- a/lib/commons/text/visible-virtual.js
+++ b/lib/commons/text/visible-virtual.js
@@ -1,4 +1,5 @@
-/* global text, dom, axe */
+/* global dom */
+import sanitize from './sanitize';
 
 /**
  * Returns the visible text of the virtual node
@@ -14,33 +15,22 @@
  * When True, the result will only contain text from the element
  * @return {String}
  */
-text.visibleVirtual = function(element, screenReader, noRecursing) {
+function visibleVirtual(element, screenReader, noRecursing) {
 	const result = element.children
 		.map(child => {
 			if (child.actualNode.nodeType === 3) {
 				// filter on text nodes
 				const nodeValue = child.actualNode.nodeValue;
+				// TODO: es-module-dom.isVisible
 				if (nodeValue && dom.isVisible(element.actualNode, screenReader)) {
 					return nodeValue;
 				}
 			} else if (!noRecursing) {
-				return text.visibleVirtual(child, screenReader);
+				return visibleVirtual(child, screenReader);
 			}
 		})
 		.join('');
-	return text.sanitize(result);
-};
+	return sanitize(result);
+}
 
-/**
- * Finds virtual node and calls visibleVirtual()
- * IMPORTANT: This method requires the composed tree at axe._tree
- * @param  {Element} element
- * @param  {Boolean} screenReader When provided, will evaluate visibility from the perspective of a screen reader
- * @param  {Boolean} noRecursing When False, the result will contain text from the element and it's children.
- * When True, the result will only contain text from the element
- * @return {String}
- */
-text.visible = function(element, screenReader, noRecursing) {
-	element = axe.utils.getNodeFromTree(element);
-	return text.visibleVirtual(element, screenReader, noRecursing);
-};
+export default visibleVirtual;

--- a/lib/commons/text/visible.js
+++ b/lib/commons/text/visible.js
@@ -1,0 +1,18 @@
+import visibleVirtual from './visible-virtual';
+
+/**
+ * Finds virtual node and calls visibleVirtual()
+ * IMPORTANT: This method requires the composed tree at axe._tree
+ * @param  {Element} element
+ * @param  {Boolean} screenReader When provided, will evaluate visibility from the perspective of a screen reader
+ * @param  {Boolean} noRecursing When False, the result will contain text from the element and it's children.
+ * When True, the result will only contain text from the element
+ * @return {String}
+ */
+function visible(element, screenReader, noRecursing) {
+	// TODO: es-module-utils.getNodeFromTree
+	element = axe.utils.getNodeFromTree(element);
+	return visibleVirtual(element, screenReader, noRecursing);
+}
+
+export default visible;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5086,6 +5086,15 @@
 			"dev": true,
 			"optional": true
 		},
+		"fill-keys": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+			"requires": {
+				"is-object": "~1.0.1",
+				"merge-descriptors": "~1.0.0"
+			}
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6795,6 +6804,15 @@
 				"q": "~0.8.12"
 			}
 		},
+		"grunt-rollup": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-rollup/-/grunt-rollup-11.0.0.tgz",
+			"integrity": "sha512-bQSKGTae0wDlEesJ1L/4bqWwKvDobUsi9B6WZtmor+SStXNkbV4qs9t14d0PvgLNRFNAEL1wTbaS3hJvtbxUUA==",
+			"dev": true,
+			"requires": {
+				"rollup": "^2.0.6"
+			}
+		},
 		"grunt-run": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/grunt-run/-/grunt-run-0.8.1.tgz",
@@ -7497,6 +7515,11 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"is-observable": {
 			"version": "1.1.0",
@@ -8478,6 +8501,11 @@
 				"trim-newlines": "^1.0.0"
 			}
 		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8946,6 +8974,11 @@
 				"through2": "^2.0.0",
 				"xtend": "^4.0.0"
 			}
+		},
+		"module-not-found-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"morgan": {
 			"version": "1.9.1",
@@ -9687,8 +9720,7 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-platform": {
 			"version": "0.11.15",
@@ -9887,6 +9919,16 @@
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
 			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
 			"dev": true
+		},
+		"proxyquire": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+			"integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+			"requires": {
+				"fill-keys": "^1.0.2",
+				"module-not-found-error": "^1.0.1",
+				"resolve": "^1.11.1"
+			}
 		},
 		"prr": {
 			"version": "1.0.1",
@@ -10394,7 +10436,6 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
 			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -10456,6 +10497,22 @@
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
+			}
+		},
+		"rollup": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.3.2.tgz",
+			"integrity": "sha512-p66+fbfaUUOGE84sHXAOgfeaYQMslgAazoQMp//nlR519R61213EPFgrMZa48j31jNacJwexSAR1Q8V/BwGKBA==",
+			"requires": {
+				"fsevents": "~2.1.2"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"optional": true
+				}
 			}
 		},
 		"run-async": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5086,15 +5086,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6804,15 +6795,6 @@
 				"q": "~0.8.12"
 			}
 		},
-		"grunt-rollup": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/grunt-rollup/-/grunt-rollup-11.0.0.tgz",
-			"integrity": "sha512-bQSKGTae0wDlEesJ1L/4bqWwKvDobUsi9B6WZtmor+SStXNkbV4qs9t14d0PvgLNRFNAEL1wTbaS3hJvtbxUUA==",
-			"dev": true,
-			"requires": {
-				"rollup": "^2.0.6"
-			}
-		},
 		"grunt-run": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/grunt-run/-/grunt-run-0.8.1.tgz",
@@ -7515,11 +7497,6 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"is-observable": {
 			"version": "1.1.0",
@@ -8501,11 +8478,6 @@
 				"trim-newlines": "^1.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8974,11 +8946,6 @@
 				"through2": "^2.0.0",
 				"xtend": "^4.0.0"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"morgan": {
 			"version": "1.9.1",
@@ -9720,7 +9687,8 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-platform": {
 			"version": "0.11.15",
@@ -9919,16 +9887,6 @@
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
 			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
 			"dev": true
-		},
-		"proxyquire": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
-			"integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.1",
-				"resolve": "^1.11.1"
-			}
 		},
 		"prr": {
 			"version": "1.0.1",
@@ -10436,6 +10394,7 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
 			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -10497,22 +10456,6 @@
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
-			}
-		},
-		"rollup": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.3.2.tgz",
-			"integrity": "sha512-p66+fbfaUUOGE84sHXAOgfeaYQMslgAazoQMp//nlR519R61213EPFgrMZa48j31jNacJwexSAR1Q8V/BwGKBA==",
-			"requires": {
-				"fsevents": "~2.1.2"
-			},
-			"dependencies": {
-				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"optional": true
-				}
 			}
 		},
 		"run-async": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 		"grunt-contrib-uglify": "^4.0.0",
 		"grunt-contrib-watch": "^1.1.0",
 		"grunt-parallel": "^0.5.1",
+		"grunt-rollup": "^11.0.0",
 		"grunt-run": "^0.8.1",
 		"grunt-webpack": "^3.1.3",
 		"html-entities": "^1.2.0",
@@ -134,7 +135,10 @@
 		"weakmap-polyfill": "^2.0.0",
 		"webpack": "^4.42.0"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"proxyquire": "^2.1.3",
+		"rollup": "^2.3.2"
+	},
 	"lint-staged": {
 		"*.{md,json,ts,html}": [
 			"prettier --write",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
 		"grunt-contrib-uglify": "^4.0.0",
 		"grunt-contrib-watch": "^1.1.0",
 		"grunt-parallel": "^0.5.1",
-		"grunt-rollup": "^11.0.0",
 		"grunt-run": "^0.8.1",
 		"grunt-webpack": "^3.1.3",
 		"html-entities": "^1.2.0",
@@ -135,10 +134,7 @@
 		"weakmap-polyfill": "^2.0.0",
 		"webpack": "^4.42.0"
 	},
-	"dependencies": {
-		"proxyquire": "^2.1.3",
-		"rollup": "^2.3.2"
-	},
+	"dependencies": {},
 	"lint-staged": {
 		"*.{md,json,ts,html}": [
 			"prettier --write",

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -1438,11 +1438,11 @@ describe('text.accessibleTextVirtual', function() {
 		var _unsupported;
 
 		before(function() {
-			_unsupported = axe.commons.text.unsupported;
-			axe.commons.text.unsupported = {};
+			_unsupported = axe.commons.text.unsupported.accessibleNameFromFieldValue;
+			axe.commons.text.unsupported._set([]);
 		});
 		after(function() {
-			axe.commons.text.unsupported = _unsupported;
+			axe.commons.text.unsupported._set(_unsupported);
 		});
 
 		afterEach(function() {

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -1439,10 +1439,10 @@ describe('text.accessibleTextVirtual', function() {
 
 		before(function() {
 			_unsupported = axe.commons.text.unsupported.accessibleNameFromFieldValue;
-			axe.commons.text.unsupported._set([]);
+			axe.commons.text.unsupported.accessibleNameFromFieldValue = [];
 		});
 		after(function() {
-			axe.commons.text.unsupported._set(_unsupported);
+			axe.commons.text.unsupported.accessibleNameFromFieldValue = _unsupported;
 		});
 
 		afterEach(function() {

--- a/test/commons/text/form-control-value.js
+++ b/test/commons/text/form-control-value.js
@@ -1,13 +1,9 @@
 describe('text.formControlValue', function() {
-	var __methods, __unsupported;
+	// var __methods, __unsupported;
 	var formControlValue = axe.commons.text.formControlValue;
+	var queryFixture = axe.testUtils.queryFixture;
 	var fixtureSetup = axe.testUtils.fixtureSetup;
 	var fixture = document.querySelector('#fixture');
-
-	function queryFixture(code, query) {
-		fixtureSetup(code);
-		return axe.utils.querySelectorAll(axe._tree, query)[0];
-	}
 
 	function getNodeType(node) {
 		// Note: Inconsistent response for `node.type` across browsers, hence resolving and sanitizing using getAttribute
@@ -20,53 +16,46 @@ describe('text.formControlValue', function() {
 		return nodeType;
 	}
 
-	function bar() {
-		return 'bar';
-	}
-	function empty() {
-		return '';
-	}
+	// function bar() {
+	// 	return 'bar';
+	// }
+	// function empty() {
+	// 	return '';
+	// }
 
-	beforeEach(function() {
-		__methods = axe.commons.text.formControlValueMethods;
-		__unsupported = axe.commons.text.unsupported.accessibleNameFromFieldValue;
-	});
-	afterEach(function() {
-		axe.commons.text.formControlValueMethods = __methods;
-		axe.commons.text.unsupported.accessibleNameFromFieldValue = __unsupported;
-	});
-
-	it('runs functions on text.formControlValueMethods', function() {
-		var target = queryFixture('<input value="foo" />', 'input');
-		axe.commons.text.formControlValueMethods = [bar];
-		assert.equal(formControlValue(target), 'bar');
-	});
+	// beforeEach(function() {
+	// 	__methods = axe.commons.text.formControlValueMethods;
+	// 	__unsupported = axe.commons.text.unsupported.accessibleNameFromFieldValue;
+	// });
+	// afterEach(function() {
+	// 	axe.commons.text.formControlValueMethods = __methods;
+	// 	axe.commons.text.unsupported.accessibleNameFromFieldValue = __unsupported;
+	// });
 
 	it('returns the first truthy result from text.formControlValueMethods', function() {
-		var target = queryFixture('<input value ="foo" />', 'input');
+		var target = queryFixture(
+			'<div id="target" role="textbox" value="foo">bar</div>'
+		);
 		var fixture = axe.utils.querySelectorAll(axe._tree, '#fixture')[0];
-		axe.commons.text.formControlValueMethods = [empty, bar, empty];
 		assert.equal(formControlValue(target, { startNode: fixture }), 'bar');
 	});
 
-	it('returns `` when the node equal context.startNode', function() {
-		var target = queryFixture('<input value="foo" />', 'input');
-		axe.commons.text.formControlValueMethods = [bar];
+	it('returns `` when the node equals context.startNode', function() {
+		var target = queryFixture('<input id="target" value="foo" />');
 		assert.equal(formControlValue(target, { startNode: target }), '');
 	});
 
 	it('returns `` when the role is not supposed to return a value', function() {
 		var target = queryFixture(
-			'<input value="foo" role="presentation" />',
-			'input'
+			'<input id="target" value="foo" role="presentation" />'
 		);
-		axe.commons.text.formControlValueMethods = [bar];
 		assert.equal(formControlValue(target), '');
 	});
 
 	it('returns `` when accessibleNameFromFieldValue says the role is unsupported', function() {
-		var target = queryFixture('<input value="foo" />', 'input');
-		axe.commons.text.unsupported.accessibleNameFromFieldValue = ['textbox'];
+		var target = queryFixture(
+			'<input id="target" value="foo" role="combobox"/>'
+		);
 		assert.equal(formControlValue(target), '');
 	});
 
@@ -174,11 +163,10 @@ describe('text.formControlValue', function() {
 
 		it('returns the selected option text', function() {
 			var target = queryFixture(
-				'<select>' +
+				'<select id="target">' +
 					'  <option>foo</option>' +
 					'  <option value="bar" selected>baz</option>' +
-					'</select>',
-				'select'
+					'</select>'
 			);
 			assert.equal(nativeSelectValue(target), 'baz');
 		});
@@ -186,22 +174,21 @@ describe('text.formControlValue', function() {
 		it('returns multiple options, space seperated', function() {
 			// Can't apply multiple "selected" props without setting "multiple"
 			var target = queryFixture(
-				'<select multiple>' +
+				'<select id="target" multiple>' +
 					'  <option>oof</option>' +
 					'  <option selected>foo</option>' +
 					'  <option>rab</option>' +
 					'  <option selected>bar</option>' +
 					'  <option>zab</option>' +
 					'  <option selected>baz</option>' +
-					'</select>',
-				'select'
+					'</select>'
 			);
 			assert.equal(nativeSelectValue(target), 'foo bar baz');
 		});
 
 		it('returns options from within optgroup elements', function() {
 			var target = queryFixture(
-				'<select multiple>' +
+				'<select id="target" multiple>' +
 					'  <option>oof</option>' +
 					'  <option selected>foo</option>' +
 					'  <optgroup>' +
@@ -212,8 +199,7 @@ describe('text.formControlValue', function() {
 					'    <option>zab</option>' +
 					'    <option selected>baz</option>' +
 					'  </optgroup>' +
-					'</select>',
-				'select'
+					'</select>'
 			);
 			assert.equal(nativeSelectValue(target), 'foo bar baz');
 		});
@@ -221,11 +207,10 @@ describe('text.formControlValue', function() {
 		it('returns the first option when there are no selected options', function() {
 			// Browser automatically selectes the first option
 			var target = queryFixture(
-				'<select>' +
+				'<select id="target">' +
 					'  <option>foo</option>' +
 					'  <option>baz</option>' +
-					'</select>',
-				'select'
+					'</select>'
 			);
 			assert.equal(nativeSelectValue(target), 'foo');
 		});
@@ -248,63 +233,56 @@ describe('text.formControlValue', function() {
 			axe.commons.text.formControlValueMethods.ariaTextboxValue;
 
 		it('returns the text of role=textbox elements', function() {
-			var target = queryFixture(
-				'<div role="textbox">foo</div>',
-				'[role=textbox]'
-			);
+			var target = queryFixture('<div id="target" role="textbox">foo</div>');
 			assert.equal(ariaTextboxValue(target), 'foo');
 		});
 
 		it('returns `` for elements without role=textbox', function() {
-			var target = queryFixture(
-				'<div role="combobox">foo</div>',
-				'[role=combobox]'
-			);
+			var target = queryFixture('<div id="target" role="combobox">foo</div>');
 			assert.equal(ariaTextboxValue(target), '');
 		});
 
 		it('ignores text hidden with CSS', function() {
 			var target = queryFixture(
-				'<div role="textbox">' +
+				'<div id="target" role="textbox">' +
 					'<span>foo</span>' +
 					'<span style="display: none;">bar</span>' +
 					'<span style="visibility: hidden;">baz</span>' +
-					'</div>',
-				'[role=textbox]'
+					'</div>'
 			);
 			assert.equal(ariaTextboxValue(target), 'foo');
 		});
 
 		it('ignores elements with hidden content', function() {
 			var target = queryFixture(
-				'<div role="textbox">' +
+				'<div id="target" role="textbox">' +
 					'<span>span</span>' +
 					'<style>style</style>' +
 					'<template>template</template>' +
 					'<script>script</script>' +
 					'<!-- comment -->' +
 					'<h1>h1</h1>' +
-					'</div>',
-				'[role=textbox]'
+					'</div>'
 			);
 			assert.equal(ariaTextboxValue(target), 'spanh1');
 		});
 
 		it('does not return HTML or comments', function() {
 			var target = queryFixture(
-				'<div role="textbox">' + '<i>foo</i>' + '<!-- comment -->' + '</div>',
-				'[role=textbox]'
+				'<div id="target" role="textbox">' +
+					'<i>foo</i>' +
+					'<!-- comment -->' +
+					'</div>'
 			);
 			assert.equal(ariaTextboxValue(target), 'foo');
 		});
 
 		it('returns the entire text content if the textbox is hidden', function() {
 			var target = queryFixture(
-				'<div role="textbox" style="display:none">' +
+				'<div id="target" role="textbox" style="display:none">' +
 					// Yes, this is how it works in browsers :-(
 					'<style>[role=texbox] { display: none }</style>' +
-					'</div>',
-				'[role=textbox]'
+					'</div>'
 			);
 			assert.equal(ariaTextboxValue(target), '[role=texbox] { display: none }');
 		});
@@ -316,71 +294,65 @@ describe('text.formControlValue', function() {
 
 		it('returns the selected option when the element is a listbox', function() {
 			var target = queryFixture(
-				'<div role="listbox">' +
+				'<div id="target" role="listbox">' +
 					'  <div role="option">foo</div>' +
 					'  <div role="option" aria-selected="true">bar</div>' +
 					'  <div role="option">baz</div>' +
-					'</div>',
-				'[role=listbox]'
+					'</div>'
 			);
 			assert.equal(ariaListboxValue(target), 'bar');
 		});
 
 		it('returns `` when the element is not a listbox', function() {
 			var target = queryFixture(
-				'<div role="combobox">' +
+				'<div id="target" role="combobox">' +
 					'  <div role="option">foo</div>' +
 					'  <div role="option" aria-selected="true">bar</div>' +
 					'  <div role="option">baz</div>' +
-					'</div>',
-				'[role=combobox]'
+					'</div>'
 			);
 			assert.equal(ariaListboxValue(target), '');
 		});
 
 		it('returns `` when there is no selected option', function() {
 			var target = queryFixture(
-				'<div role="listbox">' +
+				'<div id="target" role="listbox">' +
 					'  <div role="option">foo</div>' +
 					'  <div role="option">bar</div>' +
 					'  <div role="option">baz</div>' +
-					'</div>',
-				'[role=listbox]'
+					'</div>'
 			);
 			assert.equal(ariaListboxValue(target), '');
 		});
 
 		it('returns `` when aria-selected is not true option', function() {
 			var target = queryFixture(
-				'<div role="listbox">' +
+				'<div id="target" role="listbox">' +
 					'  <div role="option" aria-selected="false">foo</div>' +
 					'  <div role="option" aria-selected="TRUE">bar</div>' +
 					'  <div role="option" aria-selected="yes">baz</div>' +
 					'  <div role="option" aria-selected="selected">fiz</div>' +
-					'</div>',
-				'[role=listbox]'
+					'</div>'
 			);
 			assert.equal(ariaListboxValue(target), '');
 		});
 
 		it('returns selected options from aria-owned', function() {
 			var target = queryFixture(
-				'<div role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
+				'<div id="target" role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
 					'<div role="option" id="opt1">foo</div>' +
 					'<div role="option" id="opt2" aria-selected="true">bar</div>' +
-					'<div role="option" id="opt3">baz</div>',
-				'[role=listbox]'
+					'<div role="option" id="opt3">baz</div>'
 			);
 			assert.equal(ariaListboxValue(target), 'bar');
 		});
 
 		it('ignores aria-selected for elements that are not options', function() {
 			var target = queryFixture(
-				'<div role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
+				'<div id="target" role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
 					'<div id="opt1">foo</div>' +
 					'<div id="opt2" aria-selected="true">bar</div>' +
-					'<div id="opt3">baz</div>',
-				'[role=listbox]'
+					'<div id="opt3">baz</div>'
 			);
 			assert.equal(ariaListboxValue(target), '');
 		});
@@ -388,35 +360,32 @@ describe('text.formControlValue', function() {
 		describe('with multiple aria-selected', function() {
 			it('returns the first selected option from children', function() {
 				var target = queryFixture(
-					'<div role="listbox">' +
+					'<div id="target" role="listbox">' +
 						'  <div role="option">foo</div>' +
 						'  <div role="option" aria-selected="true">bar</div>' +
 						'  <div role="option" aria-selected="true">baz</div>' +
-						'</div>',
-					'[role=listbox]'
+						'</div>'
 				);
 				assert.equal(ariaListboxValue(target), 'bar');
 			});
 
 			it('returns the first selected option in aria-owned (as opposed to in the DOM order)', function() {
 				var target = queryFixture(
-					'<div role="listbox" aria-owns="opt3 opt2 opt1"></div>' +
+					'<div id="target" role="listbox" aria-owns="opt3 opt2 opt1"></div>' +
 						'<div role="option" id="opt1" aria-selected="true">foo</div>' +
 						'<div role="option" id="opt2" aria-selected="true">bar</div>' +
-						'<div role="option" id="opt3">baz</div>',
-					'[role=listbox]'
+						'<div role="option" id="opt3">baz</div>'
 				);
 				assert.equal(ariaListboxValue(target), 'bar');
 			});
 
 			it('returns the a selected child before a selected aria-owned element', function() {
 				var target = queryFixture(
-					'<div role="listbox" aria-owns="opt2 opt3">' +
+					'<div id="target" role="listbox" aria-owns="opt2 opt3">' +
 						'  <div role="option" aria-selected="true">foo</div>' +
 						'</div>' +
 						'<div role="option" id="opt2" aria-selected="true">bar</div>' +
-						'<div role="option" id="opt3">baz</div>',
-					'[role=listbox]'
+						'<div role="option" id="opt3">baz</div>'
 				);
 				assert.equal(ariaListboxValue(target), 'foo');
 			});
@@ -424,12 +393,11 @@ describe('text.formControlValue', function() {
 			it('ignores aria-multiselectable=true', function() {
 				// aria-multiselectable doesn't add additional content to the accessible name
 				var target = queryFixture(
-					'<div role="listbox" aria-owns="opt2 opt3" aria-multiselectable="true">' +
+					'<div id="target" role="listbox" aria-owns="opt2 opt3" aria-multiselectable="true">' +
 						'  <div role="option" aria-selected="true">foo</div>' +
 						'</div>' +
 						'<div  role="option" id="opt2" aria-selected="true">bar</div>' +
-						'<div  role="option" id="opt3" aria-selected="true">baz</div>',
-					'[role=listbox]'
+						'<div  role="option" id="opt3" aria-selected="true">baz</div>'
 				);
 				assert.equal(ariaListboxValue(target), 'foo');
 			});
@@ -439,12 +407,6 @@ describe('text.formControlValue', function() {
 	describe('ariaComboboxValue', function() {
 		var ariaComboboxValue =
 			axe.commons.text.formControlValueMethods.ariaComboboxValue;
-		var __ariaListboxValue =
-			axe.commons.text.formControlValueMethods.ariaListboxValue;
-
-		afterEach(function() {
-			axe.commons.text.formControlValueMethods.ariaListboxValue = __ariaListboxValue;
-		});
 
 		var comboboxContent =
 			'<div role="textbox" id="text">nope</div>' +
@@ -455,46 +417,33 @@ describe('text.formControlValue', function() {
 
 		it('returns the text of role=combobox elements', function() {
 			var target = queryFixture(
-				'<div role="combobox">' + comboboxContent + '</div>',
-				'[role=combobox]'
+				'<div id="target" role="combobox">' + comboboxContent + '</div>'
 			);
 			assert.equal(ariaComboboxValue(target), 'bar');
 		});
 
 		it('returns `` for elements without role=combobox', function() {
-			var target = queryFixture(
-				'<div role="combobox">' + comboboxContent + '</div>',
+			queryFixture('<div role="combobox">' + comboboxContent + '</div>');
+			var target = axe.utils.querySelectorAll(
+				axe._tree[0],
 				'[role=listbox]'
-			);
+			)[0];
 			assert.equal(ariaComboboxValue(target), '');
 		});
 
 		it('passes child listbox to `ariaListboxValue` and returns its result', function() {
 			var target = queryFixture(
-				'<div role="combobox">' + comboboxContent + '</div>',
-				'[role=combobox]'
+				'<div id="target" role="combobox">' + comboboxContent + '</div>'
 			);
-			axe.commons.text.formControlValueMethods.ariaListboxValue = function(
-				elm
-			) {
-				assert.equal(elm.actualNode.id, 'list');
-				return 'Foxtrot';
-			};
-			assert.equal(ariaComboboxValue(target), 'Foxtrot');
+			assert.equal(ariaComboboxValue(target), 'bar');
 		});
 
 		it('passes aria-owned listbox to `ariaListboxValue` and returns its result', function() {
 			var target = queryFixture(
-				'<div role="combobox" aria-owns="text list"></div>' + comboboxContent,
-				'[role=combobox]'
+				'<div id="target" role="combobox" aria-owns="text list"></div>' +
+					comboboxContent
 			);
-			axe.commons.text.formControlValueMethods.ariaListboxValue = function(
-				elm
-			) {
-				assert.equal(elm.actualNode.id, 'list');
-				return 'Foxtrot';
-			};
-			assert.equal(ariaComboboxValue(target), 'Foxtrot');
+			assert.equal(ariaComboboxValue(target), 'bar');
 		});
 	});
 
@@ -504,10 +453,7 @@ describe('text.formControlValue', function() {
 			axe.commons.text.formControlValueMethods.ariaRangeValue;
 
 		it('returns `` for roles that are not ranges', function() {
-			var target = queryFixture(
-				'<div role="textbox">foo</div>',
-				'[role=textbox]'
-			);
+			var target = queryFixture('<div id="target" role="textbox">foo</div>');
 			assert.equal(ariaRangeValue(target), '');
 		});
 
@@ -515,32 +461,34 @@ describe('text.formControlValue', function() {
 			describe('with ' + role, function() {
 				it('returns the result of aria-valuenow', function() {
 					var target = queryFixture(
-						'<div role="' + role + '" aria-valuenow="+123">foo</div>',
-						'[aria-valuenow]'
+						'<div id="target" role="' +
+							role +
+							'" aria-valuenow="+123">foo</div>'
 					);
 					assert.equal(ariaRangeValue(target), '123');
 				});
 
 				it('returns `0` if aria-valuenow is not a number', function() {
 					var target = queryFixture(
-						'<div role="' + role + '" aria-valuenow="abc">foo</div>',
-						'[aria-valuenow]'
+						'<div id="target" role="' + role + '" aria-valuenow="abc">foo</div>'
 					);
 					assert.equal(ariaRangeValue(target), '0');
 				});
 
 				it('returns decimal numbers', function() {
 					var target = queryFixture(
-						'<div role="' + role + '" aria-valuenow="1.5678">foo</div>',
-						'[aria-valuenow]'
+						'<div id="target" role="' +
+							role +
+							'" aria-valuenow="1.5678">foo</div>'
 					);
 					assert.equal(ariaRangeValue(target), '1.5678');
 				});
 
 				it('returns negative numbers', function() {
 					var target = queryFixture(
-						'<div role="' + role + '" aria-valuenow="-1.0">foo</div>',
-						'[aria-valuenow]'
+						'<div id="target" role="' +
+							role +
+							'" aria-valuenow="-1.0">foo</div>'
 					);
 					assert.equal(ariaRangeValue(target), '-1');
 				});

--- a/test/commons/text/form-control-value.js
+++ b/test/commons/text/form-control-value.js
@@ -1,5 +1,4 @@
 describe('text.formControlValue', function() {
-	// var __methods, __unsupported;
 	var formControlValue = axe.commons.text.formControlValue;
 	var queryFixture = axe.testUtils.queryFixture;
 	var fixtureSetup = axe.testUtils.fixtureSetup;
@@ -15,22 +14,6 @@ describe('text.formControlValue', function() {
 			: 'text';
 		return nodeType;
 	}
-
-	// function bar() {
-	// 	return 'bar';
-	// }
-	// function empty() {
-	// 	return '';
-	// }
-
-	// beforeEach(function() {
-	// 	__methods = axe.commons.text.formControlValueMethods;
-	// 	__unsupported = axe.commons.text.unsupported.accessibleNameFromFieldValue;
-	// });
-	// afterEach(function() {
-	// 	axe.commons.text.formControlValueMethods = __methods;
-	// 	axe.commons.text.unsupported.accessibleNameFromFieldValue = __unsupported;
-	// });
 
 	it('returns the first truthy result from text.formControlValueMethods', function() {
 		var target = queryFixture(

--- a/test/commons/text/native-text-alternative.js
+++ b/test/commons/text/native-text-alternative.js
@@ -1,83 +1,47 @@
 describe('text.nativeTextAlternative', function() {
 	var text = axe.commons.text;
-	var fixtureSetup = axe.testUtils.fixtureSetup;
-	var __nativeElementType = text.nativeElementType;
-	var __nativeTextMethods = text.nativeTextMethods;
+	var queryFixture = axe.testUtils.queryFixture;
 	var nativeTextAlternative = text.nativeTextAlternative;
 
-	beforeEach(function() {
-		text.nativeTextMethods = {
-			returnFoo: function() {
-				return 'foo';
-			},
-			returnBar: function() {
-				return 'bar';
-			},
-			returnEmpty: function() {
-				return '';
-			}
-		};
-		text.nativeElementType = [
-			{
-				matches: '.foo',
-				namingMethods: 'returnFoo'
-			},
-			{
-				matches: '.foo.bar',
-				namingMethods: ['returnEmpty', 'returnFoo', 'returnBar']
-			},
-			{
-				matches: '.baz',
-				namingMethods: ['returnEmpty']
-			}
-		];
-	});
-
-	after(function() {
-		text.nativeElementType = __nativeElementType;
-		text.nativeTextMethods = __nativeTextMethods;
-	});
-
 	it('runs accessible text methods specified for the native element', function() {
-		fixtureSetup('<div class="foo"></div>');
-		var div = axe.utils.querySelectorAll(axe._tree[0], '.foo')[0];
-		assert.equal(nativeTextAlternative(div), 'foo');
+		var vNode = queryFixture('<button id="target">foo</button>');
+		assert.equal(nativeTextAlternative(vNode), 'foo');
 	});
 
 	it('returns the accessible text of the first method that returns something', function() {
-		fixtureSetup('<div class="foo bar"></div>');
-		var div = axe.utils.querySelectorAll(axe._tree[0], '.bar')[0];
-		assert.equal(nativeTextAlternative(div), 'foo');
+		var vNode = queryFixture(
+			'<input id="target" type="image" alt="foo" value="bar" title="baz">'
+		);
+		assert.equal(nativeTextAlternative(vNode), 'foo');
 	});
 
 	it('returns `` when no method matches', function() {
-		fixtureSetup('<div class="fizz">baz</div>');
-		var div = axe.utils.querySelectorAll(axe._tree[0], '.fizz')[0];
-		assert.equal(nativeTextAlternative(div), '');
+		var vNode = queryFixture('<div id="target">baz</div>');
+		assert.equal(nativeTextAlternative(vNode), '');
 	});
 
 	it('returns `` when no accessible text method returned something', function() {
-		fixtureSetup('<div class="baz">baz</div>');
+		queryFixture('<div class="baz">baz</div>');
 		var div = axe.utils.querySelectorAll(axe._tree[0], '.baz')[0];
 		assert.equal(nativeTextAlternative(div), '');
 	});
 
 	it('returns `` when the node is not an element', function() {
-		fixtureSetup('foo bar baz');
+		queryFixture('foo bar baz');
 		var fixture = axe.utils.querySelectorAll(axe._tree[0], '#fixture')[0];
 		assert.equal(fixture.children[0].actualNode.nodeType, 3);
 		assert.equal(nativeTextAlternative(fixture.children[0]), '');
 	});
 
 	it('returns `` when the element has role=presentation', function() {
-		fixtureSetup('<div class="foo" role="presentation"></div>');
-		var div = axe.utils.querySelectorAll(axe._tree[0], '.foo')[0];
-		assert.equal(nativeTextAlternative(div), '');
+		var vNode = queryFixture(
+			'<button id="target" role="presentation">foo</button>'
+		);
+		assert.equal(nativeTextAlternative(vNode), '');
 	});
 
 	it('returns `` when the element has role=none', function() {
-		fixtureSetup('<div class="foo" role="none"></div>');
-		var div = axe.utils.querySelectorAll(axe._tree[0], '.foo')[0];
-		assert.equal(nativeTextAlternative(div), '');
+		var vNode = queryFixture('<button id="target" role="none">foo</button>');
+		assert.equal(nativeTextAlternative(vNode), '');
 	});
 });

--- a/test/commons/text/native-text-methods.js
+++ b/test/commons/text/native-text-methods.js
@@ -178,60 +178,6 @@ describe('text.nativeTextMethods', function() {
 		});
 	});
 
-	describe('titleText', function() {
-		var __titleText;
-		beforeEach(function() {
-			__titleText = text.titleText;
-		});
-		afterEach(function() {
-			text.titleText = __titleText;
-		});
-		it('returns the value from text.titleText', function() {
-			text.titleText = function(arg1, arg2) {
-				assert.equal(arg1, 'lilly');
-				assert.equal(arg2, 'bob');
-				return 'foo';
-			};
-			assert.equal(nativeTextMethods.titleText('lilly', 'bob'), 'foo');
-		});
-	});
-
-	describe('subtreeText', function() {
-		var __subtreeText;
-		beforeEach(function() {
-			__subtreeText = text.subtreeText;
-		});
-		afterEach(function() {
-			text.subtreeText = __subtreeText;
-		});
-		it('returns the value from text.subtreeText', function() {
-			text.subtreeText = function(arg1, arg2) {
-				assert.equal(arg1, 'lilly');
-				assert.equal(arg2, 'bob');
-				return 'foo';
-			};
-			assert.equal(nativeTextMethods.subtreeText('lilly', 'bob'), 'foo');
-		});
-	});
-
-	describe('labelText', function() {
-		var __labelText;
-		beforeEach(function() {
-			__labelText = text.labelText;
-		});
-		afterEach(function() {
-			text.labelText = __labelText;
-		});
-		it('returns the value from text.labelText', function() {
-			text.labelText = function(arg1, arg2) {
-				assert.equal(arg1, 'lilly');
-				assert.equal(arg2, 'bob');
-				return 'foo';
-			};
-			assert.equal(nativeTextMethods.labelText('lilly', 'bob'), 'foo');
-		});
-	});
-
 	describe('singleSpace', function() {
 		var singleSpace = nativeTextMethods.singleSpace;
 		it('returns a single space', function() {


### PR DESCRIPTION
This one was a bit rough as the tests mocked a lot of the `commons.text` functions. However, since the code no longer uses the functions through `commons.text` the mocks didn't work anymore. So I had to rewrite some of the tests to not use mocks. 

Noticed that `matches` was a circular dependency to itself so changed it to not be circular.

Finally, split the `unicode` into its separate functions, but the regex are needed by both functions so just exported those as helper functions. I know this pattern will be needed again in other places so we should probably think of a good way to have shareable code that isn't put into the public API space (not really needed in the `commons.text` group).

Closes issue: #2116 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
