### PR TITLE
refactor(Audit): Convert to ES5 class

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -32,94 +32,6 @@ function unpackToObject(collection, audit, method) {
 }
 
 /**
- * Constructor which holds configured rules and information about the document under test
- */
-function Audit(audit) {
-	// defaults
-	this.brand = 'axe';
-	this.application = 'axeAPI';
-	this.tagExclude = ['experimental'];
-	this.lang = 'en';
-
-	this.defaultConfig = audit;
-	this._init();
-
-	// A copy of the "default" locale. This will be set if the user
-	// provides a new locale to `axe.configure()` and used to undo
-	// changes in `axe.reset()`.
-	this._defaultLocale = null;
-}
-
-/**
- * Build and set the previous locale. Will noop if a previous
- * locale was already set, as we want the ability to "reset"
- * to the default ("first") configuration.
- */
-
-Audit.prototype._setDefaultLocale = function() {
-	if (this._defaultLocale) {
-		return;
-	}
-
-	const locale = {
-		checks: {},
-		rules: {},
-		failureSummaries: {},
-		incompleteFallbackMessage: '',
-		lang: this.lang
-	};
-
-	// XXX: unable to use `for-of` here, as doing so would
-	// require us to polyfill `Symbol`.
-	const checkIDs = Object.keys(this.data.checks);
-	for (let i = 0; i < checkIDs.length; i++) {
-		const id = checkIDs[i];
-		const check = this.data.checks[id];
-		const { pass, fail, incomplete } = check.messages;
-		locale.checks[id] = {
-			pass,
-			fail,
-			incomplete
-		};
-	}
-
-	const ruleIDs = Object.keys(this.data.rules);
-	for (let i = 0; i < ruleIDs.length; i++) {
-		const id = ruleIDs[i];
-		const rule = this.data.rules[id];
-		const { description, help } = rule;
-		locale.rules[id] = { description, help };
-	}
-
-	const failureSummaries = Object.keys(this.data.failureSummaries);
-	for (let i = 0; i < failureSummaries.length; i++) {
-		const type = failureSummaries[i];
-		const failureSummary = this.data.failureSummaries[type];
-		const { failureMessage } = failureSummary;
-		locale.failureSummaries[type] = { failureMessage };
-	}
-
-	locale.incompleteFallbackMessage = this.data.incompleteFallbackMessage;
-
-	this._defaultLocale = locale;
-};
-
-/**
- * Reset the locale to the "default".
- */
-
-Audit.prototype._resetLocale = function() {
-	// If the default locale has not already been set, we can exit early.
-	const defaultLocale = this._defaultLocale;
-	if (!defaultLocale) {
-		return;
-	}
-
-	// Apply the default locale
-	this.applyLocale(defaultLocale);
-};
-
-/**
  * Merge two check locales (a, b), favoring `b`.
  *
  * Both locale `a` and the returned shape resemble:
@@ -221,180 +133,480 @@ const mergeFallbackMessage = (a, b) => {
 };
 
 /**
- * Apply locale for the given `checks`.
+ * Constructor which holds configured rules and information about the document under test
  */
