### PR TITLE
chore: convert commons.table to ES Modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -77,6 +77,7 @@
         "lib/commons/aria/*.js",
         "lib/commons/forms/*.js",
         "lib/commons/matches/*.js",
+        "lib/commons/table/*.js",
         "lib/commons/utils/*.js"
       ],
       "parserOptions":{

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,6 +157,7 @@ module.exports = function(grunt) {
 					'!lib/commons/aria/*.js',
 					'!lib/commons/forms/*.js',
 					'!lib/commons/matches/*.js',
+					'!lib/commons/table/*.js',
 					'!lib/commons/utils/*.js',
 
 					// output of webpack directories
@@ -183,6 +184,10 @@ module.exports = function(grunt) {
 			commonsMatches: createWebpackConfig(
 				'lib/commons/matches/index.js',
 				'tmp/commons/matches'
+			),
+			commonsTable: createWebpackConfig(
+				'lib/commons/table/index.js',
+				'tmp/commons/table'
 			)
 		},
 		'aria-supported': {

--- a/lib/commons/table/get-all-cells.js
+++ b/lib/commons/table/get-all-cells.js
@@ -1,5 +1,3 @@
-/* global table */
-
 /**
  * Returns all cells contained in given HTMLTableElement
  * @method getAllCells
@@ -8,7 +6,7 @@
  * @param  {HTMLTableElement} tableElm Table Element to get cells from
  * @return {Array<HTMLTableCellElement>}
  */
-table.getAllCells = function(tableElm) {
+function getAllCells(tableElm) {
 	var rowIndex, cellIndex, rowLength, cellLength;
 	var cells = [];
 	for (
@@ -25,4 +23,6 @@ table.getAllCells = function(tableElm) {
 		}
 	}
 	return cells;
-};
+}
+
+export default getAllCells;

--- a/lib/commons/table/get-cell-position.js
+++ b/lib/commons/table/get-cell-position.js
@@ -1,4 +1,5 @@
-/* global table, dom */
+/* global dom */
+import toGrid from './to-grid';
 
 /**
  * Get the x, y coordinates of a table cell; normalized for rowspan and colspan
@@ -8,10 +9,11 @@
  * @param  {HTMLTableCellElement} cell The table cell of which to get the position
  * @return {Object} Object with `x` and `y` properties of the coordinates
  */
-table.getCellPosition = axe.utils.memoize(function(cell, tableGrid) {
+function getCellPosition(cell, tableGrid) {
 	var rowIndex, index;
 	if (!tableGrid) {
-		tableGrid = table.toGrid(dom.findUp(cell, 'table'));
+		// TODO: es-module-dom.findUp
+		tableGrid = toGrid(dom.findUp(cell, 'table'));
 	}
 
 	for (rowIndex = 0; rowIndex < tableGrid.length; rowIndex++) {
@@ -25,4 +27,7 @@ table.getCellPosition = axe.utils.memoize(function(cell, tableGrid) {
 			}
 		}
 	}
-});
+}
+
+// TODO: es-module-utils.memoize
+export default axe.utils.memoize(getCellPosition);

--- a/lib/commons/table/get-headers.js
+++ b/lib/commons/table/get-headers.js
@@ -1,4 +1,7 @@
-/* global table */
+import isRowHeader from './is-row-header';
+import isColumnHeader from './is-column-header';
+import toGrid from './to-grid';
+import getCellPosition from './get-cell-position';
 
 /**
  * Loop through the table grid looking for headers and caching the result.
@@ -9,8 +12,7 @@
  */
 function traverseForHeaders(headerType, position, tableGrid) {
 	const property = headerType === 'row' ? '_rowHeaders' : '_colHeaders';
-	const predicate =
-		headerType === 'row' ? table.isRowHeader : table.isColumnHeader;
+	const predicate = headerType === 'row' ? isRowHeader : isColumnHeader;
 	const rowEnd = headerType === 'row' ? position.y : 0;
 	const colEnd = headerType === 'row' ? 0 : position.x;
 
@@ -56,8 +58,9 @@ function traverseForHeaders(headerType, position, tableGrid) {
  * @param {Array} [tablegrid] A matrix of the table obtained using axe.commons.table.toGrid
  * @return {Array<HTMLTableCellElement>} Array of headers associated to the table cell
  */
-table.getHeaders = function(cell, tableGrid) {
+function getHeaders(cell, tableGrid) {
 	if (cell.getAttribute('headers')) {
+		// TODO: es-module-dom.idrefs
 		const headers = commons.dom.idrefs(cell, 'headers');
 
 		// testing has shown that if the headers attribute is incorrect the browser
@@ -67,13 +70,16 @@ table.getHeaders = function(cell, tableGrid) {
 		}
 	}
 	if (!tableGrid) {
-		tableGrid = commons.table.toGrid(commons.dom.findUp(cell, 'table'));
+		// TODO: es-module-dom.findUp
+		tableGrid = toGrid(commons.dom.findUp(cell, 'table'));
 	}
-	const position = commons.table.getCellPosition(cell, tableGrid);
+	const position = getCellPosition(cell, tableGrid);
 
 	// TODO: RTL text
 	const rowHeaders = traverseForHeaders('row', position, tableGrid);
 	const colHeaders = traverseForHeaders('col', position, tableGrid);
 
 	return [].concat(rowHeaders, colHeaders).reverse();
-};
+}
+
+export default getHeaders;

--- a/lib/commons/table/get-scope.js
+++ b/lib/commons/table/get-scope.js
@@ -1,4 +1,6 @@
-/* global table, dom */
+/* global dom */
+import toGrid from './to-grid';
+import getCellPosition from './get-cell-position';
 
 /**
  * Determine if a `HTMLTableCellElement` is a column header, if so get the scope of the header
@@ -8,7 +10,7 @@
  * @param {HTMLTableCellElement} cell The table cell to test
  * @return {Boolean|String} Returns `false` if not a column header, or the scope of the column header element
  */
-table.getScope = function(cell) {
+function getScope(cell) {
 	var scope = cell.getAttribute('scope');
 	var role = cell.getAttribute('role');
 
@@ -28,8 +30,9 @@ table.getScope = function(cell) {
 	} else if (cell.nodeName.toUpperCase() !== 'TH') {
 		return false;
 	}
-	var tableGrid = table.toGrid(dom.findUp(cell, 'table'));
-	var pos = table.getCellPosition(cell, tableGrid);
+	// TODO: es-module-dom.findUp
+	var tableGrid = toGrid(dom.findUp(cell, 'table'));
+	var pos = getCellPosition(cell, tableGrid);
 
 	// The element is in a row with all th elements, that makes it a column header
 	var headerRow = tableGrid[pos.y].reduce((headerRow, cell) => {
@@ -51,4 +54,6 @@ table.getScope = function(cell) {
 		return 'row';
 	}
 	return 'auto';
-};
+}
+
+export default getScope;

--- a/lib/commons/table/index.js
+++ b/lib/commons/table/index.js
@@ -1,9 +1,36 @@
-/* exported table */
-/*eslint no-unused-vars: 0*/
+// TODO: es-module-commons. convert to:
+// export { default as isAriaCombobox } from 'path'
+import getAllCells from './get-all-cells';
+import getCellPosition from './get-cell-position';
+import getHeaders from './get-headers';
+import getScope from './get-scope';
+import isColumnHeader from './is-column-header';
+import isDataCell from './is-data-cell';
+import isDataTable from './is-data-table';
+import isHeader from './is-header';
+import isRowHeader from './is-row-header';
+import toGrid from './to-grid';
+import traverse from './traverse';
+
 /**
  * Namespace for table-related utilities.
  * @namespace table
  * @memberof axe.commons
  */
+const table = {
+	getAllCells,
+	getCellPosition,
+	getHeaders,
+	getScope,
+	isColumnHeader,
+	isDataCell,
+	isDataTable,
+	isHeader,
+	isRowHeader,
+	toGrid,
+	traverse,
 
-var table = (commons.table = {});
+	// This was the old name
+	toArray: toGrid
+};
+commons.table = table;

--- a/lib/commons/table/is-column-header.js
+++ b/lib/commons/table/is-column-header.js
@@ -1,4 +1,4 @@
-/* global table */
+import getScope from './get-scope';
 
 /**
  * Determine if a `HTMLTableCellElement` is a column header
@@ -8,6 +8,8 @@
  * @param  {HTMLTableCellElement} element The table cell to test
  * @return {Boolean}
  */
-table.isColumnHeader = function(element) {
-	return ['col', 'auto'].indexOf(table.getScope(element)) !== -1;
-};
+function isColumnHeader(element) {
+	return ['col', 'auto'].indexOf(getScope(element)) !== -1;
+}
+
+export default isColumnHeader;

--- a/lib/commons/table/is-data-cell.js
+++ b/lib/commons/table/is-data-cell.js
@@ -1,5 +1,3 @@
-/* global table */
-
 /**
  * Determine if a `HTMLTableCellElement` is a data cell
  * @method isDataCell
@@ -8,15 +6,18 @@
  * @param  {HTMLTableCellElement} node The table cell to test
  * @return {Boolean}
  */
-table.isDataCell = function(cell) {
+function isDataCell(cell) {
 	// @see http://www.whatwg.org/specs/web-apps/current-work/multipage/tables.html#empty-cell
 	if (!cell.children.length && !cell.textContent.trim()) {
 		return false;
 	}
 	const role = cell.getAttribute('role');
+	// TODO: es-module-aria.isValidRole
 	if (axe.commons.aria.isValidRole(role)) {
 		return ['cell', 'gridcell'].includes(role);
 	} else {
 		return cell.nodeName.toUpperCase() === 'TD';
 	}
-};
+}
+
+export default isDataCell;

--- a/lib/commons/table/is-data-table.js
+++ b/lib/commons/table/is-data-table.js
@@ -1,4 +1,4 @@
-/* global table, dom */
+/* global dom */
 
 /**
  * Determines whether a table is a data table
@@ -9,10 +9,11 @@
  * @return {Boolean}
  * @see http://asurkov.blogspot.co.uk/2011/10/data-vs-layout-table.html
  */
-table.isDataTable = function(node) {
+function isDataTable(node) {
 	var role = (node.getAttribute('role') || '').toLowerCase();
 
 	// The element is not focusable and has role=presentation
+	// TODO: es-module-dom.isFocusable
 	if ((role === 'presentation' || role === 'none') && !dom.isFocusable(node)) {
 		return false;
 	}
@@ -20,6 +21,7 @@ table.isDataTable = function(node) {
 	// Table inside editable area is data table always since the table structure is crucial for table editing
 	if (
 		node.getAttribute('contenteditable') === 'true' ||
+		// TODO: es-module-dom.findUp
 		dom.findUp(node, '[contenteditable="true"]')
 	) {
 		return true;
@@ -31,6 +33,7 @@ table.isDataTable = function(node) {
 	}
 
 	// Table having ARIA landmark role is data table
+	// TODO: es-module-aria.getRoleType
 	if (commons.aria.getRoleType(role) === 'landmark') {
 		return true;
 	}
@@ -168,7 +171,9 @@ table.isDataTable = function(node) {
 
 	// Wide table (more than 95% of the document width) is layout table
 	if (
+		// TODO: es-module-dom.getElementCoordinates
 		dom.getElementCoordinates(node).width >
+		// TODO: es-module-dom.getViewportSize
 		dom.getViewportSize(window).width * 0.95
 	) {
 		return false;
@@ -186,4 +191,6 @@ table.isDataTable = function(node) {
 
 	// Otherwise it's data table
 	return true;
-};
+}
+
+export default isDataTable;

--- a/lib/commons/table/is-header.js
+++ b/lib/commons/table/is-header.js
@@ -1,4 +1,5 @@
-/* global table, axe */
+import isColumnHeader from './is-column-header';
+import isRowHeader from './is-row-header';
 
 /**
  * Determine if a `HTMLTableCellElement` is a header
@@ -8,15 +9,18 @@
  * @param  {HTMLTableCellElement} cell The table cell to test
  * @return {Boolean}
  */
-table.isHeader = function(cell) {
-	if (table.isColumnHeader(cell) || table.isRowHeader(cell)) {
+function isHeader(cell) {
+	if (isColumnHeader(cell) || isRowHeader(cell)) {
 		return true;
 	}
 
 	if (cell.getAttribute('id')) {
+		// TODO: es-module-utils.escapeSelector
 		const id = axe.utils.escapeSelector(cell.getAttribute('id'));
 		return !!document.querySelector(`[headers~="${id}"]`);
 	}
 
 	return false;
-};
+}
+
+export default isHeader;

--- a/lib/commons/table/is-row-header.js
+++ b/lib/commons/table/is-row-header.js
@@ -1,4 +1,4 @@
-/* global table */
+import getScope from './get-scope';
 
 /**
  * Determine if a `HTMLTableCellElement` is a row header
@@ -8,6 +8,8 @@
  * @param  {HTMLTableCellElement} cell The table cell to test
  * @return {Boolean}
  */
-table.isRowHeader = function(cell) {
-	return ['row', 'auto'].includes(table.getScope(cell));
-};
+function isRowHeader(cell) {
+	return ['row', 'auto'].includes(getScope(cell));
+}
+
+export default isRowHeader;

--- a/lib/commons/table/to-grid.js
+++ b/lib/commons/table/to-grid.js
@@ -1,5 +1,3 @@
-/*global table */
-
 /**
  * Converts a table to an Array of arrays, normalized for row and column spans
  * @method toGrid
@@ -8,7 +6,7 @@
  * @param  {HTMLTableElement} node The table to convert
  * @return {Array<HTMLTableCellElement>} Array of HTMLTableCellElements
  */
-table.toGrid = axe.utils.memoize(function(node) {
+function toGrid(node) {
 	var table = [];
 	var rows = node.rows;
 	for (var i = 0, rowLength = rows.length; i < rowLength; i++) {
@@ -32,7 +30,7 @@ table.toGrid = axe.utils.memoize(function(node) {
 	}
 
 	return table;
-});
+}
 
-// This was the old name
-table.toArray = table.toGrid;
+// TODO: es-module-utils.memoize
+export default axe.utils.memoize(toGrid);

--- a/lib/commons/table/traverse.js
+++ b/lib/commons/table/traverse.js
@@ -1,78 +1,76 @@
-/* global table */
-(function(table) {
-	var traverseTable = function(dir, position, tableGrid, callback) {
-		var result;
-		var cell = tableGrid[position.y]
-			? tableGrid[position.y][position.x]
-			: undefined;
-		if (!cell) {
-			return [];
+function traverseTable(dir, position, tableGrid, callback) {
+	let result;
+	const cell = tableGrid[position.y]
+		? tableGrid[position.y][position.x]
+		: undefined;
+	if (!cell) {
+		return [];
+	}
+	if (typeof callback === 'function') {
+		result = callback(cell, position, tableGrid);
+		if (result === true) {
+			// abort
+			return [cell];
 		}
-		if (typeof callback === 'function') {
-			result = callback(cell, position, tableGrid);
-			if (result === true) {
-				// abort
-				return [cell];
-			}
+	}
+
+	result = traverseTable(
+		dir,
+		{
+			x: position.x + dir.x,
+			y: position.y + dir.y
+		},
+		tableGrid,
+		callback
+	);
+	result.unshift(cell);
+	return result;
+}
+
+/**
+ * Traverses a table in a given direction, passing the cell to the callback
+ * @method traverse
+ * @memberof axe.commons.table
+ * @instance
+ * @param  {Object|String} dir Direction that will be added recursively {x: 1, y: 0}, 'left';
+ * @param  {Object}   startPos    x/y coordinate: {x: 0, y: 0};
+ * @param  {Array}    [tablegrid]  A matrix of the table obtained using axe.commons.table.toArray (OPTIONAL)
+ * @param  {Function} callback Function to which each cell will be passed
+ * @return {NodeElement}       If the callback returns true, the traversal will end and the cell will be returned
+ */
+function traverse(dir, startPos, tableGrid, callback) {
+	if (Array.isArray(startPos)) {
+		callback = tableGrid;
+		tableGrid = startPos;
+		startPos = { x: 0, y: 0 };
+	}
+
+	if (typeof dir === 'string') {
+		switch (dir) {
+			case 'left':
+				dir = { x: -1, y: 0 };
+				break;
+			case 'up':
+				dir = { x: 0, y: -1 };
+				break;
+			case 'right':
+				dir = { x: 1, y: 0 };
+				break;
+			case 'down':
+				dir = { x: 0, y: 1 };
+				break;
 		}
+	}
 
-		result = traverseTable(
-			dir,
-			{
-				x: position.x + dir.x,
-				y: position.y + dir.y
-			},
-			tableGrid,
-			callback
-		);
-		result.unshift(cell);
-		return result;
-	};
+	return traverseTable(
+		dir,
+		{
+			x: startPos.x + dir.x,
+			y: startPos.y + dir.y
+		},
+		tableGrid,
+		callback
+	);
+}
 
-	/**
-	 * Traverses a table in a given direction, passing the cell to the callback
-	 * @method traverse
-	 * @memberof axe.commons.table
-	 * @instance
-	 * @param  {Object|String} dir Direction that will be added recursively {x: 1, y: 0}, 'left';
-	 * @param  {Object}   startPos    x/y coordinate: {x: 0, y: 0};
-	 * @param  {Array}    [tablegrid]  A matrix of the table obtained using axe.commons.table.toArray (OPTIONAL)
-	 * @param  {Function} callback Function to which each cell will be passed
-	 * @return {NodeElement}       If the callback returns true, the traversal will end and the cell will be returned
-	 */
-	table.traverse = function(dir, startPos, tableGrid, callback) {
-		/* eslint indent: 0 */
-		if (Array.isArray(startPos)) {
-			callback = tableGrid;
-			tableGrid = startPos;
-			startPos = { x: 0, y: 0 };
-		}
-
-		if (typeof dir === 'string') {
-			switch (dir) {
-				case 'left':
-					dir = { x: -1, y: 0 };
-					break;
-				case 'up':
-					dir = { x: 0, y: -1 };
-					break;
-				case 'right':
-					dir = { x: 1, y: 0 };
-					break;
-				case 'down':
-					dir = { x: 0, y: 1 };
-					break;
-			}
-		}
-
-		return traverseTable(
-			dir,
-			{
-				x: startPos.x + dir.x,
-				y: startPos.y + dir.y
-			},
-			tableGrid,
-			callback
-		);
-	};
-})(table);
+export default traverse;

--- a/test/commons/table/is-column-header.js
+++ b/test/commons/table/is-column-header.js
@@ -1,53 +1,41 @@
 describe('table.isColumnHeader', function() {
 	'use strict';
 
-	var table, origGetScope;
-	beforeEach(function() {
-		table = axe.commons.table;
-		origGetScope = table.getScope;
+	var table = axe.commons.table;
+	var fixture = document.querySelector('#fixture');
+
+	var tableFixture =
+		'<table>' +
+		'<tr>' +
+		'<th id="ch1">column header 1</th>' +
+		'<th scope="col" id="ch2">column header 2</th>' +
+		'</tr>' +
+		'<tr>' +
+		'<th scope="row" id="rh">row header 1</th>' +
+		'<td id="cell">cell</td>' +
+		'</table>';
+
+	it('returns false if not a column header', function() {
+		fixture.innerHTML = tableFixture;
+		var cell = document.querySelector('#cell');
+		assert.isFalse(table.isColumnHeader(cell));
 	});
 
-	afterEach(function() {
-		table.getScope = origGetScope;
+	it('returns true if scope="auto"', function() {
+		fixture.innerHTML = tableFixture;
+		var cell = document.querySelector('#ch1');
+		assert.isTrue(table.isColumnHeader(cell));
 	});
 
-	it('passes an argument to table.getScope', function() {
-		var called = false;
-		axe.commons.table.getScope = function(arg) {
-			assert.equal(arg, 'Buzz Lightyear');
-			called = true;
-			return 'auto';
-		};
-		axe.commons.table.isColumnHeader('Buzz Lightyear');
-
-		assert.isTrue(called);
+	it('returns true if scope="col"', function() {
+		fixture.innerHTML = tableFixture;
+		var cell = document.querySelector('#ch2');
+		assert.isTrue(table.isColumnHeader(cell));
 	});
 
-	it('returns false if table.getScope returns false', function() {
-		table.getScope = function() {
-			return false;
-		};
-		assert.isFalse(table.isColumnHeader());
-	});
-
-	it('returns true if table.getScope returns auto', function() {
-		table.getScope = function() {
-			return 'auto';
-		};
-		assert.isTrue(table.isColumnHeader());
-	});
-
-	it('returns true if table.getScope returns col', function() {
-		table.getScope = function() {
-			return 'col';
-		};
-		assert.isTrue(table.isColumnHeader());
-	});
-
-	it('returns false if table.getScope returns row', function() {
-		table.getScope = function() {
-			return 'row';
-		};
-		assert.isFalse(table.isColumnHeader());
+	it('returns false if scope="row"', function() {
+		fixture.innerHTML = tableFixture;
+		var cell = document.querySelector('#rh');
+		assert.isFalse(table.isColumnHeader(cell));
 	});
 });

--- a/test/commons/table/is-column-header.js
+++ b/test/commons/table/is-column-header.js
@@ -2,40 +2,44 @@ describe('table.isColumnHeader', function() {
 	'use strict';
 
 	var table = axe.commons.table;
-	var fixture = document.querySelector('#fixture');
+	var fixtureSetup = axe.testUtils.fixtureSetup;
 
-	var tableFixture =
-		'<table>' +
-		'<tr>' +
-		'<th id="ch1">column header 1</th>' +
-		'<th scope="col" id="ch2">column header 2</th>' +
-		'</tr>' +
-		'<tr>' +
-		'<th scope="row" id="rh">row header 1</th>' +
-		'<td id="cell">cell</td>' +
-		'</table>';
+	beforeEach(function() {
+		fixtureSetup(
+			'<table>' +
+				'<tr>' +
+				'<th id="ch1">column header 1</th>' +
+				'<th scope="col" id="ch2">column header 2</th>' +
+				'</tr>' +
+				'<tr>' +
+				'<th id="rh1">row header 1</th>' +
+				'<td id="cell1">cell 1</td>' +
+				'</tr>' +
+				'<tr>' +
+				'<th scope="row" id="rh2">row header 2</th>' +
+				'<td id="cell2">cell 2</td>' +
+				'</tr>' +
+				'</table>'
+		);
+	});
 
 	it('returns false if not a column header', function() {
-		fixture.innerHTML = tableFixture;
-		var cell = document.querySelector('#cell');
+		var cell = document.querySelector('#cell1');
 		assert.isFalse(table.isColumnHeader(cell));
 	});
 
 	it('returns true if scope="auto"', function() {
-		fixture.innerHTML = tableFixture;
 		var cell = document.querySelector('#ch1');
 		assert.isTrue(table.isColumnHeader(cell));
 	});
 
 	it('returns true if scope="col"', function() {
-		fixture.innerHTML = tableFixture;
 		var cell = document.querySelector('#ch2');
 		assert.isTrue(table.isColumnHeader(cell));
 	});
 
 	it('returns false if scope="row"', function() {
-		fixture.innerHTML = tableFixture;
-		var cell = document.querySelector('#rh');
+		var cell = document.querySelector('#rh2');
 		assert.isFalse(table.isColumnHeader(cell));
 	});
 });

--- a/test/commons/table/is-header.js
+++ b/test/commons/table/is-header.js
@@ -1,60 +1,42 @@
 describe('table.isHeader', function() {
 	'use strict';
-	function $id(id) {
-		return document.getElementById(id);
-	}
 
-	var fixture = $id('fixture');
-	var cell;
+	var table = axe.commons.table;
+	var fixture = document.querySelector('#fixture');
+	var fixtureSetup = axe.testUtils.fixtureSetup;
 
-	afterEach(function() {
-		fixture.innerHTML = '<table><tr><th id="cell"></th></tr></table>';
-		cell = $id('cell');
+	var tableFixture =
+		'<table>' +
+		'<tr>' +
+		'<th id="ch1">column header 1</th>' +
+		'<th scope="col" id="ch2">column header 2</th>' +
+		'</tr>' +
+		'<tr>' +
+		'<th id="rh1">row header 1</th>' +
+		'<td id="cell1">cell 1</td>' +
+		'</tr>' +
+		'<tr>' +
+		'<th scope="row" id="rh2">row header 2</th>' +
+		'<td id="cell2">cell 2</td>' +
+		'</tr>' +
+		'</table>';
+
+	it('should return true for column headers', function() {
+		fixtureSetup(tableFixture);
+		var cell = document.querySelector('#ch1');
+		assert.isTrue(table.isHeader(cell));
 	});
 
-	it('should return true if table.isColumnHeader return true', function() {
-		var orig = axe.commons.table.isColumnHeader;
-		axe.commons.table.isColumnHeader = function() {
-			return true;
-		};
-		var orig2 = axe.commons.table.isRowHeader;
-		axe.commons.table.isRowHeader = function() {
-			return false;
-		};
-		assert.isTrue(axe.commons.table.isHeader(cell));
-
-		axe.commons.table.isColumnHeader = orig;
-		axe.commons.table.isRowHeader = orig2;
+	it('should return true if cell is a row header', function() {
+		fixtureSetup(tableFixture);
+		var cell = document.querySelector('#rh1');
+		assert.isTrue(table.isHeader(cell));
 	});
 
-	it('should return true if table.isRowHeader return true', function() {
-		var orig = axe.commons.table.isRowHeader;
-		axe.commons.table.isRowHeader = function() {
-			return true;
-		};
-		var orig2 = axe.commons.table.isColumnHeader;
-		axe.commons.table.isColumnHeader = function() {
-			return false;
-		};
-		assert.isTrue(axe.commons.table.isHeader(cell));
-
-		axe.commons.table.isRowHeader = orig;
-		axe.commons.table.isColumnHeader = orig2;
-	});
-
-	it('should return false if table.isRowHeader and table.isColumnHeader return false', function() {
-		var orig = axe.commons.table.isRowHeader;
-		axe.commons.table.isRowHeader = function() {
-			return false;
-		};
-		var orig2 = axe.commons.table.isColumnHeader;
-		axe.commons.table.isColumnHeader = function() {
-			return false;
-		};
-		assert.isFalse(axe.commons.table.isHeader(cell));
-
-		axe.commons.table.isRowHeader = orig;
-		axe.commons.table.isColumnHeader = orig2;
+	it('should return false if cell is not a column or row header', function() {
+		fixtureSetup(tableFixture);
+		var cell = document.querySelector('#cell1');
+		assert.isFalse(table.isHeader(cell));
 	});
 
 	it('should return true if referenced by another cells headers attr', function() {
@@ -63,19 +45,19 @@ describe('table.isHeader', function() {
 			'<tr><td id="target">1</td><td headers="bar target foo"></tr>' +
 			'</table>';
 
-		var target = $id('target');
+		var target = document.querySelector('#target');
 
-		assert.isTrue(axe.commons.table.isHeader(target));
+		assert.isTrue(table.isHeader(target));
 	});
 
 	it('should return false otherwise', function() {
 		fixture.innerHTML =
 			'<table>' +
-			'<tr><td class="target">1</td><td headers="bar monkeys foo"></tr>' +
+			'<tr><td id="target">1</td><td headers="bar monkeys foo"></tr>' +
 			'</table>';
 
-		var target = document.querySelector('.target');
+		var target = document.querySelector('#target');
 
-		assert.isFalse(axe.commons.table.isHeader(target));
+		assert.isFalse(table.isHeader(target));
 	});
 });

--- a/test/commons/table/is-row-header.js
+++ b/test/commons/table/is-row-header.js
@@ -33,13 +33,13 @@ describe('table.isRowHeader', function() {
 		assert.isTrue(table.isRowHeader(cell));
 	});
 
-	it('returns true if scope="col"', function() {
-		var cell = document.querySelector('#rh2');
-		assert.isTrue(table.isRowHeader(cell));
-	});
-
-	it('returns false if scope="row"', function() {
+	it('returns false if scope="col"', function() {
 		var cell = document.querySelector('#ch1');
 		assert.isFalse(table.isRowHeader(cell));
+	});
+
+	it('returns true if scope="row"', function() {
+		var cell = document.querySelector('#rh2');
+		assert.isTrue(table.isRowHeader(cell));
 	});
 });

--- a/test/commons/table/is-row-header.js
+++ b/test/commons/table/is-row-header.js
@@ -1,53 +1,45 @@
 describe('table.isRowHeader', function() {
 	'use strict';
 
-	var table, origGetScope;
+	var table = axe.commons.table;
+	var fixtureSetup = axe.testUtils.fixtureSetup;
+
 	beforeEach(function() {
-		table = axe.commons.table;
-		origGetScope = table.getScope;
+		fixtureSetup(
+			'<table>' +
+				'<tr>' +
+				'<th id="ch1">column header 1</th>' +
+				'<th scope="col" id="ch2">column header 2</th>' +
+				'</tr>' +
+				'<tr>' +
+				'<th id="rh1">row header 1</th>' +
+				'<td id="cell1">cell 1</td>' +
+				'</tr>' +
+				'<tr>' +
+				'<th scope="row" id="rh2">row header 2</th>' +
+				'<td id="cell2">cell 2</td>' +
+				'</tr>' +
+				'</table>'
+		);
 	});
 
-	afterEach(function() {
-		table.getScope = origGetScope;
+	it('returns false if not a row header', function() {
+		var cell = document.querySelector('#cell1');
+		assert.isFalse(table.isRowHeader(cell));
 	});
 
-	it('passes an argument to table.getScope', function() {
-		var called = false;
-		table.getScope = function(arg) {
-			assert.equal(arg, 'Buzz Lightyear');
-			called = true;
-			return 'auto';
-		};
-		table.isRowHeader('Buzz Lightyear');
-
-		assert.isTrue(called);
+	it('returns true if scope="auto"', function() {
+		var cell = document.querySelector('#rh1');
+		assert.isTrue(table.isRowHeader(cell));
 	});
 
-	it('returns false if table.getScope returns false', function() {
-		table.getScope = function() {
-			return false;
-		};
-		assert.isFalse(table.isRowHeader());
+	it('returns true if scope="col"', function() {
+		var cell = document.querySelector('#rh2');
+		assert.isTrue(table.isRowHeader(cell));
 	});
 
-	it('returns true if table.getScope returns auto', function() {
-		table.getScope = function() {
-			return 'auto';
-		};
-		assert.isTrue(table.isRowHeader());
-	});
-
-	it('returns false if table.getScope returns col', function() {
-		table.getScope = function() {
-			return 'col';
-		};
-		assert.isFalse(table.isRowHeader());
-	});
-
-	it('returns true if table.getScope returns row', function() {
-		table.getScope = function() {
-			return 'row';
-		};
-		assert.isTrue(table.isRowHeader());
+	it('returns false if scope="row"', function() {
+		var cell = document.querySelector('#ch1');
+		assert.isFalse(table.isRowHeader(cell));
 	});
 });


### PR DESCRIPTION
Again had to rewrite some tests that mocked. `tables/traverse.js` change is mostly removing the wrapping IIFE (no idea why it did that).

Closes issue: #2115 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
