### PR TITLE
feat(standards): add get-aria-roles-supporting-name-from-content and deprecate aria/get-roles-with-name-from-content

### DIFF
--- a/lib/commons/aria/get-roles-with-name-from-contents.js
+++ b/lib/commons/aria/get-roles-with-name-from-contents.js
@@ -1,19 +1,15 @@
-import lookupTable from './lookup-table';
+import getAriaRolesSupportingNameFromContent from '../standards/get-aria-roles-supporting-name-from-content';
 
 /**
  * Get the roles that get name from the element's contents
  * @method getRolesWithNameFromContents
  * @memberof axe.commons.aria
  * @instance
+ * @deprecated use standards/get-aria-roles-supporting-name-from-content
  * @return {Array} Array of roles that match the type
  */
 function getRolesWithNameFromContents() {
-	return Object.keys(lookupTable.role).filter(function(r) {
-		return (
-			lookupTable.role[r].nameFrom &&
-			lookupTable.role[r].nameFrom.indexOf('contents') !== -1
-		);
-	});
+	return getAriaRolesSupportingNameFromContent();
 }
 
 export default getRolesWithNameFromContents;

--- a/lib/commons/standards/get-aria-roles-supporting-name-from-content.js
+++ b/lib/commons/standards/get-aria-roles-supporting-name-from-content.js
@@ -1,0 +1,22 @@
+import cache from '../../core/base/cache';
+import standards from '../../standards';
+
+/**
+ * Return a list of aria roles which are name from content.
+ * @return {String[]} List of all roles with name from content
+ */
+function getAriaRolesSupportingNameFromContent() {
+	if (cache.get('ariaRolesNameFromContent')) {
+		return cache.get('ariaRolesNameFromContent');
+	}
+
+	const contentRoles = Object.keys(standards.ariaRoles).filter(roleName => {
+		return standards.ariaRoles[roleName].nameFromContent;
+	});
+
+	cache.set('ariaRolesNameFromContent', contentRoles);
+
+	return contentRoles;
+}
+
+export default getAriaRolesSupportingNameFromContent;

--- a/lib/commons/standards/index.js
+++ b/lib/commons/standards/index.js
@@ -4,5 +4,6 @@
  * @memberof axe
  */
 export { default as getAriaRolesByType } from './get-aria-roles-by-type';
+export { default as getAriaRolesSupportingNameFromContent } from './get-aria-roles-supporting-name-from-content';
 export { default as getGlobalAriaAttrs } from './get-global-aria-attrs';
 export { default as getElementSpec } from './get-element-spec';

--- a/lib/rules/label-content-name-mismatch-matches.js
+++ b/lib/rules/label-content-name-mismatch-matches.js
@@ -2,9 +2,9 @@ import {
 	getRole,
 	lookupTable,
 	arialabelText,
-	arialabelledbyText,
-	getRolesWithNameFromContents
+	arialabelledbyText
 } from '../commons/aria';
+import { getAriaRolesSupportingNameFromContent } from '../commons/standards';
 import { sanitize, visibleVirtual } from '../commons/text';
 
 function labelContentNameMismatchMatches(node, virtualNode) {
@@ -28,7 +28,7 @@ function labelContentNameMismatchMatches(node, virtualNode) {
 		return false;
 	}
 
-	const rolesWithNameFromContents = getRolesWithNameFromContents();
+	const rolesWithNameFromContents = getAriaRolesSupportingNameFromContent();
 	if (!rolesWithNameFromContents.includes(role)) {
 		return false;
 	}

--- a/test/commons/aria/get-roles-with-name-from-contents.js
+++ b/test/commons/aria/get-roles-with-name-from-contents.js
@@ -1,0 +1,28 @@
+describe('aria.getRolesWithNameFromContents', function() {
+	'use strict';
+
+	before(function() {
+		axe._load({});
+	});
+
+	afterEach(function() {
+		axe.reset();
+	});
+
+	it('should return array if nameFrom contents is found in the lookup table', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					dogs: {
+						type: 'things',
+						nameFromContent: true
+					},
+					cats: {
+						type: 'stuff'
+					}
+				}
+			}
+		});
+		assert.include(axe.commons.aria.getRolesWithNameFromContents(), 'dogs');
+	});
+});

--- a/test/commons/aria/roles.js
+++ b/test/commons/aria/roles.js
@@ -25,26 +25,6 @@ describe('aria.isValidRole', function() {
 	});
 });
 
-describe('aria.getRolesWithNameFromContents', function() {
-	'use strict';
-
-	it('should return array if nameFrom contents is found in the lookup table', function() {
-		var orig = axe.commons.aria.lookupTable.role;
-		axe.commons.aria.lookupTable.role = {
-			dogs: {
-				type: 'things',
-				nameFrom: ['author', 'contents']
-			},
-			cats: {
-				type: 'stuff',
-				nameFrom: ['author']
-			}
-		};
-		assert.deepEqual(axe.commons.aria.getRolesWithNameFromContents(), ['dogs']);
-		axe.commons.aria.lookupTable.role = orig;
-	});
-});
-
 describe('aria.getRolesByType', function() {
 	'use strict';
 

--- a/test/commons/standards/get-aria-roles-supporting-name-from-content.js
+++ b/test/commons/standards/get-aria-roles-supporting-name-from-content.js
@@ -1,0 +1,84 @@
+describe('standards.getAriaRolesSupportingNameFromContent', function() {
+	var getAriaRolesSupportingNameFromContent =
+		axe.commons.standards.getAriaRolesSupportingNameFromContent;
+
+	before(function() {
+		axe._load({});
+	});
+
+	after(function() {
+		axe.reset();
+	});
+
+	it('should return a list of role names which are named from content', function() {
+		// Source: https://www.w3.org/TR/wai-aria-1.1/#namefromcontent
+		// Source: https://www.w3.org/TR/dpub-aria-1.0/
+		// Note: we have added roles in our spec. also note that
+		// although "tree" is listed as supporting name from content
+		// it's role definition does not list contents in the name from
+		// section (it was removed from the list in WAI ARIA 1.2)
+		var contentRoles = getAriaRolesSupportingNameFromContent();
+		assert.deepEqual(contentRoles, [
+			'button',
+			'cell',
+			'checkbox',
+			'columnheader',
+			'directory',
+			'figure',
+			'gridcell',
+			'heading',
+			'link',
+			'listitem',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'row',
+			'rowgroup',
+			'rowheader',
+			'section',
+			'sectionhead',
+			'switch',
+			'tab',
+			'table',
+			'term',
+			'tooltip',
+			'treeitem',
+			'doc-backlink',
+			'doc-biblioref',
+			'doc-glossref',
+			'doc-noteref'
+		]);
+	});
+
+	it('should return configured roles', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					myRole: {
+						nameFromContent: true
+					}
+				}
+			}
+		});
+
+		var contentRoles = getAriaRolesSupportingNameFromContent();
+		assert.include(contentRoles, 'myRole');
+	});
+
+	it('should not return role that is configured to not be of the type', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					button: {
+						nameFromContent: false
+					}
+				}
+			}
+		});
+
+		var contentRoles = getAriaRolesSupportingNameFromContent();
+		assert.notInclude(contentRoles, 'button');
+	});
+});


### PR DESCRIPTION
The function did mostly what `getGlobalAriaAttrs` did so moved it to the standards table as another function that aggregates information about the standards object.

Part of #2108

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
