### PR TITLE
test(reporters): make tests true unit rather than integration tests

### DIFF
--- a/test/core/reporters/na.js
+++ b/test/core/reporters/na.js
@@ -1,7 +1,6 @@
 describe('reporters - na', function() {
 	'use strict';
-	var orig,
-		results,
+	var runResults,
 		_results = [
 			{
 				id: 'noMatch',
@@ -98,28 +97,20 @@ describe('reporters - na', function() {
 		];
 
 	beforeEach(function() {
-		results = JSON.parse(JSON.stringify(_results));
+		runResults = JSON.parse(JSON.stringify(_results));
 		axe._load({
 			messages: {},
 			rules: [],
 			data: {}
 		});
-		orig = axe._runRules;
-		axe._runRules = function(ctxt, options, cb) {
-			cb(results, function noop() {});
-		};
 	});
 
 	afterEach(function() {
 		axe._audit = null;
-		axe._runRules = orig;
 	});
 
-	var naOption = { reporter: 'na' };
-
-	it('should merge the runRules results into violations, passes and inapplicable', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should merge the runRules results into violations, passes and inapplicable', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.isObject(results);
 			assert.isArray(results.violations);
 			assert.lengthOf(results.violations, 1);
@@ -127,40 +118,31 @@ describe('reporters - na', function() {
 			assert.lengthOf(results.passes, 1);
 			assert.isArray(results.inapplicable);
 			assert.lengthOf(results.inapplicable, 1);
-
-			done();
 		});
 	});
-	it('should add the rule id to the rule result', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add the rule id to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].id, 'idkStuff');
 			assert.equal(results.passes[0].id, 'gimmeLabel');
 			assert.equal(results.inapplicable[0].id, 'noMatch');
-			done();
 		});
 	});
-	it('should add tags to the rule result', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add tags to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.deepEqual(results.violations[0].tags, ['tag2']);
 			assert.deepEqual(results.passes[0].tags, ['tag1']);
 			assert.deepEqual(results.inapplicable[0].tags, ['tag3']);
-			done();
 		});
 	});
-	it('should add the rule help to the rule result', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add the rule help to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.ok(!results.violations[0].helpUrl);
 			assert.equal(results.passes[0].helpUrl, 'things');
 			assert.equal(results.inapplicable[0].helpUrl, 'somewhere');
-			done();
 		});
 	});
-	it('should add the html to the node data', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add the html to the node data', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.ok(results.violations[0].nodes);
 			assert.equal(results.violations[0].nodes.length, 1);
 			assert.equal(
@@ -168,12 +150,10 @@ describe('reporters - na', function() {
 				'<pillock>george bush</pillock>'
 			);
 			assert.equal(results.passes[0].nodes[0].html, '<minkey>chimp</minky>');
-			done();
 		});
 	});
-	it('should add the target selector array to the node data', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add the target selector array to the node data', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.ok(results.violations[0].nodes);
 			assert.equal(results.violations[0].nodes.length, 1);
 			assert.deepEqual(results.violations[0].nodes[0].target, [
@@ -181,32 +161,26 @@ describe('reporters - na', function() {
 				'r',
 				'pillock'
 			]);
-			done();
 		});
 	});
-	it('should add the description to the rule result', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add the description to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].description, 'something more nifty');
 			assert.equal(results.passes[0].description, 'something nifty');
-			done();
 		});
 	});
-	it('should add the impact to the rule result', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add the impact to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].impact, 'cats');
 			assert.equal(results.violations[0].nodes[0].impact, 'cats');
 			assert.ok(!results.passes[0].impact);
 			assert.ok(!results.passes[0].nodes[0].impact);
 			assert.isNull(results.passes[0].impact);
 			assert.isNull(results.passes[0].nodes[0].impact);
-			done();
 		});
 	});
-	it('should map relatedNodes', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should map relatedNodes', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.lengthOf(results.violations[0].nodes[0].all[0].relatedNodes, 1);
 			assert.equal(
 				results.violations[0].nodes[0].all[0].relatedNodes[0].target,
@@ -226,24 +200,19 @@ describe('reporters - na', function() {
 				results.passes[0].nodes[0].any[0].relatedNodes[0].html,
 				'fred'
 			);
-			done();
 		});
 	});
-	it('should add environment data', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add environment data', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.isNotNull(results.url);
 			assert.isNotNull(results.timestamp);
 			assert.isNotNull(results.testEnvironement);
 			assert.isNotNull(results.testRunner);
-			done();
 		});
 	});
