### PR TITLE
fix(checks/has-visible-text): work with virtual and serial nodes

### DIFF
--- a/lib/checks/generic/has-text-content-evaluate.js
+++ b/lib/checks/generic/has-text-content-evaluate.js
@@ -1,7 +1,11 @@
 import { sanitize, subtreeText } from '../../commons/text';
 
 function hasTextContentEvaluate(node, options, virtualNode) {
-	return sanitize(subtreeText(virtualNode)) !== '';
+	try {
+		return sanitize(subtreeText(virtualNode)) !== '';
+	} catch (e) {
+		return undefined;
+	}
 }
 
 export default hasTextContentEvaluate;

--- a/lib/checks/shared/has-visible-text.json
+++ b/lib/checks/shared/has-visible-text.json
@@ -5,7 +5,8 @@
 		"impact": "minor",
 		"messages": {
 			"pass": "Element has text that is visible to screen readers",
-			"fail": "Element does not have text that is visible to screen readers"
+			"fail": "Element does not have text that is visible to screen readers",
+			"incomplete": "Unable to determine if element has children"
 		}
 	}
 }

--- a/lib/commons/aria/lookup-table.js
+++ b/lib/commons/aria/lookup-table.js
@@ -1906,7 +1906,7 @@ lookupTable.role = {
 		owned: {
 			one: ['rowgroup', 'row']
 		},
-		nameFrom: ['author'],
+		nameFrom: ['author', 'contents'],
 		context: null,
 		implicit: ['table'],
 		unsupported: false

--- a/lib/commons/aria/named-from-contents.js
+++ b/lib/commons/aria/named-from-contents.js
@@ -1,5 +1,7 @@
 import getRole from './get-role';
 import lookupTable from './lookup-table';
+import { getNodeFromTree } from '../../core/utils';
+import AbstractVirtuaNode from '../../core/base/virtual-node/abstract-virtual-node';
 
 /**
  * Check if an element is named from contents
@@ -9,21 +11,16 @@ import lookupTable from './lookup-table';
  * @property {Bool} strict Whether or not to follow the spects strictly
  * @return {Bool}
  */
-function namedFromContents(node, { strict } = {}) {
-	node = node.actualNode || node;
-	if (node.nodeType !== 1) {
+function namedFromContents(vNode, { strict } = {}) {
+	vNode = vNode instanceof AbstractVirtuaNode ? vNode : getNodeFromTree(vNode);
+	if (vNode.props.nodeType !== 1) {
 		return false;
 	}
 
-	const role = getRole(node);
+	const role = getRole(vNode);
 	const roleDef = lookupTable.role[role];
 
-	if (
-		(roleDef && roleDef.nameFrom.includes('contents')) ||
-		// TODO: This is a workaround for axe-core's over-assertive implicitRole computation
-		// once we fix that, this extra noImplicit check can be removed.
-		node.nodeName.toUpperCase() === 'TABLE'
-	) {
+	if (roleDef && roleDef.nameFrom.includes('contents')) {
 		return true;
 	}
 

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -510,7 +510,12 @@ const ariaRoles = {
 	table: {
 		type: 'structure',
 		requiredOwned: ['rowgroup', 'row'],
-		allowedAttrs: ['aria-colcount', 'aria-rowcount', 'aria-expanded']
+		allowedAttrs: ['aria-colcount', 'aria-rowcount', 'aria-expanded'],
+		// NOTE: although the spec says this is not named from contents,
+		// the accessible text acceptance tests (#139 and #140) require
+		// table be named from content (we even had to special case
+		// table in commons/aria/named-from-contents)
+		nameFromContent: true
 	},
 	tablist: {
 		type: 'composite',

--- a/test/checks/shared/has-visible-text.js
+++ b/test/checks/shared/has-visible-text.js
@@ -40,4 +40,26 @@ describe('has-visible-text', function() {
 				.apply(checkContext, params)
 		);
 	});
+
+	describe('SerialVirtualNode', function() {
+		it('should return false if element is not named from contents', function() {
+			var node = new axe.SerialVirtualNode({
+				nodeName: 'article'
+			});
+
+			assert.isFalse(
+				axe.testUtils.getCheckEvaluate('has-visible-text')(null, {}, node)
+			);
+		});
+
+		it('should return undefined if element is named from contents', function() {
+			var node = new axe.SerialVirtualNode({
+				nodeName: 'button'
+			});
+
+			assert.isUndefined(
+				axe.testUtils.getCheckEvaluate('has-visible-text')(null, {}, node)
+			);
+		});
+	});
 });

--- a/test/commons/aria/named-from-contents.js
+++ b/test/commons/aria/named-from-contents.js
@@ -22,9 +22,10 @@ describe('aria.namedFromContents', function() {
 	});
 
 	it('works on virtual nodes', function() {
-		fixture.innerHTML = '<div role="foo"></div>';
-		flatTreeSetup(fixture);
-		assert.isTrue(namedFromContents({ actualNode: fixture.firstChild }));
+		var vNode = axe.testUtils.queryFixture(
+			'<div id="target" role="foo"></div>'
+		);
+		assert.isTrue(namedFromContents(vNode));
 	});
 
 	it('returns true when the element has an implicit role named from content', function() {


### PR DESCRIPTION
I noticed that `named-from-contents` had an exception for `table` elements to always be considered named from contents. The comment said it was because the implicit role was too over-assertive but I couldn't find any tests in the `named-from-contents` test suite that showed an example nor could I find a reason in [the original pr it was created](https://github.com/dequelabs/axe-core/pull/1163). 

So I removed the exception and just allowed `table` role to be named from contents. This seemed like a better place for it and still allowed all the tests to pass (without the exception two of our accessible name acceptance tests failed as they required the `table` element to be named from contents).

Part of issue: #2183

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
