### PR TITLE
chore: adapt `rule-generator` script to output ES Modules snippets

### DIFF
--- a/build/rule-generator/get-files-metadata.js
+++ b/build/rule-generator/get-files-metadata.js
@@ -16,7 +16,7 @@ const getRuleSpecFileMeta = (ruleName, ruleHasMatches, ruleChecks) => {
 				id: `${ruleName}`,
 				selector: '',
 				...(ruleHasMatches && {
-					matches: `${ruleName}-matches.js`
+					matches: `${ruleName}-matches`
 				}),
 				tags: [],
 				metadata: {
@@ -60,8 +60,13 @@ const getRuleMatchesFileMeta = (
 		const ruleMatchesJs = {
 			name: `${ruleName}-matches.js`,
 			content: `
-			// TODO: Filter node(s)
-			return node;
+			// todo: use the matches function to filter out nodes that are to be checked by the rule
+			
+			function getMatchingNodes(node) {
+				return node
+			}
+
+			export default getMatchingNodes
 			`,
 			dir: directories.rules
 		};
@@ -74,7 +79,9 @@ const getRuleMatchesFileMeta = (
 			content: `
 			describe('${ruleName}-matches', function() {
 				'use strict';
-				// TODO: Write tests
+
+				// todo: Write tests
+
 			})
 			`,
 			dir: directories.testRuleMatches
@@ -98,7 +105,7 @@ const getCheckSpecFileMeta = (name, dir) => {
 		content: JSON.stringify(
 			{
 				id: `${name}`,
-				evaluate: `${name}.js`,
+				evaluate: `${name}`,
 				metadata: {
 					impact: '',
 					messages: {
@@ -126,8 +133,13 @@ const getCheckJsFileMeta = (name, dir) => {
 	return {
 		name: `${name}.js`,
 		content: `
-		// TODO: Logic for check
-		return true;
+		// todo: evaluate fn logic for check
+
+		function evaluate(node) {
+			return true
+		}
+
+		export default evaluate;
 		`,
 		dir
 	};
@@ -146,7 +158,9 @@ const getCheckTestJsFileMeta = (name, dir) => {
 		content: `
 		describe('${name} tests', function() {
 			'use strict';
-			// TODO: Write tests
+
+			// todo: Write tests
+			
 		})
 		`,
 		dir

--- a/build/rule-generator/get-files-metadata.js
+++ b/build/rule-generator/get-files-metadata.js
@@ -62,11 +62,11 @@ const getRuleMatchesFileMeta = (
 			content: `
 			// TODO: Filter node(s)	
 			
-			function getMatches(node) {
+			function myRuleMatches(node) {
 				return node
 			}
 
-			export default getMatches
+			export default myRuleMatches
 			`,
 			dir: directories.rules
 		};
@@ -103,7 +103,7 @@ const getCheckSpecFileMeta = (name, dir) => {
 		content: JSON.stringify(
 			{
 				id: `${name}`,
-				evaluate: `${name}`,
+				evaluate: `${name}-evaluate`,
 				metadata: {
 					impact: '',
 					messages: {
@@ -129,13 +129,13 @@ const getCheckSpecFileMeta = (name, dir) => {
  */
 const getCheckJsFileMeta = (name, dir) => {
 	return {
-		name: `${name}.js`,
+		name: `${name}-evaluate.js`,
 		content: `
 		// TODO: Logic for check
-		function evaluate(node) {
+		function myCheckEvaluate(node) {
 			return true
 		}
-		export default evaluate;
+		export default myCheckEvaluate;
 		`,
 		dir
 	};

--- a/build/rule-generator/get-files-metadata.js
+++ b/build/rule-generator/get-files-metadata.js
@@ -73,7 +73,7 @@ const getRuleMatchesFileMeta = (
 			content: `
 			// TODO: Filter node(s)	
 			
-			function ${fnName}(node) {
+			function ${fnName}(node, virtualNode) {
 				return node
 			}
 
@@ -90,7 +90,7 @@ const getRuleMatchesFileMeta = (
 			content: `
 			describe('${ruleName}-matches', function() {
 				'use strict';
-				// TODO: Write tests 
+				// TODO: Write tests
 			})
 			`,
 			dir: directories.testRuleMatches
@@ -144,7 +144,7 @@ const getCheckJsFileMeta = (name, dir) => {
 		name: `${name}-evaluate.js`,
 		content: `
 		// TODO: Logic for check
-		function ${fnName}(node) {
+		function ${fnName}(node, options, virtualNode) {
 			return true
 		}
 		export default ${fnName};

--- a/build/rule-generator/get-files-metadata.js
+++ b/build/rule-generator/get-files-metadata.js
@@ -60,13 +60,13 @@ const getRuleMatchesFileMeta = (
 		const ruleMatchesJs = {
 			name: `${ruleName}-matches.js`,
 			content: `
-			// todo: use the matches function to filter out nodes that are to be checked by the rule
+			// TODO: Filter node(s)	
 			
-			function getMatchingNodes(node) {
+			function getMatches(node) {
 				return node
 			}
 
-			export default getMatchingNodes
+			export default getMatches
 			`,
 			dir: directories.rules
 		};
@@ -79,9 +79,7 @@ const getRuleMatchesFileMeta = (
 			content: `
 			describe('${ruleName}-matches', function() {
 				'use strict';
-
-				// todo: Write tests
-
+				// TODO: Write tests 
 			})
 			`,
 			dir: directories.testRuleMatches
@@ -133,12 +131,10 @@ const getCheckJsFileMeta = (name, dir) => {
 	return {
 		name: `${name}.js`,
 		content: `
-		// todo: evaluate fn logic for check
-
+		// TODO: Logic for check
 		function evaluate(node) {
 			return true
 		}
-
 		export default evaluate;
 		`,
 		dir
@@ -158,9 +154,7 @@ const getCheckTestJsFileMeta = (name, dir) => {
 		content: `
 		describe('${name} tests', function() {
 			'use strict';
-
-			// todo: Write tests
-			
+			// TODO: Write tests
 		})
 		`,
 		dir

--- a/build/rule-generator/get-files-metadata.js
+++ b/build/rule-generator/get-files-metadata.js
@@ -1,6 +1,16 @@
 const directories = require('./directories');
 
 /**
+ * Helper to convert a given string to camel case (split by hyphens if any)
+ * @param {String} str given string to be camel cased
+ */
+const camelCase = str => {
+	return str.replace(/-([a-z])/g, g => {
+		return g[1].toUpperCase();
+	});
+};
+
+/**
  * Get meta data for the file to be created as RULE Specification
  * @method getRuleSpecFileMeta
  * @param {String} ruleName given name for the RULE
@@ -57,16 +67,17 @@ const getRuleMatchesFileMeta = (
 	let files = [];
 
 	if (ruleHasMatches) {
+		const fnName = `${camelCase(ruleName)}Matches`;
 		const ruleMatchesJs = {
 			name: `${ruleName}-matches.js`,
 			content: `
 			// TODO: Filter node(s)	
 			
-			function myRuleMatches(node) {
+			function ${fnName}(node) {
 				return node
 			}
 
-			export default myRuleMatches
+			export default ${fnName}
 			`,
 			dir: directories.rules
 		};
@@ -128,14 +139,15 @@ const getCheckSpecFileMeta = (name, dir) => {
  * @returns {Object} meta data of file
  */
 const getCheckJsFileMeta = (name, dir) => {
+	const fnName = `${camelCase(name)}Evaluate`;
 	return {
 		name: `${name}-evaluate.js`,
 		content: `
 		// TODO: Logic for check
-		function myCheckEvaluate(node) {
+		function ${fnName}(node) {
 			return true
 		}
-		export default myCheckEvaluate;
+		export default ${fnName};
 		`,
 		dir
 	};


### PR DESCRIPTION
We have a CLI (`npm run rule-gen`), which helps generate all the relevant files with code snippets when writing a new rule, by prompting the user to simply follow a Q&A wizard. 

This change updates the generator to output ES Modules friendly code in the matches, rules & checks file accordingly.

> Note: I recently was looking to write a new rule and used the generator & thence the PR to update this.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