-	it('should add toolOptions property', function(done) {
-		axe.run(naOption, function(err, results) {
-			assert.isNull(err);
+	it('should add toolOptions property', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.isNotNull(results.toolOptions);
-			done();
 		});
 	});
 });

--- a/test/core/reporters/no-passes.js
+++ b/test/core/reporters/no-passes.js
@@ -1,7 +1,6 @@
 describe('reporters - no-passes', function() {
 	'use strict';
-	var orig,
-		results,
+	var runResults,
 		_results = [
 			{
 				id: 'gimmeLabel',
@@ -87,72 +86,53 @@ describe('reporters - no-passes', function() {
 			}
 		];
 	beforeEach(function() {
-		results = JSON.parse(JSON.stringify(_results));
+		runResults = JSON.parse(JSON.stringify(_results));
 		axe._load({
 			messages: {},
 			rules: [],
 			data: {}
 		});
-		orig = axe._runRules;
-		axe._runRules = function(ctxt, options, cb) {
-			cb(results, function noop() {});
-		};
 	});
-
-	var noPassOpt = { reporter: 'no-passes' };
 
 	afterEach(function() {
 		axe._audit = null;
-		axe._runRules = orig;
 	});
 
-	it('should merge the runRules results into violations and  exclude passes', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should merge the runRules results into violations and  exclude passes', function() {
+		axe.getReporter('no-passes')(runResults, {}, function(results) {
 			assert.isObject(results);
 			assert.isArray(results.violations);
 			assert.lengthOf(results.violations, 1);
 			assert.isUndefined(results.passes);
-
-			done();
 		});
 	});
-	it('should add the rule id to the rule result', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add the rule id to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].id, 'idkStuff');
-			done();
 		});
 	});
-	it('should add tags to the rule result', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add tags to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.deepEqual(results.violations[0].tags, ['tag2']);
-			done();
 		});
 	});
-	it('should add the rule help to the rule result', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add the rule help to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.isNotOk(results.violations[0].helpUrl);
-			done();
 		});
 	});
-	it('should add the html to the node data', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add the html to the node data', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.ok(results.violations[0].nodes);
 			assert.equal(results.violations[0].nodes.length, 1);
 			assert.equal(
 				results.violations[0].nodes[0].html,
 				'<pillock>george bush</pillock>'
 			);
-			done();
 		});
 	});
-	it('should add the target selector array to the node data', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add the target selector array to the node data', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.ok(results.violations[0].nodes);
 			assert.equal(results.violations[0].nodes.length, 1);
 			assert.deepEqual(results.violations[0].nodes[0].target, [
@@ -160,27 +140,21 @@ describe('reporters - no-passes', function() {
 				'r',
 				'pillock'
 			]);
-			done();
 		});
 	});
-	it('should add the description to the rule result', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add the description to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].description, 'something more nifty');
-			done();
 		});
 	});
-	it('should add the impact to the rule result', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add the impact to the rule result', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].impact, 'cats');
 			assert.equal(results.violations[0].nodes[0].impact, 'cats');
-			done();
 		});
 	});
-	it('should map relatedNodes', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should map relatedNodes', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.lengthOf(results.violations[0].nodes[0].all[0].relatedNodes, 1);
 			assert.equal(
 				results.violations[0].nodes[0].all[0].relatedNodes[0].target,
@@ -190,24 +164,19 @@ describe('reporters - no-passes', function() {
 				results.violations[0].nodes[0].all[0].relatedNodes[0].html,
 				'bob'
 			);
-			done();
 		});
 	});
-	it('should add environment data', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add environment data', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.isNotNull(results.url);
 			assert.isNotNull(results.timestamp);
 			assert.isNotNull(results.testEnvironement);
 			assert.isNotNull(results.testRunner);
-			done();
 		});
 	});
