### PR TITLE
chore: fix standard roles

### DIFF
--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -288,12 +288,16 @@ const ariaRoles = {
 		type: 'landmark',
 		allowedAttrs: ['aria-expanded']
 	},
+	none: {
+		type: 'structure'
+	},
 	note: {
 		type: 'structure',
 		allowedAttrs: ['aria-expanded']
 	},
 	option: {
 		type: 'widget',
+		requiredContext: ['listbox'],
 		// Note: since the option role has an implicit
 		// aria-selected value it is not required to be added by
 		// the user

--- a/test/commons/standards/get-aria-roles-by-type.js
+++ b/test/commons/standards/get-aria-roles-by-type.js
@@ -27,6 +27,7 @@ describe('standards.getAriaRolesByType', function() {
 			'list',
 			'listitem',
 			'math',
+			'none',
 			'note',
 			'presentation',
 			'row',


### PR DESCRIPTION
Noticed the `none` role wasn't in the standards object. I think what happened is I took the standards object as the base and compared it agains the lookup table instead of the other way around. So I did that and this is the new results (that are different than the ones we already approved in https://github.com/dequelabs/axe-core/pull/2328#issuecomment-651218760)

```js
allowed attrs is not present for role: doc-pullquote, ['aria-expanded']
allowed attrs is not present for role: rowgroup, ['aria-activedescendant', 'aria-expanded', 'aria-errormessage']
```

Also, fun fact: the dpub roles in the lookup table all use `namefrom` (no capital F) and so they would never return `true` when checking name from contents. But we wouldn't know because when we ask name from contents of a role, [dpub roles are excluded from the list](https://github.com/dequelabs/axe-core/blob/develop/lib/commons/aria/get-explicit-role.js#L17-L19) as we don't pass the [dpub flag to getRole](https://github.com/dequelabs/axe-core/blob/develop/lib/commons/aria/named-from-contents.js#L20).

I find it odd that dpub roles are not counted as valid roles by default though...

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
