### PR TITLE
fix(virtual-node): default and lowercase type property

### DIFF
--- a/lib/core/base/virtual-node/serial-virtual-node.js
+++ b/lib/core/base/virtual-node/serial-virtual-node.js
@@ -52,11 +52,25 @@ function normaliseProps(serialNode) {
 		`nodeName has to be a string, got '${nodeName}'`
 	);
 
+	nodeName = nodeName.toLowerCase();
+	let type = null;
+	if (nodeName === 'input') {
+		type = (
+			serialNode.type ||
+			(serialNode.attributes && serialNode.attributes.type) ||
+			'text'
+		).toLowerCase();
+	}
+
 	const props = {
 		...serialNode,
 		nodeType,
-		nodeName: nodeName.toLowerCase()
+		nodeName
 	};
+	if (type) {
+		props.type = type;
+	}
+
 	delete props.attributes;
 	return Object.freeze(props);
 }

--- a/lib/core/base/virtual-node/serial-virtual-node.js
+++ b/lib/core/base/virtual-node/serial-virtual-node.js
@@ -1,5 +1,5 @@
 import AbstractVirtualNode from './abstract-virtual-node';
-import assert from '../../utils/assert';
+import { assert, validInputTypes } from '../../utils';
 
 class SerialVirtualNode extends AbstractVirtualNode {
 	/**
@@ -58,8 +58,12 @@ function normaliseProps(serialNode) {
 		type = (
 			serialNode.type ||
 			(serialNode.attributes && serialNode.attributes.type) ||
-			'text'
+			''
 		).toLowerCase();
+
+		if (!validInputTypes().includes(type)) {
+			type = 'text';
+		}
 	}
 
 	const props = {

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -1,5 +1,5 @@
 import AbstractVirtualNode from './abstract-virtual-node';
-import { isXHTML } from '../../utils';
+import { isXHTML, validInputTypes } from '../../utils';
 import { isFocusable, getTabbableElements } from '../../../commons/dom';
 
 let isXHTMLGlobal;
@@ -34,8 +34,14 @@ class VirtualNode extends AbstractVirtualNode {
 		// at the attribute and not what the browser resolves the type
 		// to be
 		if (node.nodeName.toLowerCase() === 'input') {
-			const type = node.getAttribute('type') || 'text';
-			this._type = this._isXHTML ? type : type.toLowerCase();
+			let type = node.getAttribute('type');
+			type = this._isXHTML ? type : (type || '').toLowerCase();
+
+			if (!validInputTypes().includes(type)) {
+				type = 'text';
+			}
+
+			this._type = type;
 		}
 
 		// TODO: es-modules_cache

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -26,6 +26,18 @@ class VirtualNode extends AbstractVirtualNode {
 		}
 		this._isXHTML = isXHTMLGlobal;
 
+		this._nodeName = this._isXHTML
+			? node.nodeName
+			: node.nodeName.toLowerCase();
+
+		// we will normalize the type prop for inputs by looking strictly
+		// at the attribute and not what the browser resolves the type
+		// to be
+		if (node.nodeName.toLowerCase() === 'input') {
+			const type = node.getAttribute('type') || 'text';
+			this._type = this._isXHTML ? type : type.toLowerCase();
+		}
+
 		// TODO: es-modules_cache
 		if (axe._cache.get('nodeMap')) {
 			axe._cache.get('nodeMap').set(node, this);
@@ -35,13 +47,13 @@ class VirtualNode extends AbstractVirtualNode {
 	// abstract Node properties so we can run axe in DOM-less environments.
 	// add to the prototype so memory is shared across all virtual nodes
 	get props() {
-		const { nodeType, nodeName, id, type, multiple } = this.actualNode;
+		const { nodeType, nodeName, id, multiple } = this.actualNode;
 
 		return {
 			nodeType,
 			nodeName: this._isXHTML ? nodeName : nodeName.toLowerCase(),
 			id,
-			type,
+			type: this._type,
 			multiple
 		};
 	}

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -26,10 +26,6 @@ class VirtualNode extends AbstractVirtualNode {
 		}
 		this._isXHTML = isXHTMLGlobal;
 
-		this._nodeName = this._isXHTML
-			? node.nodeName
-			: node.nodeName.toLowerCase();
-
 		// we will normalize the type prop for inputs by looking strictly
 		// at the attribute and not what the browser resolves the type
 		// to be

--- a/test/core/base/virtual-node/serial-virtual-node.js
+++ b/test/core/base/virtual-node/serial-virtual-node.js
@@ -89,6 +89,48 @@ describe('SerialVirtualNode', function() {
 			});
 			assert.isUndefined(vNode.props.attributes);
 		});
+
+		it('converts type prop to lower case', function() {
+			var types = ['text', 'COLOR', 'Month', 'uRL'];
+			types.forEach(function(type) {
+				var vNode = new SerialVirtualNode({
+					nodeName: 'input',
+					type: type
+				});
+				assert.equal(vNode.props.type, type.toLowerCase());
+			});
+		});
+
+		it('converts type attribute to lower case', function() {
+			var types = ['text', 'COLOR', 'Month', 'uRL'];
+			types.forEach(function(type) {
+				var vNode = new SerialVirtualNode({
+					nodeName: 'input',
+					attributes: {
+						type: type
+					}
+				});
+				assert.equal(vNode.props.type, type.toLowerCase());
+			});
+		});
+
+		it('defaults type prop to "text"', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'input'
+			});
+			assert.equal(vNode.props.type, 'text');
+		});
+
+		it('uses the type property over the type attribute', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'input',
+				type: 'month',
+				attributes: {
+					type: 'color'
+				}
+			});
+			assert.equal(vNode.props.type, 'month');
+		});
 	});
 
 	describe('attr', function() {

--- a/test/core/base/virtual-node/serial-virtual-node.js
+++ b/test/core/base/virtual-node/serial-virtual-node.js
@@ -121,6 +121,16 @@ describe('SerialVirtualNode', function() {
 			assert.equal(vNode.props.type, 'text');
 		});
 
+		it('default type prop to "text" if type is invalid', function() {
+			var vNode = new SerialVirtualNode({
+				nodeName: 'input',
+				attributes: {
+					type: 'woohoo'
+				}
+			});
+			assert.equal(vNode.props.type, 'text');
+		});
+
 		it('uses the type property over the type attribute', function() {
 			var vNode = new SerialVirtualNode({
 				nodeName: 'input',

--- a/test/core/base/virtual-node/virtual-node.js
+++ b/test/core/base/virtual-node/virtual-node.js
@@ -47,6 +47,21 @@ describe('VirtualNode', function() {
 			assert.equal(vNode.props.type, 'color');
 		});
 
+		it('should default type to text', function() {
+			var node = document.createElement('input');
+			var vNode = new VirtualNode(node);
+
+			assert.equal(vNode.props.type, 'text');
+		});
+
+		it('should default type to text if type is invalid', function() {
+			var node = document.createElement('input');
+			node.setAttribute('type', 'woohoo');
+			var vNode = new VirtualNode(node);
+
+			assert.equal(vNode.props.type, 'text');
+		});
+
 		it('should lowercase nodeName', function() {
 			var node = {
 				nodeName: 'FOOBAR'

--- a/test/core/base/virtual-node/virtual-node.js
+++ b/test/core/base/virtual-node/virtual-node.js
@@ -39,6 +39,14 @@ describe('VirtualNode', function() {
 			assert.equal(vNode.props.type, 'text');
 		});
 
+		it('should lowercase type', function() {
+			var node = document.createElement('input');
+			node.setAttribute('type', 'COLOR');
+			var vNode = new VirtualNode(node);
+
+			assert.equal(vNode.props.type, 'color');
+		});
+
 		it('should lowercase nodeName', function() {
 			var node = {
 				nodeName: 'FOOBAR'


### PR DESCRIPTION
Allows us to do input property matches with case insensitivity for serial and virtual nodes.

```js
const input = document.createElement('input');
input.setAttribute('type', 'BUTTON');
const vNode = axe.utils.getFlattenedTree(fixture)[0];

commons.matches(vNode, {
  properties: {
    type: 'button'
  }
}); // true

const serialNode = new axe.SerialVritualNode({
  nodeName: 'input',
  attributes: {
    type: 'BUTTON'
  }
});

commons.matches(serialNode, {
  properties: {
    type: 'button'
  }
}); // true
```

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
