### PR TITLE
chore(axe-linter): actually ignore all test files

### DIFF
--- a/.github/axe-linter.yml
+++ b/.github/axe-linter.yml
@@ -1,3 +1,3 @@
 exclude:
   - ./CHANGELOG.md
-  - ./test/*
+  - ./test/**/*


### PR DESCRIPTION
Regex was bad and was only ignoring the top level test files.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
