### PR TITLE
feat(aria/get-roles-by-type): deprecate in favor of standards/get-aria-roles-by-type

### DIFF
--- a/lib/checks/keyboard/landmark-is-top-level-evaluate.js
+++ b/lib/checks/keyboard/landmark-is-top-level-evaluate.js
@@ -1,8 +1,9 @@
-import { getRolesByType, implicitRole } from '../../commons/aria';
+import { implicitRole } from '../../commons/aria';
+import { getAriaRolesByType } from '../../commons/standards';
 import { getComposedParent } from '../../commons/dom';
 
 function landmarkIsTopLevelEvaluate(node) {
-	var landmarks = getRolesByType('landmark');
+	var landmarks = getAriaRolesByType('landmark');
 	var parent = getComposedParent(node);
 
 	this.data({

--- a/lib/checks/navigation/region-evaluate.js
+++ b/lib/checks/navigation/region-evaluate.js
@@ -1,11 +1,12 @@
 import * as dom from '../../commons/dom';
 import * as aria from '../../commons/aria';
+import * as standards from '../../commons/standards';
 import * as text from '../../commons/text';
 import matches from '../../commons/matches';
 import { matchesSelector } from '../../core/utils';
 import cache from '../../core/base/cache';
 
-const landmarkRoles = aria.getRolesByType('landmark');
+const landmarkRoles = standards.getAriaRolesByType('landmark');
 const implicitAriaLiveRoles = ['alert', 'log', 'status'];
 
 // Create a list of nodeNames that have a landmark as an implicit role

--- a/lib/commons/aria/get-roles-by-type.js
+++ b/lib/commons/aria/get-roles-by-type.js
@@ -1,17 +1,16 @@
-import lookupTable from './lookup-table';
+import getAriaRolesByType from '../standards/get-aria-roles-by-type';
 
 /**
  * Get the roles that have a certain "type"
  * @method getRolesByType
  * @memberof axe.commons.aria
+ * @deprecated use standards/get-aria-roles-by-type
  * @instance
  * @param {String} roleType The roletype to check
  * @return {Array} Array of roles that match the type
  */
 function getRolesByType(roleType) {
-	return Object.keys(lookupTable.role).filter(function(r) {
-		return lookupTable.role[r].type === roleType;
-	});
+	return getAriaRolesByType(roleType);
 }
 
 export default getRolesByType;

--- a/lib/rules/landmark-unique-matches.js
+++ b/lib/rules/landmark-unique-matches.js
@@ -1,5 +1,6 @@
 import { findUpVirtual, isVisible } from '../commons/dom';
-import { getRolesByType, getRole } from '../commons/aria';
+import { getRole } from '../commons/aria';
+import { getAriaRolesByType } from '../commons/standards';
 import { accessibleTextVirtual } from '../commons/text';
 
 function landmarkUniqueMatches(node, virtualNode) {
@@ -24,7 +25,7 @@ function landmarkUniqueMatches(node, virtualNode) {
 
 	function isLandmarkVirtual(virtualNode) {
 		var { actualNode } = virtualNode;
-		var landmarkRoles = getRolesByType('landmark');
+		var landmarkRoles = getAriaRolesByType('landmark');
 		var role = getRole(actualNode);
 		if (!role) {
 			return false;

--- a/test/commons/aria/get-roles-by-type.js
+++ b/test/commons/aria/get-roles-by-type.js
@@ -1,0 +1,31 @@
+describe('aria.getRolesByType', function() {
+	'use strict';
+
+	before(function() {
+		axe._load({});
+	});
+
+	afterEach(function() {
+		axe.reset();
+	});
+
+	it('should return array if roletype is found in the lookup table', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					dogs: {
+						type: 'things'
+					},
+					cats: {
+						type: 'stuff'
+					}
+				}
+			}
+		});
+		assert.deepEqual(axe.commons.aria.getRolesByType('stuff'), ['cats']);
+	});
+
+	it('should return empty array if role is not found in the lookup table', function() {
+		assert.deepEqual(axe.commons.aria.getRolesByType('blahblahblah'), []);
+	});
+});

--- a/test/commons/aria/roles.js
+++ b/test/commons/aria/roles.js
@@ -45,28 +45,6 @@ describe('aria.getRolesWithNameFromContents', function() {
 	});
 });
 
-describe('aria.getRolesByType', function() {
-	'use strict';
-
-	it('should return array if roletype is found in the lookup table', function() {
-		var orig = axe.commons.aria.lookupTable.role;
-		axe.commons.aria.lookupTable.role = {
-			dogs: {
-				type: 'things'
-			},
-			cats: {
-				type: 'stuff'
-			}
-		};
-		assert.deepEqual(axe.commons.aria.getRolesByType('stuff'), ['cats']);
-		axe.commons.aria.lookupTable.role = orig;
-	});
-
-	it('should return empty array if role is not found in the lookup table', function() {
-		assert.deepEqual(axe.commons.aria.getRolesByType('blahblahblah'), []);
-	});
-});
-
 describe('aria.getRoleType', function() {
 	'use strict';
 


### PR DESCRIPTION
We should probably have a discussion about what `commons/aria` functions should be moved into the standards helpers.

Part of #2108

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
