### PR TITLE
chore(is-unsupported-role,is-valid-role): work with standards object

### DIFF
--- a/lib/commons/aria/is-unsupported-role.js
+++ b/lib/commons/aria/is-unsupported-role.js
@@ -1,4 +1,4 @@
-import lookupTable from './lookup-table';
+import standards from '../../standards';
 
 /**
  * Check if a given role is unsupported
@@ -9,8 +9,8 @@ import lookupTable from './lookup-table';
  * @return {Boolean}
  */
 function isUnsupportedRole(role) {
-	const roleDefinition = lookupTable.role[role];
-	return roleDefinition ? roleDefinition.unsupported : false;
+	const roleDefinition = standards.ariaRoles[role];
+	return roleDefinition ? !!roleDefinition.unsupported : false;
 }
 
 export default isUnsupportedRole;

--- a/lib/commons/aria/is-valid-role.js
+++ b/lib/commons/aria/is-valid-role.js
@@ -1,4 +1,5 @@
-import lookupTable from './lookup-table';
+import standards from '../../standards';
+import isUnsupportedRole from './is-unsupported-role';
 
 /**
  * Check if a given role is valid
@@ -10,8 +11,8 @@ import lookupTable from './lookup-table';
  * @return {Boolean}
  */
 function isValidRole(role, { allowAbstract, flagUnsupported = false } = {}) {
-	const roleDefinition = lookupTable.role[role];
-	const isRoleUnsupported = roleDefinition ? roleDefinition.unsupported : false;
+	const roleDefinition = standards.ariaRoles[role];
+	const isRoleUnsupported = isUnsupportedRole(role);
 	if (!roleDefinition || (flagUnsupported && isRoleUnsupported)) {
 		return false;
 	}

--- a/test/checks/aria/unsupportedrole.js
+++ b/test/checks/aria/unsupportedrole.js
@@ -6,13 +6,21 @@ describe('unsupportedrole', function() {
 
 	afterEach(function() {
 		fixture.innerHTML = '';
+		axe.reset();
 	});
 
 	it('should return true if applied to an unsupported role', function() {
-		axe.commons.aria.lookupTable.role.mccheddarton = {
-			type: 'widget',
-			unsupported: true
-		};
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					mccheddarton: {
+						type: 'widget',
+						unsupported: true
+					}
+				}
+			}
+		});
+
 		fixture.innerHTML = '<div id="target" role="mccheddarton">Contents</div>';
 		var node = fixture.querySelector('#target');
 		flatTreeSetup(fixture);

--- a/test/commons/aria/is-unsupported-role.js
+++ b/test/commons/aria/is-unsupported-role.js
@@ -1,32 +1,37 @@
 describe('aria.isUnsupportedRole', function() {
 	'use strict';
 
+	after(function() {
+		axe.reset();
+	});
+
 	it('should return true if the role is unsupported', function() {
-		var orig = axe.commons.aria.lookupTable.role;
-		axe.commons.aria.lookupTable.role = {
-			cats: {
-				unsupported: true
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
+						unsupported: true
+					}
+				}
 			}
-		};
+		});
 		assert.isTrue(axe.commons.aria.isUnsupportedRole('cats'));
-		axe.commons.aria.lookupTable.role = orig;
 	});
 
 	it('should return false if the role is supported', function() {
-		var orig = axe.commons.aria.lookupTable.role;
-		axe.commons.aria.lookupTable.role = {
-			cats: {
-				unsupported: false
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
+						unsupported: false
+					}
+				}
 			}
-		};
+		});
 		assert.isFalse(axe.commons.aria.isUnsupportedRole('cats'));
-		axe.commons.aria.lookupTable.role = orig;
 	});
 
 	it('should return false if the role is invalid', function() {
-		var orig = axe.commons.aria.lookupTable.role;
-		axe.commons.aria.lookupTable.role = {};
 		assert.isFalse(axe.commons.aria.isUnsupportedRole('cats'));
-		axe.commons.aria.lookupTable.role = orig;
 	});
 });

--- a/test/commons/aria/is-valid-role.js
+++ b/test/commons/aria/is-valid-role.js
@@ -1,0 +1,32 @@
+describe('aria.isValidRole', function() {
+	'use strict';
+
+	afterEach(function() {
+		axe.reset();
+	});
+
+	it('should return true if role is found in the lookup table', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: true
+				}
+			}
+		});
+		assert.isTrue(axe.commons.aria.isValidRole('cats'));
+	});
+
+	it('should return false if role is not found in the lookup table', function() {
+		assert.isFalse(axe.commons.aria.isValidRole('cats'));
+	});
+
+	it('returns false for abstract roles by default', function() {
+		assert.isFalse(axe.commons.aria.isValidRole('input'));
+	});
+
+	it('returns true for abstract roles with { allowAbstract: true } ', function() {
+		assert.isTrue(
+			axe.commons.aria.isValidRole('input', { allowAbstract: true })
+		);
+	});
+});

--- a/test/commons/aria/roles.js
+++ b/test/commons/aria/roles.js
@@ -1,30 +1,3 @@
-describe('aria.isValidRole', function() {
-	'use strict';
-
-	it('should return true if role is found in the lookup table', function() {
-		var orig = axe.commons.aria.lookupTable.role;
-		axe.commons.aria.lookupTable.role = {
-			cats: true
-		};
-		assert.isTrue(axe.commons.aria.isValidRole('cats'));
-		axe.commons.aria.lookupTable.role = orig;
-	});
-
-	it('should return false if role is not found in the lookup table', function() {
-		assert.isFalse(axe.commons.aria.isValidRole('cats'));
-	});
-
-	it('returns false for abstract roles by default', function() {
-		assert.isFalse(axe.commons.aria.isValidRole('input'));
-	});
-
-	it('returns true for abstract roles with { allowAbstract: true } ', function() {
-		assert.isTrue(
-			axe.commons.aria.isValidRole('input', { allowAbstract: true })
-		);
-	});
-});
-
 describe('aria.requiredOwned', function() {
 	'use strict';
 


### PR DESCRIPTION
Notice that `is-valid-role` should have used `is-unsupported-role` but duplicated the code so converted it to use it.

Part of issue #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
