### PR TITLE
fix(color-contrast): properly handle truncated text

### DIFF
--- a/lib/commons/dom/get-text-element-stack.js
+++ b/lib/commons/dom/get-text-element-stack.js
@@ -61,9 +61,6 @@ function getTextElementStack(node) {
 		}
 	});
 
-	// if the node is truncated then the first text rect will be the full
-	// width of the text, and the last node will be the ellipsis
-
 	return clientRects.map(rect => {
 		return getRectStack(grid, rect);
 	});

--- a/lib/commons/dom/get-text-element-stack.js
+++ b/lib/commons/dom/get-text-element-stack.js
@@ -1,3 +1,4 @@
+import getElementStack from './get-element-stack';
 import { createGrid, getRectStack } from './get-rect-stack';
 import sanitize from '../text/sanitize';
 
@@ -21,6 +22,17 @@ function getTextElementStack(node) {
 
 	if (!grid) {
 		return [];
+	}
+
+	// if the element is using text truncation we need to get the rect of
+	// the element rather than look at the text node rects as they will return
+	// the full width of the text node before truncation (which can go off the
+	// screen)
+	// @see https://github.com/dequelabs/axe-core/issues/2178
+	const whiteSpace = vNode.getComputedStylePropertyValue('white-space');
+	const overflow = vNode.getComputedStylePropertyValue('overflow');
+	if (whiteSpace === 'nowrap' && overflow === 'hidden') {
+		return [getElementStack(node)];
 	}
 
 	// for code blocks that use syntax highlighting, you can get a ton of client
@@ -48,6 +60,9 @@ function getTextElementStack(node) {
 			}
 		}
 	});
+
+	// if the node is truncated then the first text rect will be the full
+	// width of the text, and the last node will be the ellipsis
 
 	return clientRects.map(rect => {
 		return getRectStack(grid, rect);

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -148,6 +148,14 @@ describe('color-contrast', function() {
 		assert.deepEqual(checkContext._relatedNodes, []);
 	});
 
+	it('should return true for truncated inline elements', function() {
+		var params = checkSetup(
+			'<p>Text oh heyyyy <b id="target" style="display: block;overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100px;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed et sollicitudin quam. Fusce mi odio, egestas pulvinar erat eget, vehicula tempus est. Proin vitae ullamcorper velit. Donec sagittis est justo, mattis iaculis arcu facilisis id. Proin pulvinar ornare arcu a fermentum. Quisque et dignissim nulla, sit amet consectetur ipsum. Donec in libero porttitor, dapibus neque imperdiet, aliquam est. Vivamus blandit volutpat fringilla. In mi magna, mollis sit amet imperdiet eu, rutrum ut tellus. Mauris vel condimentum nibh, quis ultricies nisi. Vivamus accumsan quam mauris, id iaculis quam fringilla ac. Curabitur pulvinar dolor ac magna vehicula, non auctor ligula dignissim. Nam ac nibh porttitor, malesuada tortor varius, feugiat turpis. Mauris dapibus, tellus ut viverra porta, ipsum turpis bibendum ligula, at tempor felis ante non libero. Donec dapibus, diam sit amet posuere commodo, magna orci hendrerit ipsum, eu egestas mauris nulla ut ipsum. Sed luctus, orci in fringilla finibus, odio leo porta dolor, eu dignissim risus eros eget erat</b></p>'
+		);
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._relatedNodes, []);
+	});
+
 	it('should return true for inline elements with sufficient contrast', function() {
 		var params = checkSetup(
 			'<p>Text oh heyyyy <b id="target">and here\'s bold text</b></p>'

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -562,5 +562,19 @@ describe('dom.getElementStack', function() {
 			var stacks = getTextElementStack(target).map(mapToIDs);
 			assert.deepEqual(stacks, [['target', '1', 'fixture']]);
 		});
+
+		it('should handle truncated text', function() {
+			fixture.innerHTML =
+				'<main id="1">' +
+				'<div id="target" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100px;">' +
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed et sollicitudin quam. Fusce mi odio, egestas pulvinar erat eget, vehicula tempus est. Proin vitae ullamcorper velit. Donec sagittis est justo, mattis iaculis arcu facilisis id. Proin pulvinar ornare arcu a fermentum. Quisque et dignissim nulla, sit amet consectetur ipsum. Donec in libero porttitor, dapibus neque imperdiet, aliquam est. Vivamus blandit volutpat fringilla. In mi magna, mollis sit amet imperdiet eu, rutrum ut tellus. Mauris vel condimentum nibh, quis ultricies nisi. Vivamus accumsan quam mauris, id iaculis quam fringilla ac. Curabitur pulvinar dolor ac magna vehicula, non auctor ligula dignissim. Nam ac nibh porttitor, malesuada tortor varius, feugiat turpis. Mauris dapibus, tellus ut viverra porta, ipsum turpis bibendum ligula, at tempor felis ante non libero. Donec dapibus, diam sit amet posuere commodo, magna orci hendrerit ipsum, eu egestas mauris nulla ut ipsum. Sed luctus, orci in fringilla finibus, odio leo porta dolor, eu dignissim risus eros eget erat.' +
+				'World' +
+				'</div>' +
+				'</main>';
+			axe.testUtils.flatTreeSetup(fixture);
+			var target = fixture.querySelector('#target');
+			var stacks = getTextElementStack(target).map(mapToIDs);
+			assert.deepEqual(stacks, [['target', '1', 'fixture']]);
+		});
 	});
 });


### PR DESCRIPTION
Truncated text whose untruncated text went outside the bounds of the screen caused our color-contrast code to error out. This is caused by the text rect returning the full width of the text and not the truncated width. Fix is to look at the parent nodes rect instead of the text rect if we detect truncated text.

Closes issue: #2178, #2285

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
