### PR TITLE
fix(aria-allowed-attr): Add aria-orientation to radiogroup role

### DIFF
--- a/lib/commons/aria/lookup-table.js
+++ b/lib/commons/aria/lookup-table.js
@@ -1588,7 +1588,8 @@ lookupTable.role = {
 				'aria-required',
 				'aria-expanded',
 				'aria-readonly',
-				'aria-errormessage'
+				'aria-errormessage',
+				'aria-orientation'
 			]
 		},
 		owned: {


### PR DESCRIPTION
We can read [here](https://w3c.github.io/aria/#aria-orientation) that:
> remain undefined on roles where an expected default orientation is ambiguous (e.g., radiogroup).

which, according to my understanding, implies that `aria-orientation` is allowed on `radiogroup` role, which would also make sense as visually we can present it either horizontally or vertically.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