-	it('should add toolOptions property', function(done) {
-		axe.run(noPassOpt, function(err, results) {
-			assert.isNull(err);
+	it('should add toolOptions property', function() {
+		axe.getReporter('na')(runResults, {}, function(results) {
 			assert.isNotNull(results.toolOptions);
-			done();
 		});
 	});
 });

--- a/test/core/reporters/raw.js
+++ b/test/core/reporters/raw.js
@@ -9,11 +9,10 @@ describe('reporters - raw', function() {
 		return new axe.utils.DqElement(node);
 	}
 
-	var mockResults;
-	var orig;
+	var runResults;
 
-	before(function() {
-		mockResults = [
+	beforeEach(function() {
+		runResults = [
 			{
 				id: 'gimmeLabel',
 				helpUrl: 'things',
@@ -109,33 +108,15 @@ describe('reporters - raw', function() {
 		axe.testUtils.fixtureSetup();
 
 		axe._load({});
-		orig = axe._runRules;
-		axe._runRules = function(_, __, cb) {
-			cb(mockResults, function noop() {});
-		};
+		axe._cache.set('selectorData', {});
 	});
 
 	after(function() {
-		axe._runRules = orig;
 		fixture.innerHTML = '';
 	});
 
-	it('should pass through object', function(done) {
-		axe.run({ reporter: 'raw' }, function(err, results) {
-			if (err) {
-				return done(err);
-			}
-			assert.isTrue(Array.isArray(results));
-			done();
-		});
-	});
-
-	it('should serialize DqElements (#1195)', function(done) {
-		axe.run({ reporter: 'raw' }, function(err, results) {
-			if (err) {
-				return done(err);
-			}
-
+	it('should serialize DqElements (#1195)', function() {
+		axe.getReporter('rawEnv')(runResults, {}, function(results) {
 			for (var i = 0; i < results.length; i++) {
 				var result = results[i];
 				for (var j = 0; j < result.passes.length; j++) {
@@ -143,8 +124,6 @@ describe('reporters - raw', function() {
 					assert.notInstanceOf(p.node, axe.utils.DqElement);
 				}
 			}
-
-			done();
 		});
 	});
 });

--- a/test/core/reporters/v1.js
+++ b/test/core/reporters/v1.js
@@ -1,7 +1,6 @@
 describe('reporters - v1', function() {
 	'use strict';
-	var orig,
-		results,
+	var runResults,
 		_results = [
 			{
 				id: 'gimmeLabel',
@@ -136,7 +135,7 @@ describe('reporters - v1', function() {
 			}
 		];
 	beforeEach(function() {
-		results = JSON.parse(JSON.stringify(_results));
+		runResults = JSON.parse(JSON.stringify(_results));
 		axe._load({
 			messages: {},
 			rules: [],
@@ -182,192 +181,119 @@ describe('reporters - v1', function() {
 				}
 			}
 		});
-		orig = axe._runRules;
-		axe._runRules = function(ctxt, options, cb) {
-			cb(results, function noop() {});
-		};
 	});
 
 	afterEach(function() {
 		axe._audit = null;
-		axe._runRules = orig;
 	});
 
-	var optionsV1 = { reporter: 'v1' };
-
-	it('should merge the runRules results into violations and passes', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.isObject(results);
-				assert.isArray(results.violations);
-				assert.lengthOf(results.violations, 2);
-				assert.isArray(results.passes);
-				assert.lengthOf(results.passes, 2);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should merge the runRules results into violations and passes', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.isObject(results);
+			assert.isArray(results.violations);
+			assert.lengthOf(results.violations, 2);
+			assert.isArray(results.passes);
+			assert.lengthOf(results.passes, 2);
 		});
 	});
-	it('should add the rule id to the rule result', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.equal(results.violations[0].id, 'idkStuff');
-				assert.equal(results.violations[1].id, 'bypass');
-				assert.equal(results.passes[0].id, 'gimmeLabel');
-				assert.equal(results.passes[1].id, 'blinky');
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add the rule id to the rule result', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.equal(results.violations[0].id, 'idkStuff');
+			assert.equal(results.violations[1].id, 'bypass');
+			assert.equal(results.passes[0].id, 'gimmeLabel');
+			assert.equal(results.passes[1].id, 'blinky');
 		});
 	});
-	it('should add tags to the rule result', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.deepEqual(results.violations[0].tags, ['tag2']);
-				assert.deepEqual(results.violations[1].tags, ['tag3']);
-				assert.deepEqual(results.passes[0].tags, ['tag1']);
-				assert.deepEqual(results.passes[1].tags, ['tag4']);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add tags to the rule result', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.deepEqual(results.violations[0].tags, ['tag2']);
+			assert.deepEqual(results.violations[1].tags, ['tag3']);
+			assert.deepEqual(results.passes[0].tags, ['tag1']);
+			assert.deepEqual(results.passes[1].tags, ['tag4']);
 		});
 	});
-	it('should add the rule help to the rule result', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.isNotOk(results.violations[0].helpUrl);
-				assert.isNotOk(results.violations[1].helpUrl);
-				assert.equal(results.passes[0].helpUrl, 'things');
-				assert.isNotOk(results.passes[1].helpUrl);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add the rule help to the rule result', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.isNotOk(results.violations[0].helpUrl);
+			assert.isNotOk(results.violations[1].helpUrl);
+			assert.equal(results.passes[0].helpUrl, 'things');
+			assert.isNotOk(results.passes[1].helpUrl);
 		});
 	});
-	it('should add the html to the node data', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.ok(results.violations[0].nodes);
-				assert.equal(results.violations[0].nodes.length, 1);
-				assert.equal(
-					results.violations[0].nodes[0].html,
-					'<pillock>george bush</pillock>'
-				);
-				assert.equal(
-					results.violations[1].nodes[0].html,
-					'<foon>telephone</foon>'
-				);
-				assert.equal(results.passes[0].nodes[0].html, '<minkey>chimp</minky>');
-				assert.equal(
-					results.passes[1].nodes[0].html,
-					'<clueso>nincompoop</clueso>'
-				);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add the html to the node data', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.ok(results.violations[0].nodes);
+			assert.equal(results.violations[0].nodes.length, 1);
+			assert.equal(
+				results.violations[0].nodes[0].html,
+				'<pillock>george bush</pillock>'
+			);
+			assert.equal(
+				results.violations[1].nodes[0].html,
+				'<foon>telephone</foon>'
+			);
+			assert.equal(results.passes[0].nodes[0].html, '<minkey>chimp</minky>');
+			assert.equal(
+				results.passes[1].nodes[0].html,
+				'<clueso>nincompoop</clueso>'
+			);
 		});
 	});
-	it('should add the failure summary to the node data', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.ok(results.violations[0].nodes);
-				assert.equal(results.violations[0].nodes.length, 1);
-				assert.equal(
-					typeof results.violations[0].nodes[0].failureSummary,
-					'string'
-				);
-				assert.equal(
-					typeof results.incomplete[0].nodes[0].failureSummary,
-					'string'
-				);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add the failure summary to the node data', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.ok(results.violations[0].nodes);
+			assert.equal(results.violations[0].nodes.length, 1);
+			assert.equal(
+				typeof results.violations[0].nodes[0].failureSummary,
+				'string'
+			);
+			assert.equal(
+				typeof results.incomplete[0].nodes[0].failureSummary,
+				'string'
+			);
 		});
 	});
