### PR TITLE
chore(aria-allowed-role): work with standards object

### DIFF
--- a/lib/commons/aria/is-aria-role-allowed-on-element.js
+++ b/lib/commons/aria/is-aria-role-allowed-on-element.js
@@ -1,5 +1,7 @@
-import lookupTable from './lookup-table';
-import matches from '../matches/matches';
+import { getNodeFromTree } from '../../core/utils';
+import AbstractVirtuaNode from '../../core/base/virtual-node/abstract-virtual-node';
+import getImplicitRole from './implicit-role';
+import getElementSpec from '../standards/get-element-spec';
 
 /**
  * @description validate if a given role is an allowed ARIA role for the supplied node
@@ -9,33 +11,22 @@ import matches from '../matches/matches';
  * @return {Boolean} retruns true/false
  */
 function isAriaRoleAllowedOnElement(node, role) {
-	const nodeName = node.nodeName.toUpperCase();
+	const vNode =
+		node instanceof AbstractVirtuaNode ? node : getNodeFromTree(node);
+	const implicitRole = getImplicitRole(vNode);
 
-	// if given node can have no role - return false
-	if (matches(node, lookupTable.elementsAllowedNoRole)) {
-		return false;
-	}
-	// if given node allows any role - return true
-	if (matches(node, lookupTable.elementsAllowedAnyRole)) {
+	// always allow the explicit role to match the implicit role
+	if (role === implicitRole) {
 		return true;
 	}
 
-	// get role value (if exists) from lookupTable.role
-	const roleValue = lookupTable.role[role];
+	const spec = getElementSpec(vNode);
 
-	// if given role does not exist in lookupTable - return false
-	if (!roleValue || !roleValue.allowedElements) {
-		return false;
+	if (Array.isArray(spec.allowedRoles)) {
+		return spec.allowedRoles.includes(role);
 	}
 
-	// validate attributes and conditions (if any) from allowedElement to given node
-	let out = matches(node, roleValue.allowedElements);
-
-	// if given node type has complex condition to evaluate a given aria-role, execute the same
-	if (Object.keys(lookupTable.evaluateRoleForElement).includes(nodeName)) {
-		return lookupTable.evaluateRoleForElement[nodeName]({ node, role, out });
-	}
-	return out;
+	return !!spec.allowedRoles;
 }
 
 export default isAriaRoleAllowedOnElement;

--- a/lib/commons/matches/from-primative.js
+++ b/lib/commons/matches/from-primative.js
@@ -19,17 +19,25 @@ function fromPrimative(someString, matcher) {
 	if (Array.isArray(matcher) && typeof someString !== 'undefined') {
 		return matcher.includes(someString);
 	}
+
 	if (matcherType === 'function') {
 		return !!matcher(someString);
 	}
-	if (matcher instanceof RegExp) {
-		return matcher.test(someString);
+
+	// RegExp.test(str) typecasts the str to a String value so doing
+	// `/.*/.test(null)` returns true as null is cast to "null"
+	if (someString !== null && someString !== undefined) {
+		if (matcher instanceof RegExp) {
+			return matcher.test(someString);
+		}
+
+		// matcher starts and ends with "/"
+		if (/^\/.*\/$/.test(matcher)) {
+			const pattern = matcher.substring(1, matcher.length - 1);
+			return new RegExp(pattern).test(someString);
+		}
 	}
-	// matcher starts and ends with "/"
-	if (/^\/.*\/$/.test(matcher)) {
-		const pattern = matcher.substring(1, matcher.length - 1);
-		return new RegExp(pattern).test(someString);
-	}
+
 	return matcher === someString;
 }
 

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -346,25 +346,15 @@ const htmlElms = {
 					'doc-cover'
 				]
 			},
-			emptyAlt: {
-				matches: '[alt=""]',
-				allowedRoles: ['presentation', 'none']
-			},
-			noAlt: {
-				matches: {
-					attributes: {
-						alt: null
-					}
-				},
-				// Note: if img has accessible name then uses alt="some text"
-				// but we can't match that so we'll go with false
-				allowedRoles: false
-			},
 			usemap: {
 				matches: '[usemap]',
 				contentTypes: ['interactive', 'embedded', 'phrasing', 'flow']
 			},
 			default: {
+				// Note: allow role presentation and none on image with no
+				// alt as a way to prevent axe from flagging the image as
+				// needing an alt
+				allowedRoles: ['presentation', 'none'],
 				contentTypes: ['embedded', 'phrasing', 'flow']
 			}
 		},
@@ -430,22 +420,21 @@ const htmlElms = {
 			noRoles: {
 				matches: {
 					properties: {
+						// Note: types of url, search, tel, and email are listed
+						// as not allowed roles however since they are text
+						// types they should be allowed to have role=combobox
 						type: [
 							'color',
 							'date',
 							'datetime-local',
-							'email',
 							'file',
 							'month',
 							'number',
 							'password',
 							'range',
 							'reset',
-							'search',
 							'submit',
-							'tel',
 							'time',
-							'url',
 							'week'
 						]
 					}

--- a/test/checks/aria/aria-allowed-role.js
+++ b/test/checks/aria/aria-allowed-role.js
@@ -348,7 +348,7 @@ describe('aria-allowed-role', function() {
 
 	it('returns true <img> with a non-empty alt', function() {
 		var node = document.createElement('img');
-		node.setAttribute('role', 'banner');
+		node.setAttribute('role', 'button');
 		node.alt = 'some text';
 		fixture.appendChild(node);
 		flatTreeSetup(fixture);

--- a/test/commons/aria/get-element-unallowed-roles.js
+++ b/test/commons/aria/get-element-unallowed-roles.js
@@ -28,7 +28,7 @@ describe('aria.getElementUnallowedRoles', function() {
 		node.setAttribute('role', role);
 		flatTreeSetup(node);
 		var actual = axe.commons.aria.getElementUnallowedRoles(node);
-		assert.isEmpty(actual);
+		assert.isNotEmpty(actual);
 	});
 
 	it('returns true for INPUT with type button and role menuitemcheckbox', function() {

--- a/test/commons/matches/from-primative.js
+++ b/test/commons/matches/from-primative.js
@@ -76,6 +76,9 @@ describe('matches.fromPrimative', function() {
 		it('returns false if the regexp does not match', function() {
 			assert.isFalse(fromPrimative('foobar', /^(foo|bar|baz)$/));
 		});
+		it('returns false for null value', function() {
+			assert.isFalse(fromPrimative(null, /.*/));
+		});
 	});
 
 	describe('with RegExp string', function() {
@@ -84,6 +87,9 @@ describe('matches.fromPrimative', function() {
 		});
 		it('returns false if the regexp does not match', function() {
 			assert.isFalse(fromPrimative('foobar', '/^(foo|bar|baz)$/'));
+		});
+		it('returns false for null value', function() {
+			assert.isFalse(fromPrimative(null, /.*/));
 		});
 	});
 });

--- a/test/commons/matches/from-primative.js
+++ b/test/commons/matches/from-primative.js
@@ -89,7 +89,7 @@ describe('matches.fromPrimative', function() {
 			assert.isFalse(fromPrimative('foobar', '/^(foo|bar|baz)$/'));
 		});
 		it('returns false for null value', function() {
-			assert.isFalse(fromPrimative(null, /.*/));
+			assert.isFalse(fromPrimative(null, '/.*/'));
 		});
 	});
 });

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -159,7 +159,7 @@
 <a id="pass-dpub-3" role="doc-glossref" href="#">ok</a>
 <a id="pass-dpub-4" role="doc-noteref" href="#">ok</a>
 <!-- images -->
-<img id="pass-dpub-5" role="doc-cover" />
+<img alt="foo" id="pass-dpub-5" role="doc-cover" />
 <!-- listitems -->
 <ul>
 	<li id="pass-dpub-6" role="doc-biblioentry">ok</li>


### PR DESCRIPTION
Discovered regex `.test(str)` typecasts the str to a String value, so doing `/.+/.test(null) === true` as null is cast to the string "null." So had to fix that in our matcher. Also fixed the standards object to allow roles on things the spec says are allowed no role (no alt imgs and inputs type=tel,url.search,email).

I also think our test for `get-element-unallowed-roles.js` was a false-positive as it should not have passed before but did (`menubar` should not be allowed on `li`).

Part of #2108

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
