### PR TITLE
chore(validate-attr,unsupported-attr): work with standards object

### DIFF
--- a/lib/checks/aria/aria-unsupported-attr-evaluate.js
+++ b/lib/checks/aria/aria-unsupported-attr-evaluate.js
@@ -1,14 +1,12 @@
-import { lookupTable, getRole, validateAttr } from '../../commons/aria';
+import { validateAttr } from '../../commons/aria';
+import standards from '../../standards';
 import matches from '../../commons/matches';
 import { getNodeAttributes } from '../../core/utils';
 
 function ariaUnsupportedAttrEvaluate(node) {
-	const nodeName = node.nodeName.toUpperCase();
-	const role = getRole(node);
-
 	const unsupportedAttrs = Array.from(getNodeAttributes(node))
 		.filter(({ name }) => {
-			const attribute = lookupTable.attributes[name];
+			const attribute = standards.ariaAttrs[name];
 
 			if (!validateAttr(name)) {
 				return false;
@@ -20,19 +18,7 @@ function ariaUnsupportedAttrEvaluate(node) {
 				return !!unsupported;
 			}
 
-			// validate attributes and conditions (if any) from allowedElement to given node
-			const isException = matches(node, unsupported.exceptions);
-
-			if (!Object.keys(lookupTable.evaluateRoleForElement).includes(nodeName)) {
-				return !isException;
-			}
-
-			// evaluate a given aria-role, execute the same
-			return !lookupTable.evaluateRoleForElement[nodeName]({
-				node,
-				role,
-				out: isException
-			});
+			return !matches(node, unsupported.exceptions);
 		})
 		.map(candidate => candidate.name.toString());
 

--- a/lib/commons/aria/validate-attr.js
+++ b/lib/commons/aria/validate-attr.js
@@ -1,4 +1,4 @@
-import lookupTable from './lookup-table';
+import standards from '../../standards';
 
 /**
  * Check if an aria- attribute name is valid
@@ -9,7 +9,7 @@ import lookupTable from './lookup-table';
  * @return {Boolean}
  */
 function validateAttr(att) {
-	const attrDefinition = lookupTable.attributes[att];
+	const attrDefinition = standards.ariaAttrs[att];
 	return !!attrDefinition;
 }
 

--- a/test/checks/aria/unsupportedattr.js
+++ b/test/checks/aria/unsupportedattr.js
@@ -7,12 +7,20 @@ describe('unsupportedattr', function() {
 
 	afterEach(function() {
 		checkContext.reset();
+		axe.reset();
 	});
 
 	it('should return true if applied to an unsupported attribute', function() {
-		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
-			unsupported: true
-		};
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-mccheddarton': {
+						unsupported: true
+					}
+				}
+			}
+		});
+
 		var params = checkSetup(
 			'<div id="target" aria-mccheddarton="true">Contents</div>'
 		);
@@ -20,12 +28,18 @@ describe('unsupportedattr', function() {
 	});
 
 	it('should return true with multiple unsupported and supported attributes', function() {
-		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
-			unsupported: true
-		};
-		axe.commons.aria.lookupTable.attributes['aria-bagleypants'] = {
-			unsupported: true
-		};
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-mccheddarton': {
+						unsupported: true
+					},
+					'aria-bagleypants': {
+						unsupported: true
+					}
+				}
+			}
+		});
 		var params = checkSetup(
 			'<div id="target" aria-mccheddarton="true" aria-bagleypants="false" aria-label="Nope">Contents</div>'
 		);
@@ -51,11 +65,17 @@ describe('unsupportedattr', function() {
 	});
 
 	it('should return false if applied to an element that matches the unsupported "exceptions" list', function() {
-		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
-			unsupported: {
-				exceptions: ['button']
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-mccheddarton': {
+						unsupported: {
+							exceptions: ['button']
+						}
+					}
+				}
 			}
-		};
+		});
 		var params = checkSetup(
 			'<button id="target" aria-mccheddarton="true">Contents</button>'
 		);
@@ -63,18 +83,24 @@ describe('unsupportedattr', function() {
 	});
 
 	it('should return false if applied to an element that matches the unsupported "exceptions" list using complex conditions', function() {
-		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
-			unsupported: {
-				exceptions: [
-					{
-						nodeName: 'input',
-						properties: {
-							type: 'checkbox'
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-mccheddarton': {
+						unsupported: {
+							exceptions: [
+								{
+									nodeName: 'input',
+									properties: {
+										type: 'checkbox'
+									}
+								}
+							]
 						}
 					}
-				]
+				}
 			}
-		};
+		});
 		var params = checkSetup(
 			'<input type="checkbox" id="target" aria-mccheddarton="true">'
 		);
