### PR TITLE
fix: typo in tags for avoid-inline-spacing rule

### DIFF
--- a/lib/rules/avoid-inline-spacing.json
+++ b/lib/rules/avoid-inline-spacing.json
@@ -1,7 +1,7 @@
 {
 	"id": "avoid-inline-spacing",
 	"selector": "[style]",
-	"tags": ["wcag21aa", "wcag1412"],
+	"tags": ["wcag21aa", "wcag412"],
 	"metadata": {
 		"description": "Ensure that text spacing set through style attributes can be adjusted with custom stylesheets",
 		"help": "Inline text spacing must be adjustable with custom stylesheets"


### PR DESCRIPTION
Changed `wcag1412` tag to the correct value: `wcag412`

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
