### PR TITLE
chore: convert commons to ES Modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,14 +74,7 @@
   "overrides": [
     {
       "files": [
-        "lib/commons/aria/*.js",
-        "lib/commons/color/*.js",
-        "lib/commons/dom/*.js",
-        "lib/commons/forms/*.js",
-        "lib/commons/matches/*.js",
-        "lib/commons/table/*.js",
-        "lib/commons/text/*.js",
-        "lib/commons/utils/*.js"
+        "lib/commons/**/*.js"
       ],
       "parserOptions":{
         "sourceType": "module"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,65 +145,27 @@ module.exports = function(grunt) {
 						dest: 'axe' + lang + '.js'
 					};
 				})
-			},
-			commons: {
-				src: [
-					'lib/commons/intro.stub',
-					'lib/commons/index.js',
-					'lib/commons/*/index.js',
-					'lib/commons/**/*.js',
-
-					// directories we've converted to ES Modules
-					'!lib/commons/aria/*.js',
-					'!lib/commons/color/*.js',
-					'!lib/commons/dom/*.js',
-					'!lib/commons/forms/*.js',
-					'!lib/commons/matches/*.js',
-					'!lib/commons/table/*.js',
-					'!lib/commons/text/*.js',
-					'!lib/commons/utils/*.js',
-
-					// output of webpack directories
-					'tmp/commons/**/*.js',
-
-					'lib/commons/outro.stub'
-				],
-				dest: 'tmp/commons.js'
 			}
