### PR TITLE
ci: update Golang to fix `github_release` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
   # Create a GitHub release.
   github_release:
     docker:
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.10
     steps:
       - checkout
       - run: go get gopkg.in/aktau/github-release.v0


### PR DESCRIPTION
See https://circleci.com/gh/dequelabs/axe-core/16464 / https://github.com/github-release/github-release/issues/101

I had fixed this in our private repos, but apparently neglected `axe-core` 🤦‍♂️ 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
