### PR TITLE
feat: support check evaluate functions as an id string

### DIFF
--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -1,9 +1,13 @@
-/*global CheckResult,DqElement */
+/*global CheckResult,DqElement, metadataFunctionMap */
 
 function createExecutionContext(spec) {
 	/*eslint no-eval:0 */
 	'use strict';
 	if (typeof spec === 'string') {
+		if (metadataFunctionMap.has(spec)) {
+			return metadataFunctionMap.get(spec);
+		}
+
 		return new Function('return ' + spec + ';')();
 	}
 	return spec;

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -1,0 +1,9 @@
+/*eslint no-unused-vars:0*/
+// TODO: es-modules-checks
+// TODO: es-modules-rules
+// import all check evaluate and after functions, and all rule matches functions
+
+const metadataFunctionMap = new Map();
+
+// TODO: es-modules-core
+// export default metadataFunctionMap;


### PR DESCRIPTION
Creating the stub for the map that will allow checks to use a string id to access shared evaluate and after functions. Once checks have been converted to es modules we can add them all to the map and have the feature working.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
