### PR TITLE
refactor(rules/*): convert to es modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,9 +74,7 @@
   "overrides": [
     {
       "files": [
-        "lib/core/**/*.js",
-        "lib/commons/**/*.js",
-        "lib/checks/**/*.js"
+        "lib/**/*.js"
       ],
       "parserOptions":{
         "sourceType": "module"

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -138,6 +138,43 @@ import descriptionEvaluate from '../../checks/media/description-evaluate';
 import frameTestedEvaluate from '../../checks/media/frame-tested-evaluate';
 import noAutoplayAudioEvaluate from '../../checks/media/no-autoplay-audio-evaluate';
 
+// rule matches
+import ariaAllowedAttrMatches from '../../rules/aria-allowed-attr-matches';
+import ariaAllowedRoleMatches from '../../rules/aria-allowed-role-matches';
+import ariaDpubRoleFallbackMatches from '../../rules/aria-dpub-role-fallback-matches';
+import ariaFormFieldNameMatches from '../../rules/aria-form-field-name-matches';
+import ariaHasAttrMatches from '../../rules/aria-has-attr-matches';
+import ariaHiddenFocusMatches from '../../rules/aria-hidden-focus-matches';
+import autocompleteMatches from '../../rules/autocomplete-matches';
+import bypassMatches from '../../rules/bypass-matches';
+import colorContrastMatches from '../../rules/color-contrast-matches';
+import dataTableLargeMatches from '../../rules/data-table-large-matches';
+import dataTableMatches from '../../rules/data-table-matches';
+import duplicateIdActiveMatches from '../../rules/duplicate-id-active-matches';
+import duplicateIdAriaMatches from '../../rules/duplicate-id-aria-matches';
+import duplicateIdMiscMatches from '../../rules/duplicate-id-misc-matches';
+import frameTitleHasTextMatches from '../../rules/frame-title-has-text-matches';
+import headingMatches from '../../rules/heading-matches';
+import htmlNamespaceMatches from '../../rules/html-namespace-matches';
+import identicalLinksSamePurposeMatches from '../../rules/identical-links-same-purpose-matches';
+import insertedIntoFocusOrderMatches from '../../rules/inserted-into-focus-order-matches';
+import labelContentNameMismatchMatches from '../../rules/label-content-name-mismatch-matches';
+import labelMatches from '../../rules/label-matches';
+import landmarkHasBodyContextMatches from '../../rules/landmark-has-body-context-matches';
+import landmarkUniqueMatches from '../../rules/landmark-unique-matches';
+import layoutTableMatches from '../../rules/layout-table-matches';
+import linkInTextBlockMatches from '../../rules/link-in-text-block-matches';
+import noAutoplayAudioMatches from '../../rules/no-autoplay-audio-matches';
+import noEmptyRoleMatches from '../../rules/no-empty-role-matches';
+import noRoleMatches from '../../rules/no-role-matches';
+import notHtmlMatches from '../../rules/not-html-matches';
+import pAsHeadingMatches from '../../rules/p-as-heading-matches';
+import scrollableRegionFocusableMatches from '../../rules/scrollable-region-focusable-matches';
+import skipLinkMatches from '../../rules/skip-link-matches';
+import svgNamespaceMatches from '../../rules/svg-namespace-matches';
+import windowIsTopMatches from '../../rules/window-is-top-matches';
+import xmlLangMismatchMatches from '../../rules/xml-lang-mismatch-matches';
+
 const metadataFunctionMap = {
 	// aria
 	'abstractrole-evaluate': abstractroleEvaluate,
@@ -277,7 +314,44 @@ const metadataFunctionMap = {
 	'caption-evaluate': captionEvaluate,
 	'description-evaluate': descriptionEvaluate,
 	'frame-tested-evaluate': frameTestedEvaluate,
-	'no-autoplay-audio-evaluate': noAutoplayAudioEvaluate
+	'no-autoplay-audio-evaluate': noAutoplayAudioEvaluate,
+
+	// rule matches
+	'aria-allowed-attr-matches': ariaAllowedAttrMatches,
+	'aria-allowed-role-matches': ariaAllowedRoleMatches,
+	'aria-dpub-role-fallback-matches': ariaDpubRoleFallbackMatches,
+	'aria-form-field-name-matches': ariaFormFieldNameMatches,
+	'aria-has-attr-matches': ariaHasAttrMatches,
+	'aria-hidden-focus-matches': ariaHiddenFocusMatches,
+	'autocomplete-matches': autocompleteMatches,
+	'bypass-matches': bypassMatches,
+	'color-contrast-matches': colorContrastMatches,
+	'data-table-large-matches': dataTableLargeMatches,
+	'data-table-matches': dataTableMatches,
+	'duplicate-id-active-matches': duplicateIdActiveMatches,
+	'duplicate-id-aria-matches': duplicateIdAriaMatches,
+	'duplicate-id-misc-matches': duplicateIdMiscMatches,
+	'frame-title-has-text-matches': frameTitleHasTextMatches,
+	'heading-matches': headingMatches,
+	'html-namespace-matches': htmlNamespaceMatches,
+	'identical-links-same-purpose-matches': identicalLinksSamePurposeMatches,
+	'inserted-into-focus-order-matches': insertedIntoFocusOrderMatches,
+	'label-content-name-mismatch-matches': labelContentNameMismatchMatches,
+	'label-matches': labelMatches,
+	'landmark-has-body-context-matches': landmarkHasBodyContextMatches,
+	'landmark-unique-matches': landmarkUniqueMatches,
+	'layout-table-matches': layoutTableMatches,
+	'link-in-text-block-matches': linkInTextBlockMatches,
+	'no-autoplay-audio-matches': noAutoplayAudioMatches,
+	'no-empty-role-matches': noEmptyRoleMatches,
+	'no-role-matches': noRoleMatches,
+	'not-html-matches': notHtmlMatches,
+	'p-as-heading-matches': pAsHeadingMatches,
+	'scrollable-region-focusable-matches': scrollableRegionFocusableMatches,
+	'skip-link-matches': skipLinkMatches,
+	'svg-namespace-matches': svgNamespaceMatches,
+	'window-is-top-matches': windowIsTopMatches,
+	'xml-lang-mismatch-matches': xmlLangMismatchMatches
 };
 
 export default metadataFunctionMap;

--- a/lib/rules/aria-allowed-attr-matches.js
+++ b/lib/rules/aria-allowed-attr-matches.js
@@ -1,11 +1,17 @@
-const aria = /^aria-/;
-if (node.hasAttributes()) {
-	let attrs = axe.utils.getNodeAttributes(node);
-	for (let i = 0, l = attrs.length; i < l; i++) {
-		if (aria.test(attrs[i].name)) {
-			return true;
+import { getNodeAttributes } from '../core/utils';
+
+function ariaAllowedAttrMatches(node) {
+	const aria = /^aria-/;
+	if (node.hasAttributes()) {
+		let attrs = getNodeAttributes(node);
+		for (let i = 0, l = attrs.length; i < l; i++) {
+			if (aria.test(attrs[i].name)) {
+				return true;
+			}
 		}
 	}
+
+	return false;
 }
 
-return false;
+export default ariaAllowedAttrMatches;

--- a/lib/rules/aria-allowed-attr.json
+++ b/lib/rules/aria-allowed-attr.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-allowed-attr",
-	"matches": "aria-allowed-attr-matches.js",
+	"matches": "aria-allowed-attr-matches",
 	"tags": ["cat.aria", "wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures ARIA attributes are allowed for an element's role",

--- a/lib/rules/aria-allowed-role-matches.js
+++ b/lib/rules/aria-allowed-role-matches.js
@@ -1,7 +1,13 @@
-return (
-	axe.commons.aria.getRole(node, {
-		noImplicit: true,
-		dpub: true,
-		fallback: true
-	}) !== null
-);
+import { getRole } from '../commons/aria';
+
+function ariaAllowedRoleMatches(node) {
+	return (
+		getRole(node, {
+			noImplicit: true,
+			dpub: true,
+			fallback: true
+		}) !== null
+	);
+}
+
+export default ariaAllowedRoleMatches;

--- a/lib/rules/aria-allowed-role.json
+++ b/lib/rules/aria-allowed-role.json
@@ -2,7 +2,7 @@
 	"id": "aria-allowed-role",
 	"excludeHidden": false,
 	"selector": "[role]",
-	"matches": "aria-allowed-role-matches.js",
+	"matches": "aria-allowed-role-matches",
 	"tags": ["cat.aria", "best-practice"],
 	"metadata": {
 		"description": "Ensures role attribute has an appropriate value for the element",

--- a/lib/rules/aria-dpub-role-fallback-matches.js
+++ b/lib/rules/aria-dpub-role-fallback-matches.js
@@ -1,10 +1,14 @@
-var role = node.getAttribute('role');
-return [
-	'doc-backlink',
-	'doc-biblioentry',
-	'doc-biblioref',
-	'doc-cover',
-	'doc-endnote',
-	'doc-glossref',
-	'doc-noteref'
-].includes(role);
+function ariaDpubRoleFallbackMatches(node) {
+	var role = node.getAttribute('role');
+	return [
+		'doc-backlink',
+		'doc-biblioentry',
+		'doc-biblioref',
+		'doc-cover',
+		'doc-endnote',
+		'doc-glossref',
+		'doc-noteref'
+	].includes(role);
+}
+
+export default ariaDpubRoleFallbackMatches;

--- a/lib/rules/aria-dpub-role-fallback.json
+++ b/lib/rules/aria-dpub-role-fallback.json
@@ -1,7 +1,7 @@
 {
 	"id": "aria-dpub-role-fallback",
 	"selector": "[role]",
-	"matches": "aria-dpub-role-fallback-matches.js",
+	"matches": "aria-dpub-role-fallback-matches",
 	"tags": ["cat.aria", "wcag2a", "wcag131", "deprecated"],
 	"metadata": {
 		"description": "Ensures unsupported DPUB roles are only used on elements with implicit fallback roles",

--- a/lib/rules/aria-form-field-name-matches.js
+++ b/lib/rules/aria-form-field-name-matches.js
@@ -1,50 +1,55 @@
-/**
- * Note:
- * This rule filters elements with 'role=*' attribute via 'selector'
- * see relevant rule spec for details of 'role(s)' being filtered.
- */
-const { aria } = axe.commons;
+import { getRole } from '../commons/aria';
+import { querySelectorAll } from '../core/utils';
 
-const nodeName = node.nodeName.toUpperCase();
-const role = aria.getRole(node, { noImplicit: true });
+function ariaFormFieldNameMatches(node, virtualNode) {
+	/**
+	 * Note:
+	 * This rule filters elements with 'role=*' attribute via 'selector'
+	 * see relevant rule spec for details of 'role(s)' being filtered.
+	 */
+	const nodeName = node.nodeName.toUpperCase();
+	const role = getRole(node, { noImplicit: true });
 
-/**
- * Ignore elements from rule -> 'area-alt'
- */
-if (nodeName === 'AREA' && !!node.getAttribute('href')) {
-	return false;
+	/**
+	 * Ignore elements from rule -> 'area-alt'
+	 */
+	if (nodeName === 'AREA' && !!node.getAttribute('href')) {
+		return false;
+	}
+
+	/**
+	 * Ignore elements from rule -> 'label'
+	 */
+	if (['INPUT', 'SELECT', 'TEXTAREA'].includes(nodeName)) {
+		return false;
+	}
+
+	/**
+	 * Ignore elements from rule -> 'image-alt'
+	 */
+	if (nodeName === 'IMG' || (role === 'img' && nodeName !== 'SVG')) {
+		return false;
+	}
+
+	/**
+	 * Ignore elements from rule -> 'button-name'
+	 */
+	if (nodeName === 'BUTTON' || role === 'button') {
+		return false;
+	}
+
+	/**
+	 * Ignore combobox elements if they have a child input
+	 * (ARIA 1.1 pattern)
+	 */
+	if (
+		role === 'combobox' &&
+		querySelectorAll(virtualNode, 'input:not([type="hidden"])').length
+	) {
+		return false;
+	}
+
+	return true;
 }
 
-/**
- * Ignore elements from rule -> 'label'
- */
-if (['INPUT', 'SELECT', 'TEXTAREA'].includes(nodeName)) {
-	return false;
-}
-
-/**
- * Ignore elements from rule -> 'image-alt'
- */
-if (nodeName === 'IMG' || (role === 'img' && nodeName !== 'SVG')) {
-	return false;
-}
-
-/**
- * Ignore elements from rule -> 'button-name'
- */
-if (nodeName === 'BUTTON' || role === 'button') {
-	return false;
-}
-
-/**
- * Ignore combobox elements if they have a child input
- * (ARIA 1.1 pattern)
- */
-if (
-	role === 'combobox' &&
-	axe.utils.querySelectorAll(virtualNode, 'input:not([type="hidden"])').length
-) {
-	return false;
-}
-
-return true;
+export default ariaFormFieldNameMatches;

--- a/lib/rules/aria-has-attr-matches.js
+++ b/lib/rules/aria-has-attr-matches.js
@@ -1,11 +1,17 @@
-var aria = /^aria-/;
-if (node.hasAttributes()) {
-	var attrs = axe.utils.getNodeAttributes(node);
-	for (var i = 0, l = attrs.length; i < l; i++) {
-		if (aria.test(attrs[i].name)) {
-			return true;
+import { getNodeAttributes } from '../core/utils';
+
+function ariaHasAttrMatches(node) {
+	var aria = /^aria-/;
+	if (node.hasAttributes()) {
+		var attrs = getNodeAttributes(node);
+		for (var i = 0, l = attrs.length; i < l; i++) {
+			if (aria.test(attrs[i].name)) {
+				return true;
+			}
 		}
 	}
+
+	return false;
 }
 
-return false;
+export default ariaHasAttrMatches;

--- a/lib/rules/aria-hidden-focus-matches.js
+++ b/lib/rules/aria-hidden-focus-matches.js
@@ -1,4 +1,4 @@
-const { getComposedParent } = axe.commons.dom;
+import { getComposedParent } from '../commons/dom';
 
 /**
  * Only match the outer-most `aria-hidden=true` element
@@ -15,4 +15,8 @@ function shouldMatchElement(el) {
 	return shouldMatchElement(getComposedParent(el));
 }
 
-return shouldMatchElement(getComposedParent(node));
+function ariaHiddenFocusMatches(node) {
+	return shouldMatchElement(getComposedParent(node));
+}
+
+export default ariaHiddenFocusMatches;

--- a/lib/rules/aria-hidden-focus.json
+++ b/lib/rules/aria-hidden-focus.json
@@ -1,7 +1,7 @@
 {
 	"id": "aria-hidden-focus",
 	"selector": "[aria-hidden=\"true\"]",
-	"matches": "aria-hidden-focus-matches.js",
+	"matches": "aria-hidden-focus-matches",
 	"excludeHidden": false,
 	"tags": ["cat.name-role-value", "wcag2a", "wcag412", "wcag131"],
 	"metadata": {

--- a/lib/rules/aria-input-field-name.json
+++ b/lib/rules/aria-input-field-name.json
@@ -1,7 +1,7 @@
 {
 	"id": "aria-input-field-name",
 	"selector": "[role=\"combobox\"], [role=\"listbox\"], [role=\"searchbox\"], [role=\"slider\"], [role=\"spinbutton\"], [role=\"textbox\"]",
-	"matches": "aria-form-field-name-matches.js",
+	"matches": "aria-form-field-name-matches",
 	"tags": ["wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures every ARIA input field has an accessible name",

--- a/lib/rules/aria-roles.json
+++ b/lib/rules/aria-roles.json
@@ -1,7 +1,7 @@
 {
 	"id": "aria-roles",
 	"selector": "[role]",
-	"matches": "no-empty-role-matches.js",
+	"matches": "no-empty-role-matches",
 	"tags": ["cat.aria", "wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures all elements with a role attribute use a valid value",

--- a/lib/rules/aria-toggle-field-name.json
+++ b/lib/rules/aria-toggle-field-name.json
@@ -1,7 +1,7 @@
 {
 	"id": "aria-toggle-field-name",
 	"selector": "[role=\"checkbox\"], [role=\"menuitemcheckbox\"], [role=\"menuitemradio\"], [role=\"radio\"], [role=\"switch\"]",
-	"matches": "aria-form-field-name-matches.js",
+	"matches": "aria-form-field-name-matches",
 	"tags": ["wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures every ARIA toggle field has an accessible name",

--- a/lib/rules/aria-valid-attr-value.json
+++ b/lib/rules/aria-valid-attr-value.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-valid-attr-value",
-	"matches": "aria-has-attr-matches.js",
+	"matches": "aria-has-attr-matches",
 	"tags": ["cat.aria", "wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures all ARIA attributes have valid values",

--- a/lib/rules/aria-valid-attr.json
+++ b/lib/rules/aria-valid-attr.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-valid-attr",
-	"matches": "aria-has-attr-matches.js",
+	"matches": "aria-has-attr-matches",
 	"tags": ["cat.aria", "wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures attributes that begin with aria- are valid ARIA attributes",

--- a/lib/rules/autocomplete-matches.js
+++ b/lib/rules/autocomplete-matches.js
@@ -1,49 +1,58 @@
-const { text, aria, dom } = axe.commons;
+import { sanitize } from '../commons/text';
+import { lookupTable } from '../commons/aria';
+import { isVisible } from '../commons/dom';
 
-const autocomplete = virtualNode.attr('autocomplete');
-if (!autocomplete || text.sanitize(autocomplete) === '') {
-	return false;
-}
-
-const nodeName = virtualNode.props.nodeName;
-if (['textarea', 'input', 'select'].includes(nodeName) === false) {
-	return false;
-}
-
-// The element is an `input` element a `type` of `hidden`, `button`, `submit` or `reset`
-const excludedInputTypes = ['submit', 'reset', 'button', 'hidden'];
-if (
-	nodeName === 'input' &&
-	excludedInputTypes.includes(virtualNode.props.type)
-) {
-	return false;
-}
-
-// The element has a `disabled` or `aria-disabled="true"` attribute
-const ariaDisabled = virtualNode.attr('aria-disabled') || 'false';
-if (virtualNode.hasAttr('disabled') || ariaDisabled.toLowerCase() === 'true') {
-	return false;
-}
-
-// The element has `tabindex="-1"` and has a [[semantic role]] that is
-//   not a [widget](https://www.w3.org/TR/wai-aria-1.1/#widget_roles)
-const role = virtualNode.attr('role');
-const tabIndex = virtualNode.attr('tabindex');
-if (tabIndex === '-1' && role) {
-	const roleDef = aria.lookupTable.role[role];
-	if (roleDef === undefined || roleDef.type !== 'widget') {
+function autocompleteMatches(node, virtualNode) {
+	const autocomplete = virtualNode.attr('autocomplete');
+	if (!autocomplete || sanitize(autocomplete) === '') {
 		return false;
 	}
+
+	const nodeName = virtualNode.props.nodeName;
+	if (['textarea', 'input', 'select'].includes(nodeName) === false) {
+		return false;
+	}
+
+	// The element is an `input` element a `type` of `hidden`, `button`, `submit` or `reset`
+	const excludedInputTypes = ['submit', 'reset', 'button', 'hidden'];
+	if (
+		nodeName === 'input' &&
+		excludedInputTypes.includes(virtualNode.props.type)
+	) {
+		return false;
+	}
+
+	// The element has a `disabled` or `aria-disabled="true"` attribute
+	const ariaDisabled = virtualNode.attr('aria-disabled') || 'false';
+	if (
+		virtualNode.hasAttr('disabled') ||
+		ariaDisabled.toLowerCase() === 'true'
+	) {
+		return false;
+	}
+
+	// The element has `tabindex="-1"` and has a [[semantic role]] that is
+	//   not a [widget](https://www.w3.org/TR/wai-aria-1.1/#widget_roles)
+	const role = virtualNode.attr('role');
+	const tabIndex = virtualNode.attr('tabindex');
+	if (tabIndex === '-1' && role) {
+		const roleDef = lookupTable.role[role];
+		if (roleDef === undefined || roleDef.type !== 'widget') {
+			return false;
+		}
+	}
+
+	// The element is **not** visible on the page or exposed to assistive technologies
+	if (
+		tabIndex === '-1' &&
+		virtualNode.actualNode &&
+		!isVisible(virtualNode.actualNode, false) &&
+		!isVisible(virtualNode.actualNode, true)
+	) {
+		return false;
+	}
+
+	return true;
 }
 
-// The element is **not** visible on the page or exposed to assistive technologies
-if (
-	tabIndex === '-1' &&
-	virtualNode.actualNode &&
-	!dom.isVisible(virtualNode.actualNode, false) &&
-	!dom.isVisible(virtualNode.actualNode, true)
-) {
-	return false;
-}
-
-return true;
+export default autocompleteMatches;

--- a/lib/rules/autocomplete-valid.json
+++ b/lib/rules/autocomplete-valid.json
@@ -1,6 +1,6 @@
 {
 	"id": "autocomplete-valid",
-	"matches": "autocomplete-matches.js",
+	"matches": "autocomplete-matches",
 	"tags": ["cat.forms", "wcag21aa", "wcag135"],
 	"metadata": {
 		"description": "Ensure the autocomplete attribute is correct and suitable for the form field",

--- a/lib/rules/bypass-matches.js
+++ b/lib/rules/bypass-matches.js
@@ -1,1 +1,5 @@
-return !!node.querySelector('a[href]');
+function bypassMatches(node) {
+	return !!node.querySelector('a[href]');
+}
+
+export default bypassMatches;

--- a/lib/rules/bypass.json
+++ b/lib/rules/bypass.json
@@ -2,7 +2,7 @@
 	"id": "bypass",
 	"selector": "html",
 	"pageLevel": true,
-	"matches": "bypass-matches.js",
+	"matches": "bypass-matches",
 	"tags": [
 		"cat.keyboard",
 		"wcag2a",

--- a/lib/rules/color-contrast-matches.js
+++ b/lib/rules/color-contrast-matches.js
@@ -1,161 +1,170 @@
-/* global document */
+import { findUpVirtual, visuallyOverlaps, getRootNode } from '../commons/dom';
+import { visibleVirtual, removeUnicode, sanitize } from '../commons/text';
+import {
+	getNodeFromTree,
+	querySelectorAll,
+	escapeSelector
+} from '../core/utils';
 
-const nodeName = node.nodeName.toUpperCase();
-const nodeType = node.type;
+function colorContrastMatches(node, virtualNode) {
+	/* global document */
 
-if (
-	node.getAttribute('aria-disabled') === 'true' ||
-	axe.commons.dom.findUpVirtual(virtualNode, '[aria-disabled="true"]')
-) {
-	return false;
-}
+	const nodeName = node.nodeName.toUpperCase();
+	const nodeType = node.type;
 
-// form elements that don't have direct child text nodes need to check that
-// the text indent has not been changed and moved the text away from the
-// control
-const formElements = ['INPUT', 'SELECT', 'TEXTAREA'];
-if (formElements.includes(nodeName)) {
-	const style = window.getComputedStyle(node);
-	const textIndent = parseInt(style.getPropertyValue('text-indent'), 10);
+	if (
+		node.getAttribute('aria-disabled') === 'true' ||
+		findUpVirtual(virtualNode, '[aria-disabled="true"]')
+	) {
+		return false;
+	}
 
-	if (textIndent) {
-		// since we can't get the actual bounding rect of the text node, we'll
-		// use the current nodes bounding rect and adjust by the text-indent to
-		// see if it still overlaps the node
-		let rect = node.getBoundingClientRect();
-		rect = {
-			top: rect.top,
-			bottom: rect.bottom,
-			left: rect.left + textIndent,
-			right: rect.right + textIndent
-		};
+	// form elements that don't have direct child text nodes need to check that
+	// the text indent has not been changed and moved the text away from the
+	// control
+	const formElements = ['INPUT', 'SELECT', 'TEXTAREA'];
+	if (formElements.includes(nodeName)) {
+		const style = window.getComputedStyle(node);
+		const textIndent = parseInt(style.getPropertyValue('text-indent'), 10);
 
-		if (!axe.commons.dom.visuallyOverlaps(rect, node)) {
+		if (textIndent) {
+			// since we can't get the actual bounding rect of the text node, we'll
+			// use the current nodes bounding rect and adjust by the text-indent to
+			// see if it still overlaps the node
+			let rect = node.getBoundingClientRect();
+			rect = {
+				top: rect.top,
+				bottom: rect.bottom,
+				left: rect.left + textIndent,
+				right: rect.right + textIndent
+			};
+
+			if (!visuallyOverlaps(rect, node)) {
+				return false;
+			}
+		}
+	}
+
+	if (nodeName === 'INPUT') {
+		return (
+			['hidden', 'range', 'color', 'checkbox', 'radio', 'image'].indexOf(
+				nodeType
+			) === -1 && !node.disabled
+		);
+	}
+
+	if (nodeName === 'SELECT') {
+		return !!node.options.length && !node.disabled;
+	}
+
+	if (nodeName === 'TEXTAREA') {
+		return !node.disabled;
+	}
+
+	if (nodeName === 'OPTION') {
+		return false;
+	}
+
+	if (
+		(nodeName === 'BUTTON' && node.disabled) ||
+		findUpVirtual(virtualNode, 'button[disabled]')
+	) {
+		return false;
+	}
+
+	if (
+		(nodeName === 'FIELDSET' && node.disabled) ||
+		findUpVirtual(virtualNode, 'fieldset[disabled]')
+	) {
+		return false;
+	}
+
+	// check if the element is a label or label descendant for a disabled control
+	const nodeParentLabel = findUpVirtual(virtualNode, 'label');
+	if (nodeName === 'LABEL' || nodeParentLabel) {
+		let relevantNode = node;
+		let relevantVirtualNode = virtualNode;
+
+		if (nodeParentLabel) {
+			relevantNode = nodeParentLabel;
+			// we need an input candidate from a parent to account for label children
+			relevantVirtualNode = getNodeFromTree(nodeParentLabel);
+		}
+		// explicit label of disabled input
+		const doc = getRootNode(relevantNode);
+		let candidate =
+			relevantNode.htmlFor && doc.getElementById(relevantNode.htmlFor);
+		const candidateVirtualNode = getNodeFromTree(candidate);
+
+		if (
+			candidate &&
+			(candidate.disabled ||
+				candidate.getAttribute('aria-disabled') === 'true' ||
+				findUpVirtual(candidateVirtualNode, '[aria-disabled="true"]'))
+		) {
+			return false;
+		}
+
+		candidate = querySelectorAll(
+			relevantVirtualNode,
+			'input:not([type="hidden"]):not([type="image"])' +
+				':not([type="button"]):not([type="submit"]):not([type="reset"]), select, textarea'
+		);
+		if (candidate.length && candidate[0].actualNode.disabled) {
 			return false;
 		}
 	}
-}
 
-if (nodeName === 'INPUT') {
-	return (
-		['hidden', 'range', 'color', 'checkbox', 'radio', 'image'].indexOf(
-			nodeType
-		) === -1 && !node.disabled
-	);
-}
-
-if (nodeName === 'SELECT') {
-	return !!node.options.length && !node.disabled;
-}
-
-if (nodeName === 'TEXTAREA') {
-	return !node.disabled;
-}
-
-if (nodeName === 'OPTION') {
-	return false;
-}
-
-if (
-	(nodeName === 'BUTTON' && node.disabled) ||
-	axe.commons.dom.findUpVirtual(virtualNode, 'button[disabled]')
-) {
-	return false;
-}
-
-if (
-	(nodeName === 'FIELDSET' && node.disabled) ||
-	axe.commons.dom.findUpVirtual(virtualNode, 'fieldset[disabled]')
-) {
-	return false;
-}
-
-// check if the element is a label or label descendant for a disabled control
-const nodeParentLabel = axe.commons.dom.findUpVirtual(virtualNode, 'label');
-if (nodeName === 'LABEL' || nodeParentLabel) {
-	let relevantNode = node;
-	let relevantVirtualNode = virtualNode;
-
-	if (nodeParentLabel) {
-		relevantNode = nodeParentLabel;
-		// we need an input candidate from a parent to account for label children
-		relevantVirtualNode = axe.utils.getNodeFromTree(nodeParentLabel);
+	// label of disabled control associated w/ aria-labelledby
+	if (node.getAttribute('id')) {
+		const id = escapeSelector(node.getAttribute('id'));
+		const doc = getRootNode(node);
+		const candidate = doc.querySelector('[aria-labelledby~=' + id + ']');
+		if (candidate && candidate.disabled) {
+			return false;
+		}
 	}
-	// explicit label of disabled input
-	const doc = axe.commons.dom.getRootNode(relevantNode);
-	let candidate =
-		relevantNode.htmlFor && doc.getElementById(relevantNode.htmlFor);
-	const candidateVirtualNode = axe.utils.getNodeFromTree(candidate);
 
+	const visibleText = visibleVirtual(virtualNode, false, true);
 	if (
-		candidate &&
-		(candidate.disabled ||
-			candidate.getAttribute('aria-disabled') === 'true' ||
-			axe.commons.dom.findUpVirtual(
-				candidateVirtualNode,
-				'[aria-disabled="true"]'
-			))
+		visibleText === '' ||
+		removeUnicode(visibleText, {
+			emoji: true,
+			nonBmp: false,
+			punctuations: true
+		}) === ''
 	) {
 		return false;
 	}
 
-	candidate = axe.utils.querySelectorAll(
-		relevantVirtualNode,
-		'input:not([type="hidden"]):not([type="image"])' +
-			':not([type="button"]):not([type="submit"]):not([type="reset"]), select, textarea'
-	);
-	if (candidate.length && candidate[0].actualNode.disabled) {
-		return false;
-	}
-}
+	const range = document.createRange();
+	const childNodes = virtualNode.children;
+	let length = childNodes.length;
+	let child = null;
+	let index = 0;
 
-// label of disabled control associated w/ aria-labelledby
-if (node.getAttribute('id')) {
-	const id = axe.utils.escapeSelector(node.getAttribute('id'));
-	const doc = axe.commons.dom.getRootNode(node);
-	const candidate = doc.querySelector('[aria-labelledby~=' + id + ']');
-	if (candidate && candidate.disabled) {
-		return false;
-	}
-}
+	for (index = 0; index < length; index++) {
+		child = childNodes[index];
 
-const visibleText = axe.commons.text.visibleVirtual(virtualNode, false, true);
-if (
-	visibleText === '' ||
-	axe.commons.text.removeUnicode(visibleText, {
-		emoji: true,
-		nonBmp: false,
-		punctuations: true
-	}) === ''
-) {
+		if (
+			child.actualNode.nodeType === 3 &&
+			sanitize(child.actualNode.nodeValue) !== ''
+		) {
+			range.selectNodeContents(child.actualNode);
+		}
+	}
+
+	const rects = range.getClientRects();
+	length = rects.length;
+
+	for (index = 0; index < length; index++) {
+		//check to see if the rectangle impinges
+		if (visuallyOverlaps(rects[index], node)) {
+			return true;
+		}
+	}
+
 	return false;
 }
 
-const range = document.createRange();
-const childNodes = virtualNode.children;
-let length = childNodes.length;
-let child = null;
-let index = 0;
-
-for (index = 0; index < length; index++) {
-	child = childNodes[index];
-
-	if (
-		child.actualNode.nodeType === 3 &&
-		axe.commons.text.sanitize(child.actualNode.nodeValue) !== ''
-	) {
-		range.selectNodeContents(child.actualNode);
-	}
-}
-
-const rects = range.getClientRects();
-length = rects.length;
-
-for (index = 0; index < length; index++) {
-	//check to see if the rectangle impinges
-	if (axe.commons.dom.visuallyOverlaps(rects[index], node)) {
-		return true;
-	}
-}
-
-return false;
+export default colorContrastMatches;

--- a/lib/rules/color-contrast.json
+++ b/lib/rules/color-contrast.json
@@ -1,6 +1,6 @@
 {
 	"id": "color-contrast",
-	"matches": "color-contrast-matches.js",
+	"matches": "color-contrast-matches",
 	"excludeHidden": false,
 	"tags": ["cat.color", "wcag2aa", "wcag143"],
 	"metadata": {

--- a/lib/rules/data-table-large-matches.js
+++ b/lib/rules/data-table-large-matches.js
@@ -1,11 +1,17 @@
-if (axe.commons.table.isDataTable(node)) {
-	var tableArray = axe.commons.table.toArray(node);
-	return (
-		tableArray.length >= 3 &&
-		tableArray[0].length >= 3 &&
-		tableArray[1].length >= 3 &&
-		tableArray[2].length >= 3
-	);
+import { isDataTable, toArray } from '../commons/table';
+
+function dataTableLargeMatches(node) {
+	if (isDataTable(node)) {
+		var tableArray = toArray(node);
+		return (
+			tableArray.length >= 3 &&
+			tableArray[0].length >= 3 &&
+			tableArray[1].length >= 3 &&
+			tableArray[2].length >= 3
+		);
+	}
+
+	return false;
 }
 
-return false;
+export default dataTableLargeMatches;

--- a/lib/rules/data-table-matches.js
+++ b/lib/rules/data-table-matches.js
@@ -1,1 +1,7 @@
-return axe.commons.table.isDataTable(node);
+import { isDataTable } from '../commons/table';
+
+function dataTableMatches(node) {
+	return isDataTable(node);
+}
+
+export default dataTableMatches;

--- a/lib/rules/definition-list.json
+++ b/lib/rules/definition-list.json
@@ -1,7 +1,7 @@
 {
 	"id": "definition-list",
 	"selector": "dl",
-	"matches": "no-role-matches.js",
+	"matches": "no-role-matches",
 	"tags": ["cat.structure", "wcag2a", "wcag131"],
 	"metadata": {
 		"description": "Ensures <dl> elements are structured correctly",

--- a/lib/rules/dlitem.json
+++ b/lib/rules/dlitem.json
@@ -1,7 +1,7 @@
 {
 	"id": "dlitem",
 	"selector": "dd, dt",
-	"matches": "no-role-matches.js",
+	"matches": "no-role-matches",
 	"tags": ["cat.structure", "wcag2a", "wcag131"],
 	"metadata": {
 		"description": "Ensures <dt> and <dd> elements are contained by a <dl>",

--- a/lib/rules/document-title.json
+++ b/lib/rules/document-title.json
@@ -1,7 +1,7 @@
 {
 	"id": "document-title",
 	"selector": "html",
-	"matches": "window-is-top-matches.js",
+	"matches": "window-is-top-matches",
 	"tags": ["cat.text-alternatives", "wcag2a", "wcag242"],
 	"metadata": {
 		"description": "Ensures each HTML document contains a non-empty <title> element",

--- a/lib/rules/duplicate-id-active-matches.js
+++ b/lib/rules/duplicate-id-active-matches.js
@@ -1,8 +1,15 @@
-const { dom, aria } = axe.commons;
-const id = node.getAttribute('id').trim();
-const idSelector = `*[id="${axe.utils.escapeSelector(id)}"]`;
-const idMatchingElms = Array.from(
-	dom.getRootNode(node).querySelectorAll(idSelector)
-);
+import { getRootNode, isFocusable } from '../commons/dom';
+import { isAccessibleRef } from '../commons/aria';
+import { escapeSelector } from '../core/utils';
 
-return !aria.isAccessibleRef(node) && idMatchingElms.some(dom.isFocusable);
+function duplicateIdActiveMatches(node) {
+	const id = node.getAttribute('id').trim();
+	const idSelector = `*[id="${escapeSelector(id)}"]`;
+	const idMatchingElms = Array.from(
+		getRootNode(node).querySelectorAll(idSelector)
+	);
+
+	return !isAccessibleRef(node) && idMatchingElms.some(isFocusable);
+}
+
+export default duplicateIdActiveMatches;

--- a/lib/rules/duplicate-id-active.json
+++ b/lib/rules/duplicate-id-active.json
@@ -1,7 +1,7 @@
 {
 	"id": "duplicate-id-active",
 	"selector": "[id]",
-	"matches": "duplicate-id-active-matches.js",
+	"matches": "duplicate-id-active-matches",
 	"excludeHidden": false,
 	"tags": ["cat.parsing", "wcag2a", "wcag411"],
 	"metadata": {

--- a/lib/rules/duplicate-id-aria-matches.js
+++ b/lib/rules/duplicate-id-aria-matches.js
@@ -1,1 +1,7 @@
-return axe.commons.aria.isAccessibleRef(node);
+import { isAccessibleRef } from '../commons/aria';
+
+function duplicateIdAriaMatches(node) {
+	return isAccessibleRef(node);
+}
+
+export default duplicateIdAriaMatches;

--- a/lib/rules/duplicate-id-aria.json
+++ b/lib/rules/duplicate-id-aria.json
@@ -1,7 +1,7 @@
 {
 	"id": "duplicate-id-aria",
 	"selector": "[id]",
-	"matches": "duplicate-id-aria-matches.js",
+	"matches": "duplicate-id-aria-matches",
 	"excludeHidden": false,
 	"tags": ["cat.parsing", "wcag2a", "wcag411"],
 	"metadata": {

--- a/lib/rules/duplicate-id-misc-matches.js
+++ b/lib/rules/duplicate-id-misc-matches.js
@@ -1,11 +1,17 @@
-const { dom, aria } = axe.commons;
-const id = node.getAttribute('id').trim();
-const idSelector = `*[id="${axe.utils.escapeSelector(id)}"]`;
-const idMatchingElms = Array.from(
-	dom.getRootNode(node).querySelectorAll(idSelector)
-);
+import { getRootNode, isFocusable } from '../commons/dom';
+import { isAccessibleRef } from '../commons/aria';
+import { escapeSelector } from '../core/utils';
 
-return (
-	!aria.isAccessibleRef(node) &&
-	idMatchingElms.every(elm => !dom.isFocusable(elm))
-);
+function duplicateIdMiscMatches(node) {
+	const id = node.getAttribute('id').trim();
+	const idSelector = `*[id="${escapeSelector(id)}"]`;
+	const idMatchingElms = Array.from(
+		getRootNode(node).querySelectorAll(idSelector)
+	);
+
+	return (
+		!isAccessibleRef(node) && idMatchingElms.every(elm => !isFocusable(elm))
+	);
+}
+
+export default duplicateIdMiscMatches;

--- a/lib/rules/duplicate-id.json
+++ b/lib/rules/duplicate-id.json
@@ -1,7 +1,7 @@
 {
 	"id": "duplicate-id",
 	"selector": "[id]",
-	"matches": "duplicate-id-misc-matches.js",
+	"matches": "duplicate-id-misc-matches",
 	"excludeHidden": false,
 	"tags": ["cat.parsing", "wcag2a", "wcag411"],
 	"metadata": {

--- a/lib/rules/empty-heading.json
+++ b/lib/rules/empty-heading.json
@@ -1,7 +1,7 @@
 {
 	"id": "empty-heading",
 	"selector": "h1, h2, h3, h4, h5, h6, [role=\"heading\"]",
-	"matches": "heading-matches.js",
+	"matches": "heading-matches",
 	"tags": ["cat.name-role-value", "best-practice"],
 	"metadata": {
 		"description": "Ensures headings have discernible text",

--- a/lib/rules/focus-order-semantics.json
+++ b/lib/rules/focus-order-semantics.json
@@ -1,7 +1,7 @@
 {
 	"id": "focus-order-semantics",
 	"selector": "div, h1, h2, h3, h4, h5, h6, [role=heading], p, span",
-	"matches": "inserted-into-focus-order-matches.js",
+	"matches": "inserted-into-focus-order-matches",
 	"tags": ["cat.keyboard", "best-practice", "experimental"],
 	"metadata": {
 		"description": "Ensures elements in the focus order have an appropriate role",

--- a/lib/rules/form-field-multiple-labels.json
+++ b/lib/rules/form-field-multiple-labels.json
@@ -1,7 +1,7 @@
 {
 	"id": "form-field-multiple-labels",
 	"selector": "input, select, textarea",
-	"matches": "label-matches.js",
+	"matches": "label-matches",
 	"tags": ["cat.forms", "wcag2a", "wcag332"],
 	"metadata": {
 		"description": "Ensures form field does not have multiple label elements",

--- a/lib/rules/frame-title-has-text-matches.js
+++ b/lib/rules/frame-title-has-text-matches.js
@@ -1,2 +1,8 @@
-var title = node.getAttribute('title');
-return !!(title ? axe.commons.text.sanitize(title).trim() : '');
+import { sanitize } from '../commons/text';
+
+function frameTitleHasTextMatches(node) {
+	var title = node.getAttribute('title');
+	return !!(title ? sanitize(title).trim() : '');
+}
+
+export default frameTitleHasTextMatches;

--- a/lib/rules/frame-title-unique.json
+++ b/lib/rules/frame-title-unique.json
@@ -1,7 +1,7 @@
 {
 	"id": "frame-title-unique",
 	"selector": "frame[title], iframe[title]",
-	"matches": "frame-title-has-text-matches.js",
+	"matches": "frame-title-has-text-matches",
 	"tags": ["cat.text-alternatives", "best-practice"],
 	"metadata": {
 		"description": "Ensures <iframe> and <frame> elements contain a unique title attribute",

--- a/lib/rules/heading-matches.js
+++ b/lib/rules/heading-matches.js
@@ -1,15 +1,19 @@
-// Get all valid roles
-let explicitRoles;
-if (node.hasAttribute('role')) {
-	explicitRoles = node
-		.getAttribute('role')
-		.split(/\s+/i)
-		.filter(axe.commons.aria.isValidRole);
+function headingMatches(node) {
+	// Get all valid roles
+	let explicitRoles;
+	if (node.hasAttribute('role')) {
+		explicitRoles = node
+			.getAttribute('role')
+			.split(/\s+/i)
+			.filter(axe.commons.aria.isValidRole);
+	}
+
+	// Check valid roles if there are any, otherwise fall back to the inherited role
+	if (explicitRoles && explicitRoles.length > 0) {
+		return explicitRoles.includes('heading');
+	} else {
+		return axe.commons.aria.implicitRole(node) === 'heading';
+	}
 }
 
-// Check valid roles if there are any, otherwise fall back to the inherited role
-if (explicitRoles && explicitRoles.length > 0) {
-	return explicitRoles.includes('heading');
-} else {
-	return axe.commons.aria.implicitRole(node) === 'heading';
-}
+export default headingMatches;

--- a/lib/rules/heading-order.json
+++ b/lib/rules/heading-order.json
@@ -1,7 +1,7 @@
 {
 	"id": "heading-order",
 	"selector": "h1, h2, h3, h4, h5, h6, [role=heading]",
-	"matches": "heading-matches.js",
+	"matches": "heading-matches",
 	"tags": ["cat.semantics", "best-practice"],
 	"metadata": {
 		"description": "Ensures the order of headings is semantically correct",

--- a/lib/rules/html-has-lang.json
+++ b/lib/rules/html-has-lang.json
@@ -1,7 +1,7 @@
 {
 	"id": "html-has-lang",
 	"selector": "html",
-	"matches": "window-is-top-matches.js",
+	"matches": "window-is-top-matches",
 	"tags": ["cat.language", "wcag2a", "wcag311"],
 	"metadata": {
 		"description": "Ensures every HTML document has a lang attribute",

--- a/lib/rules/html-namespace-matches.js
+++ b/lib/rules/html-namespace-matches.js
@@ -1,1 +1,5 @@
-return node.namespaceURI === 'http://www.w3.org/1999/xhtml';
+function htmlNamespaceMatches(node) {
+	return node.namespaceURI === 'http://www.w3.org/1999/xhtml';
+}
+
+export default htmlNamespaceMatches;

--- a/lib/rules/html-xml-lang-mismatch.json
+++ b/lib/rules/html-xml-lang-mismatch.json
@@ -1,7 +1,7 @@
 {
 	"id": "html-xml-lang-mismatch",
 	"selector": "html[lang][xml\\:lang]",
-	"matches": "xml-lang-mismatch-matches.js",
+	"matches": "xml-lang-mismatch-matches",
 	"tags": ["cat.language", "wcag2a", "wcag311"],
 	"metadata": {
 		"description": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page",

--- a/lib/rules/identical-links-same-purpose-matches.js
+++ b/lib/rules/identical-links-same-purpose-matches.js
@@ -1,13 +1,18 @@
-const { aria, text } = axe.commons;
+import { accessibleTextVirtual } from '../commons/text';
+import { getRole } from '../commons/aria';
 
-const hasAccName = !!text.accessibleTextVirtual(virtualNode);
-if (!hasAccName) {
-	return false;
+function identicalLinksSamePurposeMatches(node, virtualNode) {
+	const hasAccName = !!accessibleTextVirtual(virtualNode);
+	if (!hasAccName) {
+		return false;
+	}
+
+	const role = getRole(node);
+	if (role && role !== 'link') {
+		return false;
+	}
+
+	return true;
 }
 
-const role = aria.getRole(node);
-if (role && role !== 'link') {
-	return false;
-}
-
-return true;
+export default identicalLinksSamePurposeMatches;

--- a/lib/rules/identical-links-same-purpose.json
+++ b/lib/rules/identical-links-same-purpose.json
@@ -2,7 +2,7 @@
 	"id": "identical-links-same-purpose",
 	"selector": "a[href], area[href], [role=\"link\"]",
 	"excludeHidden": false,
-	"matches": "identical-links-same-purpose-matches.js",
+	"matches": "identical-links-same-purpose-matches",
 	"tags": ["wcag2aaa", "wcag249", "best-practice"],
 	"metadata": {
 		"description": "Ensure that links with the same accessible name serve a similar purpose",

--- a/lib/rules/inserted-into-focus-order-matches.js
+++ b/lib/rules/inserted-into-focus-order-matches.js
@@ -1,1 +1,7 @@
-return axe.commons.dom.insertedIntoFocusOrder(node);
+import { insertedIntoFocusOrder } from '../commons/dom';
+
+function insertedIntoFocusOrderMatches(node) {
+	return insertedIntoFocusOrder(node);
+}
+
+export default insertedIntoFocusOrderMatches;

--- a/lib/rules/label-content-name-mismatch-matches.js
+++ b/lib/rules/label-content-name-mismatch-matches.js
@@ -1,45 +1,56 @@
-/**
- * Applicability:
- * Rule applies to any element that has
- * a) a semantic role that is `widget` that supports name from content
- * b) has visible text content
- * c) has accessible name (eg: `aria-label`)
- */
-const { aria, text } = axe.commons;
+import {
+	getRole,
+	lookupTable,
+	arialabelText,
+	arialabelledbyText,
+	getRolesWithNameFromContents
+} from '../commons/aria';
+import { sanitize, visibleVirtual } from '../commons/text';
 
-const role = aria.getRole(node);
-if (!role) {
-	return false;
+function labelContentNameMismatchMatches(node, virtualNode) {
+	/**
+	 * Applicability:
+	 * Rule applies to any element that has
+	 * a) a semantic role that is `widget` that supports name from content
+	 * b) has visible text content
+	 * c) has accessible name (eg: `aria-label`)
+	 */
+	const role = getRole(node);
+	if (!role) {
+		return false;
+	}
+
+	const widgetRoles = Object.keys(lookupTable.role).filter(
+		key => lookupTable.role[key].type === `widget`
+	);
+	const isWidgetType = widgetRoles.includes(role);
+	if (!isWidgetType) {
+		return false;
+	}
+
+	const rolesWithNameFromContents = getRolesWithNameFromContents();
+	if (!rolesWithNameFromContents.includes(role)) {
+		return false;
+	}
+
+	/**
+	 * if no `aria-label` or `aria-labelledby` attribute - ignore `node`
+	 */
+	if (
+		!sanitize(arialabelText(virtualNode)) &&
+		!sanitize(arialabelledbyText(node))
+	) {
+		return false;
+	}
+
+	/**
+	 * if no `contentText` - ignore `node`
+	 */
+	if (!sanitize(visibleVirtual(virtualNode))) {
+		return false;
+	}
+
+	return true;
 }
 
-const widgetRoles = Object.keys(aria.lookupTable.role).filter(
-	key => aria.lookupTable.role[key].type === `widget`
-);
-const isWidgetType = widgetRoles.includes(role);
-if (!isWidgetType) {
-	return false;
-}
-
-const rolesWithNameFromContents = aria.getRolesWithNameFromContents();
-if (!rolesWithNameFromContents.includes(role)) {
-	return false;
-}
-
-/**
- * if no `aria-label` or `aria-labelledby` attribute - ignore `node`
- */
-if (
-	!text.sanitize(aria.arialabelText(virtualNode)) &&
-	!text.sanitize(aria.arialabelledbyText(node))
-) {
-	return false;
-}
-
-/**
- * if no `contentText` - ignore `node`
- */
-if (!text.sanitize(text.visibleVirtual(virtualNode))) {
-	return false;
-}
-
-return true;
+export default labelContentNameMismatchMatches;

--- a/lib/rules/label-content-name-mismatch.json
+++ b/lib/rules/label-content-name-mismatch.json
@@ -1,6 +1,6 @@
 {
 	"id": "label-content-name-mismatch",
-	"matches": "label-content-name-mismatch-matches.js",
+	"matches": "label-content-name-mismatch-matches",
 	"tags": ["wcag21a", "wcag253", "experimental"],
 	"metadata": {
 		"description": "Ensures that elements labelled through their content must have their visible text as part of their accessible name",

--- a/lib/rules/label-matches.js
+++ b/lib/rules/label-matches.js
@@ -1,11 +1,15 @@
-if (
-	node.nodeName.toLowerCase() !== 'input' ||
-	node.hasAttribute('type') === false
-) {
-	return true;
+function labelMatches(node) {
+	if (
+		node.nodeName.toLowerCase() !== 'input' ||
+		node.hasAttribute('type') === false
+	) {
+		return true;
+	}
+
+	var type = node.getAttribute('type').toLowerCase();
+	return (
+		['hidden', 'image', 'button', 'submit', 'reset'].includes(type) === false
+	);
 }
 
-var type = node.getAttribute('type').toLowerCase();
-return (
-	['hidden', 'image', 'button', 'submit', 'reset'].includes(type) === false
-);
+export default labelMatches;

--- a/lib/rules/label-title-only.json
+++ b/lib/rules/label-title-only.json
@@ -1,7 +1,7 @@
 {
 	"id": "label-title-only",
 	"selector": "input, select, textarea",
-	"matches": "label-matches.js",
+	"matches": "label-matches",
 	"tags": ["cat.forms", "best-practice"],
 	"metadata": {
 		"description": "Ensures that every form element is not solely labeled using the title or aria-describedby attributes",

--- a/lib/rules/label.json
+++ b/lib/rules/label.json
@@ -1,7 +1,7 @@
 {
 	"id": "label",
 	"selector": "input, select, textarea",
-	"matches": "label-matches.js",
+	"matches": "label-matches",
 	"tags": [
 		"cat.forms",
 		"wcag2a",

--- a/lib/rules/landmark-banner-is-top-level.json
+++ b/lib/rules/landmark-banner-is-top-level.json
@@ -1,7 +1,7 @@
 {
 	"id": "landmark-banner-is-top-level",
 	"selector": "header:not([role]), [role=banner]",
-	"matches": "landmark-has-body-context-matches.js",
+	"matches": "landmark-has-body-context-matches",
 	"tags": ["cat.semantics", "best-practice"],
 	"metadata": {
 		"description": "Ensures the banner landmark is at top level",

--- a/lib/rules/landmark-contentinfo-is-top-level.json
+++ b/lib/rules/landmark-contentinfo-is-top-level.json
@@ -1,7 +1,7 @@
 {
 	"id": "landmark-contentinfo-is-top-level",
 	"selector": "footer:not([role]), [role=contentinfo]",
-	"matches": "landmark-has-body-context-matches.js",
+	"matches": "landmark-has-body-context-matches",
 	"tags": ["cat.semantics", "best-practice"],
 	"metadata": {
 		"description": "Ensures the contentinfo landmark is at top level",

--- a/lib/rules/landmark-has-body-context-matches.js
+++ b/lib/rules/landmark-has-body-context-matches.js
@@ -1,8 +1,13 @@
-const nativeScopeFilter = 'article, aside, main, nav, section';
+import { findUpVirtual } from '../commons/dom';
 
-// Filter elements that, within certain contexts, don't map their role.
-// e.g. a <header> inside a <main> is not a banner, but in the <body> context it is
-return (
-	node.hasAttribute('role') ||
-	!axe.commons.dom.findUpVirtual(virtualNode, nativeScopeFilter)
-);
+function landmarkHasBodyContextMatches(node, virtualNode) {
+	const nativeScopeFilter = 'article, aside, main, nav, section';
+
+	// Filter elements that, within certain contexts, don't map their role.
+	// e.g. a <header> inside a <main> is not a banner, but in the <body> context it is
+	return (
+		node.hasAttribute('role') || !findUpVirtual(virtualNode, nativeScopeFilter)
+	);
+}
+
+export default landmarkHasBodyContextMatches;

--- a/lib/rules/landmark-unique-matches.js
+++ b/lib/rules/landmark-unique-matches.js
@@ -1,41 +1,49 @@
-/*
- * Since this is a best-practice rule, we are filtering elements as dictated by ARIA 1.1 Practices regardless of treatment by browser/AT combinations.
- *
- * Info: https://www.w3.org/TR/wai-aria-practices-1.1/#aria_landmark
- */
-var excludedParentsForHeaderFooterLandmarks = [
-	'article',
-	'aside',
-	'main',
-	'nav',
-	'section'
-].join(',');
-function isHeaderFooterLandmark(headerFooterElement) {
-	return !axe.commons.dom.findUpVirtual(
-		headerFooterElement,
-		excludedParentsForHeaderFooterLandmarks
-	);
+import { findUpVirtual, isVisible } from '../commons/dom';
+import { getRolesByType, getRole } from '../commons/aria';
+import { accessibleTextVirtual } from '../commons/text';
+
+function landmarkUniqueMatches(node, virtualNode) {
+	/*
+	 * Since this is a best-practice rule, we are filtering elements as dictated by ARIA 1.1 Practices regardless of treatment by browser/AT combinations.
+	 *
+	 * Info: https://www.w3.org/TR/wai-aria-practices-1.1/#aria_landmark
+	 */
+	var excludedParentsForHeaderFooterLandmarks = [
+		'article',
+		'aside',
+		'main',
+		'nav',
+		'section'
+	].join(',');
+	function isHeaderFooterLandmark(headerFooterElement) {
+		return !findUpVirtual(
+			headerFooterElement,
+			excludedParentsForHeaderFooterLandmarks
+		);
+	}
+
+	function isLandmarkVirtual(virtualNode) {
+		var { actualNode } = virtualNode;
+		var landmarkRoles = getRolesByType('landmark');
+		var role = getRole(actualNode);
+		if (!role) {
+			return false;
+		}
+
+		var nodeName = actualNode.nodeName.toUpperCase();
+		if (nodeName === 'HEADER' || nodeName === 'FOOTER') {
+			return isHeaderFooterLandmark(virtualNode);
+		}
+
+		if (nodeName === 'SECTION' || nodeName === 'FORM') {
+			var accessibleText = accessibleTextVirtual(virtualNode);
+			return !!accessibleText;
+		}
+
+		return landmarkRoles.indexOf(role) >= 0 || role === 'region';
+	}
+
+	return isLandmarkVirtual(virtualNode) && isVisible(node, true);
 }
 
-function isLandmarkVirtual(virtualNode) {
-	var { actualNode } = virtualNode;
-	var landmarkRoles = axe.commons.aria.getRolesByType('landmark');
-	var role = axe.commons.aria.getRole(actualNode);
-	if (!role) {
-		return false;
-	}
-
-	var nodeName = actualNode.nodeName.toUpperCase();
-	if (nodeName === 'HEADER' || nodeName === 'FOOTER') {
-		return isHeaderFooterLandmark(virtualNode);
-	}
-
-	if (nodeName === 'SECTION' || nodeName === 'FORM') {
-		var accessibleText = axe.commons.text.accessibleTextVirtual(virtualNode);
-		return !!accessibleText;
-	}
-
-	return landmarkRoles.indexOf(role) >= 0 || role === 'region';
-}
-
-return isLandmarkVirtual(virtualNode) && axe.commons.dom.isVisible(node, true);
+export default landmarkUniqueMatches;

--- a/lib/rules/landmark-unique.json
+++ b/lib/rules/landmark-unique.json
@@ -6,7 +6,7 @@
 		"help": "Ensures landmarks are unique",
 		"description": "Landmarks must have a unique role or role/label/title (i.e. accessible name) combination"
 	},
-	"matches": "landmark-unique-matches.js",
+	"matches": "landmark-unique-matches",
 	"all": [],
 	"any": ["landmark-is-unique"],
 	"none": []

--- a/lib/rules/layout-table-matches.js
+++ b/lib/rules/layout-table-matches.js
@@ -1,8 +1,13 @@
-var role = (node.getAttribute('role') || '').toLowerCase();
+import { isFocusable } from '../commons/dom';
+import { isDataTable } from '../commons/table';
 
-return (
-	!(
-		(role === 'presentation' || role === 'none') &&
-		!axe.commons.dom.isFocusable(node)
-	) && !axe.commons.table.isDataTable(node)
-);
+function layoutTableMatches(node) {
+	var role = (node.getAttribute('role') || '').toLowerCase();
+
+	return (
+		!((role === 'presentation' || role === 'none') && !isFocusable(node)) &&
+		!isDataTable(node)
+	);
+}
+
+export default layoutTableMatches;

--- a/lib/rules/layout-table.json
+++ b/lib/rules/layout-table.json
@@ -1,7 +1,7 @@
 {
 	"id": "layout-table",
 	"selector": "table",
-	"matches": "layout-table-matches.js",
+	"matches": "layout-table-matches",
 	"tags": ["cat.semantics", "wcag2a", "wcag131", "deprecated"],
 	"metadata": {
 		"description": "Ensures presentational <table> elements do not use <th>, <caption> elements or the summary attribute",

--- a/lib/rules/link-in-text-block-matches.js
+++ b/lib/rules/link-in-text-block-matches.js
@@ -1,14 +1,21 @@
-var text = axe.commons.text.sanitize(node.textContent);
-var role = node.getAttribute('role');
+import { sanitize } from '../commons/text';
+import { isVisible, isInTextBlock } from '../commons/dom';
 
-if (role && role !== 'link') {
-	return false;
-}
-if (!text) {
-	return false;
-}
-if (!axe.commons.dom.isVisible(node, false)) {
-	return false;
+function linkInTextBlockMatches(node) {
+	var text = sanitize(node.textContent);
+	var role = node.getAttribute('role');
+
+	if (role && role !== 'link') {
+		return false;
+	}
+	if (!text) {
+		return false;
+	}
+	if (!isVisible(node, false)) {
+		return false;
+	}
+
+	return isInTextBlock(node);
 }
 
-return axe.commons.dom.isInTextBlock(node);
+export default linkInTextBlockMatches;

--- a/lib/rules/link-in-text-block.json
+++ b/lib/rules/link-in-text-block.json
@@ -1,7 +1,7 @@
 {
 	"id": "link-in-text-block",
 	"selector": "a[href], [role=link]",
-	"matches": "link-in-text-block-matches.js",
+	"matches": "link-in-text-block-matches",
 	"excludeHidden": false,
 	"tags": ["cat.color", "experimental", "wcag2a", "wcag141"],
 	"metadata": {

--- a/lib/rules/list.json
+++ b/lib/rules/list.json
@@ -1,7 +1,7 @@
 {
 	"id": "list",
 	"selector": "ul, ol",
-	"matches": "no-role-matches.js",
+	"matches": "no-role-matches",
 	"tags": ["cat.structure", "wcag2a", "wcag131"],
 	"metadata": {
 		"description": "Ensures that lists are structured correctly",

--- a/lib/rules/listitem.json
+++ b/lib/rules/listitem.json
@@ -1,7 +1,7 @@
 {
 	"id": "listitem",
 	"selector": "li",
-	"matches": "no-role-matches.js",
+	"matches": "no-role-matches",
 	"tags": ["cat.structure", "wcag2a", "wcag131"],
 	"metadata": {
 		"description": "Ensures <li> elements are used semantically",

--- a/lib/rules/no-autoplay-audio-matches.js
+++ b/lib/rules/no-autoplay-audio-matches.js
@@ -1,18 +1,22 @@
-/**
- * Ignore media nodes without `currenSrc`
- * 	Notes:
- * 	- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentSrc
- * 	- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/src
- */
-if (!node.currentSrc) {
-	return false;
+function noAutoplayAudioMatches(node) {
+	/**
+	 * Ignore media nodes without `currenSrc`
+	 * 	Notes:
+	 * 	- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentSrc
+	 * 	- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/src
+	 */
+	if (!node.currentSrc) {
+		return false;
+	}
+
+	/**
+	 * Ignore media nodes which are `paused` or `muted`
+	 */
+	if (node.hasAttribute('paused') || node.hasAttribute('muted')) {
+		return false;
+	}
+
+	return true;
 }
 
-/**
- * Ignore media nodes which are `paused` or `muted`
- */
-if (node.hasAttribute('paused') || node.hasAttribute('muted')) {
-	return false;
-}
-
-return true;
+export default noAutoplayAudioMatches;

--- a/lib/rules/no-autoplay-audio.json
+++ b/lib/rules/no-autoplay-audio.json
@@ -2,7 +2,7 @@
 	"id": "no-autoplay-audio",
 	"excludeHidden": false,
 	"selector": "audio[autoplay], video[autoplay]",
-	"matches": "no-autoplay-audio-matches.js",
+	"matches": "no-autoplay-audio-matches",
 	"tags": ["wcag2a", "wcag142", "experimental"],
 	"metadata": {
 		"description": "Ensures <video> or <audio> elements do not autoplay audio for more than 3 seconds without a control mechanism to stop or mute the audio",

--- a/lib/rules/no-empty-role-matches.js
+++ b/lib/rules/no-empty-role-matches.js
@@ -1,9 +1,13 @@
-if (!virtualNode.hasAttr('role')) {
-	return false;
+function noEmptyRoleMatches(node, virtualNode) {
+	if (!virtualNode.hasAttr('role')) {
+		return false;
+	}
+
+	if (!virtualNode.attr('role').trim()) {
+		return false;
+	}
+
+	return true;
 }
 
-if (!virtualNode.attr('role').trim()) {
-	return false;
-}
-
-return true;
+export default noEmptyRoleMatches;

--- a/lib/rules/no-role-matches.js
+++ b/lib/rules/no-role-matches.js
@@ -1,1 +1,5 @@
-return !node.getAttribute('role');
+function noRoleMatches(node) {
+	return !node.getAttribute('role');
+}
+
+export default noRoleMatches;

--- a/lib/rules/not-html-matches.js
+++ b/lib/rules/not-html-matches.js
@@ -1,1 +1,5 @@
-return node.nodeName.toLowerCase() !== 'html';
+function notHtmlMatches(node) {
+	return node.nodeName.toLowerCase() !== 'html';
+}
+
+export default notHtmlMatches;

--- a/lib/rules/p-as-heading-matches.js
+++ b/lib/rules/p-as-heading-matches.js
@@ -1,17 +1,21 @@
-const children = Array.from(node.parentNode.childNodes);
-const nodeText = node.textContent.trim();
-const isSentence = /[.!?:;](?![.!?:;])/g;
+function pAsHeadingMatches(node) {
+	const children = Array.from(node.parentNode.childNodes);
+	const nodeText = node.textContent.trim();
+	const isSentence = /[.!?:;](?![.!?:;])/g;
 
-// Check that there is text, and it is not more than a single sentence
-if (nodeText.length === 0 || (nodeText.match(isSentence) || []).length >= 2) {
-	return false;
+	// Check that there is text, and it is not more than a single sentence
+	if (nodeText.length === 0 || (nodeText.match(isSentence) || []).length >= 2) {
+		return false;
+	}
+
+	// Grab sibling p element following the current node
+	const siblingsAfter = children
+		.slice(children.indexOf(node) + 1)
+		.filter(
+			elm => elm.nodeName.toUpperCase() === 'P' && elm.textContent.trim() !== ''
+		);
+
+	return siblingsAfter.length !== 0;
 }
 
-// Grab sibling p element following the current node
-const siblingsAfter = children
-	.slice(children.indexOf(node) + 1)
-	.filter(
-		elm => elm.nodeName.toUpperCase() === 'P' && elm.textContent.trim() !== ''
-	);
-
-return siblingsAfter.length !== 0;
+export default pAsHeadingMatches;

--- a/lib/rules/p-as-heading.json
+++ b/lib/rules/p-as-heading.json
@@ -1,7 +1,7 @@
 {
 	"id": "p-as-heading",
 	"selector": "p",
-	"matches": "p-as-heading-matches.js",
+	"matches": "p-as-heading-matches",
 	"tags": ["cat.semantics", "wcag2a", "wcag131", "experimental"],
 	"metadata": {
 		"description": "Ensure p elements are not used to style headings",

--- a/lib/rules/role-img-alt.json
+++ b/lib/rules/role-img-alt.json
@@ -1,7 +1,7 @@
 {
 	"id": "role-img-alt",
 	"selector": "[role='img']:not(img):not(area):not(input):not(object)",
-	"matches": "html-namespace-matches.js",
+	"matches": "html-namespace-matches",
 	"tags": [
 		"cat.text-alternatives",
 		"wcag2a",

--- a/lib/rules/scrollable-region-focusable-matches.js
+++ b/lib/rules/scrollable-region-focusable-matches.js
@@ -1,30 +1,35 @@
-/**
- * Note:
- * `excludeHidden=true` for this rule, thus considering only elements in the accessibility tree.
- */
-const { querySelectorAll } = axe.utils;
-const { hasContentVirtual } = axe.commons.dom;
+import { hasContentVirtual } from '../commons/dom';
+import { querySelectorAll, getScroll } from '../core/utils';
 
-/**
- * if not scrollable -> `return`
- */
-if (!!axe.utils.getScroll(node, 13) === false) {
-	return false;
+function scrollableRegionFocusableMatches(node, virtualNode) {
+	/**
+	 * Note:
+	 * `excludeHidden=true` for this rule, thus considering only elements in the accessibility tree.
+	 */
+
+	/**
+	 * if not scrollable -> `return`
+	 */
+	if (!!getScroll(node, 13) === false) {
+		return false;
+	}
+
+	/**
+	 * check if node has visible contents
+	 */
+	const nodeAndDescendents = querySelectorAll(virtualNode, '*');
+	const hasVisibleChildren = nodeAndDescendents.some(elm =>
+		hasContentVirtual(
+			elm,
+			true, // noRecursion
+			true // ignoreAria
+		)
+	);
+	if (!hasVisibleChildren) {
+		return false;
+	}
+
+	return true;
 }
 
-/**
- * check if node has visible contents
- */
-const nodeAndDescendents = querySelectorAll(virtualNode, '*');
-const hasVisibleChildren = nodeAndDescendents.some(elm =>
-	hasContentVirtual(
-		elm,
-		true, // noRecursion
-		true // ignoreAria
-	)
-);
-if (!hasVisibleChildren) {
-	return false;
-}
-
-return true;
+export default scrollableRegionFocusableMatches;

--- a/lib/rules/scrollable-region-focusable.json
+++ b/lib/rules/scrollable-region-focusable.json
@@ -1,6 +1,6 @@
 {
 	"id": "scrollable-region-focusable",
-	"matches": "scrollable-region-focusable-matches.js",
+	"matches": "scrollable-region-focusable-matches",
 	"tags": ["wcag2a", "wcag211"],
 	"metadata": {
 		"description": "Elements that have scrollable content should be accessible by keyboard",

--- a/lib/rules/skip-link-matches.js
+++ b/lib/rules/skip-link-matches.js
@@ -1,1 +1,7 @@
-return axe.commons.dom.isSkipLink(node) && axe.commons.dom.isOffscreen(node);
+import { isSkipLink, isOffscreen } from '../commons/dom';
+
+function skipLinkMatches(node) {
+	return isSkipLink(node) && isOffscreen(node);
+}
+
+export default skipLinkMatches;

--- a/lib/rules/skip-link.json
+++ b/lib/rules/skip-link.json
@@ -1,7 +1,7 @@
 {
 	"id": "skip-link",
 	"selector": "a[href^=\"#\"], a[href^=\"/#\"]",
-	"matches": "skip-link-matches.js",
+	"matches": "skip-link-matches",
 	"tags": ["cat.keyboard", "best-practice"],
 	"metadata": {
 		"description": "Ensure all skip links have a focusable target",

--- a/lib/rules/svg-img-alt.json
+++ b/lib/rules/svg-img-alt.json
@@ -1,7 +1,7 @@
 {
 	"id": "svg-img-alt",
 	"selector": "[role=\"img\"], [role=\"graphics-symbol\"], svg[role=\"graphics-document\"]",
-	"matches": "svg-namespace-matches.js",
+	"matches": "svg-namespace-matches",
 	"tags": [
 		"cat.text-alternatives",
 		"wcag2a",

--- a/lib/rules/svg-namespace-matches.js
+++ b/lib/rules/svg-namespace-matches.js
@@ -1,1 +1,5 @@
-return node.namespaceURI === 'http://www.w3.org/2000/svg';
+function svgNamespaceMatches(node) {
+	return node.namespaceURI === 'http://www.w3.org/2000/svg';
+}
+
+export default svgNamespaceMatches;

--- a/lib/rules/table-fake-caption.json
+++ b/lib/rules/table-fake-caption.json
@@ -1,7 +1,7 @@
 {
 	"id": "table-fake-caption",
 	"selector": "table",
-	"matches": "data-table-matches.js",
+	"matches": "data-table-matches",
 	"tags": [
 		"cat.tables",
 		"experimental",

--- a/lib/rules/td-has-header.json
+++ b/lib/rules/td-has-header.json
@@ -1,7 +1,7 @@
 {
 	"id": "td-has-header",
 	"selector": "table",
-	"matches": "data-table-large-matches.js",
+	"matches": "data-table-large-matches",
 	"tags": [
 		"cat.tables",
 		"experimental",

--- a/lib/rules/th-has-data-cells.json
+++ b/lib/rules/th-has-data-cells.json
@@ -1,7 +1,7 @@
 {
 	"id": "th-has-data-cells",
 	"selector": "table",
-	"matches": "data-table-matches.js",
+	"matches": "data-table-matches",
 	"tags": ["cat.tables", "wcag2a", "wcag131", "section508", "section508.22.g"],
 	"metadata": {
 		"description": "Ensure that each table header in a data table refers to data cells",

--- a/lib/rules/valid-lang.json
+++ b/lib/rules/valid-lang.json
@@ -1,7 +1,7 @@
 {
 	"id": "valid-lang",
 	"selector": "[lang], [xml\\:lang]",
-	"matches": "not-html-matches.js",
+	"matches": "not-html-matches",
 	"tags": ["cat.language", "wcag2aa", "wcag312"],
 	"metadata": {
 		"description": "Ensures lang attributes have valid values",

--- a/lib/rules/window-is-top-matches.js
+++ b/lib/rules/window-is-top-matches.js
@@ -1,3 +1,7 @@
-return (
-	node.ownerDocument.defaultView.self === node.ownerDocument.defaultView.top
-);
+function windowIsTopMatches(node) {
+	return (
+		node.ownerDocument.defaultView.self === node.ownerDocument.defaultView.top
+	);
+}
+
+export default windowIsTopMatches;

--- a/lib/rules/xml-lang-mismatch-matches.js
+++ b/lib/rules/xml-lang-mismatch-matches.js
@@ -1,12 +1,17 @@
-// using -> "selector": "html[lang][xml\\:lang]" to narrow down html with lang and xml:lang attributes
+import { getBaseLang, validLangs } from '../core/utils';
 
-// get primary base language for each of the attributes
-const { getBaseLang } = axe.utils;
-const primaryLangValue = getBaseLang(node.getAttribute('lang'));
-const primaryXmlLangValue = getBaseLang(node.getAttribute('xml:lang'));
+function xmlLangMismatchMatches(node) {
+	// using -> "selector": "html[lang][xml\\:lang]" to narrow down html with lang and xml:lang attributes
 
-// ensure that the value specified is valid lang for both `lang` and `xml:lang`
-return (
-	axe.utils.validLangs().includes(primaryLangValue) &&
-	axe.utils.validLangs().includes(primaryXmlLangValue)
-);
+	// get primary base language for each of the attributes
+	const primaryLangValue = getBaseLang(node.getAttribute('lang'));
+	const primaryXmlLangValue = getBaseLang(node.getAttribute('xml:lang'));
+
+	// ensure that the value specified is valid lang for both `lang` and `xml:lang`
+	return (
+		validLangs().includes(primaryLangValue) &&
+		validLangs().includes(primaryXmlLangValue)
+	);
+}
+
+export default xmlLangMismatchMatches;


### PR DESCRIPTION
The metadata-function-map is probably too big and unwieldy, but we can worry about that later. I created a [tech debt ticket to clean it up](https://github.com/dequelabs/axe-core/issues/2208). 

Closes issue: #2123 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