@@ -82,11 +108,17 @@ describe('unsupportedattr', function() {
 	});
 
 	it('should return true if applied to an element that does not match the unsupported "exceptions" list', function() {
-		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
-			unsupported: {
-				exceptions: ['button']
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-mccheddarton': {
+						unsupported: {
+							exceptions: ['button']
+						}
+					}
+				}
 			}
-		};
+		});
 		var params = checkSetup(
 			'<div id="target" aria-mccheddarton="true">Contents</div>'
 		);
@@ -94,18 +126,24 @@ describe('unsupportedattr', function() {
 	});
 
 	it('should return true if applied to an element that does not match the unsupported "exceptions" list using complex conditions', function() {
-		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
-			unsupported: {
-				exceptions: [
-					{
-						nodeName: 'input',
-						properties: {
-							type: 'checkbox'
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-mccheddarton': {
+						unsupported: {
+							exceptions: [
+								{
+									nodeName: 'input',
+									properties: {
+										type: 'checkbox'
+									}
+								}
+							]
 						}
 					}
-				]
+				}
 			}
-		};
+		});
 		var params = checkSetup(
 			'<input type="radio" id="target" aria-mccheddarton="true">'
 		);

--- a/test/checks/aria/valid-attr.js
+++ b/test/checks/aria/valid-attr.js
@@ -7,6 +7,7 @@ describe('aria-valid-attr', function() {
 	afterEach(function() {
 		fixture.innerHTML = '';
 		checkContext.reset();
+		axe.reset();
 	});
 
 	it('should return false if any invalid ARIA attributes are found', function() {
@@ -37,9 +38,15 @@ describe('aria-valid-attr', function() {
 	});
 
 	it('should return true for unsupported ARIA attributes', function() {
-		axe.commons.aria.lookupTable.attributes['aria-mccheddarton'] = {
-			unsupported: true
-		};
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					'aria-mccheddarton': {
+						unsupported: true
+					}
+				}
+			}
+		});
 
 		var node = document.createElement('div');
 		node.id = 'test';

--- a/test/commons/aria/attributes.js
+++ b/test/commons/aria/attributes.js
@@ -28,30 +28,3 @@ describe('aria.requiredAttr', function() {
 		assert.deepEqual(result, []);
 	});
 });
-
-describe('aria.validateAttr', function() {
-	'use strict';
-
-	var orig;
-	beforeEach(function() {
-		orig = axe.commons.aria.lookupTable.attributes;
-	});
-
-	afterEach(function() {
-		axe.commons.aria.lookupTable.attributes = orig;
-	});
-
-	it('should return true if attribute is found in lut', function() {
-		axe.commons.aria.lookupTable.attributes = {
-			cats: {}
-		};
-
-		assert.isTrue(axe.commons.aria.validateAttr('cats'));
-	});
-
-	it('should return false if attribute is found in lut', function() {
-		axe.commons.aria.lookupTable.attributes = {};
-
-		assert.isFalse(axe.commons.aria.validateAttr('cats'));
-	});
-});

--- a/test/commons/aria/validate-attr.js
+++ b/test/commons/aria/validate-attr.js
@@ -1,0 +1,23 @@
+describe('aria.validateAttr', function() {
+	'use strict';
+
+	afterEach(function() {
+		axe.reset();
+	});
+
+	it('should return true if attribute is found in lut', function() {
+		axe.configure({
+			standards: {
+				ariaAttrs: {
+					cats: {}
+				}
+			}
+		});
+
+		assert.isTrue(axe.commons.aria.validateAttr('cats'));
+	});
+
+	it('should return false if attribute is found in lut', function() {
+		assert.isFalse(axe.commons.aria.validateAttr('cats'));
+	});
+});

--- a/test/integration/rules/aria-allowed-attr/failures.html
+++ b/test/integration/rules/aria-allowed-attr/failures.html
@@ -2,6 +2,3 @@
 <div role="link" aria-selected="true" id="fail2">fail</div>
 <div role="row" aria-colcount="value" id="fail3">fail</div>
 <div role="row" aria-rowcount="value" id="fail4">fail</div>
-
-<!-- unsupported attributes -->
-<div aria-describedat="#fail4" id="fail5">fail</div>

--- a/test/integration/rules/aria-allowed-attr/failures.json
+++ b/test/integration/rules/aria-allowed-attr/failures.json
@@ -1,5 +1,5 @@
 {
 	"description": "aria-allowed-attr failing tests",
 	"rule": "aria-allowed-attr",
-	"violations": [["#fail1"], ["#fail2"], ["#fail3"], ["#fail4"], ["#fail5"]]
+	"violations": [["#fail1"], ["#fail2"], ["#fail3"], ["#fail4"]]
 }


### PR DESCRIPTION
Aria-describat was removed in https://github.com/dequelabs/axe-core/pull/2315.

Part of issue #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
