### PR TITLE
chore: ignore files for axe-linter

### DIFF
--- a/.github/axe-linter.yml
+++ b/.github/axe-linter.yml
@@ -1,0 +1,3 @@
+exclude:
+  - ./CHANGELOG.md
+  - ./test/*


### PR DESCRIPTION
A bug in axe-linter seems to be crashing on invalid HTML files that we use for our integration tests, as seen in #2304 and #2300. Ignoring our test directory as we purposefully write inaccessible examples. Also ignoring the CHANGELOG which will cause axe-linter to fail from an automated file.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