-
-Audit.prototype._applyCheckLocale = function(checks) {
-	const keys = Object.keys(checks);
-	for (let i = 0; i < keys.length; i++) {
-		const id = keys[i];
-		if (!this.data.checks[id]) {
-			throw new Error(`Locale provided for unknown check: "${id}"`);
+class Audit {
+	constructor(audit) {
+		// defaults
+		this.brand = 'axe';
+		this.application = 'axeAPI';
+		this.tagExclude = ['experimental'];
+		this.lang = 'en';
+		this.defaultConfig = audit;
+		this._init();
+		// A copy of the "default" locale. This will be set if the user
+		// provides a new locale to `axe.configure()` and used to undo
+		// changes in `axe.reset()`.
+		this._defaultLocale = null;
+	}
+	/**
+	 * Build and set the previous locale. Will noop if a previous
+	 * locale was already set, as we want the ability to "reset"
+	 * to the default ("first") configuration.
+	 */
+	_setDefaultLocale() {
+		if (this._defaultLocale) {
+			return;
 		}
-
-		this.data.checks[id] = mergeCheckLocale(this.data.checks[id], checks[id]);
-	}
-};
-
-/**
- * Apply locale for the given `rules`.
- */
-
-Audit.prototype._applyRuleLocale = function(rules) {
-	const keys = Object.keys(rules);
-	for (let i = 0; i < keys.length; i++) {
-		const id = keys[i];
-		if (!this.data.rules[id]) {
-			throw new Error(`Locale provided for unknown rule: "${id}"`);
+		const locale = {
+			checks: {},
+			rules: {},
+			failureSummaries: {},
+			incompleteFallbackMessage: '',
+			lang: this.lang
+		};
+		// XXX: unable to use `for-of` here, as doing so would
+		// require us to polyfill `Symbol`.
+		const checkIDs = Object.keys(this.data.checks);
+		for (let i = 0; i < checkIDs.length; i++) {
+			const id = checkIDs[i];
+			const check = this.data.checks[id];
+			const { pass, fail, incomplete } = check.messages;
+			locale.checks[id] = {
+				pass,
+				fail,
+				incomplete
+			};
 		}
-		this.data.rules[id] = mergeRuleLocale(this.data.rules[id], rules[id]);
-	}
-};
-
-/**
- * Apply locale for the given failureMessage
- */
-
-Audit.prototype._applyFailureSummaries = function(messages) {
-	const keys = Object.keys(messages);
-	for (let i = 0; i < keys.length; i++) {
-		const key = keys[i];
-		if (!this.data.failureSummaries[key]) {
-			throw new Error(`Locale provided for unknown failureMessage: "${key}"`);
+		const ruleIDs = Object.keys(this.data.rules);
+		for (let i = 0; i < ruleIDs.length; i++) {
+			const id = ruleIDs[i];
+			const rule = this.data.rules[id];
+			const { description, help } = rule;
+			locale.rules[id] = { description, help };
 		}
-		this.data.failureSummaries[key] = mergeFailureMessage(
-			this.data.failureSummaries[key],
-			messages[key]
-		);
+		const failureSummaries = Object.keys(this.data.failureSummaries);
+		for (let i = 0; i < failureSummaries.length; i++) {
+			const type = failureSummaries[i];
+			const failureSummary = this.data.failureSummaries[type];
+			const { failureMessage } = failureSummary;
+			locale.failureSummaries[type] = { failureMessage };
+		}
+		locale.incompleteFallbackMessage = this.data.incompleteFallbackMessage;
+		this._defaultLocale = locale;
 	}
-};
-
-/**
- * Apply the given `locale`.
- *
- * @param {axe.Locale}
- */
-
-Audit.prototype.applyLocale = function(locale) {
-	this._setDefaultLocale();
-
-	if (locale.checks) {
-		this._applyCheckLocale(locale.checks);
+	/**
+	 * Reset the locale to the "default".
+	 */
+	_resetLocale() {
+		// If the default locale has not already been set, we can exit early.
+		const defaultLocale = this._defaultLocale;
+		if (!defaultLocale) {
+			return;
+		}
+		// Apply the default locale
+		this.applyLocale(defaultLocale);
 	}
-
-	if (locale.rules) {
-		this._applyRuleLocale(locale.rules);
+	/**
+	 * Apply locale for the given `checks`.
+	 */
+	_applyCheckLocale(checks) {
+		const keys = Object.keys(checks);
+		for (let i = 0; i < keys.length; i++) {
+			const id = keys[i];
+			if (!this.data.checks[id]) {
+				throw new Error(`Locale provided for unknown check: "${id}"`);
+			}
+			this.data.checks[id] = mergeCheckLocale(this.data.checks[id], checks[id]);
+		}
 	}
-
-	if (locale.failureSummaries) {
-		this._applyFailureSummaries(locale.failureSummaries, 'failureSummaries');
+	/**
+	 * Apply locale for the given `rules`.
+	 */
+	_applyRuleLocale(rules) {
+		const keys = Object.keys(rules);
+		for (let i = 0; i < keys.length; i++) {
+			const id = keys[i];
+			if (!this.data.rules[id]) {
+				throw new Error(`Locale provided for unknown rule: "${id}"`);
+			}
+			this.data.rules[id] = mergeRuleLocale(this.data.rules[id], rules[id]);
+		}
 	}
-
-	if (locale.incompleteFallbackMessage) {
-		this.data.incompleteFallbackMessage = mergeFallbackMessage(
-			this.data.incompleteFallbackMessage,
-			locale.incompleteFallbackMessage
-		);
+	/**
+	 * Apply locale for the given failureMessage
+	 */
+	_applyFailureSummaries(messages) {
+		const keys = Object.keys(messages);
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i];
+			if (!this.data.failureSummaries[key]) {
+				throw new Error(`Locale provided for unknown failureMessage: "${key}"`);
+			}
+			this.data.failureSummaries[key] = mergeFailureMessage(
+				this.data.failureSummaries[key],
+				messages[key]
+			);
+		}
 	}
-
-	if (locale.lang) {
-		this.lang = locale.lang;
+	/**
+	 * Apply the given `locale`.
+	 *
+	 * @param {axe.Locale}
+	 */
+	applyLocale(locale) {
+		this._setDefaultLocale();
+		if (locale.checks) {
+			this._applyCheckLocale(locale.checks);
+		}
+		if (locale.rules) {
+			this._applyRuleLocale(locale.rules);
+		}
+		if (locale.failureSummaries) {
+			this._applyFailureSummaries(locale.failureSummaries, 'failureSummaries');
+		}
+		if (locale.incompleteFallbackMessage) {
+			this.data.incompleteFallbackMessage = mergeFallbackMessage(
+				this.data.incompleteFallbackMessage,
+				locale.incompleteFallbackMessage
+			);
+		}
+		if (locale.lang) {
+			this.lang = locale.lang;
+		}
 	}
-};
-
-/**
- * Initializes the rules and checks
- */
-Audit.prototype._init = function() {
-	var audit = getDefaultConfiguration(this.defaultConfig);
-
-	axe.commons = commons = audit.commons;
-
-	this.lang = audit.lang || 'en';
-	this.reporter = audit.reporter;
-	this.commands = {};
-	this.rules = [];
-	this.checks = {};
-
-	unpackToObject(audit.rules, this, 'addRule');
-	unpackToObject(audit.checks, this, 'addCheck');
-
-	this.data = {};
-	this.data.checks = (audit.data && audit.data.checks) || {};
-	this.data.rules = (audit.data && audit.data.rules) || {};
-	this.data.failureSummaries =
-		(audit.data && audit.data.failureSummaries) || {};
-	this.data.incompleteFallbackMessage =
-		(audit.data && audit.data.incompleteFallbackMessage) || '';
-
-	this._constructHelpUrls(); // create default helpUrls
-};
-
-/**
- * Adds a new command to the audit
- */
-
-Audit.prototype.registerCommand = function(command) {
-	'use strict';
-	this.commands[command.id] = command.callback;
-};
-
-/**
- * Adds a new rule to the Audit.  If a rule with specified ID already exists, it will be overridden
- * @param {Object} spec Rule specification object
- */
-Audit.prototype.addRule = function(spec) {
-	'use strict';
-
-	if (spec.metadata) {
-		this.data.rules[spec.id] = spec.metadata;
+	/**
+	 * Initializes the rules and checks
+	 */
+	_init() {
+		var audit = getDefaultConfiguration(this.defaultConfig);
+		axe.commons = commons = audit.commons;
+		this.lang = audit.lang || 'en';
+		this.reporter = audit.reporter;
+		this.commands = {};
+		this.rules = [];
+		this.checks = {};
+		unpackToObject(audit.rules, this, 'addRule');
+		unpackToObject(audit.checks, this, 'addCheck');
+		this.data = {};
+		this.data.checks = (audit.data && audit.data.checks) || {};
+		this.data.rules = (audit.data && audit.data.rules) || {};
+		this.data.failureSummaries =
+			(audit.data && audit.data.failureSummaries) || {};
+		this.data.incompleteFallbackMessage =
+			(audit.data && audit.data.incompleteFallbackMessage) || '';
+		this._constructHelpUrls(); // create default helpUrls
 	}
-
-	let rule = this.getRule(spec.id);
-	if (rule) {
-		rule.configure(spec);
-	} else {
-		this.rules.push(new Rule(spec, this));
+	/**
+	 * Adds a new command to the audit
+	 */
+	registerCommand(command) {
+		'use strict';
+		this.commands[command.id] = command.callback;
 	}
-};
-
-/**
- * Adds a new check to the Audit.  If a Check with specified ID already exists, it will be
- * reconfigured
- *
- * @param {Object} spec Check specification object
- */
-Audit.prototype.addCheck = function(spec) {
-	/*eslint no-eval: 0 */
-	'use strict';
-	let metadata = spec.metadata;
-
-	if (typeof metadata === 'object') {
-		this.data.checks[spec.id] = metadata;
-		// Transform messages into functions:
-		if (typeof metadata.messages === 'object') {
-			Object.keys(metadata.messages)
-				.filter(
-					prop =>
-						metadata.messages.hasOwnProperty(prop) &&
-						typeof metadata.messages[prop] === 'string'
-				)
-				.forEach(prop => {
-					if (metadata.messages[prop].indexOf('function') === 0) {
-						metadata.messages[prop] = new Function(
-							'return ' + metadata.messages[prop] + ';'
-						)();
+	/**
+	 * Adds a new rule to the Audit.  If a rule with specified ID already exists, it will be overridden
+	 * @param {Object} spec Rule specification object
+	 */
+	addRule(spec) {
+		'use strict';
+		if (spec.metadata) {
+			this.data.rules[spec.id] = spec.metadata;
+		}
+		let rule = this.getRule(spec.id);
+		if (rule) {
+			rule.configure(spec);
+		} else {
+			this.rules.push(new Rule(spec, this));
+		}
+	}
+	/**
+	 * Adds a new check to the Audit.  If a Check with specified ID already exists, it will be
+	 * reconfigured
+	 *
+	 * @param {Object} spec Check specification object
+	 */
+	addCheck(spec) {
+		/*eslint no-eval: 0 */
+		'use strict';
+		let metadata = spec.metadata;
+		if (typeof metadata === 'object') {
+			this.data.checks[spec.id] = metadata;
+			// Transform messages into functions:
+			if (typeof metadata.messages === 'object') {
+				Object.keys(metadata.messages)
+					.filter(
+						prop =>
+							metadata.messages.hasOwnProperty(prop) &&
+							typeof metadata.messages[prop] === 'string'
+					)
+					.forEach(prop => {
+						if (metadata.messages[prop].indexOf('function') === 0) {
+							metadata.messages[prop] = new Function(
+								'return ' + metadata.messages[prop] + ';'
+							)();
+						}
+					});
+			}
+		}
+		if (this.checks[spec.id]) {
+			this.checks[spec.id].configure(spec);
+		} else {
+			this.checks[spec.id] = new Check(spec);
+		}
+	}
+	/**
+	 * Runs the Audit; which in turn should call `run` on each rule.
+	 * @async
+	 * @param  {Context}   context The scope definition/context for analysis (include/exclude)
+	 * @param  {Object}    options Options object to pass into rules and/or disable rules or checks
+	 * @param  {Function} fn       Callback function to fire when audit is complete
+	 */
+	run(context, options, resolve, reject) {
+		'use strict';
+		this.normalizeOptions(options);
+		axe._selectCache = [];
+		// get a list of rules to run NOW vs. LATER (later are preload assets dependent rules)
+		const allRulesToRun = getRulesToRun(this.rules, context, options);
+		const runNowRules = allRulesToRun.now;
+		const runLaterRules = allRulesToRun.later;
+		// init a NOW queue for rules to run immediately
+		const nowRulesQueue = axe.utils.queue();
+		// construct can run NOW rules into NOW queue
+		runNowRules.forEach(rule => {
+			nowRulesQueue.defer(getDefferedRule(rule, context, options));
+		});
+		// init a PRELOADER queue to start preloading assets
+		const preloaderQueue = axe.utils.queue();
+		// defer preload if preload dependent rules exist
+		if (runLaterRules.length) {
+			preloaderQueue.defer(resolve => {
+				// handle both success and fail of preload
+				// and resolve, to allow to run all checks
+				axe.utils
+					.preload(options)
+					.then(assets => resolve(assets))
+					.catch(err => {
+						/**
+						 * Note:
+						 * we do not reject, to allow other (non-preload) rules to `run`
+						 * -> instead we resolve as `undefined`
+						 */
+						console.warn(`Couldn't load preload assets: `, err);
+						resolve(undefined);
+					});
+			});
+		}
+		// defer now and preload queue to run immediately
+		const queueForNowRulesAndPreloader = axe.utils.queue();
+		queueForNowRulesAndPreloader.defer(nowRulesQueue);
+		queueForNowRulesAndPreloader.defer(preloaderQueue);
+		// invoke the now queue
+		queueForNowRulesAndPreloader
+			.then(nowRulesAndPreloaderResults => {
+				// interpolate results into separate variables
+				const assetsFromQueue = nowRulesAndPreloaderResults.pop();
+				if (assetsFromQueue && assetsFromQueue.length) {
+					// result is a queue (again), hence the index resolution
+					// assets is either an object of key value pairs of asset type and values
+					// eg: cssom: [stylesheets]
+					// or undefined if preload failed
+					const assets = assetsFromQueue[0];
+					// extend context with preloaded assets
+					if (assets) {
+						context = {
+							...context,
+							...assets
+						};
+					}
+				}
+				// the reminder of the results are RuleResults
+				const nowRulesResults = nowRulesAndPreloaderResults[0];
+				// if there are no rules to run LATER - resolve with rule results
+				if (!runLaterRules.length) {
+					// remove the cache
+					axe._selectCache = undefined;
+					// resolve
+					resolve(nowRulesResults.filter(result => !!result));
+					return;
+				}
+				// init a LATER queue for rules that are dependant on preloaded assets
+				const laterRulesQueue = axe.utils.queue();
+				runLaterRules.forEach(rule => {
+					const deferredRule = getDefferedRule(rule, context, options);
+					laterRulesQueue.defer(deferredRule);
+				});
+				// invoke the later queue
+				laterRulesQueue
+					.then(laterRuleResults => {
+						// remove the cache
+						axe._selectCache = undefined;
+						// resolve
+						resolve(
+							nowRulesResults
+								.concat(laterRuleResults)
+								.filter(result => !!result)
+						);
+					})
+					.catch(reject);
+			})
+			.catch(reject);
+	}
+	/**
+	 * Runs Rule `after` post processing functions
+	 * @param  {Array} results  Array of RuleResults to postprocess
+	 * @param  {Mixed} options  Options object to pass into rules and/or disable rules or checks
+	 */
+	after(results, options) {
+		'use strict';
+		var rules = this.rules;
+		return results.map(function(ruleResult) {
+			var rule = axe.utils.findBy(rules, 'id', ruleResult.id);
+			if (!rule) {
+				// If you see this, you're probably running the Mocha tests with the axe extension installed
+				throw new Error(
+					'Result for unknown rule. You may be running mismatch axe-core versions'
+				);
+			}
+			return rule.after(ruleResult, options);
+		});
+	}
+	/**
+	 * Get the rule with a given ID
+	 * @param  {string}
+	 * @return {Rule}
+	 */
+	getRule(ruleId) {
+		return this.rules.find(rule => rule.id === ruleId);
+	}
+	/**
+	 * Ensure all rules that are expected to run exist
+	 * @throws {Error} If any tag or rule specified in options is unknown
+	 * @param  {Object} options  Options object
+	 * @return {Object}          Validated options object
+	 */
+	normalizeOptions(options) {
+		'use strict';
+		var audit = this;
+		const tags = [];
+		const ruleIds = [];
+		audit.rules.forEach(rule => {
+			ruleIds.push(rule.id);
+			rule.tags.forEach(tag => {
+				if (!tags.includes(tag)) {
+					tags.push(tag);
+				}
+			});
+		});
+		// Validate runOnly
+		if (typeof options.runOnly === 'object') {
+			if (Array.isArray(options.runOnly)) {
+				const hasTag = options.runOnly.find(value => tags.includes(value));
+				const hasRule = options.runOnly.find(value => ruleIds.includes(value));
+				if (hasTag && hasRule) {
+					throw new Error('runOnly cannot be both rules and tags');
+				}
+				if (hasRule) {
+					options.runOnly = {
+						type: 'rule',
+						values: options.runOnly
+					};
+				} else {
+					options.runOnly = {
+						type: 'tag',
+						values: options.runOnly
+					};
+				}
+			}
+			const only = options.runOnly;
+			if (only.value && !only.values) {
+				only.values = only.value;
+				delete only.value;
+			}
+			if (!Array.isArray(only.values) || only.values.length === 0) {
+				throw new Error('runOnly.values must be a non-empty array');
+			}
+			// Check if every value in options.runOnly is a known rule ID
+			if (['rule', 'rules'].includes(only.type)) {
+				only.type = 'rule';
+				only.values.forEach(function(ruleId) {
+					if (!ruleIds.includes(ruleId)) {
+						throw new Error('unknown rule `' + ruleId + '` in options.runOnly');
 					}
 				});
+				// Validate 'tags' (e.g. anything not 'rule')
+			} else if (['tag', 'tags', undefined].includes(only.type)) {
+				only.type = 'tag';
+				const unmatchedTags = only.values.filter(tag => !tags.includes(tag));
+				if (unmatchedTags.length !== 0) {
+					axe.log('Could not find tags `' + unmatchedTags.join('`, `') + '`');
+				}
+			} else {
+				throw new Error(`Unknown runOnly type '${only.type}'`);
+			}
 		}
+		if (typeof options.rules === 'object') {
+			Object.keys(options.rules).forEach(function(ruleId) {
+				if (!ruleIds.includes(ruleId)) {
+					throw new Error('unknown rule `' + ruleId + '` in options.rules');
+				}
+			});
+		}
+		return options;
 	}
-
-	if (this.checks[spec.id]) {
-		this.checks[spec.id].configure(spec);
-	} else {
-		this.checks[spec.id] = new Check(spec);
+	/*
+	 * Updates the default options and then applies them
+	 * @param  {Mixed} options  Options object
+	 */
+	setBranding(branding) {
+		'use strict';
+		let previous = {
+			brand: this.brand,
+			application: this.application
+		};
+		if (
+			branding &&
+			branding.hasOwnProperty('brand') &&
+			branding.brand &&
+			typeof branding.brand === 'string'
+		) {
+			this.brand = branding.brand;
+		}
+		if (
+			branding &&
+			branding.hasOwnProperty('application') &&
+			branding.application &&
+			typeof branding.application === 'string'
+		) {
+			this.application = branding.application;
+		}
+		this._constructHelpUrls(previous);
 	}
-};
+	_constructHelpUrls(previous = null) {
+		var version = (axe.version.match(/^[1-9][0-9]*\.[0-9]+/) || ['x.y'])[0];
+		this.rules.forEach(rule => {
+			if (!this.data.rules[rule.id]) {
+				this.data.rules[rule.id] = {};
+			}
+			let metaData = this.data.rules[rule.id];
+			if (
+				typeof metaData.helpUrl !== 'string' ||
+				(previous &&
+					metaData.helpUrl === getHelpUrl(previous, rule.id, version))
+			) {
+				metaData.helpUrl = getHelpUrl(this, rule.id, version);
+			}
+		});
+	}
+	/**
+	 * Reset the default rules, checks and meta data
+	 */
+	resetRulesAndChecks() {
+		'use strict';
+		this._init();
+		this._resetLocale();
+	}
+}
 
 /**
  * Splits a given array of rules to two, with rules that can be run immediately and one's that are dependent on preloadedAssets
@@ -486,258 +698,6 @@ function getDefferedRule(rule, context, options) {
 }
 
 /**
- * Runs the Audit; which in turn should call `run` on each rule.
- * @async
- * @param  {Context}   context The scope definition/context for analysis (include/exclude)
- * @param  {Object}    options Options object to pass into rules and/or disable rules or checks
- * @param  {Function} fn       Callback function to fire when audit is complete
- */
-Audit.prototype.run = function(context, options, resolve, reject) {
-	'use strict';
-
-	this.normalizeOptions(options);
-	axe._selectCache = [];
-
-	// get a list of rules to run NOW vs. LATER (later are preload assets dependent rules)
-	const allRulesToRun = getRulesToRun(this.rules, context, options);
-	const runNowRules = allRulesToRun.now;
-	const runLaterRules = allRulesToRun.later;
-
-	// init a NOW queue for rules to run immediately
-	const nowRulesQueue = axe.utils.queue();
-	// construct can run NOW rules into NOW queue
-	runNowRules.forEach(rule => {
-		nowRulesQueue.defer(getDefferedRule(rule, context, options));
-	});
-
-	// init a PRELOADER queue to start preloading assets
-	const preloaderQueue = axe.utils.queue();
-	// defer preload if preload dependent rules exist
-	if (runLaterRules.length) {
-		preloaderQueue.defer(resolve => {
-			// handle both success and fail of preload
-			// and resolve, to allow to run all checks
-			axe.utils
-				.preload(options)
-				.then(assets => resolve(assets))
-				.catch(err => {
-					/**
-					 * Note:
-					 * we do not reject, to allow other (non-preload) rules to `run`
-					 * -> instead we resolve as `undefined`
-					 */
-					console.warn(`Couldn't load preload assets: `, err);
-					resolve(undefined);
-				});
-		});
-	}
-
-	// defer now and preload queue to run immediately
-	const queueForNowRulesAndPreloader = axe.utils.queue();
-	queueForNowRulesAndPreloader.defer(nowRulesQueue);
-	queueForNowRulesAndPreloader.defer(preloaderQueue);
-
-	// invoke the now queue
-	queueForNowRulesAndPreloader
-		.then(nowRulesAndPreloaderResults => {
-			// interpolate results into separate variables
-			const assetsFromQueue = nowRulesAndPreloaderResults.pop();
-			if (assetsFromQueue && assetsFromQueue.length) {
-				// result is a queue (again), hence the index resolution
-				// assets is either an object of key value pairs of asset type and values
-				// eg: cssom: [stylesheets]
-				// or undefined if preload failed
-				const assets = assetsFromQueue[0];
-				// extend context with preloaded assets
-				if (assets) {
-					context = {
-						...context,
-						...assets
-					};
-				}
-			}
-
-			// the reminder of the results are RuleResults
-			const nowRulesResults = nowRulesAndPreloaderResults[0];
-
-			// if there are no rules to run LATER - resolve with rule results
-			if (!runLaterRules.length) {
-				// remove the cache
-				axe._selectCache = undefined;
-				// resolve
-				resolve(nowRulesResults.filter(result => !!result));
-				return;
-			}
-
-			// init a LATER queue for rules that are dependant on preloaded assets
-			const laterRulesQueue = axe.utils.queue();
-			runLaterRules.forEach(rule => {
-				const deferredRule = getDefferedRule(rule, context, options);
-				laterRulesQueue.defer(deferredRule);
-			});
-			// invoke the later queue
-			laterRulesQueue
-				.then(laterRuleResults => {
-					// remove the cache
-					axe._selectCache = undefined;
-					// resolve
-					resolve(
-						nowRulesResults.concat(laterRuleResults).filter(result => !!result)
-					);
-				})
-				.catch(reject);
-		})
-		.catch(reject);
-};
-
-/**
- * Runs Rule `after` post processing functions
- * @param  {Array} results  Array of RuleResults to postprocess
- * @param  {Mixed} options  Options object to pass into rules and/or disable rules or checks
- */
-Audit.prototype.after = function(results, options) {
-	'use strict';
-
-	var rules = this.rules;
-
-	return results.map(function(ruleResult) {
-		var rule = axe.utils.findBy(rules, 'id', ruleResult.id);
-		if (!rule) {
-			// If you see this, you're probably running the Mocha tests with the axe extension installed
-			throw new Error(
-				'Result for unknown rule. You may be running mismatch axe-core versions'
-			);
-		}
-
-		return rule.after(ruleResult, options);
-	});
-};
-
-/**
- * Get the rule with a given ID
- * @param  {string}
- * @return {Rule}
- */
-Audit.prototype.getRule = function(ruleId) {
-	return this.rules.find(rule => rule.id === ruleId);
-};
-
-/**
- * Ensure all rules that are expected to run exist
- * @throws {Error} If any tag or rule specified in options is unknown
- * @param  {Object} options  Options object
- * @return {Object}          Validated options object
- */
-Audit.prototype.normalizeOptions = function(options) {
-	'use strict';
-	var audit = this;
-
-	const tags = [];
-	const ruleIds = [];
-	audit.rules.forEach(rule => {
-		ruleIds.push(rule.id);
-		rule.tags.forEach(tag => {
-			if (!tags.includes(tag)) {
-				tags.push(tag);
-			}
-		});
-	});
-
-	// Validate runOnly
-	if (typeof options.runOnly === 'object') {
-		if (Array.isArray(options.runOnly)) {
-			const hasTag = options.runOnly.find(value => tags.includes(value));
-			const hasRule = options.runOnly.find(value => ruleIds.includes(value));
-
-			if (hasTag && hasRule) {
-				throw new Error('runOnly cannot be both rules and tags');
-			}
-			if (hasRule) {
-				options.runOnly = {
-					type: 'rule',
-					values: options.runOnly
-				};
-			} else {
-				options.runOnly = {
-					type: 'tag',
-					values: options.runOnly
-				};
-			}
-		}
-		const only = options.runOnly;
-		if (only.value && !only.values) {
-			only.values = only.value;
-			delete only.value;
-		}
-
-		if (!Array.isArray(only.values) || only.values.length === 0) {
-			throw new Error('runOnly.values must be a non-empty array');
-		}
-
-		// Check if every value in options.runOnly is a known rule ID
-		if (['rule', 'rules'].includes(only.type)) {
-			only.type = 'rule';
-			only.values.forEach(function(ruleId) {
-				if (!ruleIds.includes(ruleId)) {
-					throw new Error('unknown rule `' + ruleId + '` in options.runOnly');
-				}
-			});
-
-			// Validate 'tags' (e.g. anything not 'rule')
-		} else if (['tag', 'tags', undefined].includes(only.type)) {
-			only.type = 'tag';
-			const unmatchedTags = only.values.filter(tag => !tags.includes(tag));
-
-			if (unmatchedTags.length !== 0) {
-				axe.log('Could not find tags `' + unmatchedTags.join('`, `') + '`');
-			}
-		} else {
-			throw new Error(`Unknown runOnly type '${only.type}'`);
-		}
-	}
-
-	if (typeof options.rules === 'object') {
-		Object.keys(options.rules).forEach(function(ruleId) {
-			if (!ruleIds.includes(ruleId)) {
-				throw new Error('unknown rule `' + ruleId + '` in options.rules');
-			}
-		});
-	}
-
-	return options;
-};
-
-/*
- * Updates the default options and then applies them
- * @param  {Mixed} options  Options object
- */
-
-Audit.prototype.setBranding = function(branding) {
-	'use strict';
-	let previous = {
-		brand: this.brand,
-		application: this.application
-	};
-	if (
-		branding &&
-		branding.hasOwnProperty('brand') &&
-		branding.brand &&
-		typeof branding.brand === 'string'
-	) {
-		this.brand = branding.brand;
-	}
-	if (
-		branding &&
-		branding.hasOwnProperty('application') &&
-		branding.application &&
-		typeof branding.application === 'string'
-	) {
-		this.application = branding.application;
-	}
-	this._constructHelpUrls(previous);
-};
-
-/**
  * For all the rules, create the helpUrl and add it to the data for that rule
  */
 function getHelpUrl({ brand, application, lang }, ruleId, version) {
@@ -753,29 +713,3 @@ function getHelpUrl({ brand, application, lang }, ruleId, version) {
 		(lang && lang !== 'en' ? '&lang=' + encodeURIComponent(lang) : '')
 	);
 }
-
-Audit.prototype._constructHelpUrls = function(previous = null) {
-	var version = (axe.version.match(/^[1-9][0-9]*\.[0-9]+/) || ['x.y'])[0];
-	this.rules.forEach(rule => {
-		if (!this.data.rules[rule.id]) {
-			this.data.rules[rule.id] = {};
-		}
-		let metaData = this.data.rules[rule.id];
-		if (
-			typeof metaData.helpUrl !== 'string' ||
-			(previous && metaData.helpUrl === getHelpUrl(previous, rule.id, version))
-		) {
-			metaData.helpUrl = getHelpUrl(this, rule.id, version);
-		}
-	});
-};
-
-/**
- * Reset the default rules, checks and meta data
- */
-
-Audit.prototype.resetRulesAndChecks = function() {
-	'use strict';
-	this._init();
-	this._resetLocale();
-};


### PR DESCRIPTION
This patch refactors the `Audit` into a proper ES5 class. This improves readability while keeping the same functional behavior.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
