### PR TITLE
fix(meta-viewport): don't throw error if viewport property doesn't have a value

### DIFF
--- a/lib/checks/mobile/meta-viewport-scale-evaluate.js
+++ b/lib/checks/mobile/meta-viewport-scale-evaluate.js
@@ -14,7 +14,7 @@ function metaViewportScaleEvaluate(node, options) {
 
 		const [key, value] = contentValue.split('=');
 		const curatedKey = key.toLowerCase().trim();
-		let curatedValue = value.toLowerCase().trim();
+		let curatedValue = value && value.toLowerCase().trim();
 
 		// convert `yes` to `1`
 		if (curatedKey === 'maximum-scale' && curatedValue === 'yes') {

--- a/lib/checks/mobile/meta-viewport-scale-evaluate.js
+++ b/lib/checks/mobile/meta-viewport-scale-evaluate.js
@@ -14,7 +14,7 @@ function metaViewportScaleEvaluate(node, options) {
 
 		const [key, value] = contentValue.split('=');
 		const curatedKey = key.toLowerCase().trim();
-		let curatedValue = value && value.toLowerCase().trim();
+		let curatedValue = (value || "").toLowerCase().trim();
 
 		// convert `yes` to `1`
 		if (curatedKey === 'maximum-scale' && curatedValue === 'yes') {

--- a/lib/checks/mobile/meta-viewport-scale-evaluate.js
+++ b/lib/checks/mobile/meta-viewport-scale-evaluate.js
@@ -13,8 +13,11 @@ function metaViewportScaleEvaluate(node, options) {
 		}
 
 		const [key, value] = contentValue.split('=');
+		if (!key || !value) {
+			return out;
+		}
 		const curatedKey = key.toLowerCase().trim();
-		let curatedValue = (value || "").toLowerCase().trim();
+		let curatedValue = value.toLowerCase().trim();
 
 		// convert `yes` to `1`
 		if (curatedKey === 'maximum-scale' && curatedValue === 'yes') {

--- a/test/checks/mobile/meta-viewport-scale.js
+++ b/test/checks/mobile/meta-viewport-scale.js
@@ -99,6 +99,14 @@ describe('meta-viewport', function() {
 				axe.testUtils.getCheckEvaluate('meta-viewport').call(checkContext, node)
 			);
 		});
+
+		it('should not crash if viewport property does not have a value', function() {
+			fixture.innerHTML =
+				'<meta name="viewport" content="user-scalable=1, minimal-ui">';
+			var node = fixture.querySelector('meta');
+
+			assert.isTrue(axe.testUtils.getCheckEvaluate('meta-viewport')(node));
+		});
 	});
 
 	describe(', separator', function() {


### PR DESCRIPTION
Currently checking this meta viewport tag throws an error:

    <meta name="viewport" content="user-scalable=1, minimal-ui">

> TypeError: Cannot read property 'toLowerCase' of undefined

I think the issue was [introduced by this change](https://github.com/dequelabs/axe-core/pull/2137).

This PR fixes the issue by tolerating meta viewport properties without a value.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
