### PR TITLE
refactor: convert aria/checks to es modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -75,7 +75,8 @@
     {
       "files": [
         "lib/core/**/*.js",
-        "lib/commons/**/*.js"
+        "lib/commons/**/*.js",
+        "lib/checks/aria/**/*.js"
       ],
       "parserOptions":{
         "sourceType": "module"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -357,17 +357,11 @@ module.exports = function(grunt) {
 		}
 	});
 
-	grunt.registerTask('translate', [
-		'validate',
-		'webpack',
-		'concat:commons',
-		'add-locale'
-	]);
+	grunt.registerTask('translate', ['validate', 'webpack', 'add-locale']);
 	grunt.registerTask('build', [
 		'clean',
 		'validate',
 		'webpack',
-		// 'concat:commons',
 		'configure',
 		'babel',
 		'concat:engine',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -154,8 +154,7 @@ module.exports = function(grunt) {
 			}
 		},
 		webpack: {
-			core: createWebpackConfig('lib/core/core.js', 'tmp/core', 'core.js'),
-			commons: createWebpackConfig('lib/commons/index.js', 'tmp/commons')
+			core: createWebpackConfig('lib/core/core.js', 'tmp/core', 'core.js')
 		},
 		'aria-supported': {
 			data: {
@@ -172,7 +171,7 @@ module.exports = function(grunt) {
 				},
 				files: langs.map(function(lang) {
 					return {
-						src: ['<%= concat.commons.dest %>'],
+						src: [''],
 						dest: {
 							auto: 'tmp/rules' + lang + '.js',
 							descriptions: 'doc/rule-descriptions' + lang + '.md'
@@ -186,7 +185,7 @@ module.exports = function(grunt) {
 				options: {
 					lang: grunt.option('lang')
 				},
-				src: ['<%= concat.commons.dest %>'],
+				src: ['tmp/core/core.js'],
 				dest: './locales/' + (grunt.option('lang') || 'new-locale') + '.json'
 			}
 		},
@@ -368,7 +367,7 @@ module.exports = function(grunt) {
 		'clean',
 		'validate',
 		'webpack',
-		'concat:commons',
+		// 'concat:commons',
 		'configure',
 		'babel',
 		'concat:engine',

--- a/build/build-manual.js
+++ b/build/build-manual.js
@@ -38,6 +38,5 @@ module.exports = function build(grunt, options, commons, callback) {
 		rules: parseObject(options.rules),
 		checks: parseObject(options.checks),
 		misc: parseObject(options.misc)
-		// commons: commons
 	});
 };

--- a/build/build-manual.js
+++ b/build/build-manual.js
@@ -15,7 +15,7 @@ module.exports = function build(grunt, options, commons, callback) {
 			var json = grunt.file.readJSON(file);
 			var dirname = path.dirname(file);
 			Object.keys(templates).forEach(function(templateName) {
-				if (json[templateName]) {
+				if (json[templateName] && json[templateName].endsWith('.js')) {
 					json[templateName] = path.resolve(dirname, json[templateName]);
 					if (options.getFiles) {
 						json[templateName] = getSource(json[templateName], templateName);
@@ -37,7 +37,7 @@ module.exports = function build(grunt, options, commons, callback) {
 	callback({
 		rules: parseObject(options.rules),
 		checks: parseObject(options.checks),
-		misc: parseObject(options.misc),
-		commons: commons
+		misc: parseObject(options.misc)
+		// commons: commons
 	});
 };

--- a/build/configure.js
+++ b/build/configure.js
@@ -379,7 +379,6 @@ ${ruleTables}`;
 						data: metadata,
 						rules: rules,
 						checks: checks
-						// commons: result.commons
 					},
 					blacklist
 				)
@@ -390,7 +389,6 @@ ${ruleTables}`;
 						data: metadata,
 						rules: rules,
 						checks: checks
-						// commons: result.commons
 					},
 					blacklist
 				)

--- a/build/configure.js
+++ b/build/configure.js
@@ -152,7 +152,7 @@ function buildRules(grunt, options, commons, callback) {
 		function replaceFunctions(string) {
 			return string
 				.replace(
-					/"(evaluate|after|gather|matches|source|commons)":\s*("[^"]+?")/g,
+					/"(evaluate|after|gather|matches|source|commons)":\s*("[^"]+?.js")/g,
 					function(m, p1, p2) {
 						return m.replace(p2, getSource(p2.replace(/^"|"$/g, ''), p1));
 					}
@@ -378,8 +378,8 @@ ${ruleTables}`;
 						lang: options.locale || 'en',
 						data: metadata,
 						rules: rules,
-						checks: checks,
-						commons: result.commons
+						checks: checks
+						// commons: result.commons
 					},
 					blacklist
 				)
@@ -389,8 +389,8 @@ ${ruleTables}`;
 					{
 						data: metadata,
 						rules: rules,
-						checks: checks,
-						commons: result.commons
+						checks: checks
+						// commons: result.commons
 					},
 					blacklist
 				)

--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -18,13 +18,13 @@ module.exports = function(grunt) {
 			});
 
 			this.files.forEach(function(file) {
-				var commons = file.src[0];
+				// var commons = file.src[0];
 				var match = file.dest.auto.match(/\.([a-z]{2,3})\.js/);
 				if (match) {
 					options.locale = match[1];
 				}
 
-				buildRules(grunt, options, commons, function(result) {
+				buildRules(grunt, options, null, function(result) {
 					grunt.file.write(file.dest.auto, 'axe._load(' + result.auto + ');');
 
 					// Format the content so Prettier doesn't create a diff after running.

--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -18,7 +18,6 @@ module.exports = function(grunt) {
 			});
 
 			this.files.forEach(function(file) {
-				// var commons = file.src[0];
 				var match = file.dest.auto.match(/\.([a-z]{2,3})\.js/);
 				if (match) {
 					options.locale = match[1];

--- a/build/tasks/validate.js
+++ b/build/tasks/validate.js
@@ -6,6 +6,10 @@ var revalidator = require('revalidator').validate,
 	path = require('path');
 
 function fileExists(v, o) {
+	if (!v.endsWith('.js')) {
+		return true;
+	}
+
 	var file = path.resolve(path.dirname(o._path), v);
 	var exists;
 	try {

--- a/build/test/engine.js
+++ b/build/test/engine.js
@@ -1,11 +1,15 @@
 /*eslint no-unused-vars: ["off"]*/
 /*global axe */
 
-var checks, commons;
+var checks;
+var commons = axe.commons;
+var origLoad = axe._load;
 axe._load = function(r) {
-	commons = r.commons;
-	checks = r.checks.reduce(function(acc, check) {
-		acc[check.id] = check;
-		return acc;
-	}, {});
+	origLoad(r);
+	checks = {};
+	var props = Object.keys(axe._audit.checks);
+	for (var i = 0; i < props.length; i++) {
+		var prop = props[i];
+		checks[prop] = axe._audit.checks[prop];
+	}
 };

--- a/lib/checks/aria/abstractrole-evaluate.js
+++ b/lib/checks/aria/abstractrole-evaluate.js
@@ -1,10 +1,17 @@
-const abstractRoles = axe.utils
-	.tokenList(virtualNode.attr('role'))
-	.filter(role => axe.commons.aria.getRoleType(role) === 'abstract');
+import { tokenList } from '../../core/utils';
+import { getRoleType } from '../../commons/aria';
 
-if (abstractRoles.length > 0) {
-	this.data(abstractRoles);
-	return true;
+function abstractroleEvaluate(node, options, virtualNode) {
+	const abstractRoles = tokenList(virtualNode.attr('role')).filter(
+		role => getRoleType(role) === 'abstract'
+	);
+
+	if (abstractRoles.length > 0) {
+		this.data(abstractRoles);
+		return true;
+	}
+
+	return false;
 }
 
-return false;
+export default abstractroleEvaluate;

--- a/lib/checks/aria/abstractrole.json
+++ b/lib/checks/aria/abstractrole.json
@@ -1,6 +1,6 @@
 {
 	"id": "abstractrole",
-	"evaluate": "abstractrole-evaluate.js",
+	"evaluate": "abstractrole-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/aria/aria-allowed-attr-evaluate.js
+++ b/lib/checks/aria/aria-allowed-attr-evaluate.js
@@ -1,39 +1,41 @@
-options = options || {};
+import { getNodeAttributes, uniqueArray } from '../../core/utils';
+import { implicitRole, allowedAttr, validateAttr } from '../../commons/aria';
 
-var invalid = [];
+function ariaAllowedAttrEvaluate(node, options = {}) {
+	var invalid = [];
 
-var attr,
-	attrName,
-	allowed,
-	role = node.getAttribute('role'),
-	attrs = axe.utils.getNodeAttributes(node);
+	var attr,
+		attrName,
+		allowed,
+		role = node.getAttribute('role'),
+		attrs = getNodeAttributes(node);
 
-if (!role) {
-	role = axe.commons.aria.implicitRole(node);
-}
+	if (!role) {
+		role = implicitRole(node);
+	}
 
-allowed = axe.commons.aria.allowedAttr(role);
+	allowed = allowedAttr(role);
 
-if (Array.isArray(options[role])) {
-	allowed = axe.utils.uniqueArray(options[role].concat(allowed));
-}
+	if (Array.isArray(options[role])) {
+		allowed = uniqueArray(options[role].concat(allowed));
+	}
 
-if (role && allowed) {
-	for (var i = 0, l = attrs.length; i < l; i++) {
-		attr = attrs[i];
-		attrName = attr.name;
-		if (
-			axe.commons.aria.validateAttr(attrName) &&
-			!allowed.includes(attrName)
-		) {
-			invalid.push(attrName + '="' + attr.nodeValue + '"');
+	if (role && allowed) {
+		for (var i = 0, l = attrs.length; i < l; i++) {
+			attr = attrs[i];
+			attrName = attr.name;
+			if (validateAttr(attrName) && !allowed.includes(attrName)) {
+				invalid.push(attrName + '="' + attr.nodeValue + '"');
+			}
 		}
 	}
+
+	if (invalid.length) {
+		this.data(invalid);
+		return false;
+	}
+
+	return true;
 }
 
-if (invalid.length) {
-	this.data(invalid);
-	return false;
-}
-
-return true;
+export default ariaAllowedAttrEvaluate;

--- a/lib/checks/aria/aria-allowed-attr.json
+++ b/lib/checks/aria/aria-allowed-attr.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-allowed-attr",
-	"evaluate": "aria-allowed-attr-evaluate.js",
+	"evaluate": "aria-allowed-attr-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/aria-allowed-role-evaluate.js
+++ b/lib/checks/aria/aria-allowed-role-evaluate.js
@@ -1,28 +1,31 @@
-/**
- * Implements allowed roles defined at:
- * https://www.w3.org/TR/html-aria/#docconformance
- * https://www.w3.org/TR/SVG2/struct.html#implicit-aria-semantics
- */
-const { dom } = axe.commons;
-const { allowImplicit = true, ignoredTags = [] } = options || {};
-const tagName = node.nodeName.toUpperCase();
+import { isVisible } from '../../commons/dom';
+import { getElementUnallowedRoles } from '../../commons/aria';
 
-// check if the element should be ignored, by an user setting
-if (ignoredTags.map(t => t.toUpperCase()).includes(tagName)) {
+function ariaAllowedRoledEvaluate(node, options = {}) {
+	/**
+	 * Implements allowed roles defined at:
+	 * https://www.w3.org/TR/html-aria/#docconformance
+	 * https://www.w3.org/TR/SVG2/struct.html#implicit-aria-semantics
+	 */
+	const { allowImplicit = true, ignoredTags = [] } = options;
+	const tagName = node.nodeName.toUpperCase();
+
+	// check if the element should be ignored, by an user setting
+	if (ignoredTags.map(t => t.toUpperCase()).includes(tagName)) {
+		return true;
+	}
+
+	const unallowedRoles = getElementUnallowedRoles(node, allowImplicit);
+
+	if (unallowedRoles.length) {
+		this.data(unallowedRoles);
+		if (!isVisible(node, true)) {
+			// flag hidden elements for review
+			return undefined;
+		}
+		return false;
+	}
 	return true;
 }
 
-const unallowedRoles = axe.commons.aria.getElementUnallowedRoles(
-	node,
-	allowImplicit
-);
-
-if (unallowedRoles.length) {
-	this.data(unallowedRoles);
-	if (!dom.isVisible(node, true)) {
-		// flag hidden elements for review
-		return undefined;
-	}
-	return false;
-}
-return true;
+export default ariaAllowedRoledEvaluate;

--- a/lib/checks/aria/aria-allowed-role.json
+++ b/lib/checks/aria/aria-allowed-role.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-allowed-role",
-	"evaluate": "aria-allowed-role-evaluate.js",
+	"evaluate": "aria-allowed-role-evaluate",
 	"options": {
 		"allowImplicit": true,
 		"ignoredTags": []

--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -1,33 +1,39 @@
-const { aria, dom } = axe.commons;
-options = Array.isArray(options) ? options : [];
+import { lookupTable } from '../../commons/aria';
+import { getRootNode } from '../../commons/dom';
+import { tokenList } from '../../core/utils';
 
-const attr = node.getAttribute('aria-errormessage');
-const hasAttr = node.hasAttribute('aria-errormessage');
+function ariaErrormessageEvaluate(node, options) {
+	options = Array.isArray(options) ? options : [];
 
-const doc = dom.getRootNode(node);
+	const attr = node.getAttribute('aria-errormessage');
+	const hasAttr = node.hasAttribute('aria-errormessage');
 
-function validateAttrValue(attr) {
-	if (attr.trim() === '') {
-		return aria.lookupTable.attributes['aria-errormessage'].allowEmpty;
+	const doc = getRootNode(node);
+
+	function validateAttrValue(attr) {
+		if (attr.trim() === '') {
+			return lookupTable.attributes['aria-errormessage'].allowEmpty;
+		}
+		const idref = attr && doc.getElementById(attr);
+		if (idref) {
+			return (
+				idref.getAttribute('role') === 'alert' ||
+				idref.getAttribute('aria-live') === 'assertive' ||
+				tokenList(node.getAttribute('aria-describedby') || '').indexOf(attr) >
+					-1
+			);
+		}
 	}
-	const idref = attr && doc.getElementById(attr);
-	if (idref) {
-		return (
-			idref.getAttribute('role') === 'alert' ||
-			idref.getAttribute('aria-live') === 'assertive' ||
-			axe.utils
-				.tokenList(node.getAttribute('aria-describedby') || '')
-				.indexOf(attr) > -1
-		);
+
+	// limit results to elements that actually have this attribute
+	if (options.indexOf(attr) === -1 && hasAttr) {
+		if (!validateAttrValue(attr)) {
+			this.data(tokenList(attr));
+			return false;
+		}
 	}
+
+	return true;
 }
 
-// limit results to elements that actually have this attribute
-if (options.indexOf(attr) === -1 && hasAttr) {
-	if (!validateAttrValue(attr)) {
-		this.data(axe.utils.tokenList(attr));
-		return false;
-	}
-}
-
-return true;
+export default ariaErrormessageEvaluate;

--- a/lib/checks/aria/aria-errormessage.json
+++ b/lib/checks/aria/aria-errormessage.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-errormessage",
-	"evaluate": "aria-errormessage-evaluate.js",
+	"evaluate": "aria-errormessage-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/aria-hidden-body-evaluate.js
+++ b/lib/checks/aria/aria-hidden-body-evaluate.js
@@ -1,1 +1,5 @@
-return node.getAttribute('aria-hidden') !== 'true';
+function ariaHiddenBodyEvaluate(node) {
+	return node.getAttribute('aria-hidden') !== 'true';
+}
+
+export default ariaHiddenBodyEvaluate;

--- a/lib/checks/aria/aria-hidden-body.json
+++ b/lib/checks/aria/aria-hidden-body.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-hidden-body",
-	"evaluate": "aria-hidden-body-evaluate.js",
+	"evaluate": "aria-hidden-body-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/aria-required-attr-evaluate.js
+++ b/lib/checks/aria/aria-required-attr-evaluate.js
@@ -1,53 +1,58 @@
-options = options || {};
-
-const missing = [];
-const {
+import {
 	isNativeTextbox,
 	isNativeSelect,
 	isAriaTextbox,
 	isAriaListbox,
 	isAriaCombobox,
 	isAriaRange
-} = axe.commons.forms;
+} from '../../commons/forms';
+import { requiredAttr } from '../../commons/aria';
+import { uniqueArray } from '../../core/utils';
 
-// aria-valuenow should fail if element does not have a value property
-// @see https://github.com/dequelabs/axe-core/issues/1501
-const preChecks = {
-	'aria-valuenow': function() {
-		return !(
-			isNativeTextbox(node) ||
-			isNativeSelect(node) ||
-			isAriaTextbox(node) ||
-			isAriaListbox(node) ||
-			isAriaCombobox(node) ||
-			(isAriaRange(node) && node.hasAttribute('aria-valuenow'))
-		);
-	}
-};
+function ariaRequiredAttrEvaluate(node, options = {}) {
+	const missing = [];
 
-if (node.hasAttributes()) {
-	const role = node.getAttribute('role');
-	let required = axe.commons.aria.requiredAttr(role);
+	// aria-valuenow should fail if element does not have a value property
+	// @see https://github.com/dequelabs/axe-core/issues/1501
+	const preChecks = {
+		'aria-valuenow': function() {
+			return !(
+				isNativeTextbox(node) ||
+				isNativeSelect(node) ||
+				isAriaTextbox(node) ||
+				isAriaListbox(node) ||
+				isAriaCombobox(node) ||
+				(isAriaRange(node) && node.hasAttribute('aria-valuenow'))
+			);
+		}
+	};
 
-	if (Array.isArray(options[role])) {
-		required = axe.utils.uniqueArray(options[role], required);
-	}
-	if (role && required) {
-		for (let i = 0, l = required.length; i < l; i++) {
-			const attr = required[i];
-			if (
-				!node.getAttribute(attr) &&
-				(preChecks[attr] ? preChecks[attr]() : true)
-			) {
-				missing.push(attr);
+	if (node.hasAttributes()) {
+		const role = node.getAttribute('role');
+		let required = requiredAttr(role);
+
+		if (Array.isArray(options[role])) {
+			required = uniqueArray(options[role], required);
+		}
+		if (role && required) {
+			for (let i = 0, l = required.length; i < l; i++) {
+				const attr = required[i];
+				if (
+					!node.getAttribute(attr) &&
+					(preChecks[attr] ? preChecks[attr]() : true)
+				) {
+					missing.push(attr);
+				}
 			}
 		}
 	}
+
+	if (missing.length) {
+		this.data(missing);
+		return false;
+	}
+
+	return true;
 }
 
-if (missing.length) {
-	this.data(missing);
-	return false;
-}
-
-return true;
+export default ariaRequiredAttrEvaluate;

--- a/lib/checks/aria/aria-required-attr.json
+++ b/lib/checks/aria/aria-required-attr.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-required-attr",
-	"evaluate": "aria-required-attr-evaluate.js",
+	"evaluate": "aria-required-attr-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/aria-required-children-evaluate.js
+++ b/lib/checks/aria/aria-required-children-evaluate.js
@@ -1,50 +1,10 @@
-const { aria, dom } = axe.commons;
-const { requiredOwned, implicitNodes, getRole } = aria;
-const { hasContentVirtual, idrefs } = dom;
-const { matchesSelector, querySelectorAll, getNodeFromTree } = axe.utils;
-
-const reviewEmpty =
-	options && Array.isArray(options.reviewEmpty) ? options.reviewEmpty : [];
-const role = node.getAttribute('role');
-const required = requiredOwned(role);
-if (!required) {
-	return true;
-}
-
-let all = false;
-let childRoles = required.one;
-if (!childRoles) {
-	all = true;
-	childRoles = required.all;
-}
-
-const ownedElements = idrefs(node, 'aria-owns');
-const descendantRole = getDescendantRole(node, ownedElements);
-const missing = missingRequiredChildren(
-	node,
-	childRoles,
-	all,
-	role,
-	ownedElements,
-	descendantRole
-);
-if (!missing) {
-	return true;
-}
-
-this.data(missing);
-
-// Only review empty nodes when a node is both empty and does not have an aria-owns relationship
-if (
-	reviewEmpty.includes(role) &&
-	!hasContentVirtual(virtualNode, false, true) &&
-	!descendantRole.length &&
-	idrefs(node, 'aria-owns').length === 0
-) {
-	return undefined;
-}
-
-return false;
+import { requiredOwned, implicitNodes, getRole } from '../../commons/aria';
+import { hasContentVirtual, idrefs } from '../../commons/dom';
+import {
+	matchesSelector,
+	querySelectorAll,
+	getNodeFromTree
+} from '../../core/utils';
 
 /**
  * Get missing children roles
@@ -54,7 +14,9 @@ return false;
  * @param {String} role role of given node
  */
 function missingRequiredChildren(
+	/* eslint max-params: 0 */
 	node,
+	virtualNode,
 	childRoles,
 	all,
 	role,
@@ -217,3 +179,51 @@ function getDescendantRole(node, ownedEls) {
 		return out;
 	}, []);
 }
+
+function ariaRequiredChildrenEvaluate(node, options, virtualNode) {
+	const reviewEmpty =
+		options && Array.isArray(options.reviewEmpty) ? options.reviewEmpty : [];
+	const role = node.getAttribute('role');
+	const required = requiredOwned(role);
+	if (!required) {
+		return true;
+	}
+
+	let all = false;
+	let childRoles = required.one;
+	if (!childRoles) {
+		all = true;
+		childRoles = required.all;
+	}
+
+	const ownedElements = idrefs(node, 'aria-owns');
+	const descendantRole = getDescendantRole(node, ownedElements);
+	const missing = missingRequiredChildren(
+		node,
+		virtualNode,
+		childRoles,
+		all,
+		role,
+		ownedElements,
+		descendantRole
+	);
+	if (!missing) {
+		return true;
+	}
+
+	this.data(missing);
+
+	// Only review empty nodes when a node is both empty and does not have an aria-owns relationship
+	if (
+		reviewEmpty.includes(role) &&
+		!hasContentVirtual(virtualNode, false, true) &&
+		!descendantRole.length &&
+		idrefs(node, 'aria-owns').length === 0
+	) {
+		return undefined;
+	}
+
+	return false;
+}
+
+export default ariaRequiredChildrenEvaluate;

--- a/lib/checks/aria/aria-required-children.json
+++ b/lib/checks/aria/aria-required-children.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-required-children",
-	"evaluate": "aria-required-children-evaluate.js",
+	"evaluate": "aria-required-children-evaluate",
 	"options": {
 		"reviewEmpty": [
 			"doc-bibliography",

--- a/lib/checks/aria/aria-required-parent-evaluate.js
+++ b/lib/checks/aria/aria-required-parent-evaluate.js
@@ -1,42 +1,42 @@
+import { implicitNodes, requiredContext } from '../../commons/aria';
+import { findUpVirtual, getRootNode } from '../../commons/dom';
+import {
+	getNodeFromTree,
+	matchesSelector,
+	escapeSelector
+} from '../../core/utils';
+
 function getSelector(role) {
-	var impliedNative = axe.commons.aria.implicitNodes(role) || [];
+	var impliedNative = implicitNodes(role) || [];
 	return impliedNative.concat('[role="' + role + '"]').join(',');
 }
 
-function getMissingContext(virtualNode, requiredContext, includeElement) {
+function getMissingContext(virtualNode, reqContext, includeElement) {
 	var index,
 		length,
 		role = virtualNode.actualNode.getAttribute('role'),
 		missing = [];
 
-	if (!requiredContext) {
-		requiredContext = axe.commons.aria.requiredContext(role);
+	if (!reqContext) {
+		reqContext = requiredContext(role);
 	}
 
-	if (!requiredContext) {
+	if (!reqContext) {
 		return null;
 	}
 
-	for (index = 0, length = requiredContext.length; index < length; index++) {
+	for (index = 0, length = reqContext.length; index < length; index++) {
 		if (
 			includeElement &&
-			axe.utils.matchesSelector(
-				virtualNode.actualNode,
-				getSelector(requiredContext[index])
-			)
+			matchesSelector(virtualNode.actualNode, getSelector(reqContext[index]))
 		) {
 			return null;
 		}
-		if (
-			axe.commons.dom.findUpVirtual(
-				virtualNode,
-				getSelector(requiredContext[index])
-			)
-		) {
+		if (findUpVirtual(virtualNode, getSelector(reqContext[index]))) {
 			//if one matches, it passes
 			return null;
 		} else {
-			missing.push(requiredContext[index]);
+			missing.push(reqContext[index]);
 		}
 	}
 
@@ -49,8 +49,8 @@ function getAriaOwners(element) {
 
 	while (element) {
 		if (element.getAttribute('id')) {
-			const id = axe.utils.escapeSelector(element.getAttribute('id'));
-			let doc = axe.commons.dom.getRootNode(element);
+			const id = escapeSelector(element.getAttribute('id'));
+			let doc = getRootNode(element);
 			o = doc.querySelector(`[aria-owns~=${id}]`);
 			if (o) {
 				owners.push(o);
@@ -62,26 +62,30 @@ function getAriaOwners(element) {
 	return owners.length ? owners : null;
 }
 
-var missingParents = getMissingContext(virtualNode);
+function ariaRequiredParentEvaluate(node, options, virtualNode) {
+	var missingParents = getMissingContext(virtualNode);
 
-if (!missingParents) {
-	return true;
-}
+	if (!missingParents) {
+		return true;
+	}
 
-var owners = getAriaOwners(node);
+	var owners = getAriaOwners(node);
 
-if (owners) {
-	for (var i = 0, l = owners.length; i < l; i++) {
-		missingParents = getMissingContext(
-			axe.utils.getNodeFromTree(owners[i]),
-			missingParents,
-			true
-		);
-		if (!missingParents) {
-			return true;
+	if (owners) {
+		for (var i = 0, l = owners.length; i < l; i++) {
+			missingParents = getMissingContext(
+				getNodeFromTree(owners[i]),
+				missingParents,
+				true
+			);
+			if (!missingParents) {
+				return true;
+			}
 		}
 	}
+
+	this.data(missingParents);
+	return false;
 }
 
-this.data(missingParents);
-return false;
+export default ariaRequiredParentEvaluate;

--- a/lib/checks/aria/aria-required-parent.json
+++ b/lib/checks/aria/aria-required-parent.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-required-parent",
-	"evaluate": "aria-required-parent-evaluate.js",
+	"evaluate": "aria-required-parent-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/aria-roledescription-evaluate.js
+++ b/lib/checks/aria/aria-roledescription-evaluate.js
@@ -1,14 +1,18 @@
-options = options || {};
+import { getRole } from '../../commons/aria';
 
-const role = axe.commons.aria.getRole(node);
-const supportedRoles = options.supportedRoles || [];
+function ariaRoledescriptionEvaluate(node, options = {}) {
+	const role = getRole(node);
+	const supportedRoles = options.supportedRoles || [];
 
-if (supportedRoles.includes(role)) {
-	return true;
+	if (supportedRoles.includes(role)) {
+		return true;
+	}
+
+	if (role && role !== 'presentation' && role !== 'none') {
+		return undefined;
+	}
+
+	return false;
 }
 
-if (role && role !== 'presentation' && role !== 'none') {
-	return undefined;
-}
-
-return false;
+export default ariaRoledescriptionEvaluate;

--- a/lib/checks/aria/aria-roledescription.json
+++ b/lib/checks/aria/aria-roledescription.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-roledescription",
-	"evaluate": "aria-roledescription-evaluate.js",
+	"evaluate": "aria-roledescription-evaluate",
 	"options": {
 		"supportedRoles": [
 			"button",

--- a/lib/checks/aria/aria-unsupported-attr-evaluate.js
+++ b/lib/checks/aria/aria-unsupported-attr-evaluate.js
@@ -1,39 +1,46 @@
-const nodeName = node.nodeName.toUpperCase();
-const lookupTable = axe.commons.aria.lookupTable;
-const role = axe.commons.aria.getRole(node);
+import { lookupTable, getRole, validateAttr } from '../../commons/aria';
+import matches from '../../commons/matches';
+import { getNodeAttributes } from '../../core/utils';
 
-const unsupportedAttrs = Array.from(axe.utils.getNodeAttributes(node))
-	.filter(({ name }) => {
-		const attribute = lookupTable.attributes[name];
+function ariaUnsupportedAttrEvaluate(node) {
+	const nodeName = node.nodeName.toUpperCase();
+	const role = getRole(node);
 
-		if (!axe.commons.aria.validateAttr(name)) {
-			return false;
-		}
+	const unsupportedAttrs = Array.from(getNodeAttributes(node))
+		.filter(({ name }) => {
+			const attribute = lookupTable.attributes[name];
 
-		const { unsupported } = attribute;
+			if (!validateAttr(name)) {
+				return false;
+			}
 
-		if (typeof unsupported !== 'object') {
-			return !!unsupported;
-		}
+			const { unsupported } = attribute;
 
-		// validate attributes and conditions (if any) from allowedElement to given node
-		const isException = axe.commons.matches(node, unsupported.exceptions);
+			if (typeof unsupported !== 'object') {
+				return !!unsupported;
+			}
 
-		if (!Object.keys(lookupTable.evaluateRoleForElement).includes(nodeName)) {
-			return !isException;
-		}
+			// validate attributes and conditions (if any) from allowedElement to given node
+			const isException = matches(node, unsupported.exceptions);
 
-		// evaluate a given aria-role, execute the same
-		return !lookupTable.evaluateRoleForElement[nodeName]({
-			node,
-			role,
-			out: isException
-		});
-	})
-	.map(candidate => candidate.name.toString());
+			if (!Object.keys(lookupTable.evaluateRoleForElement).includes(nodeName)) {
+				return !isException;
+			}
 
-if (unsupportedAttrs.length) {
-	this.data(unsupportedAttrs);
-	return true;
+			// evaluate a given aria-role, execute the same
+			return !lookupTable.evaluateRoleForElement[nodeName]({
+				node,
+				role,
+				out: isException
+			});
+		})
+		.map(candidate => candidate.name.toString());
+
+	if (unsupportedAttrs.length) {
+		this.data(unsupportedAttrs);
+		return true;
+	}
+	return false;
 }
-return false;
+
+export default ariaUnsupportedAttrEvaluate;

--- a/lib/checks/aria/aria-unsupported-attr.json
+++ b/lib/checks/aria/aria-unsupported-attr.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-unsupported-attr",
-	"evaluate": "aria-unsupported-attr-evaluate.js",
+	"evaluate": "aria-unsupported-attr-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/aria-valid-attr-evaluate.js
+++ b/lib/checks/aria/aria-valid-attr-evaluate.js
@@ -1,25 +1,32 @@
-options = Array.isArray(options) ? options : [];
+import { validateAttr } from '../../commons/aria';
+import { getNodeAttributes } from '../../core/utils';
 
-var invalid = [],
-	aria = /^aria-/;
+function ariaValidAttrEvaluate(node, options) {
+	options = Array.isArray(options) ? options : [];
 
-var attr,
-	attrs = axe.utils.getNodeAttributes(node);
+	var invalid = [],
+		aria = /^aria-/;
 
-for (var i = 0, l = attrs.length; i < l; i++) {
-	attr = attrs[i].name;
-	if (
-		options.indexOf(attr) === -1 &&
-		aria.test(attr) &&
-		!axe.commons.aria.validateAttr(attr)
-	) {
-		invalid.push(attr);
+	var attr,
+		attrs = getNodeAttributes(node);
+
+	for (var i = 0, l = attrs.length; i < l; i++) {
+		attr = attrs[i].name;
+		if (
+			options.indexOf(attr) === -1 &&
+			aria.test(attr) &&
+			!validateAttr(attr)
+		) {
+			invalid.push(attr);
+		}
 	}
+
+	if (invalid.length) {
+		this.data(invalid);
+		return false;
+	}
+
+	return true;
 }
 
-if (invalid.length) {
-	this.data(invalid);
-	return false;
-}
-
-return true;
+export default ariaValidAttrEvaluate;

--- a/lib/checks/aria/aria-valid-attr-value-evaluate.js
+++ b/lib/checks/aria/aria-valid-attr-value-evaluate.js
@@ -1,80 +1,87 @@
-options = Array.isArray(options) ? options : [];
+import { validateAttrValue } from '../../commons/aria';
+import { getNodeAttributes } from '../../core/utils';
 
-let needsReview = '';
-let messageKey = '';
-const invalid = [];
-const aria = /^aria-/;
-const attrs = axe.utils.getNodeAttributes(node);
+function ariaValidAttrValueEvaluate(node, options) {
+	options = Array.isArray(options) ? options : [];
 
-const skipAttrs = ['aria-errormessage'];
+	let needsReview = '';
+	let messageKey = '';
+	const invalid = [];
+	const aria = /^aria-/;
+	const attrs = getNodeAttributes(node);
 
-const preChecks = {
-	// aria-controls should only check if element exists if the element
-	// doesn't have aria-expanded=false or aria-selected=false (tabs)
-	// @see https://github.com/dequelabs/axe-core/issues/1463
-	'aria-controls': () => {
-		return (
-			node.getAttribute('aria-expanded') !== 'false' &&
-			node.getAttribute('aria-selected') !== 'false'
-		);
-	},
-	// aria-current should mark as needs review if any value is used that is
-	// not one of the valid values (since any value is treated as "true")
-	'aria-current': () => {
-		if (!axe.commons.aria.validateAttrValue(node, 'aria-current')) {
-			needsReview = `aria-current="${node.getAttribute('aria-current')}"`;
-			messageKey = 'ariaCurrent';
+	const skipAttrs = ['aria-errormessage'];
+
+	const preChecks = {
+		// aria-controls should only check if element exists if the element
+		// doesn't have aria-expanded=false or aria-selected=false (tabs)
+		// @see https://github.com/dequelabs/axe-core/issues/1463
+		'aria-controls': () => {
+			return (
+				node.getAttribute('aria-expanded') !== 'false' &&
+				node.getAttribute('aria-selected') !== 'false'
+			);
+		},
+		// aria-current should mark as needs review if any value is used that is
+		// not one of the valid values (since any value is treated as "true")
+		'aria-current': () => {
+			if (!validateAttrValue(node, 'aria-current')) {
+				needsReview = `aria-current="${node.getAttribute('aria-current')}"`;
+				messageKey = 'ariaCurrent';
+			}
+
+			return;
+		},
+		// aria-owns should only check if element exists if the element
+		// doesn't have aria-expanded=false (combobox)
+		// @see https://github.com/dequelabs/axe-core/issues/1524
+		'aria-owns': () => {
+			return node.getAttribute('aria-expanded') !== 'false';
+		},
+		// aria-describedby should not mark missing element as violation but
+		// instead as needs review
+		// @see https://github.com/dequelabs/axe-core/issues/1151
+		'aria-describedby': () => {
+			if (!validateAttrValue(node, 'aria-describedby')) {
+				needsReview = `aria-describedby="${node.getAttribute(
+					'aria-describedby'
+				)}"`;
+				messageKey = 'noId';
+			}
+
+			return;
 		}
+	};
 
-		return;
-	},
-	// aria-owns should only check if element exists if the element
-	// doesn't have aria-expanded=false (combobox)
-	// @see https://github.com/dequelabs/axe-core/issues/1524
-	'aria-owns': () => {
-		return node.getAttribute('aria-expanded') !== 'false';
-	},
-	// aria-describedby should not mark missing element as violation but
-	// instead as needs review
-	// @see https://github.com/dequelabs/axe-core/issues/1151
-	'aria-describedby': () => {
-		if (!axe.commons.aria.validateAttrValue(node, 'aria-describedby')) {
-			needsReview = `aria-describedby="${node.getAttribute(
-				'aria-describedby'
-			)}"`;
-			messageKey = 'noId';
+	for (let i = 0, l = attrs.length; i < l; i++) {
+		const attr = attrs[i];
+		const attrName = attr.name;
+		// skip any attributes handled elsewhere
+		if (
+			!skipAttrs.includes(attrName) &&
+			options.indexOf(attrName) === -1 &&
+			aria.test(attrName) &&
+			(preChecks[attrName] ? preChecks[attrName]() : true) &&
+			!validateAttrValue(node, attrName)
+		) {
+			invalid.push(`${attrName}="${attr.nodeValue}"`);
 		}
-
-		return;
 	}
-};
 
-for (let i = 0, l = attrs.length; i < l; i++) {
-	const attr = attrs[i];
-	const attrName = attr.name;
-	// skip any attributes handled elsewhere
-	if (
-		!skipAttrs.includes(attrName) &&
-		options.indexOf(attrName) === -1 &&
-		aria.test(attrName) &&
-		(preChecks[attrName] ? preChecks[attrName]() : true) &&
-		!axe.commons.aria.validateAttrValue(node, attrName)
-	) {
-		invalid.push(`${attrName}="${attr.nodeValue}"`);
+	if (needsReview) {
+		this.data({
+			messageKey,
+			needsReview
+		});
+		return undefined;
 	}
+
+	if (invalid.length) {
+		this.data(invalid);
+		return false;
+	}
+
+	return true;
 }
 
-if (needsReview) {
-	this.data({
-		messageKey,
-		needsReview
-	});
-	return undefined;
-}
-
-if (invalid.length) {
-	this.data(invalid);
-	return false;
-}
-
-return true;
+export default ariaValidAttrValueEvaluate;

--- a/lib/checks/aria/aria-valid-attr-value.json
+++ b/lib/checks/aria/aria-valid-attr-value.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-valid-attr-value",
-	"evaluate": "aria-valid-attr-value-evaluate.js",
+	"evaluate": "aria-valid-attr-value-evaluate",
 	"options": [],
 	"metadata": {
 		"impact": "critical",

--- a/lib/checks/aria/aria-valid-attr.json
+++ b/lib/checks/aria/aria-valid-attr.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-valid-attr",
-	"evaluate": "aria-valid-attr-evaluate.js",
+	"evaluate": "aria-valid-attr-evaluate",
 	"options": [],
 	"metadata": {
 		"impact": "critical",

--- a/lib/checks/aria/fallbackrole-evaluate.js
+++ b/lib/checks/aria/fallbackrole-evaluate.js
@@ -1,1 +1,7 @@
-return axe.utils.tokenList(virtualNode.attr('role')).length > 1;
+import { tokenList } from '../../core/utils';
+
+function fallbackroleEvaluate(node, options, virtualNode) {
+	return tokenList(virtualNode.attr('role')).length > 1;
+}
+
+export default fallbackroleEvaluate;

--- a/lib/checks/aria/fallbackrole.json
+++ b/lib/checks/aria/fallbackrole.json
@@ -1,6 +1,6 @@
 {
 	"id": "fallbackrole",
-	"evaluate": "fallbackrole-evaluate.js",
+	"evaluate": "fallbackrole-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/aria/has-widget-role-evaluate.js
+++ b/lib/checks/aria/has-widget-role-evaluate.js
@@ -1,6 +1,12 @@
-var role = node.getAttribute('role');
-if (role === null) {
-	return false;
+import { getRoleType } from '../../commons/aria';
+
+function hasWidgetRoleEvaluate(node) {
+	const role = node.getAttribute('role');
+	if (role === null) {
+		return false;
+	}
+	const roleType = getRoleType(role);
+	return roleType === 'widget' || roleType === 'composite';
 }
-var roleType = axe.commons.aria.getRoleType(role);
-return roleType === 'widget' || roleType === 'composite';
+
+export default hasWidgetRoleEvaluate;

--- a/lib/checks/aria/has-widget-role.json
+++ b/lib/checks/aria/has-widget-role.json
@@ -1,6 +1,6 @@
 {
 	"id": "has-widget-role",
-	"evaluate": "has-widget-role-evaluate.js",
+	"evaluate": "has-widget-role-evaluate",
 	"options": [],
 	"metadata": {
 		"impact": "minor",

--- a/lib/checks/aria/implicit-role-fallback-evaluate.js
+++ b/lib/checks/aria/implicit-role-fallback-evaluate.js
@@ -1,6 +1,12 @@
-var role = node.getAttribute('role');
-if (role === null || !axe.commons.aria.isValidRole(role)) {
-	return true;
+import { isValidRole, getRoleType, implicitRole } from '../../commons/aria';
+
+function implicitRoleFallbackEvaluate(node) {
+	const role = node.getAttribute('role');
+	if (role === null || !isValidRole(role)) {
+		return true;
+	}
+	const roleType = getRoleType(role);
+	return implicitRole(node) === roleType;
 }
-var roleType = axe.commons.aria.getRoleType(role);
-return axe.commons.aria.implicitRole(node) === roleType;
+
+export default implicitRoleFallbackEvaluate;

--- a/lib/checks/aria/implicit-role-fallback.json
+++ b/lib/checks/aria/implicit-role-fallback.json
@@ -1,6 +1,6 @@
 {
 	"id": "implicit-role-fallback",
-	"evaluate": "implicit-role-fallback-evaluate.js",
+	"evaluate": "implicit-role-fallback-evaluate",
 	"deprecated": true,
 	"metadata": {
 		"impact": "moderate",

--- a/lib/checks/aria/invalidrole-evaluate.js
+++ b/lib/checks/aria/invalidrole-evaluate.js
@@ -1,17 +1,21 @@
-const { tokenList } = axe.utils;
-const { aria } = axe.commons;
+import { isValidRole } from '../../commons/aria';
+import { tokenList } from '../../core/utils';
 
-const allRoles = tokenList(virtualNode.attr('role'));
-const allInvalid = allRoles.every(
-	role => !aria.isValidRole(role, { allowAbstract: true })
-);
+function invalidroleEvaluate(node, options, virtualNode) {
+	const allRoles = tokenList(virtualNode.attr('role'));
+	const allInvalid = allRoles.every(
+		role => !isValidRole(role, { allowAbstract: true })
+	);
 
-/**
- * Only fail when all the roles are invalid
- */
-if (allInvalid) {
-	this.data(allRoles);
-	return true;
+	/**
+	 * Only fail when all the roles are invalid
+	 */
+	if (allInvalid) {
+		this.data(allRoles);
+		return true;
+	}
+
+	return false;
 }
 
-return false;
+export default invalidroleEvaluate;

--- a/lib/checks/aria/invalidrole.json
+++ b/lib/checks/aria/invalidrole.json
@@ -1,6 +1,6 @@
 {
 	"id": "invalidrole",
-	"evaluate": "invalidrole-evaluate.js",
+	"evaluate": "invalidrole-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/no-implicit-explicit-label-evaluate.js
+++ b/lib/checks/aria/no-implicit-explicit-label-evaluate.js
@@ -1,21 +1,26 @@
-const { aria, text } = axe.commons;
+import { getRole } from '../../commons/aria';
+import { sanitize, labelText, accessibleText } from '../../commons/text';
 
-const role = aria.getRole(node, { noImplicit: true });
-this.data(role);
+function noImplicitExplicitLabelEvaluate(node, options, virtualNode) {
+	const role = getRole(node, { noImplicit: true });
+	this.data(role);
 
-const labelText = text.sanitize(text.labelText(virtualNode)).toLowerCase();
-const accText = text.sanitize(text.accessibleText(node)).toLowerCase();
+	const label = sanitize(labelText(virtualNode)).toLowerCase();
+	const accText = sanitize(accessibleText(node)).toLowerCase();
 
-if (!accText && !labelText) {
+	if (!accText && !label) {
+		return false;
+	}
+
+	if (!accText && label) {
+		return undefined;
+	}
+
+	if (!accText.includes(label)) {
+		return undefined;
+	}
+
 	return false;
 }
 
-if (!accText && labelText) {
-	return undefined;
-}
-
-if (!accText.includes(labelText)) {
-	return undefined;
-}
-
-return false;
+export default noImplicitExplicitLabelEvaluate;

--- a/lib/checks/aria/no-implicit-explicit-label.json
+++ b/lib/checks/aria/no-implicit-explicit-label.json
@@ -1,6 +1,6 @@
 {
 	"id": "no-implicit-explicit-label",
-	"evaluate": "no-implicit-explicit-label-evaluate.js",
+	"evaluate": "no-implicit-explicit-label-evaluate",
 	"metadata": {
 		"impact": "moderate",
 		"messages": {

--- a/lib/checks/aria/unsupportedrole-evaluate.js
+++ b/lib/checks/aria/unsupportedrole-evaluate.js
@@ -1,1 +1,7 @@
-return axe.commons.aria.isUnsupportedRole(axe.commons.aria.getRole(node));
+import { isUnsupportedRole, getRole } from '../../commons/aria';
+
+function unsupportedroleEvaluate(node) {
+	return isUnsupportedRole(getRole(node));
+}
+
+export default unsupportedroleEvaluate;

--- a/lib/checks/aria/unsupportedrole.json
+++ b/lib/checks/aria/unsupportedrole.json
@@ -1,6 +1,6 @@
 {
 	"id": "unsupportedrole",
-	"evaluate": "unsupportedrole-evaluate.js",
+	"evaluate": "unsupportedrole-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/aria/valid-scrollable-semantics-evaluate.js
+++ b/lib/checks/aria/valid-scrollable-semantics-evaluate.js
@@ -55,8 +55,8 @@ function validScrollableRole(node) {
  * @return {Boolean} Whether the element would have valid semantics if it were a
  *			scrollable region.
  */
-function validScrollableSemantics(node) {
+function validScrollableSemanticsEvaluate(node) {
 	return validScrollableRole(node) || validScrollableTagName(node);
 }
 
-return validScrollableSemantics(node);
+export default validScrollableSemanticsEvaluate;

--- a/lib/checks/aria/valid-scrollable-semantics.json
+++ b/lib/checks/aria/valid-scrollable-semantics.json
@@ -1,6 +1,6 @@
 {
 	"id": "valid-scrollable-semantics",
-	"evaluate": "valid-scrollable-semantics-evaluate.js",
+	"evaluate": "valid-scrollable-semantics-evaluate",
 	"options": [],
 	"metadata": {
 		"impact": "minor",

--- a/lib/commons/index.js
+++ b/lib/commons/index.js
@@ -13,9 +13,9 @@ import * as forms from './forms';
 import matches from './matches';
 import * as table from './table';
 import * as text from './text';
-import utils from './utils';
+import * as utils from '../core/utils';
 
-commons = {
+var commons = {
 	aria,
 	color,
 	dom,
@@ -25,3 +25,5 @@ commons = {
 	text,
 	utils
 };
+
+export { aria, color, dom, forms, matches, table, text, utils };

--- a/lib/commons/table/get-cell-position.js
+++ b/lib/commons/table/get-cell-position.js
@@ -1,5 +1,6 @@
 import toGrid from './to-grid';
 import findUp from '../dom/find-up';
+import { memoize } from '../../core/utils';
 
 /**
  * Get the x, y coordinates of a table cell; normalized for rowspan and colspan
@@ -28,5 +29,4 @@ function getCellPosition(cell, tableGrid) {
 	}
 }
 
-// TODO: es-module-utils.memoize
-export default axe.utils.memoize(getCellPosition);
+export default memoize(getCellPosition);

--- a/lib/commons/table/to-grid.js
+++ b/lib/commons/table/to-grid.js
@@ -1,3 +1,5 @@
+import { memoize } from '../../core/utils';
+
 /**
  * Converts a table to an Array of arrays, normalized for row and column spans
  * @method toGrid
@@ -32,5 +34,4 @@ function toGrid(node) {
 	return table;
 }
 
-// TODO: es-module-utils.memoize
-export default axe.utils.memoize(toGrid);
+export default memoize(toGrid);

--- a/lib/commons/utils/index.js
+++ b/lib/commons/utils/index.js
@@ -1,6 +1,0 @@
-/**
- * Namespace for general utilities.
- * @namespace utils
- * @memberof axe.commons
- */
-export default axe.utils;

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -289,7 +289,6 @@ class Audit {
 	 */
 	_init() {
 		var audit = getDefaultConfiguration(this.defaultConfig);
-		// axe.commons = audit.commons;
 		this.lang = audit.lang || 'en';
 		this.reporter = audit.reporter;
 		this.commands = {};

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -289,7 +289,7 @@ class Audit {
 	 */
 	_init() {
 		var audit = getDefaultConfiguration(this.defaultConfig);
-		axe.commons = audit.commons;
+		// axe.commons = audit.commons;
 		this.lang = audit.lang || 'en';
 		this.reporter = audit.reporter;
 		this.commands = {};

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -5,8 +5,8 @@ import { DqElement, checkHelper } from '../utils';
 export function createExecutionContext(spec) {
 	/*eslint no-eval:0 */
 	if (typeof spec === 'string') {
-		if (metadataFunctionMap.has(spec)) {
-			return metadataFunctionMap.get(spec);
+		if (metadataFunctionMap[spec]) {
+			return metadataFunctionMap[spec];
 		}
 
 		return new Function('return ' + spec + ';')();

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -1,8 +1,45 @@
-/*eslint no-unused-vars:0*/
-// TODO: es-modules-checks
-// TODO: es-modules-rules
-// import all check evaluate and after functions, and all rule matches functions
+// aria
+import abstractroleEvaluate from '../../checks/aria/abstractrole-evaluate';
+import ariaAllowedAttrEvaluate from '../../checks/aria/aria-allowed-attr-evaluate';
+import ariaAllowedRoledEvaluate from '../../checks/aria/aria-allowed-role-evaluate';
+import ariaErrormessageEvaluate from '../../checks/aria/aria-errormessage-evaluate';
+import ariaHiddenBodyEvaluate from '../../checks/aria/aria-hidden-body-evaluate';
+import ariaRequiredAttrEvaluate from '../../checks/aria/aria-required-attr-evaluate';
+import ariaRequiredChildrenEvaluate from '../../checks/aria/aria-required-children-evaluate';
+import ariaRequiredParentEvaluate from '../../checks/aria/aria-required-parent-evaluate';
+import ariaRoledescriptionEvaluate from '../../checks/aria/aria-roledescription-evaluate';
+import ariaUnsupportedAttrEvaluate from '../../checks/aria/aria-unsupported-attr-evaluate';
+import ariaValidAttrEvaluate from '../../checks/aria/aria-valid-attr-evaluate';
+import ariaValidAttrValueEvaluate from '../../checks/aria/aria-valid-attr-value-evaluate';
+import fallbackroleEvaluate from '../../checks/aria/fallbackrole-evaluate';
+import hasWidgetRoleEvaluate from '../../checks/aria/has-widget-role-evaluate';
+import implicitRoleFallbackEvaluate from '../../checks/aria/implicit-role-fallback-evaluate';
+import invalidroleEvaluate from '../../checks/aria/invalidrole-evaluate';
+import noImplicitExplicitLabelEvaluate from '../../checks/aria/no-implicit-explicit-label-evaluate';
+import unsupportedroleEvaluate from '../../checks/aria/unsupportedrole-evaluate';
+import validScrollableSemanticsEvaluate from '../../checks/aria/valid-scrollable-semantics-evaluate';
 
-const metadataFunctionMap = new Map();
+const metadataFunctionMap = {
+	// aria
+	'abstractrole-evaluate': abstractroleEvaluate,
+	'aria-allowed-attr-evaluate': ariaAllowedAttrEvaluate,
+	'aria-allowed-role-evaluate': ariaAllowedRoledEvaluate,
+	'aria-errormessage-evaluate': ariaErrormessageEvaluate,
+	'aria-hidden-body-evaluate': ariaHiddenBodyEvaluate,
+	'aria-required-attr-evaluate': ariaRequiredAttrEvaluate,
+	'aria-required-children-evaluate': ariaRequiredChildrenEvaluate,
+	'aria-required-parent-evaluate': ariaRequiredParentEvaluate,
+	'aria-roledescription-evaluate': ariaRoledescriptionEvaluate,
+	'aria-unsupported-attr-evaluate': ariaUnsupportedAttrEvaluate,
+	'aria-valid-attr-evaluate': ariaValidAttrEvaluate,
+	'aria-valid-attr-value-evaluate': ariaValidAttrValueEvaluate,
+	'fallbackrole-evaluate': fallbackroleEvaluate,
+	'has-widget-role-evaluate': hasWidgetRoleEvaluate,
+	'implicit-role-fallback-evaluate': implicitRoleFallbackEvaluate,
+	'invalidrole-evaluate': invalidroleEvaluate,
+	'no-implicit-explicit-label-evaluate': noImplicitExplicitLabelEvaluate,
+	'unsupportedrole-evaluate': unsupportedroleEvaluate,
+	'valid-scrollable-semantics-evaluate': validScrollableSemanticsEvaluate
+};
 
 export default metadataFunctionMap;

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -35,6 +35,7 @@ import rawReporter from './reporters/raw';
 import v1Reporter from './reporters/v1';
 import v2Reporter from './reporters/v2';
 
+import * as commons from '../commons';
 import * as utils from './utils';
 
 axe.constants = constants;
@@ -76,6 +77,7 @@ axe._runRules = runRules;
 axe.runVirtualRule = runVirtualRule;
 axe.run = run;
 
+axe.commons = commons;
 axe.utils = utils;
 
 axe.addReporter('na', naReporter);

--- a/test/commons/index.js
+++ b/test/commons/index.js
@@ -1,7 +1,14 @@
 describe('axe.commons', function() {
 	'use strict';
 
-	it('should be an object', function() {
-		assert.isObject(axe.commons);
+	it('should export public api', function() {
+		assert.exists(axe.commons.aria);
+		assert.exists(axe.commons.color);
+		assert.exists(axe.commons.dom);
+		assert.exists(axe.commons.forms);
+		assert.exists(axe.commons.matches);
+		assert.exists(axe.commons.table);
+		assert.exists(axe.commons.text);
+		assert.exists(axe.commons.utils);
 	});
 });

--- a/test/core/public/load.js
+++ b/test/core/public/load.js
@@ -23,13 +23,6 @@ describe('axe._load', function() {
 		assert.equal(axe._audit.rules[1].id, 'bananas');
 	});
 
-	it('should define commons on axe', function() {
-		axe._load({
-			commons: 'foo'
-		});
-		assert.equal(axe.commons, 'foo');
-	});
-
 	it('should load with a lang', function() {
 		axe._load({
 			lang: 'ja'


### PR DESCRIPTION
I figured out how to do the checks in piecemeal and still have the code work. So here is the aria checks converted to use the function map instead of build time compilation of the function. I also was able to reduce the webpack to just the single `core.js` entry point. 

I'm not sure why `build/test/engine.js` decided to override the `_load` function to set the check data instead of just getting it from axe directly. Needed to fix this so the tests would work in the new format.

Lastly, for some reason `commons` was able to be set from the Audit, but that would no longer work with importing functions directly (and would break our code anyway if it didn't have functions we expected). It's not documented anywhere in our code comments nor public documentation, so I removed it. @WilcoFiers will need your OK on that one.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
