### PR TITLE
fix(aria-required-attr): pass aria-checked for elements with checked property

### DIFF
--- a/lib/checks/aria/aria-required-attr-evaluate.js
+++ b/lib/checks/aria/aria-required-attr-evaluate.js
@@ -7,14 +7,16 @@ import {
 	isAriaRange
 } from '../../commons/forms';
 import { requiredAttr } from '../../commons/aria';
-import { uniqueArray } from '../../core/utils';
+import { uniqueArray, getNodeFromTree } from '../../core/utils';
+import matches from '../../commons/matches';
 
 function ariaRequiredAttrEvaluate(node, options = {}) {
+	const vNode = getNodeFromTree(node);
 	const missing = [];
 
-	// aria-valuenow should fail if element does not have a value property
-	// @see https://github.com/dequelabs/axe-core/issues/1501
 	const preChecks = {
+		// aria-valuenow should fail if element does not have a value property
+		// @see https://github.com/dequelabs/axe-core/issues/1501
 		'aria-valuenow': function() {
 			return !(
 				isNativeTextbox(node) ||
@@ -24,6 +26,16 @@ function ariaRequiredAttrEvaluate(node, options = {}) {
 				isAriaCombobox(node) ||
 				(isAriaRange(node) && node.hasAttribute('aria-valuenow'))
 			);
+		},
+		// aria-checked should fail if element does not have a checked property
+		// @see https://github.com/dequelabs/axe-core/issues/2225
+		'aria-checked': function() {
+			return !matches(vNode, {
+				nodeName: 'input',
+				attributes: {
+					type: ['checkbox', 'radio']
+				}
+			});
 		}
 	};
 

--- a/test/checks/aria/required-attr.js
+++ b/test/checks/aria/required-attr.js
@@ -52,6 +52,21 @@ describe('aria-required-attr', function() {
 		);
 	});
 
+	it('should pass aria-checkbox if element has checked property', function() {
+		var vNode = queryFixture(
+			'<input id="target" type="checkbox" role="switch">'
+		);
+
+		assert.isTrue(
+			checks['aria-required-attr'].evaluate.call(
+				checkContext,
+				vNode.actualNode,
+				options,
+				vNode
+			)
+		);
+	});
+
 	describe('options', function() {
 		it('should require provided attribute names for a role', function() {
 			axe.commons.aria.lookupTable.role.mccheddarton = {


### PR DESCRIPTION
We already have an exception for `aria-valuenow` so we needed the same exception for `aria-checked`. See https://w3c.github.io/html-aam/#el-input-checkbox.

Closes issue: #2225

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
