### PR TITLE
chore(process-message): import helper function

### DIFF
--- a/lib/core/utils/process-message.js
+++ b/lib/core/utils/process-message.js
@@ -1,4 +1,5 @@
-/* global helpers */
+import { incompleteFallbackMessage } from '../reporters/helpers';
+
 const dataRegex = /\$\{\s?data\s?\}/g;
 
 /**
@@ -62,8 +63,7 @@ function processMessage(message, data) {
 	}
 
 	// message uses value of data property to determine message
-	// TODO: `helpers.incompleteFallbackMessage` should be imported from `lib/core/reporters/helpers`
-	let str = message.default || helpers.incompleteFallbackMessage();
+	let str = message.default || incompleteFallbackMessage();
 
 	if (data && data.messageKey && message[data.messageKey]) {
 		str = message[data.messageKey];


### PR DESCRIPTION
Found a global variable that didn't get imported properly. Would throw an error when we got to that line (very rarely happens).

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
