### PR TITLE
feat(non-space-content): switch all non-empty checks to new generic check

### DIFF
--- a/lib/checks/generic/README.md
+++ b/lib/checks/generic/README.md
@@ -1,0 +1,11 @@
+Generic checks are evaluate functions that are used by multiple checks. They cannot be used directly by a rule (thus there is no check meatadata file associated with them) and must be used by another check passing in the required options.
+
+To use these checks, pass the check id (found in the metadata-function-map file) as the value of a checks `evaluate` property.
+
+```json
+{
+	"id": "my-check",
+	"evaluate": "generic-check-id"
+	// ...
+}
+```

--- a/lib/checks/generic/README.md
+++ b/lib/checks/generic/README.md
@@ -1,11 +1,13 @@
 Generic checks are evaluate functions that are used by multiple checks. They cannot be used directly by a rule (thus there is no check meatadata file associated with them) and must be used by another check passing in the required options.
 
-To use these checks, pass the check id (found in the metadata-function-map file) as the value of a checks `evaluate` property.
+To use these checks, pass the check id (found in the metadata-function-map file) as the value of a checks `evaluate` property and pass any required options.
 
 ```json
 {
 	"id": "my-check",
-	"evaluate": "generic-check-id"
-	// ...
+	"evaluate": "generic-check-id",
+	"options": {
+		"required": true
+	}
 }
 ```

--- a/lib/checks/generic/attr-non-space-content-evaluate.js
+++ b/lib/checks/generic/attr-non-space-content-evaluate.js
@@ -1,0 +1,14 @@
+import { sanitize } from '../../commons/text';
+
+function attrNonSpaceContentEvaluate(node, options = {}, vNode) {
+	if (!options.attribute || typeof options.attribute !== 'string') {
+		throw new TypeError(
+			'attr-non-space-content requires options.attribute to be a string'
+		);
+	}
+
+	const attribute = vNode.attr(options.attribute) || '';
+	return !!sanitize(attribute.trim());
+}
+
+export default attrNonSpaceContentEvaluate;

--- a/lib/checks/shared/non-empty-alt-evaluate.js
+++ b/lib/checks/shared/non-empty-alt-evaluate.js
@@ -1,8 +1,0 @@
-import { sanitize } from '../../commons/text';
-
-function nonEmptyAltEvaluate(node, options, virtualNode) {
-	const label = virtualNode.attr('alt');
-	return !!(label ? sanitize(label).trim() : '');
-}
-
-export default nonEmptyAltEvaluate;