-	it('should add the target selector array to the node data', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.ok(results.violations[0].nodes);
-				assert.equal(results.violations[0].nodes.length, 1);
-				assert.deepEqual(results.violations[0].nodes[0].target, [
-					'q',
-					'r',
-					'pillock'
-				]);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add the target selector array to the node data', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.ok(results.violations[0].nodes);
+			assert.equal(results.violations[0].nodes.length, 1);
+			assert.deepEqual(results.violations[0].nodes[0].target, [
+				'q',
+				'r',
+				'pillock'
+			]);
 		});
 	});
-	it('should add the description to the rule result', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.equal(results.violations[0].description, 'something more nifty');
-				assert.equal(
-					results.violations[1].description,
-					'something even more nifty'
-				);
-				assert.equal(results.passes[0].description, 'something nifty');
-				assert.equal(results.passes[1].description, 'something awesome');
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add the description to the rule result', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.equal(results.violations[0].description, 'something more nifty');
+			assert.equal(
+				results.violations[1].description,
+				'something even more nifty'
+			);
+			assert.equal(results.passes[0].description, 'something nifty');
+			assert.equal(results.passes[1].description, 'something awesome');
 		});
 	});
-	it('should add the impact to the rule result', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.equal(results.violations[0].impact, 'cats');
-				assert.equal(results.violations[0].nodes[0].impact, 'cats');
-				assert.equal(results.violations[1].impact, 'monkeys');
-				assert.equal(results.violations[1].nodes[0].impact, 'monkeys');
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add the impact to the rule result', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.equal(results.violations[0].impact, 'cats');
+			assert.equal(results.violations[0].nodes[0].impact, 'cats');
+			assert.equal(results.violations[1].impact, 'monkeys');
+			assert.equal(results.violations[1].nodes[0].impact, 'monkeys');
 		});
 	});
-	it('should add environment data', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.isNotNull(results.url);
-				assert.isNotNull(results.timestamp);
-				assert.isNotNull(results.testEnvironement);
-				assert.isNotNull(results.testRunner);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add environment data', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.isNotNull(results.url);
+			assert.isNotNull(results.timestamp);
+			assert.isNotNull(results.testEnvironement);
+			assert.isNotNull(results.testRunner);
 		});
 	});