+			// commons: {
+			// 	src: [
+			// 		'lib/commons/intro.stub',
+			// 		'lib/commons/index.js',
+			// 		'lib/commons/*/index.js',
+			// 		'lib/commons/**/*.js',
+
+			// 		// directories we've converted to ES Modules
+			// 		'!lib/commons/*/*.js',
+
+			// 		// output of webpack directories
+			// 		'tmp/commons/**/*.js',
+
+			// 		'lib/commons/outro.stub'
+			// 	],
+			// 	dest: 'tmp/commons.js'
+			// }
 		},
 		webpack: {
-			commonsUtils: createWebpackConfig(
-				'lib/commons/utils/index.js',
-				'tmp/commons/utils'
-			),
-			commonsAria: createWebpackConfig(
-				'lib/commons/aria/index.js',
-				'tmp/commons/aria'
-			),
-			commonsColor: createWebpackConfig(
-				'lib/commons/color/index.js',
-				'tmp/commons/color'
-			),
-			commonsDOM: createWebpackConfig(
-				'lib/commons/dom/index.js',
-				'tmp/commons/dom'
-			),
-			commonsForms: createWebpackConfig(
-				'lib/commons/forms/index.js',
-				'tmp/commons/forms'
-			),
-			commonsMatches: createWebpackConfig(
-				'lib/commons/matches/index.js',
-				'tmp/commons/matches'
-			),
-			commonsTable: createWebpackConfig(
-				'lib/commons/table/index.js',
-				'tmp/commons/table'
-			),
-			commonsText: createWebpackConfig(
-				'lib/commons/text/index.js',
-				'tmp/commons/text'
-			)
+			commons: createWebpackConfig('lib/commons/index.js', 'tmp/commons')
 		},
 		'aria-supported': {
 			data: {
@@ -220,7 +182,7 @@ module.exports = function(grunt) {
 				},
 				files: langs.map(function(lang) {
 					return {
-						src: ['<%= concat.commons.dest %>'],
+						src: ['tmp/commons/index.js'],
 						dest: {
 							auto: 'tmp/rules' + lang + '.js',
 							descriptions: 'doc/rule-descriptions' + lang + '.md'
@@ -234,7 +196,7 @@ module.exports = function(grunt) {
 				options: {
 					lang: grunt.option('lang')
 				},
-				src: ['<%= concat.commons.dest %>'],
+				src: ['tmp/commons/index.js'],
 				dest: './locales/' + (grunt.option('lang') || 'new-locale') + '.json'
 			}
 		},
@@ -414,7 +376,7 @@ module.exports = function(grunt) {
 		'pre-build',
 		'validate',
 		'webpack',
-		'concat:commons',
+		// 'concat:commons',
 		'add-locale'
 	]);
 	grunt.registerTask('pre-build', ['clean', 'run:npm_run_imports']);
@@ -422,7 +384,7 @@ module.exports = function(grunt) {
 		'pre-build',
 		'validate',
 		'webpack',
-		'concat:commons',
+		// 'concat:commons',
 		'configure',
 		'babel',
 		'concat:engine',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,24 +145,18 @@ module.exports = function(grunt) {
 						dest: 'axe' + lang + '.js'
 					};
 				})
+			},
+			commons: {
+				src: [
+					'lib/commons/intro.stub',
+
+					// output of webpack directories
+					'tmp/commons/index.js',
+
+					'lib/commons/outro.stub'
+				],
+				dest: 'tmp/commons.js'
 			}
-			// commons: {
-			// 	src: [
-			// 		'lib/commons/intro.stub',
-			// 		'lib/commons/index.js',
-			// 		'lib/commons/*/index.js',
-			// 		'lib/commons/**/*.js',
-
-			// 		// directories we've converted to ES Modules
-			// 		'!lib/commons/*/*.js',
-
-			// 		// output of webpack directories
-			// 		'tmp/commons/**/*.js',
-
-			// 		'lib/commons/outro.stub'
-			// 	],
-			// 	dest: 'tmp/commons.js'
-			// }
 		},
 		webpack: {
 			commons: createWebpackConfig('lib/commons/index.js', 'tmp/commons')
@@ -182,7 +176,7 @@ module.exports = function(grunt) {
 				},
 				files: langs.map(function(lang) {
 					return {
-						src: ['tmp/commons/index.js'],
+						src: ['<%= concat.commons.dest %>'],
 						dest: {
 							auto: 'tmp/rules' + lang + '.js',
 							descriptions: 'doc/rule-descriptions' + lang + '.md'
@@ -196,7 +190,7 @@ module.exports = function(grunt) {
 				options: {
 					lang: grunt.option('lang')
 				},
-				src: ['tmp/commons/index.js'],
+				src: ['<%= concat.commons.dest %>'],
 				dest: './locales/' + (grunt.option('lang') || 'new-locale') + '.json'
 			}
 		},
@@ -376,7 +370,7 @@ module.exports = function(grunt) {
 		'pre-build',
 		'validate',
 		'webpack',
-		// 'concat:commons',
+		'concat:commons',
 		'add-locale'
 	]);
 	grunt.registerTask('pre-build', ['clean', 'run:npm_run_imports']);
@@ -384,7 +378,7 @@ module.exports = function(grunt) {
 		'pre-build',
 		'validate',
 		'webpack',
-		// 'concat:commons',
+		'concat:commons',
 		'configure',
 		'babel',
 		'concat:engine',

--- a/build/configure.js
+++ b/build/configure.js
@@ -378,8 +378,7 @@ ${ruleTables}`;
 						lang: options.locale || 'en',
 						data: metadata,
 						rules: rules,
-						checks: checks,
-						commons: result.commons
+						checks: checks
 					},
 					blacklist
 				)
@@ -389,8 +388,7 @@ ${ruleTables}`;
 					{
 						data: metadata,
 						rules: rules,
-						checks: checks,
-						commons: result.commons
+						checks: checks
 					},
 					blacklist
 				)

--- a/build/configure.js
+++ b/build/configure.js
@@ -378,7 +378,8 @@ ${ruleTables}`;
 						lang: options.locale || 'en',
 						data: metadata,
 						rules: rules,
-						checks: checks
+						checks: checks,
+						commons: result.commons
 					},
 					blacklist
 				)
@@ -388,7 +389,8 @@ ${ruleTables}`;
 					{
 						data: metadata,
 						rules: rules,
-						checks: checks
+						checks: checks,
+						commons: result.commons
 					},
 					blacklist
 				)

--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -13,7 +13,7 @@ export { default as getRole } from './get-role';
 export { default as getRolesByType } from './get-roles-by-type';
 export { default as getRolesWithNameFromContents } from './get-roles-with-name-from-contents';
 export { default as implicitNodes } from './implicit-nodes';
-export { default as getImplicitRole } from './implicit-role';
+export { default as implicitRole } from './implicit-role';
 export { default as isAccessibleRef } from './is-accessible-ref';
 export { default as isAriaRoleAllowedOnElement } from './is-aria-role-allowed-on-element';
 export { default as isUnsupportedRole } from './is-unsupported-role';

--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -1,62 +1,29 @@
-/* global aria */
-
-// TODO: es-module-commons. convert to:
-// export { default as allowedAttr } from 'path'
-import allowedAttr from './allowed-attr';
-import arialabelText from './arialabel-text';
-import arialabelledbyText from './arialabelledby-text';
-import getElementUnallowedRoles from './get-element-unallowed-roles';
-import getOwnedVirtual from './get-owned-virtual';
-import getRoleType from './get-role-type';
-import getRole from './get-role';
-import getRolesByType from './get-roles-by-type';
-import getRolesWithNameFromContents from './get-roles-with-name-from-contents';
-import implicitNodes from './implicit-nodes';
-import getImplicitRole from './implicit-role';
-import isAccessibleRef from './is-accessible-ref';
-import isAriaRoleAllowedOnElement from './is-aria-role-allowed-on-element';
-import isUnsupportedRole from './is-unsupported-role';
-import isValidRole from './is-valid-role';
-import labelVirtual from './label-virtual';
-import label from './label';
-import lookupTable from './lookup-table';
-import namedFromContents from './named-from-contents';
-import requiredAttr from './required-attr';
-import requiredContext from './required-context';
-import requiredOwned from './required-owned';
-import validateAttrValue from './validate-attr-value';
-import validateAttr from './validate-attr';
-
 /**
  * Namespace for aria-related utilities.
  * @namespace commons.aria
  * @memberof axe
  */
-// TODO: es-module-commons. don't rely on global
-aria = {
-	allowedAttr,
-	arialabelText,
-	arialabelledbyText,
-	getElementUnallowedRoles,
-	getOwnedVirtual,
-	getRoleType,
-	getRole,
-	getRolesByType,
-	getRolesWithNameFromContents,
-	implicitNodes,
-	implicitRole: getImplicitRole,
-	isAccessibleRef,
-	isAriaRoleAllowedOnElement,
-	isUnsupportedRole,
-	isValidRole,
-	labelVirtual,
-	label,
-	lookupTable,
-	namedFromContents,
-	requiredAttr,
-	requiredContext,
-	requiredOwned,
-	validateAttrValue,
-	validateAttr
-};
-commons.aria = aria;
+export { default as allowedAttr } from './allowed-attr';
+export { default as arialabelText } from './arialabel-text';
+export { default as arialabelledbyText } from './arialabelledby-text';
+export { default as getElementUnallowedRoles } from './get-element-unallowed-roles';
+export { default as getOwnedVirtual } from './get-owned-virtual';
+export { default as getRoleType } from './get-role-type';
+export { default as getRole } from './get-role';
+export { default as getRolesByType } from './get-roles-by-type';
+export { default as getRolesWithNameFromContents } from './get-roles-with-name-from-contents';
+export { default as implicitNodes } from './implicit-nodes';
+export { default as getImplicitRole } from './implicit-role';
+export { default as isAccessibleRef } from './is-accessible-ref';
+export { default as isAriaRoleAllowedOnElement } from './is-aria-role-allowed-on-element';
+export { default as isUnsupportedRole } from './is-unsupported-role';
+export { default as isValidRole } from './is-valid-role';
+export { default as labelVirtual } from './label-virtual';
+export { default as label } from './label';
+export { default as lookupTable } from './lookup-table';
+export { default as namedFromContents } from './named-from-contents';
+export { default as requiredAttr } from './required-attr';
+export { default as requiredContext } from './required-context';
+export { default as requiredOwned } from './required-owned';
+export { default as validateAttrValue } from './validate-attr-value';
+export { default as validateAttr } from './validate-attr';

--- a/lib/commons/color/index.js
+++ b/lib/commons/color/index.js
@@ -1,39 +1,19 @@
-// TODO: es-module-commons. convert to:
-// export { default as isAriaCombobox } from 'path'
-import centerPointOfRect from './center-point-of-rect';
-import Color from './color';
-import elementHasImage from './element-has-image';
-import elementIsDistinct from './element-is-distinct';
-import filteredRectStack from './filtered-rect-stack';
-import flattenColors from './flatten-colors';
-import getBackgroundColor from './get-background-color';
-import getBackgroundStack from './get-background-stack';
-import getContrast from './get-contrast';
-import getForegroundColor from './get-foreground-color';
-import getOwnBackgroundColor from './get-own-background-color';
-import getRectStack from './get-rect-stack';
-import hasValidContrastRatio from './has-valid-contrast-ratio';
-import incompleteData from './incomplete-data';
-
 /**
  * Namespace for color-related utilities.
  * @namespace commons.color
  * @memberof axe
  */
-const color = {
-	centerPointOfRect,
-	Color,
-	elementHasImage,
-	elementIsDistinct,
-	filteredRectStack,
-	flattenColors,
-	getBackgroundColor,
-	getBackgroundStack,
-	getContrast,
-	getForegroundColor,
-	getOwnBackgroundColor,
-	getRectStack,
-	hasValidContrastRatio,
-	incompleteData
-};
-commons.color = color;
+export { default as centerPointOfRect } from './center-point-of-rect';
+export { default as Color } from './color';
+export { default as elementHasImage } from './element-has-image';
+export { default as elementIsDistinct } from './element-is-distinct';
+export { default as filteredRectStack } from './filtered-rect-stack';
+export { default as flattenColors } from './flatten-colors';
+export { default as getBackgroundColor } from './get-background-color';
+export { default as getBackgroundStack } from './get-background-stack';
+export { default as getContrast } from './get-contrast';
+export { default as getForegroundColor } from './get-foreground-color';
+export { default as getOwnBackgroundColor } from './get-own-background-color';
+export { default as getRectStack } from './get-rect-stack';
+export { default as hasValidContrastRatio } from './has-valid-contrast-ratio';
+export { default as incompleteData } from './incomplete-data';

--- a/lib/commons/dom/index.js
+++ b/lib/commons/dom/index.js
@@ -1,77 +1,38 @@
-// TODO: es-module-commons. convert to:
-// export { default as isAriaCombobox } from 'path'
-import findElmsInContext from './find-elms-in-context';
-import findUpVirtual from './find-up-virtual';
-import findUp from './find-up';
-import getComposedParent from './get-composed-parent';
-import getElementByReference from './get-element-by-reference';
-import getElementCoordinates from './get-element-coordinates';
-import getElementStack from './get-element-stack';
-import getRootNode from './get-root-node';
-import getScrollOffset from './get-scroll-offset';
-import getTabbableElements from './get-tabbable-elements';
-import getTextElementStack from './get-text-element-stack';
-import getViewportSize from './get-viewport-size';
-import hasContentVirtual from './has-content-virtual';
-import hasContent from './has-content';
-import idrefs from './idrefs';
-import insertedIntoFocusOrder from './inserted-into-focus-order';
-import isFocusable from './is-focusable';
-import isHiddenWithCSS from './is-hidden-with-css';
-import isHTML5 from './is-html5';
-import isInTextBlock from './is-in-text-block';
-import isModalOpen from './is-modal-open';
-import isNativelyFocusable from './is-natively-focusable';
-import isNode from './is-node';
-import isOffscreen from './is-offscreen';
-import isOpaque from './is-opaque';
-import isSkipLink from './is-skip-link';
-import isVisible from './is-visible';
-import isVisualContent from './is-visual-content';
-import reduceToElementsBelowFloating from './reduce-to-elements-below-floating';
-import shadowElementsFromPoint from './shadow-elements-from-point';
-import urlPropsFromAttribute from './url-props-from-attribute';
-import visuallyContains from './visually-contains';
-import visuallyOverlaps from './visually-overlaps';
-
 /**
  * Namespace for dom-related utilities.
  * @namespace dom
  * @memberof axe.commons
  */
-const dom = {
-	findElmsInContext,
-	findUpVirtual,
-	findUp,
-	getComposedParent,
-	getElementByReference,
-	getElementCoordinates,
-	getElementStack,
-	getRootNode,
-	getScrollOffset,
-	getTabbableElements,
-	getTextElementStack,
-	getViewportSize,
-	hasContentVirtual,
-	hasContent,
-	idrefs,
-	insertedIntoFocusOrder,
-	isFocusable,
-	isHiddenWithCSS,
-	isHTML5,
-	isInTextBlock,
-	isModalOpen,
-	isNativelyFocusable,
-	isNode,
-	isOffscreen,
-	isOpaque,
-	isSkipLink,
-	isVisible,
-	isVisualContent,
-	reduceToElementsBelowFloating,
-	shadowElementsFromPoint,
-	urlPropsFromAttribute,
-	visuallyContains,
-	visuallyOverlaps
-};
-commons.dom = dom;
+export { default as findElmsInContext } from './find-elms-in-context';
+export { default as findUpVirtual } from './find-up-virtual';
+export { default as findUp } from './find-up';
+export { default as getComposedParent } from './get-composed-parent';
+export { default as getElementByReference } from './get-element-by-reference';
+export { default as getElementCoordinates } from './get-element-coordinates';
+export { default as getElementStack } from './get-element-stack';
+export { default as getRootNode } from './get-root-node';
+export { default as getScrollOffset } from './get-scroll-offset';
+export { default as getTabbableElements } from './get-tabbable-elements';
+export { default as getTextElementStack } from './get-text-element-stack';
+export { default as getViewportSize } from './get-viewport-size';
+export { default as hasContentVirtual } from './has-content-virtual';
+export { default as hasContent } from './has-content';
+export { default as idrefs } from './idrefs';
+export { default as insertedIntoFocusOrder } from './inserted-into-focus-order';
+export { default as isFocusable } from './is-focusable';
+export { default as isHiddenWithCSS } from './is-hidden-with-css';
+export { default as isHTML5 } from './is-html5';
+export { default as isInTextBlock } from './is-in-text-block';
+export { default as isModalOpen } from './is-modal-open';
+export { default as isNativelyFocusable } from './is-natively-focusable';
+export { default as isNode } from './is-node';
+export { default as isOffscreen } from './is-offscreen';
+export { default as isOpaque } from './is-opaque';
+export { default as isSkipLink } from './is-skip-link';
+export { default as isVisible } from './is-visible';
+export { default as isVisualContent } from './is-visual-content';
+export { default as reduceToElementsBelowFloating } from './reduce-to-elements-below-floating';
+export { default as shadowElementsFromPoint } from './shadow-elements-from-point';
+export { default as urlPropsFromAttribute } from './url-props-from-attribute';
+export { default as visuallyContains } from './visually-contains';
+export { default as visuallyOverlaps } from './visually-overlaps';

--- a/lib/commons/forms/index.js
+++ b/lib/commons/forms/index.js
@@ -1,23 +1,11 @@
-// TODO: es-module-commons. convert to:
-// export { default as isAriaCombobox } from 'path'
-import isAriaCombobox from './is-aria-combobox';
-import isAriaListbox from './is-aria-listbox';
-import isAriaRange from './is-aria-range';
-import isAriaTextbox from './is-aria-textbox';
-import isNativeSelect from './is-native-select';
-import isNativeTextbox from './is-native-textbox';
-
 /**
  * Namespace for forms-related utilities.
  * @namespace commons.forms
  * @memberof axe
  */
-const forms = {
-	isAriaCombobox,
-	isAriaListbox,
-	isAriaRange,
-	isAriaTextbox,
-	isNativeSelect,
-	isNativeTextbox
-};
-commons.forms = forms;
+export { default as isAriaCombobox } from './is-aria-combobox';
+export { default as isAriaListbox } from './is-aria-listbox';
+export { default as isAriaRange } from './is-aria-range';
+export { default as isAriaTextbox } from './is-aria-textbox';
+export { default as isNativeSelect } from './is-native-select';
+export { default as isNativeTextbox } from './is-native-textbox';

--- a/lib/commons/index.js
+++ b/lib/commons/index.js
@@ -1,3 +1,6 @@
+/* global commons */
+/*eslint no-unused-vars: 0*/
+
 /**
  * Namespace for axe common methods.
  * @namespace commons
@@ -12,7 +15,7 @@ import * as table from './table';
 import * as text from './text';
 import utils from './utils';
 
-axe.commons = {
+commons = {
 	aria,
 	color,
 	dom,

--- a/lib/commons/index.js
+++ b/lib/commons/index.js
@@ -1,14 +1,24 @@
-/*exported commons */
-/*eslint no-unused-vars: 0*/
-/** @namespace axe */
-
 /**
  * Namespace for axe common methods.
  * @namespace commons
  * @memberof axe
  */
+import * as aria from './aria';
+import * as color from './color';
+import * as dom from './dom';
+import * as forms from './forms';
+import matches from './matches';
+import * as table from './table';
+import * as text from './text';
+import utils from './utils';
 
-var commons = {};
-var aria = {};
-var text = {};
-var matches;
+axe.commons = {
+	aria,
+	color,
+	dom,
+	forms,
+	matches,
+	table,
+	text,
+	utils
+};

--- a/lib/commons/matches/index.js
+++ b/lib/commons/matches/index.js
@@ -1,5 +1,3 @@
-/* global matches */
-
 /**
  * Namespace for matching utilities.
  * @namespace commons.matches
@@ -10,14 +8,10 @@ import condition from './condition';
 import fromDefinition from './from-definition';
 import fromFunction from './from-function';
 import fromPrimative from './from-primative';
-// TODO: es-module-commons. change to:
-// import matches from './matches'
-import matchesFn from './matches';
+import matches from './matches';
 import nodeName from './node-name';
 import properties from './properties';
 
-// TODO: es-module-commons. remove matches setter
-matches = matchesFn;
 matches.attributes = attributes;
 matches.condition = condition;
 matches.fromDefinition = fromDefinition;
@@ -26,5 +20,4 @@ matches.fromPrimative = fromPrimative;
 matches.nodeName = nodeName;
 matches.properties = properties;
 
-// TODO: es-module-commons. remove
-commons.matches = matchesFn;
+export default matches;

--- a/lib/commons/table/index.js
+++ b/lib/commons/table/index.js
@@ -1,36 +1,16 @@
-// TODO: es-module-commons. convert to:
-// export { default as isAriaCombobox } from 'path'
-import getAllCells from './get-all-cells';
-import getCellPosition from './get-cell-position';
-import getHeaders from './get-headers';
-import getScope from './get-scope';
-import isColumnHeader from './is-column-header';
-import isDataCell from './is-data-cell';
-import isDataTable from './is-data-table';
-import isHeader from './is-header';
-import isRowHeader from './is-row-header';
-import toGrid from './to-grid';
-import traverse from './traverse';
-
 /**
  * Namespace for table-related utilities.
  * @namespace table
  * @memberof axe.commons
  */
-const table = {
-	getAllCells,
-	getCellPosition,
-	getHeaders,
-	getScope,
-	isColumnHeader,
-	isDataCell,
-	isDataTable,
-	isHeader,
-	isRowHeader,
-	toGrid,
-	traverse,
-
-	// This was the old name
-	toArray: toGrid
-};
-commons.table = table;
+export { default as getAllCells } from './get-all-cells';
+export { default as getCellPosition } from './get-cell-position';
+export { default as getHeaders } from './get-headers';
+export { default as getScope } from './get-scope';
+export { default as isColumnHeader } from './is-column-header';
+export { default as isDataCell } from './is-data-cell';
+export { default as isDataTable } from './is-data-table';
+export { default as isHeader } from './is-header';
+export { default as isRowHeader } from './is-row-header';
+export { default as toGrid } from './to-grid';
+export { default as traverse } from './traverse';

--- a/lib/commons/table/index.js
+++ b/lib/commons/table/index.js
@@ -14,3 +14,6 @@ export { default as isHeader } from './is-header';
 export { default as isRowHeader } from './is-row-header';
 export { default as toGrid } from './to-grid';
 export { default as traverse } from './traverse';
+
+// This was the old name
+export { default as toArray } from './to-grid';

--- a/lib/commons/text/index.js
+++ b/lib/commons/text/index.js
@@ -1,60 +1,32 @@
-/* global text */
-
-// TODO: es-module-commons. convert to:
-// export { default as isAriaCombobox } from 'path'
-import accessibleTextVirtual from './accessible-text-virtual';
-import accessibleText from './accessible-text';
-import formControlValue, {
-	formControlValueMethods
-} from './form-control-value';
-import hasUnicode from './has-unicode';
-import isHumanInterpretable from './is-human-interpretable';
-import isIconLigature from './is-icon-ligature';
-import isValidAutocomplete, { autocomplete } from './is-valid-autocomplete';
-import labelText from './label-text';
-import labelVirtual from './label-virtual';
-import label from './label';
-import nativeElementType from './native-element-type';
-import nativeTextAlternative from './native-text-alternative';
-import nativeTextMethods from './native-text-methods';
-import removeUnicode from './remove-unicode';
-import sanitize from './sanitize';
-import subtreeText from './subtree-text';
-import titleText from './title-text';
-import unsupported from './unsupported';
-import visibleTextNodes from './visible-text-nodes';
-import visibleVirtual from './visible-virtual';
-import visible from './visible';
-
 /**
  * Namespace for text-related utilities.
  * @namespace text
  * @memberof axe.commons
  */
-// TODO: es-module-commons. don't rely on global
-text = {
-	accessibleTextVirtual,
-	accessibleText,
-	formControlValue,
-	formControlValueMethods,
-	hasUnicode,
-	isHumanInterpretable,
-	isIconLigature,
-	isValidAutocomplete,
-	autocomplete,
-	labelText,
-	labelVirtual,
-	label,
-	nativeElementType,
-	nativeTextAlternative,
-	nativeTextMethods,
-	removeUnicode,
-	sanitize,
-	subtreeText,
-	titleText,
-	unsupported,
-	visibleTextNodes,
-	visibleVirtual,
-	visible
-};
-commons.text = text;
+export { default as accessibleTextVirtual } from './accessible-text-virtual';
+export { default as accessibleText } from './accessible-text';
+export {
+	default as formControlValue,
+	formControlValueMethods
+} from './form-control-value';
+export { default as hasUnicode } from './has-unicode';
+export { default as isHumanInterpretable } from './is-human-interpretable';
+export { default as isIconLigature } from './is-icon-ligature';
+export {
+	default as isValidAutocomplete,
+	autocomplete
+} from './is-valid-autocomplete';
+export { default as labelText } from './label-text';
+export { default as labelVirtual } from './label-virtual';
+export { default as label } from './label';
+export { default as nativeElementType } from './native-element-type';
+export { default as nativeTextAlternative } from './native-text-alternative';
+export { default as nativeTextMethods } from './native-text-methods';
+export { default as removeUnicode } from './remove-unicode';
+export { default as sanitize } from './sanitize';
+export { default as subtreeText } from './subtree-text';
+export { default as titleText } from './title-text';
+export { default as unsupported } from './unsupported';
+export { default as visibleTextNodes } from './visible-text-nodes';
+export { default as visibleVirtual } from './visible-virtual';
+export { default as visible } from './visible';

--- a/lib/commons/utils/index.js
+++ b/lib/commons/utils/index.js
@@ -1,12 +1,6 @@
-/* exported utils */
-/* global axe */
-/*eslint no-unused-vars: 0*/
 /**
  * Namespace for general utilities.
  * @namespace utils
  * @memberof axe.commons
  */
-
-const utils = (commons.utils = axe.utils);
-
-export default utils;
+export default axe.utils;

--- a/test/checks/aria/allowed-attr.js
+++ b/test/checks/aria/allowed-attr.js
@@ -64,31 +64,6 @@ describe('aria-allowed-attr', function() {
 		assert.isNull(checkContext._data);
 	});
 
-	it('should determine attribute validity by calling axe.commons.aria.allowedAttr', function() {
-		var node = document.createElement('div');
-		node.id = 'test';
-		node.tabIndex = 1;
-		node.setAttribute('role', 'cats');
-		node.setAttribute('aria-cats', 'maybe');
-		node.setAttribute('aria-bats', 'dead');
-		fixture.appendChild(node);
-
-		var orig = axe.commons.aria.allowedAttr;
-		var called = 0;
-		axe.commons.aria.allowedAttr = function(role) {
-			assert.equal(role, 'cats');
-			called++;
-			return ['aria-cats', 'aria-bats'];
-		};
-		assert.isTrue(
-			checks['aria-allowed-attr'].evaluate.call(checkContext, node)
-		);
-		assert.isNull(checkContext._data);
-		assert.equal(called, 1);
-
-		axe.commons.aria.allowedAttr = orig;
-	});
-
 	it('should not report on invalid attributes', function() {
 		var node = document.createElement('div');
 		node.id = 'test';

--- a/test/checks/aria/required-attr.js
+++ b/test/checks/aria/required-attr.js
@@ -39,32 +39,6 @@ describe('aria-required-attr', function() {
 		assert.isNull(checkContext._data);
 	});
 
-	it('should determine attribute validity by calling axe.commons.aria.requiredAttr', function() {
-		var vNode = queryFixture(
-			'<div id="target" role="cats" tabindex="1" aria-cats="maybe">'
-		);
-
-		var orig = axe.commons.aria.requiredAttr;
-		var called = 0;
-		axe.commons.aria.requiredAttr = function(role) {
-			assert.equal(role, 'cats');
-			called++;
-			return ['aria-cats', 'aria-bats'];
-		};
-		assert.isFalse(
-			checks['aria-required-attr'].evaluate.call(
-				checkContext,
-				vNode.actualNode,
-				options,
-				vNode
-			)
-		);
-		assert.deepEqual(checkContext._data, ['aria-bats']);
-		assert.equal(called, 1);
-
-		axe.commons.aria.requiredAttr = orig;
-	});
-
 	it('should pass aria-valuenow if element has value property', function() {
 		var vNode = queryFixture('<input id="target" type="range" role="slider">');
 

--- a/test/checks/aria/valid-attr-value.js
+++ b/test/checks/aria/valid-attr-value.js
@@ -75,31 +75,6 @@ describe('aria-valid-attr-value', function() {
 		assert.deepEqual(checkContext._data, ['aria-selected="0"']);
 	});
 
-	it('should determine attribute validity by calling axe.commons.aria.validateAttrValue', function() {
-		var node = document.createElement('div');
-		node.id = 'test';
-		node.tabIndex = 1;
-		node.setAttribute('aria-selected', 'maybe');
-		node.setAttribute('aria-live', 'dead');
-		fixture.appendChild(node);
-
-		var orig = axe.commons.aria.validateAttrValue;
-		var called = 0;
-		axe.commons.aria.validateAttrValue = function(nd, attrName) {
-			assert.equal(nd, node);
-			assert.match(attrName, /^aria-/);
-			called++;
-			return true;
-		};
-		assert.isTrue(
-			checks['aria-valid-attr-value'].evaluate.call(checkContext, node)
-		);
-		assert.isNull(checkContext._data);
-		assert.equal(called, 2);
-
-		axe.commons.aria.validateAttrValue = orig;
-	});
-
 	it('should allow empty strings rather than idref', function() {
 		fixtureSetup(
 			'<button aria-controls="">Button</button>' +

--- a/test/checks/aria/valid-attr.js
+++ b/test/checks/aria/valid-attr.js
@@ -32,28 +32,6 @@ describe('aria-valid-attr', function() {
 		assert.isNull(checkContext._data);
 	});
 
-	it('should determine attribute validity by calling axe.commons.aria.validateAttr', function() {
-		var node = document.createElement('div');
-		node.id = 'test';
-		node.tabIndex = 1;
-		node.setAttribute('aria-cats', 'true');
-		node.setAttribute('aria-dogs', 'true');
-		fixture.appendChild(node);
-
-		var orig = axe.commons.aria.validateAttr;
-		var called = 0;
-		axe.commons.aria.validateAttr = function(attrName) {
-			assert.match(attrName, /^aria-/);
-			called++;
-			return true;
-		};
-		assert.isTrue(checks['aria-valid-attr'].evaluate.call(checkContext, node));
-		assert.isNull(checkContext._data);
-		assert.equal(called, 2);
-
-		axe.commons.aria.validateAttr = orig;
-	});
-
 	it('should return true for unsupported ARIA attributes', function() {
 		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
 			unsupported: true

--- a/test/checks/color/link-in-text-block.js
+++ b/test/checks/color/link-in-text-block.js
@@ -110,63 +110,37 @@ describe('link-in-text-block', function() {
 			});
 		});
 
-		it('uses color.elementIsDistinct to test the initial state', function() {
-			var isCalled;
-			var orig = axe.commons.color.elementIsDistinct;
-			var linkElm = getLinkElm();
-
-			axe.commons.color.elementIsDistinct = function(arg1, arg2) {
-				isCalled = true;
-				return orig(arg1, arg2);
-			};
-
-			checks['link-in-text-block'].evaluate.call(checkContext, linkElm);
-			assert.ok(isCalled);
-			axe.commons.color.elementIsDistinct = orig;
-		});
-
 		it('passes the selected node and closest ancestral block element', function() {
 			fixture.innerHTML =
-				'<div> <span style="display:block" id="parent">' +
+				'<div> <span style="display:block; color: #100" id="parent">' +
 				'	<p style="display:inline"><a href="" id="link">' +
 				'		 link text ' +
 				'	</a> inside block </p> inside block' +
 				'</span> outside block </div>';
 
 			axe.testUtils.flatTreeSetup(fixture);
-			var orig = axe.commons.color.elementIsDistinct;
 			var linkElm = document.getElementById('link');
-			var parentElm = document.getElementById('parent');
 
-			axe.commons.color.elementIsDistinct = function(arg1, arg2) {
-				assert.deepEqual(arg1, linkElm);
-				assert.deepEqual(arg2, parentElm);
-				return orig(arg1, arg2);
-			};
-
-			checks['link-in-text-block'].evaluate.call(checkContext, linkElm);
-			axe.commons.color.elementIsDistinct = orig;
+			assert.isTrue(
+				checks['link-in-text-block'].evaluate.call(checkContext, linkElm)
+			);
 		});
 
 		(shadowSupport.v1 ? it : xit)(
 			'works with the block outside the shadow tree',
 			function() {
 				var parentElm = document.createElement('div');
+				parentElm.setAttribute('style', 'color:#100;');
 				var shadow = parentElm.attachShadow({ mode: 'open' });
-				shadow.innerHTML = '<a href="">Link</a>';
+				shadow.innerHTML = '<a href="" style="color:#100;">Link</a>';
 				var linkElm = shadow.querySelector('a');
 				fixture.appendChild(parentElm);
 
 				axe.testUtils.flatTreeSetup(fixture);
-				var orig = axe.commons.color.elementIsDistinct;
-				axe.commons.color.elementIsDistinct = function(arg1, arg2) {
-					assert.deepEqual(arg1, linkElm);
-					assert.deepEqual(arg2, parentElm);
-					return orig(arg1, arg2);
-				};
 
-				checks['link-in-text-block'].evaluate.call(checkContext, linkElm);
-				axe.commons.color.elementIsDistinct = orig;
+				assert.isTrue(
+					checks['link-in-text-block'].evaluate.call(checkContext, linkElm)
+				);
 			}
 		);
 
@@ -174,24 +148,18 @@ describe('link-in-text-block', function() {
 			'works with the link inside the shadow tree slot',
 			function() {
 				var div = document.createElement('div');
-				div.innerHTML = '<a href="">Link</a>';
+				div.setAttribute('style', 'color:#100;');
+				div.innerHTML = '<a href="" style="color:#100;">Link</a>';
 				var shadow = div.attachShadow({ mode: 'open' });
 				shadow.innerHTML = '<p><slot></slot></p>';
 				fixture.appendChild(div);
 
 				axe.testUtils.flatTreeSetup(fixture);
 				var linkElm = div.querySelector('a');
-				var parentElm = shadow.querySelector('p');
 
-				var orig = axe.commons.color.elementIsDistinct;
-				axe.commons.color.elementIsDistinct = function(arg1, arg2) {
-					assert.deepEqual(arg1, linkElm);
-					assert.deepEqual(arg2, parentElm);
-					return orig(arg1, arg2);
-				};
-
-				checks['link-in-text-block'].evaluate.call(checkContext, linkElm);
-				axe.commons.color.elementIsDistinct = orig;
+				assert.isTrue(
+					checks['link-in-text-block'].evaluate.call(checkContext, linkElm)
+				);
 			}
 		);
 	});

--- a/test/checks/forms/autocomplete-valid.js
+++ b/test/checks/forms/autocomplete-valid.js
@@ -6,62 +6,27 @@ describe('autocomplete-valid', function() {
 	var checkContext = axe.testUtils.MockCheckContext();
 	var evaluate = checks['autocomplete-valid'].evaluate;
 
-	var options = {
-		standaloneTerms: ['standalone-term'],
-		qualifiedTerms: ['qualified-term']
-	};
-
-	var _isValidAutocomplete;
-	beforeEach(function() {
-		axe._tree = undefined;
-		_isValidAutocomplete = axe.commons.text.isValidAutocomplete;
-	});
-
 	afterEach(function() {
-		axe.commons.text.isValidAutocomplete = _isValidAutocomplete;
 		fixture.innerHTML = '';
 		checkContext.reset();
 	});
 
-	it('passes autocomplete attribute to text.isValidAutocomplete', function() {
-		var params = checkSetup('<input autocomplete="foo" id="target" />');
-		var called = false;
-		axe.commons.text.isValidAutocomplete = function(arg1) {
-			assert.equal(arg1, 'foo');
-			called = true;
-		};
-		evaluate.apply(checkContext, params);
-		assert.isTrue(called);
+	it('returns true if autocomplete is valid', function() {
+		var params = checkSetup('<input autocomplete="on" id="target" />');
+		assert.isTrue(evaluate.apply(checkContext, params));
 	});
 
-	it('passes options to text.isValidAutocomplete', function() {
-		var options = { foo: 'bar' };
+	it('returns false if autocomplete is not valid', function() {
+		var params = checkSetup('<input autocomplete="foo" id="target" />');
+		assert.isFalse(evaluate.apply(checkContext, params));
+	});
+
+	it('uses options to change what is valid autocomplete', function() {
+		var options = { stateTerms: ['foo'] };
 		var params = checkSetup(
 			'<input autocomplete="foo" id="target" />',
 			options
 		);
-		var called = false;
-		axe.commons.text.isValidAutocomplete = function(_, arg2) {
-			assert.equal(arg2, options);
-			called = true;
-		};
-		evaluate.apply(checkContext, params);
-		assert.isTrue(called);
-	});
-
-	it('returns the outcome of text.isValidAutocomplete', function() {
-		var params1 = checkSetup(
-			'<input autocomplete="badvalue" id="target" />',
-			options
-		);
-		assert.isFalse(_isValidAutocomplete('badvalue'));
-		assert.isFalse(evaluate.apply(checkContext, params1));
-
-		var params2 = checkSetup(
-			'<input autocomplete="email" id="target" />',
-			options
-		);
-		assert.isTrue(_isValidAutocomplete('email'));
-		assert.isTrue(evaluate.apply(checkContext, params2));
+		assert.isTrue(evaluate.apply(checkContext, params));
 	});
 });

--- a/test/checks/tables/html5-scope.js
+++ b/test/checks/tables/html5-scope.js
@@ -22,16 +22,11 @@ describe('html5-scope', function() {
 	});
 
 	it('should return true on non-HTML5 documents', function() {
-		var orig = axe.commons.dom.isHTML5;
-		axe.commons.dom.isHTML5 = function() {
-			return false;
-		};
-
+		var origPublicId = document.publicId;
 		fixture.innerHTML = '<table><tr><th scope="col"></th></tr></table>';
 		var node = fixture.querySelector('th');
 
 		assert.isTrue(checks['html5-scope'].evaluate(node));
-
-		axe.commons.dom.isHTML5 = orig;
+		document.publicId = origPublicId;
 	});
 });

--- a/test/commons/color/element-has-image.js
+++ b/test/commons/color/element-has-image.js
@@ -4,12 +4,11 @@ describe('color.elementHasImage', function() {
 	var fixture = document.getElementById('fixture');
 	var queryFixture = axe.testUtils.queryFixture;
 	var elementHasImage = axe.commons.color.elementHasImage;
-	var origColorIncompleteData = axe.commons.color.incompleteData;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 		axe._tree = undefined;
-		axe.commons.color.incompleteData = origColorIncompleteData;
+		axe.commons.color.incompleteData.clear();
 	});
 
 	it('returns true when `HTMLElement` is of graphical type', function() {

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 describe('color.getForegroundColor', function() {
 	'use strict';
 
@@ -110,12 +108,20 @@ describe('color.getForegroundColor', function() {
 	});
 
 	it('should not recalculate bgColor if passed in', function() {
-		var spy = sinon.spy(axe.commons.color, 'getBackgroundColor');
-		var bgColor = new axe.commons.color.Color(255, 255, 255, 1);
-		var node = document.createElement('div');
-		axe.commons.color.getForegroundColor(node, false, bgColor);
-		assert.isFalse(spy.called);
-		spy.restore();
+		fixture.innerHTML =
+			'<div style="height: 40px; background-color: #000000;">' +
+			'<div id="target" style="height: 40px; color: rgba(0, 0, 128, 0.5);">' +
+			'This is my text' +
+			'</div></div>';
+		axe.testUtils.flatTreeSetup(fixture);
+		var target = fixture.querySelector('#target');
+		var bgColor = new axe.commons.color.Color(64, 64, 0, 1);
+		var actual = axe.commons.color.getForegroundColor(target, false, bgColor);
+		var expected = new axe.commons.color.Color(32, 32, 64, 1);
+		assert.closeTo(actual.red, expected.red, 0.8);
+		assert.closeTo(actual.green, expected.green, 0.8);
+		assert.closeTo(actual.blue, expected.blue, 0.8);
+		assert.closeTo(actual.alpha, expected.alpha, 0.1);
 	});
 
 	(shadowSupported ? it : xit)(

--- a/test/commons/table/get-headers.js
+++ b/test/commons/table/get-headers.js
@@ -5,14 +5,10 @@ describe('table.getHeaders', function() {
 	}
 
 	var fixture = $id('fixture');
-	var origToGrid = axe.commons.table.toGrid;
-	var origCellPosition = axe.commons.table.getCellPosition;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 		axe._tree = undefined;
-		axe.commons.table.toGrid = origToGrid;
-		axe.commons.table.getCellPosition = origCellPosition;
 	});
 
 	it('should work with scope=auto', function() {
@@ -177,39 +173,5 @@ describe('table.getHeaders', function() {
 
 		axe.testUtils.flatTreeSetup(fixture.firstChild);
 		assert.deepEqual(axe.commons.table.getHeaders(target), []);
-	});
-
-	it('should not call toGrid if a tableGrid is passed in', function() {
-		fixture.innerHTML =
-			'<table id="table">' +
-			'<tr><td></td><th id="t1">1</th><th>2</th></tr>' +
-			'<tr><th id="t2">2</th><td id="target">ok</td><td></td></tr>' +
-			'</table>';
-
-		var target = $id('target');
-		var table = $id('table');
-
-		axe.testUtils.flatTreeSetup(fixture.firstChild);
-		var tableGrid = axe.commons.table.toGrid(table);
-
-		// getCellPosition will eventually call into toGrid when checking for
-		// scope but we're only interested if the toGrid call was called before
-		// cellPosition
-		var called = false;
-		axe.commons.table.toGrid = function(table) {
-			called = true;
-			return origToGrid(table);
-		};
-		axe.commons.table.getCellPosition = function(cell, tableGrid) {
-			axe.commons.table.toGrid = origToGrid;
-			return origCellPosition(cell, tableGrid);
-		};
-
-		axe.commons.table.getHeaders(target, tableGrid);
-		assert.isFalse(called);
-		assert.deepEqual(axe.commons.table.getHeaders(target), [
-			$id('t1'),
-			$id('t2')
-		]);
 	});
 });


### PR DESCRIPTION
`commons` needs to be a global var to support our current build process (wrapping the entire file in a function and returning it). We can remove that later when we convert the entire build process to just use webpack.

Needed to remove or rewrite some tests that mocked.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
