### PR TITLE
fix: ensure correctly generated axe is required by `aria-supported` build step

### DIFF
--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -16,7 +16,10 @@ module.exports = function(grunt) {
 			 * as `axe` does not exist until grunt task `build:uglify` is complete,
 			 * hence cannot be required at the top of the file.
 			 */
-			const axe = require('../../axe');
+			const langOption = grunt.option('lang');
+			const fileNameSuffix =
+				langOption && langOption.length > 0 ? `.${langOption}` : '';
+			const axe = require(`../../axe${fileNameSuffix}`);
 			const listType = this.data.listType.toLowerCase();
 			const headings = {
 				main:


### PR DESCRIPTION
When passing the grunt lang option, the generated `axe` file has a suffix of the language supplied. This needs to be catered for when dynamically requiring `axe` in the build step `aria-supported`

Closes issue:
- https://github.com/dequelabs/axe-core/issues/2290

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
