### PR TITLE
chore(aria-errormessage): work with standards object

### DIFF
--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -1,4 +1,4 @@
-import { lookupTable } from '../../commons/aria';
+import standards from '../../standards';
 import { getRootNode } from '../../commons/dom';
 import { tokenList } from '../../core/utils';
 
@@ -12,7 +12,7 @@ function ariaErrormessageEvaluate(node, options) {
 
 	function validateAttrValue(attr) {
 		if (attr.trim() === '') {
-			return lookupTable.attributes['aria-errormessage'].allowEmpty;
+			return standards.ariaAttrs['aria-errormessage'].allowEmpty;
 		}
 		const idref = attr && doc.getElementById(attr);
 		if (idref) {

--- a/test/checks/aria/errormessage.js
+++ b/test/checks/aria/errormessage.js
@@ -5,17 +5,11 @@ describe('aria-errormessage', function() {
 	var shadowSupported = axe.testUtils.shadowSupport.v1;
 	var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
 	var checkContext = axe.testUtils.MockCheckContext();
-	var attrData = Object.assign(
-		{},
-		axe.commons.aria.lookupTable.attributes['aria-errormessage']
-	);
 
 	afterEach(function() {
-		axe.commons.aria.lookupTable.attributes[
-			'aria-errormessage'
-		] = Object.assign({}, attrData);
 		fixture.innerHTML = '';
 		checkContext.reset();
+		axe.reset();
 	});
 
 	it('should return false if aria-errormessage value is invalid', function() {
@@ -84,9 +78,15 @@ describe('aria-errormessage', function() {
 	});
 
 	it('returns true when aria-errormessage is empty, if that is allowed', function() {
-		axe.commons.aria.lookupTable.attributes[
-			'aria-errormessage'
-		].allowEmpty = true;
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-errormessage': {
+						allowEmpty: true
+					}
+				}
+			}
+		});
 		fixture.innerHTML = '<div aria-errormessage=" "></div>';
 		assert.isTrue(
 			axe.testUtils
@@ -96,9 +96,15 @@ describe('aria-errormessage', function() {
 	});
 
 	it('returns false when aria-errormessage is empty, if that is not allowed', function() {
-		axe.commons.aria.lookupTable.attributes[
-			'aria-errormessage'
-		].allowEmpty = false;
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-errormessage': {
+						allowEmpty: false
+					}
+				}
+			}
+		});
 		fixture.innerHTML = '<div aria-errormessage=" "></div>';
 		assert.isFalse(
 			axe.testUtils


### PR DESCRIPTION
Part of #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