--- a/lib/checks/shared/non-empty-alt.json
+++ b/lib/checks/shared/non-empty-alt.json
@@ -1,6 +1,9 @@
 {
 	"id": "non-empty-alt",
-	"evaluate": "non-empty-alt-evaluate",
+	"evaluate": "attr-non-space-content-evaluate",
+	"options": {
+		"attribute": "alt"
+	},
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/checks/shared/non-empty-title-evaluate.js
+++ b/lib/checks/shared/non-empty-title-evaluate.js
@@ -1,7 +1,0 @@
-import { sanitize, titleText } from '../../commons/text';
-
-function nonEmptyTitleEvaluate(node) {
-	return !!sanitize(titleText(node));
-}
-
-export default nonEmptyTitleEvaluate;

--- a/lib/checks/shared/non-empty-title.json
+++ b/lib/checks/shared/non-empty-title.json
@@ -1,6 +1,9 @@
 {
 	"id": "non-empty-title",
-	"evaluate": "non-empty-title-evaluate",
+	"evaluate": "attr-non-space-content-evaluate",
+	"options": {
+		"attribute": "title"
+	},
 	"metadata": {
 		"impact": "serious",
 		"messages": {

--- a/lib/checks/shared/non-empty-value-evaluate.js
+++ b/lib/checks/shared/non-empty-value-evaluate.js
@@ -1,8 +1,0 @@
-import { sanitize } from '../../commons/text';
-
-function nonEmptyValueEvaluate(node) {
-	var label = node.getAttribute('value');
-	return !!(label ? sanitize(label).trim() : '');
-}
-
-export default nonEmptyValueEvaluate;

--- a/lib/checks/shared/non-empty-value.json
+++ b/lib/checks/shared/non-empty-value.json
@@ -1,6 +1,9 @@
 {
 	"id": "non-empty-value",
-	"evaluate": "non-empty-value-evaluate",
+	"evaluate": "attr-non-space-content-evaluate",
+	"options": {
+		"attribute": "value"
+	},
 	"metadata": {
 		"impact": "critical",
 		"messages": {

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -48,6 +48,9 @@ import fieldsetEvaluate from '../../checks/forms/fieldset-evaluate';
 import groupLabelledbyAfter from '../../checks/forms/group-labelledby-after';
 import groupLabelledbyEvaluate from '../../checks/forms/group-labelledby-evaluate';
 
+// generic
+import attrNonSpaceContentEvaluate from '../../checks/generic/attr-non-space-content-evaluate';
+
 // navigation
 import headerPresentEvaluate from '../../checks/navigation/header-present-evaluate';
 import headingOrderAfter from '../../checks/navigation/heading-order-after';
@@ -73,10 +76,7 @@ import existsEvaluate from '../../checks/shared/exists-evaluate';
 import hasAltEvaluate from '../../checks/shared/has-alt-evaluate';
 import hasVisibleTextEvaluate from '../../checks/shared/has-visible-text-evaluate';
 import isOnScreenEvaluate from '../../checks/shared/is-on-screen-evaluate';
-import nonEmptyAltEvaluate from '../../checks/shared/non-empty-alt-evaluate';
 import nonEmptyIfPresentEvaluate from '../../checks/shared/non-empty-if-present-evaluate';
-import nonEmptyTitleEvaluate from '../../checks/shared/non-empty-title-evaluate';
-import nonEmptyValueEvaluate from '../../checks/shared/non-empty-value-evaluate';
 import roleNoneEvaluate from '../../checks/shared/role-none-evaluate';
 import rolePresentationEvaluate from '../../checks/shared/role-presentation-evaluate';
 import svgNonEmptyTitleEvaluate from '../../checks/shared/svg-non-empty-title-evaluate';
@@ -226,6 +226,9 @@ const metadataFunctionMap = {
 	'group-labelledby-after': groupLabelledbyAfter,
 	'group-labelledby-evaluate': groupLabelledbyEvaluate,
 
+	// generic
+	'attr-non-space-content-evaluate': attrNonSpaceContentEvaluate,
+
 	// navigation
 	'header-present-evaluate': headerPresentEvaluate,
 	'heading-order-after': headingOrderAfter,
@@ -251,10 +254,7 @@ const metadataFunctionMap = {
 	'has-alt-evaluate': hasAltEvaluate,
 	'has-visible-text-evaluate': hasVisibleTextEvaluate,
 	'is-on-screen-evaluate': isOnScreenEvaluate,
-	'non-empty-alt-evaluate': nonEmptyAltEvaluate,
 	'non-empty-if-present-evaluate': nonEmptyIfPresentEvaluate,
-	'non-empty-title-evaluate': nonEmptyTitleEvaluate,
-	'non-empty-value-evaluate': nonEmptyValueEvaluate,
 	'role-none-evaluate': roleNoneEvaluate,
 	'role-presentation-evaluate': rolePresentationEvaluate,
 	'svg-non-empty-title-evaluate': svgNonEmptyTitleEvaluate,

--- a/test/checks/shared/non-empty-alt.js
+++ b/test/checks/shared/non-empty-alt.js
@@ -9,22 +9,28 @@ describe('non-empty-alt', function() {
 	});
 
 	it('should return true if an alt is present', function() {
-		var params = checkSetup('<img id="target" alt="woohoo" />');
+		var params = checkSetup('<img id="target" alt="woohoo" />', {
+			attribute: 'alt'
+		});
 		assert.isTrue(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 
 	it('should return false if an alt is not present', function() {
-		var params = checkSetup('<img id="target" />');
+		var params = checkSetup('<img id="target" />', { attribute: 'alt' });
 		assert.isFalse(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 
 	it('should return false if an alt is present, but empty', function() {
-		var params = checkSetup('<img id="target" alt=" " />');
+		var params = checkSetup('<img id="target" alt=" " />', {
+			attribute: 'alt'
+		});
 		assert.isFalse(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 
 	it('should collapse whitespace', function() {
-		var params = checkSetup('<img id="target" alt=" \t \n \r \t  \t\r\n " />');
+		var params = checkSetup('<img id="target" alt=" \t \n \r \t  \t\r\n " />', {
+			attribute: 'alt'
+		});
 		assert.isFalse(checks['non-empty-alt'].evaluate.apply(null, params));
 	});
 });

--- a/test/checks/shared/non-empty-title.js
+++ b/test/checks/shared/non-empty-title.js
@@ -2,44 +2,40 @@ describe('non-empty-title', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
-	var flatTreeSetup = axe.testUtils.flatTreeSetup;
+	var checkSetup = axe.testUtils.checkSetup;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 	});
 
 	it('should return true if a title is present', function() {
-		var node = document.createElement('img');
-		node.setAttribute('title', 'woohoo');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		var params = checkSetup('<img id="target" title="woohoo" />', {
+			attribute: 'title'
+		});
 
-		assert.isTrue(checks['non-empty-title'].evaluate(node));
+		assert.isTrue(checks['non-empty-title'].evaluate.apply(null, params));
 	});
 
 	it('should return false if a title is not present', function() {
-		var node = document.createElement('img');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		var params = checkSetup('<img id="target" />', { attribute: 'title' });
 
-		assert.isFalse(checks['non-empty-title'].evaluate(node));
+		assert.isFalse(checks['non-empty-title'].evaluate.apply(null, params));
 	});
 
 	it('should return false if a title is present, but empty', function() {
-		var node = document.createElement('img');
-		node.setAttribute('title', ' ');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		var params = checkSetup('<img id="target" title=" " />', {
+			attribute: 'title'
+		});
 
-		assert.isFalse(checks['non-empty-title'].evaluate(node));
+		assert.isFalse(checks['non-empty-title'].evaluate.apply(null, params));
 	});
 
 	it('should collapse whitespace', function() {
-		var node = document.createElement('div');
-		node.setAttribute('title', ' \t \n \r \t  \t\r\n ');
-		fixture.appendChild(node);
-		flatTreeSetup(fixture);
+		var params = checkSetup(
+			'<img id="target" title=" \t \n \r \t  \t\r\n " />',
+			{ attribute: 'title' }
+		);
 
-		assert.isFalse(checks['non-empty-title'].evaluate(node));
+		assert.isFalse(checks['non-empty-title'].evaluate.apply(null, params));
 	});
 });

--- a/test/checks/shared/non-empty-value.js
+++ b/test/checks/shared/non-empty-value.js
@@ -2,39 +2,40 @@ describe('non-empty-value', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var checkSetup = axe.testUtils.checkSetup;
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 	});
 
 	it('should return true if an value is present', function() {
-		var node = document.createElement('input');
-		node.setAttribute('value', 'woohoo');
-		fixture.appendChild(node);
+		var params = checkSetup('<input id="target" value="woohoo" />', {
+			attribute: 'value'
+		});
 
-		assert.isTrue(checks['non-empty-value'].evaluate(node));
+		assert.isTrue(checks['non-empty-value'].evaluate.apply(null, params));
 	});
 
 	it('should return false if an value is not present', function() {
-		var node = document.createElement('input');
-		fixture.appendChild(node);
+		var params = checkSetup('<input id="target" />', { attribute: 'value' });
 
-		assert.isFalse(checks['non-empty-value'].evaluate(node));
+		assert.isFalse(checks['non-empty-value'].evaluate.apply(null, params));
 	});
 
 	it('should return false if an value is present, but empty', function() {
-		var node = document.createElement('input');
-		node.setAttribute('value', ' ');
-		fixture.appendChild(node);
+		var params = checkSetup('<input id="target" value=" " />', {
+			attribute: 'value'
+		});
 
-		assert.isFalse(checks['non-empty-value'].evaluate(node));
+		assert.isFalse(checks['non-empty-value'].evaluate.apply(null, params));
 	});
 
 	it('should collapse whitespace', function() {
-		var node = document.createElement('div');
-		node.setAttribute('value', ' \t \n \r \t  \t\r\n ');
-		fixture.appendChild(node);
+		var params = checkSetup(
+			'<input id="target" value=" \t \n \r \t  \t\r\n " />',
+			{ attribute: 'value' }
+		);
 
-		assert.isFalse(checks['non-empty-value'].evaluate(node));
+		assert.isFalse(checks['non-empty-value'].evaluate.apply(null, params));
 	});
 });


### PR DESCRIPTION
`non-empty-alt`, `non-empty-title`, and `non-empty-value` were all the same function so combined them into a single generic check. Generic checks are new checks that don't have metadata files associated with them so are just evaluate functions called from other checks (can't be used directly in a rule). They typically will need options passed into them to work.

I talked to wilco about `non-empty-title` using `titleText` function and he said it didn't need to do that so was fine to just look at the title attribute directly.

Lastly, all the tests for the old checks are the exact same, especially since now they use the same evaluate underneath. I think we should remove them and just have a single test for the generic one and let the integration tests for the rules that use these checks catch things, but we should discuss that here.

Closes issue: #2192 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
