### PR TITLE
chore(get-role): work with standards object

### DIFF
--- a/lib/commons/aria/get-role.js
+++ b/lib/commons/aria/get-role.js
@@ -1,6 +1,6 @@
 import getExplicitRole from './get-explicit-role';
 import getImplicitRole from './implicit-role';
-import lookupTable from './lookup-table';
+import getGlobalAriaAttrs from '../standards/get-global-aria-attrs';
 import isFocusable from '../dom/is-focusable';
 import { getNodeFromTree } from '../../core/utils';
 import AbstractVirtuaNode from '../../core/base/virtual-node/abstract-virtual-node';
@@ -105,9 +105,7 @@ function resolveImplicitRole(vNode, explicitRoleOptions) {
 // Source: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none
 // See also: https://github.com/w3c/aria/issues/1270
 function hasConflictResolution(vNode) {
-	const hasGlobalAria = lookupTable.globalAttributes.some(attr =>
-		vNode.hasAttr(attr)
-	);
+	const hasGlobalAria = getGlobalAriaAttrs().some(attr => vNode.hasAttr(attr));
 	return hasGlobalAria || isFocusable(vNode.actualNode);
 }
 

--- a/test/commons/aria/get-role.js
+++ b/test/commons/aria/get-role.js
@@ -1,18 +1,11 @@
 describe('aria.getRole', function() {
 	'use strict';
 	var aria = axe.commons.aria;
-	var roleDefinitions = aria.lookupTable.role;
 	var flatTreeSetup = axe.testUtils.flatTreeSetup;
 	var fixture = document.querySelector('#fixture');
 
-	var orig;
-	beforeEach(function() {
-		orig = axe.commons.aria.lookupTable.role;
-	});
-
 	afterEach(function() {
 		fixture.innerHTML = '';
-		axe.commons.aria.lookupTable.role = orig;
 	});
 
 	it('returns valid roles', function() {
@@ -289,7 +282,6 @@ describe('aria.getRole', function() {
 			fixture.innerHTML = '<ul><li id="target" role="section"></li></ul>';
 			flatTreeSetup(fixture);
 			var node = fixture.querySelector('#target');
-			assert.equal(roleDefinitions.section.type, 'abstract');
 			assert.equal(aria.getRole(node), 'listitem');
 		});
 
@@ -297,7 +289,6 @@ describe('aria.getRole', function() {
 			var node = document.createElement('li');
 			node.setAttribute('role', 'section');
 			flatTreeSetup(node);
-			assert.equal(roleDefinitions.section.type, 'abstract');
 			assert.equal(aria.getRole(node, { abstracts: true }), 'section');
 		});
 
@@ -305,7 +296,6 @@ describe('aria.getRole', function() {
 			fixture.innerHTML = '<ul><li id="target" role="section"></li></ul>';
 			flatTreeSetup(fixture);
 			var node = fixture.querySelector('#target');
-			assert.equal(roleDefinitions.section.type, 'abstract');
 			assert.equal(aria.getRole(node, { abstracts: false }), 'listitem');
 		});
 	});


### PR DESCRIPTION
Part of #2108

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
