### PR TITLE
fix(aria/get-role-type): work with standards object

### DIFF
--- a/lib/commons/aria/get-role-type.js
+++ b/lib/commons/aria/get-role-type.js
@@ -1,4 +1,4 @@
-import lookupTable from './lookup-table';
+import standards from '../../standards';
 
 /**
  * Get the "type" of role; either widget, composite, abstract, landmark or `null`
@@ -9,8 +9,13 @@ import lookupTable from './lookup-table';
  * @return {Mixed} String if a matching role and its type are found, otherwise `null`
  */
 function getRoleType(role) {
-	var r = lookupTable.role[role];
-	return (r && r.type) || null;
+	const roleDef = standards.ariaRoles[role];
+
+	if (!roleDef) {
+		return null;
+	}
+
+	return roleDef.type;
 }
 
 export default getRoleType;

--- a/test/commons/aria/get-role-type.js
+++ b/test/commons/aria/get-role-type.js
@@ -1,0 +1,28 @@
+describe('aria.getRoleType', function() {
+	'use strict';
+
+	before(function() {
+		axe._load({});
+	});
+
+	afterEach(function() {
+		axe.reset();
+	});
+
+	it('should return true if role is found in the lookup table', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
+						type: 'stuff'
+					}
+				}
+			}
+		});
+		assert.equal(axe.commons.aria.getRoleType('cats'), 'stuff');
+	});
+
+	it('should return null if role is not found in the lookup table', function() {
+		assert.isNull(axe.commons.aria.getRoleType('cats'));
+	});
+});

--- a/test/commons/aria/roles.js
+++ b/test/commons/aria/roles.js
@@ -67,25 +67,6 @@ describe('aria.getRolesByType', function() {
 	});
 });
 
-describe('aria.getRoleType', function() {
-	'use strict';
-
-	it('should return true if role is found in the lookup table', function() {
-		var orig = axe.commons.aria.lookupTable.role;
-		axe.commons.aria.lookupTable.role = {
-			cats: {
-				type: 'stuff'
-			}
-		};
-		assert.equal(axe.commons.aria.getRoleType('cats'), 'stuff');
-		axe.commons.aria.lookupTable.role = orig;
-	});
-
-	it('should return null if role is not found in the lookup table', function() {
-		assert.isNull(axe.commons.aria.getRoleType('cats'));
-	});
-});
-
 describe('aria.requiredOwned', function() {
 	'use strict';
 


### PR DESCRIPTION
Refactored `get-role-type` to have a better happy path and return early rather than doing the `&&` and `||` checks.

Part of #2108

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
