### PR TITLE
feat(matches-definition): add generic check matches-definition

### DIFF
--- a/lib/checks/generic/matches-definition-evaluate.js
+++ b/lib/checks/generic/matches-definition-evaluate.js
@@ -1,0 +1,7 @@
+import matches from '../../commons/matches';
+
+function matchesDefinitionEvaluate(_, options, virtualNode) {
+	return matches(virtualNode, options.matcher);
+}
+
+export default matchesDefinitionEvaluate;

--- a/lib/checks/shared/role-none-evaluate.js
+++ b/lib/checks/shared/role-none-evaluate.js
@@ -1,5 +1,0 @@
-function roleNoneEvaluate(node) {
-	return node.getAttribute('role') === 'none';
-}
-
-export default roleNoneEvaluate;

--- a/lib/checks/shared/role-none.json
+++ b/lib/checks/shared/role-none.json
@@ -1,6 +1,13 @@
 {
 	"id": "role-none",
-	"evaluate": "role-none-evaluate",
+	"evaluate": "matches-definition-evaluate",
+	"options": {
+		"matcher": {
+			"attributes": {
+				"role": "none"
+			}
+		}
+	},
 	"metadata": {
 		"impact": "minor",
 		"messages": {

--- a/lib/checks/shared/role-presentation-evaluate.js
+++ b/lib/checks/shared/role-presentation-evaluate.js
@@ -1,5 +1,0 @@
-function rolePresentationEvaluate(node) {
-	return node.getAttribute('role') === 'presentation';
-}
-
-export default rolePresentationEvaluate;

--- a/lib/checks/shared/role-presentation.json
+++ b/lib/checks/shared/role-presentation.json
@@ -1,6 +1,13 @@
 {
 	"id": "role-presentation",
-	"evaluate": "role-presentation-evaluate",
+	"evaluate": "matches-definition-evaluate",
+	"options": {
+		"matcher": {
+			"attributes": {
+				"role": "presentation"
+			}
+		}
+	},
 	"metadata": {
 		"impact": "minor",
 		"messages": {

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -42,6 +42,7 @@ import autocompleteValidEvaluate from '../../checks/forms/autocomplete-valid-eva
 import attrNonSpaceContentEvaluate from '../../checks/generic/attr-non-space-content-evaluate';
 import hasDescendantAfter from '../../checks/generic/has-descendant-after';
 import hasDescendantEvaluate from '../../checks/generic/has-descendant-evaluate';
+import matchesDefinitionEvaluate from '../../checks/generic/matches-definition-evaluate';
 import pageNoDuplicateAfter from '../../checks/generic/page-no-duplicate-after';
 import pageNoDuplicateEvaluate from '../../checks/generic/page-no-duplicate-evaluate';
 
@@ -69,8 +70,6 @@ import hasAltEvaluate from '../../checks/shared/has-alt-evaluate';
 import hasVisibleTextEvaluate from '../../checks/shared/has-visible-text-evaluate';
 import isOnScreenEvaluate from '../../checks/shared/is-on-screen-evaluate';
 import nonEmptyIfPresentEvaluate from '../../checks/shared/non-empty-if-present-evaluate';
-import roleNoneEvaluate from '../../checks/shared/role-none-evaluate';
-import rolePresentationEvaluate from '../../checks/shared/role-presentation-evaluate';
 import svgNonEmptyTitleEvaluate from '../../checks/shared/svg-non-empty-title-evaluate';
 
 // mobile
@@ -205,6 +204,7 @@ const metadataFunctionMap = {
 	'attr-non-space-content-evaluate': attrNonSpaceContentEvaluate,
 	'has-descendant-after': hasDescendantAfter,
 	'has-descendant-evaluate': hasDescendantEvaluate,
+	'matches-definition-evaluate': matchesDefinitionEvaluate,
 	'page-no-duplicate-after': pageNoDuplicateAfter,
 	'page-no-duplicate-evaluate': pageNoDuplicateEvaluate,
 
@@ -232,8 +232,6 @@ const metadataFunctionMap = {
 	'has-visible-text-evaluate': hasVisibleTextEvaluate,
 	'is-on-screen-evaluate': isOnScreenEvaluate,
 	'non-empty-if-present-evaluate': nonEmptyIfPresentEvaluate,
-	'role-none-evaluate': roleNoneEvaluate,
-	'role-presentation-evaluate': rolePresentationEvaluate,
 	'svg-non-empty-title-evaluate': svgNonEmptyTitleEvaluate,
 
 	// mobile

--- a/test/checks/shared/role-none.js
+++ b/test/checks/shared/role-none.js
@@ -2,29 +2,28 @@ describe('role-none', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var queryFixture = axe.testUtils.queryFixture;
+	var checkEvaluate = axe.testUtils.getCheckEvaluate('role-none');
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 	});
 
 	it('should detect role="none" on the element', function() {
-		fixture.innerHTML = '<div role="none"></div>';
-		var node = fixture.querySelector('div');
+		var vNode = queryFixture('<div id="target" role="none"></div>');
 
-		assert.isTrue(axe.testUtils.getCheckEvaluate('role-none')(node));
+		assert.isTrue(checkEvaluate(null, null, vNode));
 	});
 
 	it('should return false when role !== none', function() {
-		fixture.innerHTML = '<div role="cats"></div>';
-		var node = fixture.querySelector('div');
+		var vNode = queryFixture('<div id="target" role="cats"></div>');
 
-		assert.isFalse(axe.testUtils.getCheckEvaluate('role-none')(node));
+		assert.isFalse(checkEvaluate(null, null, vNode));
 	});
 
 	it('should return false when there is no role attribute', function() {
-		fixture.innerHTML = '<div></div>';
-		var node = fixture.querySelector('div');
+		var vNode = queryFixture('<div id="target"></div>');
 
-		assert.isFalse(axe.testUtils.getCheckEvaluate('role-none')(node));
+		assert.isFalse(checkEvaluate(null, null, vNode));
 	});
 });

--- a/test/checks/shared/role-presentation.js
+++ b/test/checks/shared/role-presentation.js
@@ -2,29 +2,28 @@ describe('role-presentation', function() {
 	'use strict';
 
 	var fixture = document.getElementById('fixture');
+	var queryFixture = axe.testUtils.queryFixture;
+	var checkEvaluate = axe.testUtils.getCheckEvaluate('role-presentation');
 
 	afterEach(function() {
 		fixture.innerHTML = '';
 	});
 
 	it('should detect role="presentation" on the element', function() {
-		fixture.innerHTML = '<div role="presentation"></div>';
-		var node = fixture.querySelector('div');
+		var vNode = queryFixture('<div id="target" role="presentation"></div>');
 
-		assert.isTrue(axe.testUtils.getCheckEvaluate('role-presentation')(node));
+		assert.isTrue(checkEvaluate(null, null, vNode));
 	});
 
 	it('should return false when role !== presentation', function() {
-		fixture.innerHTML = '<div role="cats"></div>';
-		var node = fixture.querySelector('div');
+		var vNode = queryFixture('<div id="target" role="cats"></div>');
 
-		assert.isFalse(axe.testUtils.getCheckEvaluate('role-presentation')(node));
+		assert.isFalse(checkEvaluate(null, null, vNode));
 	});
 
 	it('should return false when there is no role attribute', function() {
-		fixture.innerHTML = '<div></div>';
-		var node = fixture.querySelector('div');
+		var vNode = queryFixture('<div id="target"></div>');
 
-		assert.isFalse(axe.testUtils.getCheckEvaluate('role-presentation')(node));
+		assert.isFalse(checkEvaluate(null, null, vNode));
 	});
 });


### PR DESCRIPTION
There are a few checks we could replace with this if matches could handle things like "attribute is not empty" or "attribute is empty" type checks as well. Once we extend matches with role matching, there are a few more checks we can replace as well.

Closes issue: #2185

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
