### PR TITLE
fix(aria/allowed-attr): work with standards object

### DIFF
--- a/lib/commons/aria/allowed-attr.js
+++ b/lib/commons/aria/allowed-attr.js
@@ -1,4 +1,5 @@
-import lookupTable from './lookup-table';
+import standards from '../../standards';
+import getGlobalAriaAttrs from '../standards/get-global-aria-attrs';
 
 /**
  * Get allowed attributes for a given role
@@ -9,12 +10,22 @@ import lookupTable from './lookup-table';
  * @return {Array}
  */
 function allowedAttr(role) {
-	const roles = lookupTable.role[role];
-	const attr = (roles && roles.attributes && roles.attributes.allowed) || [];
-	const requiredAttr =
-		(roles && roles.attributes && roles.attributes.required) || [];
+	const roleDef = standards.ariaRoles[role];
+	const attrs = [...getGlobalAriaAttrs()];
 
-	return attr.concat(lookupTable.globalAttributes).concat(requiredAttr);
+	if (!roleDef) {
+		return attrs;
+	}
+
+	if (roleDef.allowedAttrs) {
+		attrs.push(...roleDef.allowedAttrs);
+	}
+
+	if (roleDef.requiredAttrs) {
+		attrs.push(...roleDef.requiredAttrs);
+	}
+
+	return attrs;
 }
 
 export default allowedAttr;

--- a/lib/commons/standards/get-global-aria-attrs.js
+++ b/lib/commons/standards/get-global-aria-attrs.js
@@ -10,7 +10,7 @@ function getGlobalAriaAttrs() {
 		return cache.get('globalAriaAttrs');
 	}
 
-	let globalAttrs = Object.keys(standards.ariaAttrs).filter(attrName => {
+	const globalAttrs = Object.keys(standards.ariaAttrs).filter(attrName => {
 		return standards.ariaAttrs[attrName].global;
 	});
 

--- a/lib/commons/standards/get-global-aria-attrs.js
+++ b/lib/commons/standards/get-global-aria-attrs.js
@@ -1,3 +1,4 @@
+import cache from '../../core/base/cache';
 import standards from '../../standards';
 
 /**
@@ -5,9 +6,17 @@ import standards from '../../standards';
  * @return {String[]} List of all global aria attributes
  */
 function getGlobalAriaAttrs() {
-	return Object.keys(standards.ariaAttrs).filter(attrName => {
+	if (cache.get('globalAriaAttrs')) {
+		return cache.get('globalAriaAttrs');
+	}
+
+	let globalAttrs = Object.keys(standards.ariaAttrs).filter(attrName => {
 		return standards.ariaAttrs[attrName].global;
 	});
+
+	cache.set('globalAriaAttrs', globalAttrs);
+
+	return globalAttrs;
 }
 
 export default getGlobalAriaAttrs;

--- a/test/commons/aria/allowed-attr.js
+++ b/test/commons/aria/allowed-attr.js
@@ -1,0 +1,52 @@
+describe('aria.allowedAttr', function() {
+	'use strict';
+
+	var globalAttrs;
+	before(function() {
+		axe._load({});
+		globalAttrs = axe.commons.standards.getGlobalAriaAttrs();
+	});
+
+	afterEach(function() {
+		axe.reset();
+	});
+
+	it('should returned the attributes property for the proper role', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
+						allowedAttrs: ['hello']
+					}
+				}
+			}
+		});
+
+		assert.deepEqual(
+			axe.commons.aria.allowedAttr('cats'),
+			globalAttrs.concat(['hello'])
+		);
+	});
+
+	it('should also check required attributes', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
+						requiredAttrs: ['hello'],
+						allowedAttrs: ['ok']
+					}
+				}
+			}
+		});
+
+		assert.deepEqual(
+			axe.commons.aria.allowedAttr('cats'),
+			globalAttrs.concat(['ok', 'hello'])
+		);
+	});
+
+	it('should return an array with globally allowed attributes', function() {
+		assert.deepEqual(axe.commons.aria.allowedAttr('cats'), globalAttrs);
+	});
+});

--- a/test/commons/aria/attributes.js
+++ b/test/commons/aria/attributes.js
@@ -29,60 +29,6 @@ describe('aria.requiredAttr', function() {
 	});
 });
 
-describe('aria.allowedAttr', function() {
-	'use strict';
-
-	var orig;
-	var origGlobals;
-	beforeEach(function() {
-		orig = axe.commons.aria.lookupTable.role;
-		origGlobals = axe.commons.aria.lookupTable.globalAttributes;
-	});
-
-	afterEach(function() {
-		axe.commons.aria.lookupTable.role = orig;
-		axe.commons.aria.lookupTable.globalAttributes = origGlobals;
-	});
-
-	it('should returned the attributes property for the proper role', function() {
-		axe.commons.aria.lookupTable.globalAttributes = ['world'];
-		axe.commons.aria.lookupTable.role = {
-			cats: {
-				attributes: {
-					allowed: ['hello']
-				}
-			}
-		};
-
-		assert.deepEqual(axe.commons.aria.allowedAttr('cats'), ['hello', 'world']);
-	});
-
-	it('should also check required attributes', function() {
-		axe.commons.aria.lookupTable.globalAttributes = ['world'];
-		axe.commons.aria.lookupTable.role = {
-			cats: {
-				attributes: {
-					required: ['hello'],
-					allowed: ['ok']
-				}
-			}
-		};
-
-		assert.deepEqual(axe.commons.aria.allowedAttr('cats'), [
-			'ok',
-			'world',
-			'hello'
-		]);
-	});
-
-	it('should return an array with globally allowed attributes', function() {
-		axe.commons.aria.lookupTable.globalAttributes = ['world'];
-		axe.commons.aria.lookupTable.role = {};
-
-		assert.deepEqual(axe.commons.aria.allowedAttr('cats'), ['world']);
-	});
-});
-
 describe('aria.validateAttr', function() {
 	'use strict';
 

--- a/test/integration/rules/aria-allowed-attr/passes.html
+++ b/test/integration/rules/aria-allowed-attr/passes.html
@@ -938,7 +938,6 @@
 <div
 	role="menuitemradio"
 	id="pass35"
-	aria-selected="value"
 	aria-posinset="value"
 	aria-setsize="value"
 	aria-checked="value"
@@ -1078,7 +1077,6 @@
 <div
 	role="radio"
 	id="pass40"
-	aria-selected="value"
 	aria-posinset="value"
 	aria-setsize="value"
 	aria-checked="value"
@@ -1193,8 +1191,6 @@
 <div
 	role="rowgroup"
 	id="pass44"
-	aria-activedescendant="value"
-	aria-expanded="value"
 	aria-atomic="value"
 	aria-busy="value"
 	aria-controls="value"
@@ -1310,7 +1306,6 @@
 <div
 	role="separator"
 	id="pass48"
-	aria-expanded="value"
 	aria-orientation="value"
 	aria-atomic="value"
 	aria-busy="value"


### PR DESCRIPTION
Refactored `allowedAttr` to have a better happy path and return early if no role def was found, also didn't need to `concat` everything. Since getting global attrs is found in a lot of code, went ahead and cached the result as it shouldn't change during a run. 

The integration tests were expected from the diff in our lookup table in https://github.com/dequelabs/axe-core/pull/2328#issuecomment-651218760

Part of #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
