### PR TITLE
fix(get-element-stack): properly calculate position of children of floated elements

### DIFF
--- a/lib/commons/dom/get-rect-stack.js
+++ b/lib/commons/dom/get-rect-stack.js
@@ -142,6 +142,32 @@ function isStackingContext(vNode, parentVNode) {
 }
 
 /**
+ * Check if a node or one of it's parents is floated.
+ * Floating position should be inherited from the parent tree
+ * @see https://github.com/dequelabs/axe-core/issues/2222
+ */
+function isFloated(vNode) {
+	if (!vNode) {
+		return false;
+	}
+
+	if (vNode._isFloated !== undefined) {
+		return vNode._isFloated;
+	}
+
+	const floatStyle = vNode.getComputedStylePropertyValue('float');
+
+	if (floatStyle !== 'none') {
+		vNode._isFloated = true;
+		return true;
+	}
+
+	const floated = isFloated(vNode.parent);
+	vNode._isFloated = floated;
+	return floated;
+}
+
+/**
  * Return the index order of how to position this element. return nodes in non-positioned, floating, positioned order
  * References:
  * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index
@@ -160,7 +186,7 @@ function getPositionOrder(vNode) {
 		}
 
 		// 4. the non-positioned floats.
-		if (vNode.getComputedStylePropertyValue('float') !== 'none') {
+		if (isFloated(vNode)) {
 			return 1;
 		}
 

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -85,6 +85,21 @@ describe('dom.getElementStack', function() {
 			assert.deepEqual(stack, ['4', '1', '2', 'target', 'fixture']);
 		});
 
+		it('should handle floating parent elements', function() {
+			fixture.innerHTML =
+				'<div id="1" style="float: left; background: #000000; color: #fff;">' +
+				'<div id="2"><span id="target">whole picture</span></div>' +
+				'</div>' +
+				'<div id="3">' +
+				'<div id="4" style="background: #f2f2f2;">English</div>' +
+				'</div>';
+
+			axe.testUtils.flatTreeSetup(fixture);
+			var target = fixture.querySelector('#target');
+			var stack = mapToIDs(getElementStack(target));
+			assert.deepEqual(stack, ['target', '2', '1', '4', '3', 'fixture']);
+		});
+
 		it('should handle z-index positioned elements in the same stacking context', function() {
 			// see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1
 			fixture.innerHTML =


### PR DESCRIPTION
Digging into this issue, I realized that children of floated elements should share the same position as their floated parent. Floats do not create stacking contexts, but their children are part of the "floating stack." So comparing a non-floated stack element to floating stack element should not result in the same position (which was causing the bug as the nested `div#2` was being compared against `div#3` and `div#4` and returning the same position, so it defaulted to the inverse DOM order putting `div#2` after the other two).

Closes issue: #2222

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
