### PR TITLE
fix(aria-input-field-name): add the missing word "must" to help metadata

### DIFF
--- a/lib/rules/aria-input-field-name.json
+++ b/lib/rules/aria-input-field-name.json
@@ -5,7 +5,7 @@
 	"tags": ["wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures every ARIA input field has an accessible name",
-		"help": "ARIA input fields have an accessible name"
+		"help": "ARIA input fields must have an accessible name"
 	},
 	"all": [],
 	"any": ["aria-label", "aria-labelledby", "non-empty-title"],


### PR DESCRIPTION
Adds the missing word "must" to help metadata for ARIA input field name. This puts it in line with the other ARIA rules that include the word "must."

This is helpful for @webhintio, which uses the help field in `axe-core` to provide developer guidance. With the word "must" missing, it is not clear what developer action is needed.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
