### PR TITLE
refactor(checks/*): convert remaining checks to es modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -76,18 +76,7 @@
       "files": [
         "lib/core/**/*.js",
         "lib/commons/**/*.js",
-        "lib/checks/navigation/**/*.js",
-        "lib/checks/aria/**/*.js",
-        "lib/checks/shared/**/*.js",
-        "lib/checks/tables/*.js",
-        "lib/checks/parsing/**/*.js",
-        "lib/checks/visibility/*.js",
-        "lib/checks/color/**/*.js",
-        "lib/checks/mobile/**/*.js",
-        "lib/checks/keyboard/**/*.js",
-        "lib/checks/label/**/*.js",
-        "lib/checks/forms/autocomplete-appropriate-evaluate.js",
-        "lib/checks/forms/autocomplete-valid-evaluate.js"
+        "lib/checks/**/*.js"
       ],
       "parserOptions":{
         "sourceType": "module"

--- a/lib/checks/forms/fieldset-after.js
+++ b/lib/checks/forms/fieldset-after.js
@@ -1,25 +1,29 @@
-var seen = {};
+function fieldsetAfter(results) {
+	var seen = {};
 
-return results.filter(function(result) {
-	// passes can pass through
-	if (result.result) {
-		return true;
-	}
-	var data = result.data;
-	if (data) {
-		seen[data.type] = seen[data.type] || {};
-		if (!seen[data.type][data.name]) {
-			seen[data.type][data.name] = [data];
+	return results.filter(function(result) {
+		// passes can pass through
+		if (result.result) {
 			return true;
 		}
-		var hasBeenSeen = seen[data.type][data.name].some(function(candidate) {
-			return candidate.failureCode === data.failureCode;
-		});
-		if (!hasBeenSeen) {
-			seen[data.type][data.name].push(data);
-		}
+		var data = result.data;
+		if (data) {
+			seen[data.type] = seen[data.type] || {};
+			if (!seen[data.type][data.name]) {
+				seen[data.type][data.name] = [data];
+				return true;
+			}
+			var hasBeenSeen = seen[data.type][data.name].some(function(candidate) {
+				return candidate.failureCode === data.failureCode;
+			});
+			if (!hasBeenSeen) {
+				seen[data.type][data.name].push(data);
+			}
 
-		return !hasBeenSeen;
-	}
-	return false;
-});
+			return !hasBeenSeen;
+		}
+		return false;
+	});
+}
+
+export default fieldsetAfter;

--- a/lib/checks/forms/fieldset-evaluate.js
+++ b/lib/checks/forms/fieldset-evaluate.js
@@ -1,109 +1,115 @@
-var failureCode,
-	self = this;
+function fieldsetEvaluate(node, options, virtualNode) {
+	var failureCode,
+		self = this;
 
-function getUnrelatedElements(parent, name) {
-	return axe.utils.toArray(
-		parent.querySelectorAll(
-			'select,textarea,button,input:not([name="' +
-				name +
-				'"]):not([type="hidden"])'
-		)
-	);
-}
-
-function checkFieldset(group, name) {
-	var firstNode = group.firstElementChild;
-	if (!firstNode || firstNode.nodeName.toUpperCase() !== 'LEGEND') {
-		self.relatedNodes([group]);
-		failureCode = 'no-legend';
-		return false;
-	}
-	if (!axe.commons.text.accessibleText(firstNode)) {
-		self.relatedNodes([firstNode]);
-		failureCode = 'empty-legend';
-		return false;
-	}
-	var otherElements = getUnrelatedElements(group, name);
-	if (otherElements.length) {
-		self.relatedNodes(otherElements);
-		failureCode = 'mixed-inputs';
-		return false;
-	}
-	return true;
-}
-
-function checkARIAGroup(group, name) {
-	var hasLabelledByText = axe.commons.dom
-		.idrefs(group, 'aria-labelledby')
-		.some(function(element) {
-			return element && axe.commons.text.accessibleText(element);
-		});
-	var ariaLabel = group.getAttribute('aria-label');
-	if (
-		!hasLabelledByText &&
-		!(ariaLabel && axe.commons.text.sanitize(ariaLabel))
-	) {
-		self.relatedNodes(group);
-		failureCode = 'no-group-label';
-		return false;
+	function getUnrelatedElements(parent, name) {
+		return axe.utils.toArray(
+			parent.querySelectorAll(
+				'select,textarea,button,input:not([name="' +
+					name +
+					'"]):not([type="hidden"])'
+			)
+		);
 	}
 
-	var otherElements = getUnrelatedElements(group, name);
-	if (otherElements.length) {
-		self.relatedNodes(otherElements);
-		failureCode = 'group-mixed-inputs';
-		return false;
-	}
-	return true;
-}
-
-function spliceCurrentNode(nodes, current) {
-	return axe.utils.toArray(nodes).filter(function(candidate) {
-		return candidate !== current;
-	});
-}
-
-function runCheck(virtualNode) {
-	const name = axe.utils.escapeSelector(virtualNode.actualNode.name);
-	const root = axe.commons.dom.getRootNode(virtualNode.actualNode);
-	const matchingNodes = root.querySelectorAll(
-		'input[type="' +
-			axe.utils.escapeSelector(virtualNode.actualNode.type) +
-			'"][name="' +
-			name +
-			'"]'
-	);
-
-	if (matchingNodes.length < 2) {
+	function checkFieldset(group, name) {
+		var firstNode = group.firstElementChild;
+		if (!firstNode || firstNode.nodeName.toUpperCase() !== 'LEGEND') {
+			self.relatedNodes([group]);
+			failureCode = 'no-legend';
+			return false;
+		}
+		if (!axe.commons.text.accessibleText(firstNode)) {
+			self.relatedNodes([firstNode]);
+			failureCode = 'empty-legend';
+			return false;
+		}
+		var otherElements = getUnrelatedElements(group, name);
+		if (otherElements.length) {
+			self.relatedNodes(otherElements);
+			failureCode = 'mixed-inputs';
+			return false;
+		}
 		return true;
 	}
-	const fieldset = axe.commons.dom.findUpVirtual(virtualNode, 'fieldset');
-	const group = axe.commons.dom.findUpVirtual(
-		virtualNode,
-		'[role="group"]' +
-			(virtualNode.actualNode.type === 'radio' ? ',[role="radiogroup"]' : '')
-	);
 
-	if (!group && !fieldset) {
-		failureCode = 'no-group';
-		self.relatedNodes(spliceCurrentNode(matchingNodes, virtualNode.actualNode));
-		return false;
-	} else if (fieldset) {
-		return checkFieldset(fieldset, name);
-	} else {
-		return checkARIAGroup(group, name);
+	function checkARIAGroup(group, name) {
+		var hasLabelledByText = axe.commons.dom
+			.idrefs(group, 'aria-labelledby')
+			.some(function(element) {
+				return element && axe.commons.text.accessibleText(element);
+			});
+		var ariaLabel = group.getAttribute('aria-label');
+		if (
+			!hasLabelledByText &&
+			!(ariaLabel && axe.commons.text.sanitize(ariaLabel))
+		) {
+			self.relatedNodes(group);
+			failureCode = 'no-group-label';
+			return false;
+		}
+
+		var otherElements = getUnrelatedElements(group, name);
+		if (otherElements.length) {
+			self.relatedNodes(otherElements);
+			failureCode = 'group-mixed-inputs';
+			return false;
+		}
+		return true;
 	}
+
+	function spliceCurrentNode(nodes, current) {
+		return axe.utils.toArray(nodes).filter(function(candidate) {
+			return candidate !== current;
+		});
+	}
+
+	function runCheck(virtualNode) {
+		const name = axe.utils.escapeSelector(virtualNode.actualNode.name);
+		const root = axe.commons.dom.getRootNode(virtualNode.actualNode);
+		const matchingNodes = root.querySelectorAll(
+			'input[type="' +
+				axe.utils.escapeSelector(virtualNode.actualNode.type) +
+				'"][name="' +
+				name +
+				'"]'
+		);
+
+		if (matchingNodes.length < 2) {
+			return true;
+		}
+		const fieldset = axe.commons.dom.findUpVirtual(virtualNode, 'fieldset');
+		const group = axe.commons.dom.findUpVirtual(
+			virtualNode,
+			'[role="group"]' +
+				(virtualNode.actualNode.type === 'radio' ? ',[role="radiogroup"]' : '')
+		);
+
+		if (!group && !fieldset) {
+			failureCode = 'no-group';
+			self.relatedNodes(
+				spliceCurrentNode(matchingNodes, virtualNode.actualNode)
+			);
+			return false;
+		} else if (fieldset) {
+			return checkFieldset(fieldset, name);
+		} else {
+			return checkARIAGroup(group, name);
+		}
+	}
+
+	var data = {
+		name: node.getAttribute('name'),
+		type: node.getAttribute('type')
+	};
+
+	var result = runCheck(virtualNode);
+	if (!result) {
+		data.messageKey = failureCode;
+	}
+	this.data(data);
+
+	return result;
 }
 
-var data = {
-	name: node.getAttribute('name'),
-	type: node.getAttribute('type')
-};
-
-var result = runCheck(virtualNode);
-if (!result) {
-	data.messageKey = failureCode;
-}
-this.data(data);
-
-return result;
+export default fieldsetEvaluate;

--- a/lib/checks/forms/fieldset.json
+++ b/lib/checks/forms/fieldset.json
@@ -1,7 +1,7 @@
 {
 	"id": "fieldset",
-	"evaluate": "fieldset-evaluate.js",
-	"after": "fieldset-after.js",
+	"evaluate": "fieldset-evaluate",
+	"after": "fieldset-after",
 	"deprecated": true,
 	"metadata": {
 		"impact": "critical",

--- a/lib/checks/forms/group-labelledby-after.js
+++ b/lib/checks/forms/group-labelledby-after.js
@@ -1,16 +1,20 @@
-var seen = {};
+function groupLabelledbyAfter(results) {
+	var seen = {};
 
-// Filter out nodes that have the same type and name.
-// If you have two `<input type="radio" name="foo" />` elements
-// only the first one can pass / fail the rule.
-return results.filter(function(result) {
-	var data = result.data;
-	if (data) {
-		seen[data.type] = seen[data.type] || {};
-		if (!seen[data.type][data.name]) {
-			seen[data.type][data.name] = true;
-			return true;
+	// Filter out nodes that have the same type and name.
+	// If you have two `<input type="radio" name="foo" />` elements
+	// only the first one can pass / fail the rule.
+	return results.filter(function(result) {
+		var data = result.data;
+		if (data) {
+			seen[data.type] = seen[data.type] || {};
+			if (!seen[data.type][data.name]) {
+				seen[data.type][data.name] = true;
+				return true;
+			}
 		}
-	}
-	return false;
-});
+		return false;
+	});
+}
+
+export default groupLabelledbyAfter;

--- a/lib/checks/forms/group-labelledby-evaluate.js
+++ b/lib/checks/forms/group-labelledby-evaluate.js
@@ -1,66 +1,72 @@
-const { dom, text } = axe.commons;
+function groupLabelledbyEvaluate(node) {
+	const { dom, text } = axe.commons;
 
-const type = axe.utils.escapeSelector(node.type);
-const name = axe.utils.escapeSelector(node.name);
-const doc = dom.getRootNode(node);
-const data = {
-	name: node.name,
-	type: node.type
-};
+	const type = axe.utils.escapeSelector(node.type);
+	const name = axe.utils.escapeSelector(node.name);
+	const doc = dom.getRootNode(node);
+	const data = {
+		name: node.name,
+		type: node.type
+	};
 
-const matchingNodes = Array.from(
-	doc.querySelectorAll(`input[type="${type}"][name="${name}"]`)
-);
-// There is only one node with this name & type, so there's no need for a group
-if (matchingNodes.length <= 1) {
-	this.data(data);
-	return true;
-}
-
-let sharedLabels = dom.idrefs(node, 'aria-labelledby').filter(label => !!label); // Filter for "null" labels
-let uniqueLabels = sharedLabels.slice();
-
-// Figure out which labels are unique, which are shared by all items, or neither
-matchingNodes.forEach(groupItem => {
-	if (groupItem === node) {
-		return;
+	const matchingNodes = Array.from(
+		doc.querySelectorAll(`input[type="${type}"][name="${name}"]`)
+	);
+	// There is only one node with this name & type, so there's no need for a group
+	if (matchingNodes.length <= 1) {
+		this.data(data);
+		return true;
 	}
-	// Find new labels associated with current groupItem
-	const labels = dom
-		.idrefs(groupItem, 'aria-labelledby')
-		.filter(newLabel => newLabel);
 
-	sharedLabels = sharedLabels.filter(sharedLabel =>
-		labels.includes(sharedLabel)
+	let sharedLabels = dom
+		.idrefs(node, 'aria-labelledby')
+		.filter(label => !!label); // Filter for "null" labels
+	let uniqueLabels = sharedLabels.slice();
+
+	// Figure out which labels are unique, which are shared by all items, or neither
+	matchingNodes.forEach(groupItem => {
+		if (groupItem === node) {
+			return;
+		}
+		// Find new labels associated with current groupItem
+		const labels = dom
+			.idrefs(groupItem, 'aria-labelledby')
+			.filter(newLabel => newLabel);
+
+		sharedLabels = sharedLabels.filter(sharedLabel =>
+			labels.includes(sharedLabel)
+		);
+		uniqueLabels = uniqueLabels.filter(
+			uniqueLabel => !labels.includes(uniqueLabel)
+		);
+	});
+
+	const accessibleTextOptions = {
+		// Prevent following further aria-labelledby refs:
+		inLabelledByContext: true
+	};
+
+	// filter items with no accessible name, do this last for performance reasons
+	uniqueLabels = uniqueLabels.filter(labelNode =>
+		text.accessibleText(labelNode, accessibleTextOptions)
 	);
-	uniqueLabels = uniqueLabels.filter(
-		uniqueLabel => !labels.includes(uniqueLabel)
+	sharedLabels = sharedLabels.filter(labelNode =>
+		text.accessibleText(labelNode, accessibleTextOptions)
 	);
-});
 
-const accessibleTextOptions = {
-	// Prevent following further aria-labelledby refs:
-	inLabelledByContext: true
-};
+	if (uniqueLabels.length > 0 && sharedLabels.length > 0) {
+		this.data(data);
+		return true;
+	}
 
-// filter items with no accessible name, do this last for performance reasons
-uniqueLabels = uniqueLabels.filter(labelNode =>
-	text.accessibleText(labelNode, accessibleTextOptions)
-);
-sharedLabels = sharedLabels.filter(labelNode =>
-	text.accessibleText(labelNode, accessibleTextOptions)
-);
+	if (uniqueLabels.length > 0 && sharedLabels.length === 0) {
+		data.messageKey = 'no-shared-label';
+	} else if (uniqueLabels.length === 0 && sharedLabels.length > 0) {
+		data.messageKey = 'no-unique-label';
+	}
 
-if (uniqueLabels.length > 0 && sharedLabels.length > 0) {
 	this.data(data);
-	return true;
+	return false;
 }
 
-if (uniqueLabels.length > 0 && sharedLabels.length === 0) {
-	data.messageKey = 'no-shared-label';
-} else if (uniqueLabels.length === 0 && sharedLabels.length > 0) {
-	data.messageKey = 'no-unique-label';
-}
-
-this.data(data);
-return false;
+export default groupLabelledbyEvaluate;

--- a/lib/checks/forms/group-labelledby.json
+++ b/lib/checks/forms/group-labelledby.json
@@ -1,7 +1,7 @@
 {
 	"id": "group-labelledby",
-	"evaluate": "group-labelledby-evaluate.js",
-	"after": "group-labelledby-after.js",
+	"evaluate": "group-labelledby-evaluate",
+	"after": "group-labelledby-after",
 	"deprecated": true,
 	"metadata": {
 		"impact": "critical",

--- a/lib/checks/landmarks/landmark-is-unique-after.js
+++ b/lib/checks/landmarks/landmark-is-unique-after.js
@@ -1,23 +1,27 @@
-var uniqueLandmarks = [];
+function landmarkIsUniqueAfter(results) {
+	var uniqueLandmarks = [];
 
-// filter out landmark elements that share the same role and accessible text
-// so every non-unique landmark isn't reported as a failure (just the first)
-return results.filter(currentResult => {
-	var findMatch = someResult => {
-		return (
-			currentResult.data.role === someResult.data.role &&
-			currentResult.data.accessibleText === someResult.data.accessibleText
-		);
-	};
+	// filter out landmark elements that share the same role and accessible text
+	// so every non-unique landmark isn't reported as a failure (just the first)
+	return results.filter(currentResult => {
+		var findMatch = someResult => {
+			return (
+				currentResult.data.role === someResult.data.role &&
+				currentResult.data.accessibleText === someResult.data.accessibleText
+			);
+		};
 
-	var matchedResult = uniqueLandmarks.find(findMatch);
-	if (matchedResult) {
-		matchedResult.result = false;
-		matchedResult.relatedNodes.push(currentResult.relatedNodes[0]);
-		return false;
-	}
+		var matchedResult = uniqueLandmarks.find(findMatch);
+		if (matchedResult) {
+			matchedResult.result = false;
+			matchedResult.relatedNodes.push(currentResult.relatedNodes[0]);
+			return false;
+		}
 
-	uniqueLandmarks.push(currentResult);
-	currentResult.relatedNodes = [];
-	return true;
-});
+		uniqueLandmarks.push(currentResult);
+		currentResult.relatedNodes = [];
+		return true;
+	});
+}
+
+export default landmarkIsUniqueAfter;

--- a/lib/checks/landmarks/landmark-is-unique-evaluate.js
+++ b/lib/checks/landmarks/landmark-is-unique-evaluate.js
@@ -1,7 +1,14 @@
-var role = axe.commons.aria.getRole(node);
-var accessibleText = axe.commons.text.accessibleTextVirtual(virtualNode);
-accessibleText = accessibleText ? accessibleText.toLowerCase() : null;
-this.data({ role: role, accessibleText: accessibleText });
-this.relatedNodes([node]);
+import { getRole } from '../../commons/aria';
+import { accessibleTextVirtual } from '../../commons/text';
 
-return true;
+function landmarkIsUniqueEvaluate(node, options, virtualNode) {
+	var role = getRole(node);
+	var accessibleText = accessibleTextVirtual(virtualNode);
+	accessibleText = accessibleText ? accessibleText.toLowerCase() : null;
+	this.data({ role: role, accessibleText: accessibleText });
+	this.relatedNodes([node]);
+
+	return true;
+}
+
+export default landmarkIsUniqueEvaluate;

--- a/lib/checks/landmarks/landmark-is-unique.json
+++ b/lib/checks/landmarks/landmark-is-unique.json
@@ -1,7 +1,7 @@
 {
 	"id": "landmark-is-unique",
-	"evaluate": "landmark-is-unique-evaluate.js",
-	"after": "landmark-is-unique-after.js",
+	"evaluate": "landmark-is-unique-evaluate",
+	"after": "landmark-is-unique-after",
 	"metadata": {
 		"impact": "moderate",
 		"messages": {

--- a/lib/checks/language/has-lang-evaluate.js
+++ b/lib/checks/language/has-lang-evaluate.js
@@ -1,20 +1,24 @@
-const { isXHTML } = axe.utils;
+import { isXHTML } from '../../core/utils';
 
-const langValue = (node.getAttribute(`lang`) || '').trim();
-const xmlLangValue = (node.getAttribute(`xml:lang`) || '').trim();
+function hasLangEvaluate(node) {
+	const langValue = (node.getAttribute(`lang`) || '').trim();
+	const xmlLangValue = (node.getAttribute(`xml:lang`) || '').trim();
 
-if (!langValue && xmlLangValue && !isXHTML(document)) {
-	this.data({
-		messageKey: 'noXHTML'
-	});
-	return false;
+	if (!langValue && xmlLangValue && !isXHTML(document)) {
+		this.data({
+			messageKey: 'noXHTML'
+		});
+		return false;
+	}
+
+	if (!(langValue || xmlLangValue)) {
+		this.data({
+			messageKey: 'noLang'
+		});
+		return false;
+	}
+
+	return true;
 }
 
-if (!(langValue || xmlLangValue)) {
-	this.data({
-		messageKey: 'noLang'
-	});
-	return false;
-}
-
-return true;
+export default hasLangEvaluate;

--- a/lib/checks/language/has-lang.json
+++ b/lib/checks/language/has-lang.json
@@ -1,6 +1,6 @@
 {
 	"id": "has-lang",
-	"evaluate": "has-lang-evaluate.js",
+	"evaluate": "has-lang-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/language/valid-lang-evaluate.js
+++ b/lib/checks/language/valid-lang-evaluate.js
@@ -1,26 +1,32 @@
-var langs, invalid;
+import { validLangs, getBaseLang } from '../../core/utils';
 
-langs = (options ? options : axe.utils.validLangs()).map(axe.utils.getBaseLang);
+function validLangEvaluate(node, options) {
+	var langs, invalid;
 
-invalid = ['lang', 'xml:lang'].reduce(function(invalid, langAttr) {
-	var langVal = node.getAttribute(langAttr);
-	if (typeof langVal !== 'string') {
+	langs = (options ? options : validLangs()).map(getBaseLang);
+
+	invalid = ['lang', 'xml:lang'].reduce(function(invalid, langAttr) {
+		var langVal = node.getAttribute(langAttr);
+		if (typeof langVal !== 'string') {
+			return invalid;
+		}
+
+		var baselangVal = getBaseLang(langVal);
+
+		// Edge sets lang to an empty string when xml:lang is set
+		// so we need to ignore empty strings here
+		if (baselangVal !== '' && langs.indexOf(baselangVal) === -1) {
+			invalid.push(langAttr + '="' + node.getAttribute(langAttr) + '"');
+		}
 		return invalid;
+	}, []);
+
+	if (invalid.length) {
+		this.data(invalid);
+		return true;
 	}
 
-	var baselangVal = axe.utils.getBaseLang(langVal);
-
-	// Edge sets lang to an empty string when xml:lang is set
-	// so we need to ignore empty strings here
-	if (baselangVal !== '' && langs.indexOf(baselangVal) === -1) {
-		invalid.push(langAttr + '="' + node.getAttribute(langAttr) + '"');
-	}
-	return invalid;
-}, []);
-
-if (invalid.length) {
-	this.data(invalid);
-	return true;
+	return false;
 }
 
-return false;
+export default validLangEvaluate;

--- a/lib/checks/language/valid-lang.json
+++ b/lib/checks/language/valid-lang.json
@@ -1,6 +1,6 @@
 {
 	"id": "valid-lang",
-	"evaluate": "valid-lang-evaluate.js",
+	"evaluate": "valid-lang-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/language/xml-lang-mismatch-evaluate.js
+++ b/lib/checks/language/xml-lang-mismatch-evaluate.js
@@ -1,5 +1,10 @@
-const { getBaseLang } = axe.utils;
-const primaryLangValue = getBaseLang(node.getAttribute('lang'));
-const primaryXmlLangValue = getBaseLang(node.getAttribute('xml:lang'));
+import { getBaseLang } from '../../core/utils';
 
-return primaryLangValue === primaryXmlLangValue;
+function xmlLangMismatchEvaluate(node) {
+	const primaryLangValue = getBaseLang(node.getAttribute('lang'));
+	const primaryXmlLangValue = getBaseLang(node.getAttribute('xml:lang'));
+
+	return primaryLangValue === primaryXmlLangValue;
+}
+
+export default xmlLangMismatchEvaluate;

--- a/lib/checks/language/xml-lang-mismatch.json
+++ b/lib/checks/language/xml-lang-mismatch.json
@@ -1,6 +1,6 @@
 {
 	"id": "xml-lang-mismatch",
-	"evaluate": "xml-lang-mismatch-evaluate.js",
+	"evaluate": "xml-lang-mismatch-evaluate",
 	"metadata": {
 		"impact": "moderate",
 		"messages": {

--- a/lib/checks/lists/dlitem-evaluate.js
+++ b/lib/checks/lists/dlitem-evaluate.js
@@ -1,23 +1,30 @@
-let parent = axe.commons.dom.getComposedParent(node);
-let parentTagName = parent.nodeName.toUpperCase();
-let parentRole = axe.commons.aria.getRole(parent, { noImplicit: true });
+import { getComposedParent } from '../../commons/dom';
+import { getRole } from '../../commons/aria';
 
-if (
-	parentTagName === 'DIV' &&
-	['presentation', 'none', null].includes(parentRole)
-) {
-	parent = axe.commons.dom.getComposedParent(parent);
-	parentTagName = parent.nodeName.toUpperCase();
-	parentRole = axe.commons.aria.getRole(parent, { noImplicit: true });
-}
+function dlitemEvaluate(node) {
+	let parent = getComposedParent(node);
+	let parentTagName = parent.nodeName.toUpperCase();
+	let parentRole = getRole(parent, { noImplicit: true });
 
-// Unlike with UL|OL+LI, DT|DD must be in a DL
-if (parentTagName !== 'DL') {
+	if (
+		parentTagName === 'DIV' &&
+		['presentation', 'none', null].includes(parentRole)
+	) {
+		parent = getComposedParent(parent);
+		parentTagName = parent.nodeName.toUpperCase();
+		parentRole = getRole(parent, { noImplicit: true });
+	}
+
+	// Unlike with UL|OL+LI, DT|DD must be in a DL
+	if (parentTagName !== 'DL') {
+		return false;
+	}
+
+	if (!parentRole || parentRole === 'list') {
+		return true;
+	}
+
 	return false;
 }
 
-if (!parentRole || parentRole === 'list') {
-	return true;
-}
-
-return false;
+export default dlitemEvaluate;

--- a/lib/checks/lists/dlitem.json
+++ b/lib/checks/lists/dlitem.json
@@ -1,6 +1,6 @@
 {
 	"id": "dlitem",
-	"evaluate": "dlitem-evaluate.js",
+	"evaluate": "dlitem-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/lists/listitem-evaluate.js
+++ b/lib/checks/lists/listitem-evaluate.js
@@ -1,21 +1,28 @@
-const parent = axe.commons.dom.getComposedParent(node);
-if (!parent) {
-	// Can only happen with detached DOM nodes and roots:
-	return undefined;
+import { getComposedParent } from '../../commons/dom';
+import { isValidRole } from '../../commons/aria';
+
+function listitemEvaluate(node) {
+	const parent = getComposedParent(node);
+	if (!parent) {
+		// Can only happen with detached DOM nodes and roots:
+		return undefined;
+	}
+
+	const parentTagName = parent.nodeName.toUpperCase();
+	const parentRole = (parent.getAttribute('role') || '').toLowerCase();
+
+	if (parentRole === 'list') {
+		return true;
+	}
+
+	if (parentRole && isValidRole(parentRole)) {
+		this.data({
+			messageKey: 'roleNotValid'
+		});
+		return false;
+	}
+
+	return ['UL', 'OL'].includes(parentTagName);
 }
 
-const parentTagName = parent.nodeName.toUpperCase();
-const parentRole = (parent.getAttribute('role') || '').toLowerCase();
-
-if (parentRole === 'list') {
-	return true;
-}
-
-if (parentRole && axe.commons.aria.isValidRole(parentRole)) {
-	this.data({
-		messageKey: 'roleNotValid'
-	});
-	return false;
-}
-
-return ['UL', 'OL'].includes(parentTagName);
+export default listitemEvaluate;

--- a/lib/checks/lists/listitem.json
+++ b/lib/checks/lists/listitem.json
@@ -1,6 +1,6 @@
 {
 	"id": "listitem",
-	"evaluate": "listitem-evaluate.js",
+	"evaluate": "listitem-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/lists/only-dlitems-evaluate.js
+++ b/lib/checks/lists/only-dlitems-evaluate.js
@@ -1,42 +1,51 @@
-const { dom, aria } = axe.commons;
-const ALLOWED_ROLES = ['definition', 'term', 'list'];
-let base = {
-	badNodes: [],
-	hasNonEmptyTextNode: false
-};
+import { isVisible } from '../../commons/dom';
+import { getRole } from '../../commons/aria';
 
-const content = virtualNode.children.reduce((content, child) => {
-	const { actualNode } = child;
-	if (
-		actualNode.nodeName.toUpperCase() === 'DIV' &&
-		aria.getRole(actualNode) === null
-	) {
-		return content.concat(child.children);
-	}
-	return content.concat(child);
-}, []);
+function onlyDlitemsEvaluate(node, options, virtualNode) {
+	const ALLOWED_ROLES = ['definition', 'term', 'list'];
+	let base = {
+		badNodes: [],
+		hasNonEmptyTextNode: false
+	};
 
-const result = content.reduce((out, childNode) => {
-	const { actualNode } = childNode;
-	const tagName = actualNode.nodeName.toUpperCase();
-
-	if (actualNode.nodeType === 1 && dom.isVisible(actualNode, true, false)) {
-		const explicitRole = aria.getRole(actualNode, { noImplicit: true });
-
-		if ((tagName !== 'DT' && tagName !== 'DD') || explicitRole) {
-			if (!ALLOWED_ROLES.includes(explicitRole)) {
-				// handle comment - https://github.com/dequelabs/axe-core/pull/518/files#r139284668
-				out.badNodes.push(actualNode);
-			}
+	const content = virtualNode.children.reduce((content, child) => {
+		const { actualNode } = child;
+		if (
+			actualNode.nodeName.toUpperCase() === 'DIV' &&
+			getRole(actualNode) === null
+		) {
+			return content.concat(child.children);
 		}
-	} else if (actualNode.nodeType === 3 && actualNode.nodeValue.trim() !== '') {
-		out.hasNonEmptyTextNode = true;
-	}
-	return out;
-}, base);
+		return content.concat(child);
+	}, []);
 
-if (result.badNodes.length) {
-	this.relatedNodes(result.badNodes);
+	const result = content.reduce((out, childNode) => {
+		const { actualNode } = childNode;
+		const tagName = actualNode.nodeName.toUpperCase();
+
+		if (actualNode.nodeType === 1 && isVisible(actualNode, true, false)) {
+			const explicitRole = getRole(actualNode, { noImplicit: true });
+
+			if ((tagName !== 'DT' && tagName !== 'DD') || explicitRole) {
+				if (!ALLOWED_ROLES.includes(explicitRole)) {
+					// handle comment - https://github.com/dequelabs/axe-core/pull/518/files#r139284668
+					out.badNodes.push(actualNode);
+				}
+			}
+		} else if (
+			actualNode.nodeType === 3 &&
+			actualNode.nodeValue.trim() !== ''
+		) {
+			out.hasNonEmptyTextNode = true;
+		}
+		return out;
+	}, base);
+
+	if (result.badNodes.length) {
+		this.relatedNodes(result.badNodes);
+	}
+
+	return !!result.badNodes.length || result.hasNonEmptyTextNode;
 }
 
-return !!result.badNodes.length || result.hasNonEmptyTextNode;
+export default onlyDlitemsEvaluate;

--- a/lib/checks/lists/only-dlitems.json
+++ b/lib/checks/lists/only-dlitems.json
@@ -1,6 +1,6 @@
 {
 	"id": "only-dlitems",
-	"evaluate": "only-dlitems-evaluate.js",
+	"evaluate": "only-dlitems-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/lists/only-listitems-evaluate.js
+++ b/lib/checks/lists/only-listitems-evaluate.js
@@ -1,58 +1,63 @@
-const { dom, aria } = axe.commons;
+import { isVisible } from '../../commons/dom';
+import { getRole } from '../../commons/aria';
 
-let hasNonEmptyTextNode = false;
-let atLeastOneListitem = false;
-let isEmpty = true;
-let badNodes = [];
-let badRoleNodes = [];
-let badRoles = [];
+function onlyListitemsEvaluate(node, options, virtualNode) {
+	let hasNonEmptyTextNode = false;
+	let atLeastOneListitem = false;
+	let isEmpty = true;
+	let badNodes = [];
+	let badRoleNodes = [];
+	let badRoles = [];
 
-virtualNode.children.forEach(vNode => {
-	const { actualNode } = vNode;
+	virtualNode.children.forEach(vNode => {
+		const { actualNode } = vNode;
 
-	if (actualNode.nodeType === 3 && actualNode.nodeValue.trim() !== '') {
-		hasNonEmptyTextNode = true;
-		return;
-	}
-
-	if (actualNode.nodeType !== 1 || !dom.isVisible(actualNode, true, false)) {
-		return;
-	}
-
-	isEmpty = false;
-	const isLi = actualNode.nodeName.toUpperCase() === 'LI';
-	const role = aria.getRole(vNode);
-	const isListItemRole = role === 'listitem';
-
-	if (!isLi && !isListItemRole) {
-		badNodes.push(actualNode);
-	}
-
-	if (isLi && !isListItemRole) {
-		badRoleNodes.push(actualNode);
-
-		if (!badRoles.includes(role)) {
-			badRoles.push(role);
+		if (actualNode.nodeType === 3 && actualNode.nodeValue.trim() !== '') {
+			hasNonEmptyTextNode = true;
+			return;
 		}
+
+		if (actualNode.nodeType !== 1 || !isVisible(actualNode, true, false)) {
+			return;
+		}
+
+		isEmpty = false;
+		const isLi = actualNode.nodeName.toUpperCase() === 'LI';
+		const role = getRole(vNode);
+		const isListItemRole = role === 'listitem';
+
+		if (!isLi && !isListItemRole) {
+			badNodes.push(actualNode);
+		}
+
+		if (isLi && !isListItemRole) {
+			badRoleNodes.push(actualNode);
+
+			if (!badRoles.includes(role)) {
+				badRoles.push(role);
+			}
+		}
+
+		if (isListItemRole) {
+			atLeastOneListitem = true;
+		}
+	});
+
+	if (hasNonEmptyTextNode || badNodes.length) {
+		this.relatedNodes(badNodes);
+		return true;
 	}
 
-	if (isListItemRole) {
-		atLeastOneListitem = true;
+	if (isEmpty || atLeastOneListitem) {
+		return false;
 	}
-});
 
-if (hasNonEmptyTextNode || badNodes.length) {
-	this.relatedNodes(badNodes);
+	this.relatedNodes(badRoleNodes);
+	this.data({
+		messageKey: 'roleNotValid',
+		roles: badRoles.join(', ')
+	});
 	return true;
 }
 
-if (isEmpty || atLeastOneListitem) {
-	return false;
-}
-
-this.relatedNodes(badRoleNodes);
-this.data({
-	messageKey: 'roleNotValid',
-	roles: badRoles.join(', ')
-});
-return true;
+export default onlyListitemsEvaluate;

--- a/lib/checks/lists/only-listitems.json
+++ b/lib/checks/lists/only-listitems.json
@@ -1,6 +1,6 @@
 {
 	"id": "only-listitems",
-	"evaluate": "only-listitems-evaluate.js",
+	"evaluate": "only-listitems-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/lists/structured-dlitems-evaluate.js
+++ b/lib/checks/lists/structured-dlitems-evaluate.js
@@ -1,22 +1,26 @@
-var children = virtualNode.children;
-if (!children || !children.length) {
-	return false;
-}
-
-var hasDt = false,
-	hasDd = false,
-	nodeName;
-for (var i = 0; i < children.length; i++) {
-	nodeName = children[i].actualNode.nodeName.toUpperCase();
-	if (nodeName === 'DT') {
-		hasDt = true;
-	}
-	if (hasDt && nodeName === 'DD') {
+function structuredDlitemsEvaluate(node, options, virtualNode) {
+	var children = virtualNode.children;
+	if (!children || !children.length) {
 		return false;
 	}
-	if (nodeName === 'DD') {
-		hasDd = true;
+
+	var hasDt = false,
+		hasDd = false,
+		nodeName;
+	for (var i = 0; i < children.length; i++) {
+		nodeName = children[i].actualNode.nodeName.toUpperCase();
+		if (nodeName === 'DT') {
+			hasDt = true;
+		}
+		if (hasDt && nodeName === 'DD') {
+			return false;
+		}
+		if (nodeName === 'DD') {
+			hasDd = true;
+		}
 	}
+
+	return hasDt || hasDd;
 }
 
-return hasDt || hasDd;
+export default structuredDlitemsEvaluate;

--- a/lib/checks/lists/structured-dlitems.json
+++ b/lib/checks/lists/structured-dlitems.json
@@ -1,6 +1,6 @@
 {
 	"id": "structured-dlitems",
-	"evaluate": "structured-dlitems-evaluate.js",
+	"evaluate": "structured-dlitems-evaluate",
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/media/caption-evaluate.js
+++ b/lib/checks/media/caption-evaluate.js
@@ -1,8 +1,14 @@
-const tracks = axe.utils.querySelectorAll(virtualNode, 'track');
-const hasCaptions = tracks.some(
-	({ actualNode }) =>
-		(actualNode.getAttribute('kind') || '').toLowerCase() === 'captions'
-);
+import { querySelectorAll } from '../../core/utils';
 
-// Undefined if there are no tracks - media may use another caption method
-return hasCaptions ? false : undefined;
+function captionEvaluate(node, options, virtualNode) {
+	const tracks = querySelectorAll(virtualNode, 'track');
+	const hasCaptions = tracks.some(
+		({ actualNode }) =>
+			(actualNode.getAttribute('kind') || '').toLowerCase() === 'captions'
+	);
+
+	// Undefined if there are no tracks - media may use another caption method
+	return hasCaptions ? false : undefined;
+}
+
+export default captionEvaluate;

--- a/lib/checks/media/caption.json
+++ b/lib/checks/media/caption.json
@@ -1,6 +1,6 @@
 {
 	"id": "caption",
-	"evaluate": "caption-evaluate.js",
+	"evaluate": "caption-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/media/description-evaluate.js
+++ b/lib/checks/media/description-evaluate.js
@@ -1,8 +1,14 @@
-const tracks = axe.utils.querySelectorAll(virtualNode, 'track');
-const hasDescriptions = tracks.some(
-	({ actualNode }) =>
-		(actualNode.getAttribute('kind') || '').toLowerCase() === 'descriptions'
-);
+import { querySelectorAll } from '../../core/utils';
 
-// Undefined if there are no tracks - media may have another description method
-return hasDescriptions ? false : undefined;
+function descriptionEvaluate(node, options, virtualNode) {
+	const tracks = querySelectorAll(virtualNode, 'track');
+	const hasDescriptions = tracks.some(
+		({ actualNode }) =>
+			(actualNode.getAttribute('kind') || '').toLowerCase() === 'descriptions'
+	);
+
+	// Undefined if there are no tracks - media may have another description method
+	return hasDescriptions ? false : undefined;
+}
+
+export default descriptionEvaluate;

--- a/lib/checks/media/description.json
+++ b/lib/checks/media/description.json
@@ -1,6 +1,6 @@
 {
 	"id": "description",
-	"evaluate": "description-evaluate.js",
+	"evaluate": "description-evaluate",
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/media/frame-tested-evaluate.js
+++ b/lib/checks/media/frame-tested-evaluate.js
@@ -1,28 +1,28 @@
-const resolve = this.async();
-const { isViolation, timeout } = Object.assign(
-	{ isViolation: false, timeout: 500 },
-	options
-);
+import { respondable } from '../../core/utils';
 
-// give the frame .5s to respond to 'axe.ping', else log failed response
-let timer = setTimeout(function() {
-	// This double timeout is important for allowing iframes to respond
-	// DO NOT REMOVE
-	timer = setTimeout(function() {
-		timer = null;
-		resolve(isViolation ? false : undefined);
-	}, 0);
-}, timeout);
+function frameTestedEvaluate(node, options) {
+	const resolve = this.async();
+	const { isViolation, timeout } = Object.assign(
+		{ isViolation: false, timeout: 500 },
+		options
+	);
 
-axe.utils.respondable(
-	node.contentWindow,
-	'axe.ping',
-	null,
-	undefined,
-	function() {
+	// give the frame .5s to respond to 'axe.ping', else log failed response
+	let timer = setTimeout(function() {
+		// This double timeout is important for allowing iframes to respond
+		// DO NOT REMOVE
+		timer = setTimeout(function() {
+			timer = null;
+			resolve(isViolation ? false : undefined);
+		}, 0);
+	}, timeout);
+
+	respondable(node.contentWindow, 'axe.ping', null, undefined, function() {
 		if (timer !== null) {
 			clearTimeout(timer);
 			resolve(true);
 		}
-	}
-);
+	});
+}
+
+export default frameTestedEvaluate;

--- a/lib/checks/media/frame-tested.json
+++ b/lib/checks/media/frame-tested.json
@@ -1,6 +1,6 @@
 {
 	"id": "frame-tested",
-	"evaluate": "frame-tested-evaluate.js",
+	"evaluate": "frame-tested-evaluate",
 	"options": {
 		"isViolation": false
 	},

--- a/lib/checks/media/no-autoplay-audio-evaluate.js
+++ b/lib/checks/media/no-autoplay-audio-evaluate.js
@@ -1,93 +1,97 @@
-/**
- * if duration cannot be read, this means `preloadMedia` has failed
- */
-if (!node.duration) {
-	console.warn(`axe.utils.preloadMedia did not load metadata`);
-	return undefined;
-}
+function noAutoplayAudioEvaluate(node, options) {
+	/**
+	 * if duration cannot be read, this means `preloadMedia` has failed
+	 */
+	if (!node.duration) {
+		console.warn(`axe.utils.preloadMedia did not load metadata`);
+		return undefined;
+	}
 
-/**
- * Compute playable duration and verify if it within allowed duration
- */
-const { allowedDuration = 3 } = options;
-const playableDuration = getPlayableDuration(node);
-if (playableDuration <= allowedDuration && !node.hasAttribute('loop')) {
+	/**
+	 * Compute playable duration and verify if it within allowed duration
+	 */
+	const { allowedDuration = 3 } = options;
+	const playableDuration = getPlayableDuration(node);
+	if (playableDuration <= allowedDuration && !node.hasAttribute('loop')) {
+		return true;
+	}
+
+	/**
+	 * if media element does not provide controls mechanism
+	 * -> fail
+	 */
+	if (!node.hasAttribute('controls')) {
+		return false;
+	}
+
 	return true;
-}
 
-/**
- * if media element does not provide controls mechanism
- * -> fail
- */
-if (!node.hasAttribute('controls')) {
-	return false;
-}
-
-return true;
-
-/**
- * Compute playback duration
- * @param {HTMLMediaElement} elm media element
- */
-function getPlayableDuration(elm) {
-	if (!elm.currentSrc) {
-		return 0;
-	}
-
-	const playbackRange = getPlaybackRange(elm.currentSrc);
-	if (!playbackRange) {
-		return Math.abs(elm.duration - (elm.currentTime || 0));
-	}
-
-	if (playbackRange.length === 1) {
-		return Math.abs(elm.duration - playbackRange[0]);
-	}
-
-	return Math.abs(playbackRange[1] - playbackRange[0]);
-}
-
-/**
- * Get playback range from a media elements source, if specified
- * See - https://developer.mozilla.org/de/docs/Web/HTML/Using_HTML5_audio_and_video#Specifying_playback_range
- *
- * Eg:
- * src='....someMedia.mp3#t=8'
- * 	-> should yeild [8]
- * src='....someMedia.mp3#t=10,12'
- *  -> should yeild [10,12]
- * @param {String} src media src
- * @returns {Array|undefined}
- */
-function getPlaybackRange(src) {
-	const match = src.match(/#t=(.*)/);
-	if (!match) {
-		return;
-	}
-	const [, value] = match;
-	const ranges = value.split(',');
-
-	return ranges.map(range => {
-		// range is denoted in HH:MM:SS -> convert to seconds
-		if (/:/.test(range)) {
-			return convertHourMinSecToSeconds(range);
+	/**
+	 * Compute playback duration
+	 * @param {HTMLMediaElement} elm media element
+	 */
+	function getPlayableDuration(elm) {
+		if (!elm.currentSrc) {
+			return 0;
 		}
-		return parseFloat(range);
-	});
-}
 
-/**
- * Add HH, MM, SS to seconds
- * @param {String} hhMmSs time expressed in HH:MM:SS
- */
-function convertHourMinSecToSeconds(hhMmSs) {
-	let parts = hhMmSs.split(':');
-	let secs = 0;
-	let mins = 1;
+		const playbackRange = getPlaybackRange(elm.currentSrc);
+		if (!playbackRange) {
+			return Math.abs(elm.duration - (elm.currentTime || 0));
+		}
 
-	while (parts.length > 0) {
-		secs += mins * parseInt(parts.pop(), 10);
-		mins *= 60;
+		if (playbackRange.length === 1) {
+			return Math.abs(elm.duration - playbackRange[0]);
+		}
+
+		return Math.abs(playbackRange[1] - playbackRange[0]);
 	}
 
-	return parseFloat(secs);
+	/**
+	 * Get playback range from a media elements source, if specified
+	 * See - https://developer.mozilla.org/de/docs/Web/HTML/Using_HTML5_audio_and_video#Specifying_playback_range
+	 *
+	 * Eg:
+	 * src='....someMedia.mp3#t=8'
+	 * 	-> should yeild [8]
+	 * src='....someMedia.mp3#t=10,12'
+	 *  -> should yeild [10,12]
+	 * @param {String} src media src
+	 * @returns {Array|undefined}
+	 */
+	function getPlaybackRange(src) {
+		const match = src.match(/#t=(.*)/);
+		if (!match) {
+			return;
+		}
+		const [, value] = match;
+		const ranges = value.split(',');
+
+		return ranges.map(range => {
+			// range is denoted in HH:MM:SS -> convert to seconds
+			if (/:/.test(range)) {
+				return convertHourMinSecToSeconds(range);
+			}
+			return parseFloat(range);
+		});
+	}
+
+	/**
+	 * Add HH, MM, SS to seconds
+	 * @param {String} hhMmSs time expressed in HH:MM:SS
+	 */
+	function convertHourMinSecToSeconds(hhMmSs) {
+		let parts = hhMmSs.split(':');
+		let secs = 0;
+		let mins = 1;
+
+		while (parts.length > 0) {
+			secs += mins * parseInt(parts.pop(), 10);
+			mins *= 60;
+		}
+
+		return parseFloat(secs);
+	}
 }
+
+export default noAutoplayAudioEvaluate;

--- a/lib/checks/media/no-autoplay-audio.json
+++ b/lib/checks/media/no-autoplay-audio.json
@@ -1,6 +1,6 @@
 {
 	"id": "no-autoplay-audio",
-	"evaluate": "no-autoplay-audio-evaluate.js",
+	"evaluate": "no-autoplay-audio-evaluate",
 	"options": {
 		"allowedDuration": 3
 	},

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -43,6 +43,10 @@ import linkInTextBlockEvaluate from '../../checks/color/link-in-text-block-evalu
 // forms
 import autocompleteAppropriateEvaluate from '../../checks/forms/autocomplete-appropriate-evaluate';
 import autocompleteValidEvaluate from '../../checks/forms/autocomplete-valid-evaluate';
+import fieldsetAfter from '../../checks/forms/fieldset-after';
+import fieldsetEvaluate from '../../checks/forms/fieldset-evaluate';
+import groupLabelledbyAfter from '../../checks/forms/group-labelledby-after';
+import groupLabelledbyEvaluate from '../../checks/forms/group-labelledby-evaluate';
 
 // navigation
 import headerPresentEvaluate from '../../checks/navigation/header-present-evaluate';
@@ -180,6 +184,10 @@ const metadataFunctionMap = {
 	// forms
 	'autocomplete-appropriate-evaluate': autocompleteAppropriateEvaluate,
 	'autocomplete-valid-evaluate': autocompleteValidEvaluate,
+	'fieldset-after': fieldsetAfter,
+	'fieldset-evaluate': fieldsetEvaluate,
+	'group-labelledby-after': groupLabelledbyAfter,
+	'group-labelledby-evaluate': groupLabelledbyEvaluate,
 
 	// navigation
 	'header-present-evaluate': headerPresentEvaluate,

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -112,6 +112,28 @@ import labelContentNameMismatchEvaluate from '../../checks/label/label-content-n
 import multipleLabelEvaluate from '../../checks/label/multiple-label-evaluate';
 import titleOnlyEvaluate from '../../checks/label/title-only-evaluate';
 
+// landmarks
+import landmarkIsUniqueAfter from '../../checks/landmarks/landmark-is-unique-after';
+import landmarkIsUniqueEvaluate from '../../checks/landmarks/landmark-is-unique-evaluate';
+
+// language
+import hasLangEvaluate from '../../checks/language/has-lang-evaluate';
+import validLangEvaluate from '../../checks/language/valid-lang-evaluate';
+import xmlLangMismatchEvaluate from '../../checks/language/xml-lang-mismatch-evaluate';
+
+// lists
+import dlitemEvaluate from '../../checks/lists/dlitem-evaluate';
+import listitemEvaluate from '../../checks/lists/listitem-evaluate';
+import onlyDlitemsEvaluate from '../../checks/lists/only-dlitems-evaluate';
+import onlyListitemsEvaluate from '../../checks/lists/only-listitems-evaluate';
+import structuredDlitemsEvaluate from '../../checks/lists/structured-dlitems-evaluate';
+
+// media
+import captionEvaluate from '../../checks/media/caption-evaluate';
+import descriptionEvaluate from '../../checks/media/description-evaluate';
+import frameTestedEvaluate from '../../checks/media/frame-tested-evaluate';
+import noAutoplayAudioEvaluate from '../../checks/media/no-autoplay-audio-evaluate';
+
 const metadataFunctionMap = {
 	// aria
 	'abstractrole-evaluate': abstractroleEvaluate,
@@ -225,7 +247,29 @@ const metadataFunctionMap = {
 	'implicit-evaluate': implicitEvaluate,
 	'label-content-name-mismatch-evaluate': labelContentNameMismatchEvaluate,
 	'multiple-label-evaluate': multipleLabelEvaluate,
-	'title-only-evaluate': titleOnlyEvaluate
+	'title-only-evaluate': titleOnlyEvaluate,
+
+	// landmarks
+	'landmark-is-unique-after': landmarkIsUniqueAfter,
+	'landmark-is-unique-evaluate': landmarkIsUniqueEvaluate,
+
+	// language
+	'has-lang-evaluate': hasLangEvaluate,
+	'valid-lang-evaluate': validLangEvaluate,
+	'xml-lang-mismatch-evaluate': xmlLangMismatchEvaluate,
+
+	// lists
+	'dlitem-evaluate': dlitemEvaluate,
+	'listitem-evaluate': listitemEvaluate,
+	'only-dlitems-evaluate': onlyDlitemsEvaluate,
+	'only-listitems-evaluate': onlyListitemsEvaluate,
+	'structured-dlitems-evaluate': structuredDlitemsEvaluate,
+
+	// media
+	'caption-evaluate': captionEvaluate,
+	'description-evaluate': descriptionEvaluate,
+	'frame-tested-evaluate': frameTestedEvaluate,
+	'no-autoplay-audio-evaluate': noAutoplayAudioEvaluate
 };
 
 export default metadataFunctionMap;


### PR DESCRIPTION
forms/fieldset and forms/group-labelledyby are being removed for 4.0 so i didn't bother converting them fully to es modules, just enough to get past the eslint.

Closes issue: #2122

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
