### PR TITLE
fix(color-contrast): fix font-weight calculation for safari

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -41,8 +41,8 @@ function colorContrastEvaluate(node, options = {}, virtualNode) {
 
 	const nodeStyle = window.getComputedStyle(node);
 	const fontSize = parseFloat(nodeStyle.getPropertyValue('font-size'));
-	const fontWeight = parseFloat(nodeStyle.getPropertyValue('font-weight'));
-	const bold = !isNaN(fontWeight) && fontWeight >= 700;
+	const fontWeight = nodeStyle.getPropertyValue('font-weight');
+	const bold = parseFloat(fontWeight) >= 700 || fontWeight === 'bold';
 
 	const cr = hasValidContrastRatio(bgColor, fgColor, fontSize, bold);
 


### PR DESCRIPTION
Found this issue while trying to get [safari running in CI](https://github.com/dequelabs/axe-core/pull/2264). Safari does not translate `font-weight: bold` into a number but instead leaves it as `bold`.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
