### PR TITLE
tests: test the examples using local version of axe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run test
-  
+
   # Run the test suite in IE in windows
   test_win:
     <<: *defaults
@@ -83,7 +83,7 @@ jobs:
       - checkout
       # npm i or restore cache
       - <<: *restore_dependency_cache_win
-      # install selenium 
+      # install selenium
       - run: |
           choco install selenium-ie-driver --version 3.141.5
           export PATH=/c/tools/selenium:$PATH
@@ -91,8 +91,8 @@ jobs:
       # build `axe`
       - run: npm run build
       # get fixtures ready for running tests
-      - run: npx grunt testconfig	
-      - run: npx grunt fixture	
+      - run: npx grunt testconfig
+      - run: npx grunt fixture
       # run IE webdriver tests
       - run: npx grunt connect test-webdriver:ie
       # test examples
@@ -107,6 +107,7 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
+      - run: npm run build
       - run: npm run test:examples
 
   # Test locale files
@@ -191,7 +192,7 @@ workflows:
           requires:
             - dependencies_unix
             - lint
-      # Run IE/ Windows test on all commits 
+      # Run IE/ Windows test on all commits
       - test_win:
           requires:
             - dependencies_win

--- a/doc/examples/test-examples.js
+++ b/doc/examples/test-examples.js
@@ -8,8 +8,16 @@ const exampleDirs = readdirSync(__dirname)
 const config = { stdio: 'inherit', shell: true };
 
 // run npm install in parallel
-function install(dir) {
-	return execa('npm install', { cwd: dir, ...config });
+async function install(dir) {
+	await execa('npm install', { cwd: dir, ...config });
+
+	// override the package version of axe-core with the local version.
+	// this allows the examples to stay examples while allowing us to
+	// test them against our changes
+	return await execa('npm install --no-save file:..\\/..\\/..\\/', {
+		cwd: dir,
+		...config
+	});
 }
 
 // run tests synchronously so we can see which one threw an error


### PR DESCRIPTION
I noticed that all our examples use an axe-core version from npm and not the local axe.js file. This meant that us testing the examples for every pr and release does not verify the current code works in the examples, only that the last released version of axe-core works.

Since the examples are there as examples, they should act as standalone examples and install axe-core from npm as a normal user would. However, we can still test the local copy of axe for our tests by overriding the npm version with the local version just in the test run.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
