### PR TITLE
feat(matcher): allow regex string to be parsed as regex

### DIFF
--- a/lib/commons/matches/from-primative.js
+++ b/lib/commons/matches/from-primative.js
@@ -6,6 +6,7 @@
  * match.fromPrimative('foo', ['foo', 'bar']) // true, string is included
  * match.fromPrimative('foo', /foo/) // true, string matches regex
  * match.fromPrimative('foo', str => str.toUpperCase() === 'FOO') // true, function return is truthy
+ * match.fromPrimative('foo', '/foo/') // true, string matches regex string
  * ```
  *
  * @private
@@ -23,6 +24,14 @@ function fromPrimative(someString, matcher) {
 	}
 	if (matcher instanceof RegExp) {
 		return matcher.test(someString);
+	}
+	if (
+		matcherType === 'string' &&
+		matcher.startsWith('/') &&
+		matcher.endsWith('/')
+	) {
+		const pattern = matcher.substring(1, matcher.length - 1);
+		return new RegExp(pattern).test(someString);
 	}
 	return matcher === someString;
 }

--- a/lib/commons/matches/from-primative.js
+++ b/lib/commons/matches/from-primative.js
@@ -25,11 +25,8 @@ function fromPrimative(someString, matcher) {
 	if (matcher instanceof RegExp) {
 		return matcher.test(someString);
 	}
-	if (
-		// matcher starts and ends with "/"
-		matcherType === 'string' &&
-		/^\/.*\/$/.test(matcher)
-	) {
+	// matcher starts and ends with "/"
+	if (/^\/.*\/$/.test(matcher)) {
 		const pattern = matcher.substring(1, matcher.length - 1);
 		return new RegExp(pattern).test(someString);
 	}

--- a/lib/commons/matches/from-primative.js
+++ b/lib/commons/matches/from-primative.js
@@ -26,9 +26,9 @@ function fromPrimative(someString, matcher) {
 		return matcher.test(someString);
 	}
 	if (
+		// matcher starts and ends with "/"
 		matcherType === 'string' &&
-		matcher.startsWith('/') &&
-		matcher.endsWith('/')
+		/^\/.*\/$/.test(matcher)
 	) {
 		const pattern = matcher.substring(1, matcher.length - 1);
 		return new RegExp(pattern).test(someString);

--- a/test/commons/matches/from-primative.js
+++ b/test/commons/matches/from-primative.js
@@ -77,4 +77,13 @@ describe('matches.fromPrimative', function() {
 			assert.isFalse(fromPrimative('foobar', /^(foo|bar|baz)$/));
 		});
 	});
+
+	describe('with RegExp string', function() {
+		it('returns true if the regexp matches', function() {
+			assert.isTrue(fromPrimative('bar', '/^(foo|bar|baz)$/'));
+		});
+		it('returns false if the regexp does not match', function() {
+			assert.isFalse(fromPrimative('foobar', '/^(foo|bar|baz)$/'));
+		});
+	});
 });


### PR DESCRIPTION
Doing this allows us to replace our `isNotNull` function matchers in the lookup table with serializable strings. `isNull` function matcher can just be replaced by `null` since we already match `null` to `null`.


```diff
{
  nodeName: 'a',
  attributes: {
-    href: isNotNull
+    href: "/.*/"
  }
}
```

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
