### PR TITLE
fix(types): Make any tag allowed

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -5,7 +5,7 @@
 declare namespace axe {
 	type ImpactValue = 'minor' | 'moderate' | 'serious' | 'critical';
 
-	type TagValue = 'wcag2a' | 'wcag2aa' | 'section508' | 'best-practice' | 'wcag21a' | 'wcag21aa';
+	type TagValue = string;
 
 	type ReporterVersion = 'v1' | 'v2' | 'raw' | 'raw-env' | 'no-passes';
 


### PR DESCRIPTION
Tags (especially in custom rules) can be any string. Hard-coding this list prevents the ability to use custom tags.

This patch has the unfortunate side-effect of preventing intellisense in TypeScript-enabled editors, but provides more "technically correct" types.

Related #2312



## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
