### PR TITLE
fix(configure): validate rules and checks properties

### DIFF
--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -46,7 +46,7 @@ function configure(spec) {
 
 	if (spec.checks) {
 		if (!Array.isArray(spec.checks)) {
-			throw new Error('Checks property must be an array');
+			throw new TypeError('Checks property must be an array');
 		}
 
 		spec.checks.forEach(function(check) {

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -68,7 +68,7 @@ function configure(spec) {
 
 		spec.rules.forEach(function(rule) {
 			if (!rule.id) {
-				throw new Error(
+				throw new TypeError(
 					`Configured rule "${rule}" is invalid. Rules must be an object with at least an id property`
 				);
 			}

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -45,14 +45,34 @@ function configure(spec) {
 	}
 
 	if (spec.checks) {
+		if (!Array.isArray(spec.checks)) {
+			throw new Error('Checks property must be an array');
+		}
+
 		spec.checks.forEach(function(check) {
+			if (!check.id) {
+				throw new Error(
+					`Configured check "${check}" is invalid. Checks must be an object with at least an id property`
+				);
+			}
+
 			audit.addCheck(check);
 		});
 	}
 
 	const modifiedRules = [];
 	if (spec.rules) {
+		if (!Array.isArray(spec.rules)) {
+			throw new Error('Rules property must be an array');
+		}
+
 		spec.rules.forEach(function(rule) {
+			if (!rule.id) {
+				throw new Error(
+					`Configured rule "${rule}" is invalid. Rules must be an object with at least an id property`
+				);
+			}
+
 			modifiedRules.push(rule.id);
 			audit.addRule(rule);
 		});

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -51,8 +51,10 @@ function configure(spec) {
 
 		spec.checks.forEach(function(check) {
 			if (!check.id) {
+				const checkStr =
+					typeof check === 'object' ? JSON.stringify(check) : check;
 				throw new TypeError(
-					`Configured check "${check}" is invalid. Checks must be an object with at least an id property`
+					`Configured check "${checkStr}" is invalid. Checks must be an object with at least an id property`
 				);
 			}
 
@@ -68,8 +70,9 @@ function configure(spec) {
 
 		spec.rules.forEach(function(rule) {
 			if (!rule.id) {
+				const ruleStr = typeof rule === 'object' ? JSON.stringify(rule) : rule;
 				throw new TypeError(
-					`Configured rule "${rule}" is invalid. Rules must be an object with at least an id property`
+					`Configured rule "${ruleStr}" is invalid. Rules must be an object with at least an id property`
 				);
 			}
 

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -52,7 +52,10 @@ function configure(spec) {
 		spec.checks.forEach(function(check) {
 			if (!check.id) {
 				throw new TypeError(
-					`Configured check ${JSON.stringify(check)} is invalid. Checks must be an object with at least an id property`
+					// eslint-disable-next-line max-len
+					`Configured check ${JSON.stringify(
+						check
+					)} is invalid. Checks must be an object with at least an id property`
 				);
 			}
 
@@ -69,7 +72,10 @@ function configure(spec) {
 		spec.rules.forEach(function(rule) {
 			if (!rule.id) {
 				throw new TypeError(
-					`Configured rule ${JSON.stringify(rule)} is invalid. Rules must be an object with at least an id property`
+					// eslint-disable-next-line max-len
+					`Configured rule ${JSON.stringify(
+						rule
+					)} is invalid. Rules must be an object with at least an id property`
 				);
 			}
 

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -51,7 +51,7 @@ function configure(spec) {
 
 		spec.checks.forEach(function(check) {
 			if (!check.id) {
-				throw new Error(
+				throw new TypeError(
 					`Configured check "${check}" is invalid. Checks must be an object with at least an id property`
 				);
 			}

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -51,10 +51,8 @@ function configure(spec) {
 
 		spec.checks.forEach(function(check) {
 			if (!check.id) {
-				const checkStr =
-					typeof check === 'object' ? JSON.stringify(check) : check;
 				throw new TypeError(
-					`Configured check "${checkStr}" is invalid. Checks must be an object with at least an id property`
+					`Configured check ${JSON.stringify(check)} is invalid. Checks must be an object with at least an id property`
 				);
 			}
 

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -63,7 +63,7 @@ function configure(spec) {
 	const modifiedRules = [];
 	if (spec.rules) {
 		if (!Array.isArray(spec.rules)) {
-			throw new Error('Rules property must be an array');
+			throw new TypeError('Rules property must be an array');
 		}
 
 		spec.rules.forEach(function(rule) {

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -70,9 +70,8 @@ function configure(spec) {
 
 		spec.rules.forEach(function(rule) {
 			if (!rule.id) {
-				const ruleStr = typeof rule === 'object' ? JSON.stringify(rule) : rule;
 				throw new TypeError(
-					`Configured rule "${ruleStr}" is invalid. Rules must be an object with at least an id property`
+					`Configured rule ${JSON.stringify(rule)} is invalid. Rules must be an object with at least an id property`
 				);
 			}
 

--- a/test/core/public/configure.js
+++ b/test/core/public/configure.js
@@ -58,6 +58,20 @@ describe('axe.configure', function() {
 		assert.deepEqual(axe._audit.data.rules.bob.joe, 'joe');
 	});
 
+	it('should throw error if rules property is invalid', function() {
+		assert.throws(function() {
+			axe.configure({ rules: 'hello' }),
+				Error,
+				/^Rules property must be an array/;
+		});
+	});
+
+	it('should throw error if rule is invalid', function() {
+		assert.throws(function() {
+			axe.configure({ rules: ['hello'] }), Error, /Rules must be an object/;
+		});
+	});
+
 	it('should call setBranding when passed options', function() {
 		axe._load({});
 		axe.configure({
@@ -158,6 +172,20 @@ describe('axe.configure', function() {
 		assert.equal(axe._audit.checks.bob.id, 'bob');
 		assert.isTrue(axe._audit.checks.bob.options.value);
 		assert.equal(axe._audit.data.checks.bob.joe, 'joe');
+	});
+
+	it('should throw error if checks property is invalid', function() {
+		assert.throws(function() {
+			axe.configure({ checks: 'hello' }),
+				Error,
+				/^Checks property must be an array/;
+		});
+	});
+
+	it('should throw error if check is invalid', function() {
+		assert.throws(function() {
+			axe.configure({ checks: ['hello'] }), Error, /Checks must be an object/;
+		});
 	});
 
 	it('should allow for the overwriting of checks', function() {

--- a/test/core/public/configure.js
+++ b/test/core/public/configure.js
@@ -68,7 +68,17 @@ describe('axe.configure', function() {
 
 	it('should throw error if rule is invalid', function() {
 		assert.throws(function() {
-			axe.configure({ rules: ['hello'] }), TypeError, /Rules must be an object/;
+			axe.configure({ rules: ['hello'] }),
+				TypeError,
+				/Configured rule "hello" is invalid/;
+		});
+	});
+
+	it('should throw error if rule does not have an id', function() {
+		assert.throws(function() {
+			axe.configure({ rules: [{ foo: 'bar' }] }),
+				TypeError,
+				/Configured rule "{foo:\"bar\"}" is invalid/;
 		});
 	});
 
@@ -186,7 +196,15 @@ describe('axe.configure', function() {
 		assert.throws(function() {
 			axe.configure({ checks: ['hello'] }),
 				TypeError,
-				/Checks must be an object/;
+				/Configured check "hello" is invalid/;
+		});
+	});
+
+	it('should throw error if check does not have an id', function() {
+		assert.throws(function() {
+			axe.configure({ checks: [{ foo: 'bar' }] }),
+				TypeError,
+				/Configured check "{foo:\"bar\"}" is invalid/;
 		});
 	});
 

--- a/test/core/public/configure.js
+++ b/test/core/public/configure.js
@@ -61,14 +61,14 @@ describe('axe.configure', function() {
 	it('should throw error if rules property is invalid', function() {
 		assert.throws(function() {
 			axe.configure({ rules: 'hello' }),
-				Error,
+				TypeError,
 				/^Rules property must be an array/;
 		});
 	});
 
 	it('should throw error if rule is invalid', function() {
 		assert.throws(function() {
-			axe.configure({ rules: ['hello'] }), Error, /Rules must be an object/;
+			axe.configure({ rules: ['hello'] }), TypeError, /Rules must be an object/;
 		});
 	});
 
@@ -177,14 +177,16 @@ describe('axe.configure', function() {
 	it('should throw error if checks property is invalid', function() {
 		assert.throws(function() {
 			axe.configure({ checks: 'hello' }),
-				Error,
+				TypeError,
 				/^Checks property must be an array/;
 		});
 	});
 
 	it('should throw error if check is invalid', function() {
 		assert.throws(function() {
-			axe.configure({ checks: ['hello'] }), Error, /Checks must be an object/;
+			axe.configure({ checks: ['hello'] }),
+				TypeError,
+				/Checks must be an object/;
 		});
 	});
 


### PR DESCRIPTION
Prevents passing `axe.configure({ rules: ['hello'] });`. Also checked the `checks` property as it had the same problem.

Closes issue: #2282

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
