### PR TITLE
tests: ensure checks can be run using only serial virtual nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tmp
 # test - runner generated assets
 test/*/index.html
 test/integration/*/index.html
+!test/integration/virtual-rules/index.html
 
 # dist
 axe.js

--- a/build/test/config.js
+++ b/build/test/config.js
@@ -29,7 +29,10 @@ exports = module.exports = function(grunt, options) {
 						':<%= connect.test.options.port %>/test/integration/rules/',
 					'http://' +
 						host +
-						':<%= connect.test.options.port %>/test/integration/api/external/'
+						':<%= connect.test.options.port %>/test/integration/api/external/',
+					'http://' +
+						host +
+						':<%= connect.test.options.port %>/test/integration/virtual-rules/'
 				],
 				run: true,
 				growlOnSuccess: false,

--- a/lib/checks/shared/aria-labelledby-evaluate.js
+++ b/lib/checks/shared/aria-labelledby-evaluate.js
@@ -1,9 +1,9 @@
 import { sanitize } from '../../commons/text';
 import { arialabelledbyText } from '../../commons/aria';
 
-function ariaLabelledbyEvaluate(node) {
+function ariaLabelledbyEvaluate(node, options, virtualNode) {
 	try {
-		return !!sanitize(arialabelledbyText(node));
+		return !!sanitize(arialabelledbyText(virtualNode));
 	} catch (e) {
 		return undefined;
 	}

--- a/test/integration/virtual-rules/index.html
+++ b/test/integration/virtual-rules/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Virtual Rules Test</title>
+
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href="/node_modules/mocha/mocha.css"
+		/>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/axe.js"></script>
+		<script>
+			mocha.setup({
+				timeout: 10000,
+				ui: 'bdd'
+			});
+			var assert = chai.assert;
+		</script>
+		<script src="/test/integration/no-ui-reporter.js"></script>
+	</head>
+	<body>
+		<div id="mocha"></div>
+		<script src="index.js"></script>
+		<script src="/test/integration/adapter.js"></script>
+	</body>
+</html>

--- a/test/integration/virtual-rules/index.js
+++ b/test/integration/virtual-rules/index.js
@@ -1,0 +1,315 @@
+describe('virtual rules', function() {
+	describe('checks', function() {
+		describe('autocomplete-valid', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'autocomplete-valid',
+					new axe.SerialVirtualNode({
+						nodeName: 'input',
+						attributes: {
+							type: 'text',
+							autocomplete: 'country-name'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'autocomplete-valid',
+					new axe.SerialVirtualNode({
+						nodeName: 'input',
+						attributes: {
+							type: 'text',
+							autocomplete: 'foobar'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('autocomplete-appropriate', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'autocomplete-valid',
+					new axe.SerialVirtualNode({
+						nodeName: 'input',
+						attributes: {
+							type: 'text',
+							autocomplete: 'email'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'autocomplete-valid',
+					new axe.SerialVirtualNode({
+						nodeName: 'input',
+						attributes: {
+							type: 'color',
+							autocomplete: 'email'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('has-alt', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							alt: 'foobar'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('aria-label', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							'aria-label': 'foobar'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							'aria-label': ''
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('aria-labelledby', function() {
+			it('should incomplete', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							'aria-labelledby': 'foobar'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 1);
+			});
+		});
+
+		describe('non-empty-title', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							title: 'foobar'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							title: ''
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('role-presentation', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							role: 'presentation'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							role: 'text'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('role-none', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							role: 'none'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							role: 'text'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('alt-space-value', function() {
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'img',
+						attributes: {
+							alt: '     '
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+
+		describe('non-empty-alt', function() {
+			it('should pass', function() {
+				var results = axe.runVirtualRule(
+					'input-image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'input',
+						attributes: {
+							type: 'image',
+							alt: 'foobar'
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 1);
+				assert.lengthOf(results.violations, 0);
+				assert.lengthOf(results.incomplete, 0);
+			});
+
+			it('should fail', function() {
+				var results = axe.runVirtualRule(
+					'input-image-alt',
+					new axe.SerialVirtualNode({
+						nodeName: 'input',
+						attributes: {
+							type: 'image',
+							alt: ''
+						}
+					})
+				);
+
+				assert.lengthOf(results.passes, 0);
+				assert.lengthOf(results.violations, 1);
+				assert.lengthOf(results.incomplete, 0);
+			});
+		});
+	});
+});


### PR DESCRIPTION
Noticed that we don't have any tests that ensure we can run a rule/check/matches using `SerialVritualNode`. This caught the error in `aria-lablledby-evaluate` where we passed `node` into `arialabelledbyText` instead of passing `virtualNode`. 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
