### PR TITLE
fix(aria-allowed-element): Add fieldset to allowed elements for radiogroup

### DIFF
--- a/lib/commons/aria/lookup-table.js
+++ b/lib/commons/aria/lookup-table.js
@@ -1599,7 +1599,7 @@ lookupTable.role = {
 		context: null,
 		unsupported: false,
 		allowedElements: {
-			nodeName: ['ol', 'ul']
+			nodeName: ['ol', 'ul', 'fieldset']
 		}
 	},
 	range: {


### PR DESCRIPTION
Those resources mention that `radiogroup` supports being named based on `legend`:
https://w3c.github.io/aria/#radiogroup
https://w3c.github.io/aria/#namefromlegend

This mentions what naming by legend is (which is somewhat self-explanatory, but pasting it here for completeness):
https://w3c.github.io/aria/#namecalculation

And we know that `legend` must be a descendant of a `fieldset`.

In addition to that MDN mentions explicitly that `radiogroup` is allowed for a `fieldset`:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#Technical_summary

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
