### PR TITLE
ci: remove leading ./ from ignored axe-linter files

### DIFF
--- a/.github/axe-linter.yml
+++ b/.github/axe-linter.yml
@@ -1,3 +1,3 @@
 exclude:
-  - ./CHANGELOG.md
-  - ./test/**/*
+  - CHANGELOG.md
+  - test/**/*


### PR DESCRIPTION
Doesn't work with the leading `./`

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
