### PR TITLE
chore: disable document-title rule from `axe-linter`

### DIFF
--- a/.github/axe-linter.yml
+++ b/.github/axe-linter.yml
@@ -1,3 +1,5 @@
 exclude:
   - ./CHANGELOG.md
   - ./test/**/*
+rules:
+  document-title: false


### PR DESCRIPTION
## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
