### PR TITLE
feat(utils.getFlattenTree): default to documentElement

### DIFF
--- a/lib/core/utils/get-flattened-tree.js
+++ b/lib/core/utils/get-flattened-tree.js
@@ -1,5 +1,6 @@
 import isShadowRoot from './is-shadow-root';
 import VirtualNode from '../base/virtual-node/virtual-node';
+import cache from '../base/cache';
 
 /**
  * This implemnts the flatten-tree algorithm specified:
@@ -134,13 +135,12 @@ function flattenTree(node, shadowId, parent) {
  * Recursvely returns an array of the virtual DOM nodes at this level
  * excluding comment nodes and the shadow DOM nodes <content> and <slot>
  *
- * @param {Node} node the current node
- * @param {String} shadowId, optional ID of the shadow DOM that is the closest shadow
+ * @param {Node} [node=document.documentElement] optional node. NOTE: passing in anything other than body or the documentElement may result in incomplete results.
+ * @param {String} [shadowId] optional ID of the shadow DOM that is the closest shadow
  *                           ancestor of the node
  */
-function getFlattenedTree(node, shadowId) {
-	// TODO: es-modules_cache
-	axe._cache.set('nodeMap', new WeakMap());
+function getFlattenedTree(node = document.documentElement, shadowId) {
+	cache.set('nodeMap', new WeakMap());
 	return flattenTree(node, shadowId);
 }
 

--- a/test/core/utils/flattened-tree.js
+++ b/test/core/utils/flattened-tree.js
@@ -75,6 +75,12 @@ describe('axe.utils.getFlattenedTree', function() {
 		);
 	}
 
+	it('should default to document', function() {
+		fixture.innerHTML = '';
+		var tree = axe.utils.getFlattenedTree();
+		assert(tree[0].actualNode === document.documentElement);
+	});
+
 	if (shadowSupport.v0) {
 		describe('shadow DOM v0', function() {
 			afterEach(function() {


### PR DESCRIPTION
In investigating various things, we discovered that passing in a subtree of the DOM to `getFlattenTree` would give bad results when running various APIs. For example, trying to get the accessible name of this structure would return `''` and running the label rule would fail:

```html
<div id="foo">lablled</div>
<input  id="context" aria-labelledby="foo">

<script>
var input = document.getElementById('context');
axe.utils.getFlattenTree(document.getElementById('context'));
var a11yName = axe.utils.accessibleText(input);
assert('a11yName === 'foo');  // returns false
</script>
```

This doesn't happen in a normal `axe.run` as we always set up the virtual tree to be the `documentElement` regardless of what node is passed in. This is only an issue with `getFlattenTree`.

`getFlattenTree` expects a node to be passed in, but we only can get correct results if `documentElement` or `body` is passed in. If any other node is passed in we cannot guarantee correct results. [Looking through github for uses](https://github.com/search?p=4&q=utils.getFlattenedTree+-filename%3Aaxe.js+-org%3A3dwebart+-org%3Adequelabs&type=Code), it seems most users are passing in `documentElement`, but there are some uses of non-documentElement [that would cause problems](https://github.com/edx/edx-custom-a11y-rules/blob/6e53b5ee4f6a7ad69f606c9ab9a5fb0d77c48afc/lib/custom_a11y_rules.js#L109-L122).

To remedy this and not introduce a breaking change, I made passing in a node optional and instead have the code default to `documentElement`. I also added a note to the docs to warn users of problems passing in a node that is not `body` or `documentElement`.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