-	it('should add toolOptions property', function(done) {
-		axe.run(optionsV1, function(err, results) {
-			try {
-				assert.isNull(err);
-				assert.isNotNull(results.toolOptions);
-				done();
-			} catch (err) {
-				done(err);
-			}
+	it('should add toolOptions property', function() {
+		axe.getReporter('v1')(runResults, {}, function(results) {
+			assert.isNotNull(results.toolOptions);
 		});
 	});
 });

--- a/test/core/reporters/v2.js
+++ b/test/core/reporters/v2.js
@@ -1,7 +1,6 @@
 describe('reporters - v2', function() {
 	'use strict';
-	var orig,
-		results,
+	var runResults,
 		_results = [
 			{
 				id: 'gimmeLabel',
@@ -87,64 +86,47 @@ describe('reporters - v2', function() {
 			}
 		];
 	beforeEach(function() {
-		results = JSON.parse(JSON.stringify(_results));
+		runResults = JSON.parse(JSON.stringify(_results));
 		axe._load({
 			messages: {},
 			rules: [],
 			data: {}
 		});
-		orig = axe._runRules;
-		axe._runRules = function(ctxt, options, cb) {
-			cb(results, function noop() {});
-		};
 	});
 
 	afterEach(function() {
 		axe._audit = null;
-		axe._runRules = orig;
 	});
 
-	var optionsV2 = { reporter: 'v2' };
-
-	it('should merge the runRules results into violations and passes', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should merge the runRules results into violations and passes', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.isObject(results);
 			assert.isArray(results.violations);
 			assert.lengthOf(results.violations, 1);
 			assert.isArray(results.passes);
 			assert.lengthOf(results.passes, 1);
-
-			done();
 		});
 	});
-	it('should add the rule id to the rule result', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add the rule id to the rule result', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].id, 'idkStuff');
 			assert.equal(results.passes[0].id, 'gimmeLabel');
-			done();
 		});
 	});
-	it('should add tags to the rule result', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add tags to the rule result', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.deepEqual(results.violations[0].tags, ['tag2']);
 			assert.deepEqual(results.passes[0].tags, ['tag1']);
-			done();
 		});
 	});
-	it('should add the rule help to the rule result', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add the rule help to the rule result', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.isNotOk(results.violations[0].helpUrl);
 			assert.equal(results.passes[0].helpUrl, 'things');
-			done();
 		});
 	});
-	it('should add the html to the node data', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add the html to the node data', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.ok(results.violations[0].nodes);
 			assert.equal(results.violations[0].nodes.length, 1);
 			assert.equal(
@@ -152,12 +134,10 @@ describe('reporters - v2', function() {
 				'<pillock>george bush</pillock>'
 			);
 			assert.equal(results.passes[0].nodes[0].html, '<minkey>chimp</minky>');
-			done();
 		});
 	});
-	it('should add the target selector array to the node data', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add the target selector array to the node data', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.ok(results.violations[0].nodes);
 			assert.equal(results.violations[0].nodes.length, 1);
 			assert.deepEqual(results.violations[0].nodes[0].target, [
@@ -165,30 +145,24 @@ describe('reporters - v2', function() {
 				'r',
 				'pillock'
 			]);
-			done();
 		});
 	});
-	it('should add the description to the rule result', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add the description to the rule result', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].description, 'something more nifty');
 			assert.equal(results.passes[0].description, 'something nifty');
-			done();
 		});
 	});
-	it('should add the impact to the rule result', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add the impact to the rule result', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.equal(results.violations[0].impact, 'cats');
 			assert.equal(results.violations[0].nodes[0].impact, 'cats');
 			assert.isNotOk(results.passes[0].impact);
 			assert.isNotOk(results.passes[0].nodes[0].impact);
-			done();
 		});
 	});
-	it('should map relatedNodes', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should map relatedNodes', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.lengthOf(results.violations[0].nodes[0].all[0].relatedNodes, 1);
 			assert.equal(
 				results.violations[0].nodes[0].all[0].relatedNodes[0].target,
@@ -208,24 +182,19 @@ describe('reporters - v2', function() {
 				results.passes[0].nodes[0].any[0].relatedNodes[0].html,
 				'fred'
 			);
-			done();
 		});
 	});
-	it('should add environment data', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add environment data', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.isNotNull(results.url);
 			assert.isNotNull(results.timestamp);
 			assert.isNotNull(results.testEnvironement);
 			assert.isNotNull(results.testRunner);
-			done();
 		});
 	});
-	it('should add toolOptions property', function(done) {
-		axe.run(optionsV2, function(err, results) {
-			assert.isNull(err);
+	it('should add toolOptions property', function() {
+		axe.getReporter('v2')(runResults, {}, function(results) {
 			assert.isNotNull(results.toolOptions);
-			done();
 		});
 	});
 });


### PR DESCRIPTION
Going through tests and noticed the reporters test all went through `axe.run` and had to mock `axe._runRules`, which just returned the mocked results. So killed the middle man functions and just called the reporters directly with the results.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
