### PR TITLE
chore(aria-required-parent): work with standards object

### DIFF
--- a/lib/checks/aria/aria-required-parent-evaluate.js
+++ b/lib/checks/aria/aria-required-parent-evaluate.js
@@ -3,7 +3,6 @@ import { getRootNode } from '../../commons/dom';
 import { getNodeFromTree, escapeSelector } from '../../core/utils';
 
 function getMissingContext(virtualNode, reqContext, includeElement) {
-	const missing = [];
 	const explicitRole = getExplicitRole(virtualNode);
 
 	if (!reqContext) {
@@ -14,23 +13,17 @@ function getMissingContext(virtualNode, reqContext, includeElement) {
 		return null;
 	}
 
-	for (let index = 0; index < reqContext.length; index++) {
-		let vNode = includeElement ? virtualNode : virtualNode.parent;
-
-		while (vNode) {
-			const parentRole = getRole(vNode);
-
-			if (reqContext[index].includes(parentRole)) {
-				return null;
-			}
-
-			vNode = vNode.parent;
+	let vNode = includeElement ? virtualNode : virtualNode.parent;
+	while (vNode) {
+		const parentRole = getRole(vNode);
+		if (reqContext.includes(parentRole)) {
+			return null;
 		}
 
-		missing.push(reqContext[index]);
+		vNode = vNode.parent;
 	}
 
-	return missing;
+	return reqContext;
 }
 
 function getAriaOwners(element) {

--- a/lib/checks/aria/aria-required-parent-evaluate.js
+++ b/lib/checks/aria/aria-required-parent-evaluate.js
@@ -1,43 +1,33 @@
-import { implicitNodes, requiredContext } from '../../commons/aria';
-import { findUpVirtual, getRootNode } from '../../commons/dom';
-import {
-	getNodeFromTree,
-	matchesSelector,
-	escapeSelector
-} from '../../core/utils';
-
-function getSelector(role) {
-	var impliedNative = implicitNodes(role) || [];
-	return impliedNative.concat('[role="' + role + '"]').join(',');
-}
+import { getExplicitRole, getRole, requiredContext } from '../../commons/aria';
+import { getRootNode } from '../../commons/dom';
+import { getNodeFromTree, escapeSelector } from '../../core/utils';
 
 function getMissingContext(virtualNode, reqContext, includeElement) {
-	var index,
-		length,
-		role = virtualNode.actualNode.getAttribute('role'),
-		missing = [];
+	const missing = [];
+	const explicitRole = getExplicitRole(virtualNode);
 
 	if (!reqContext) {
-		reqContext = requiredContext(role);
+		reqContext = requiredContext(explicitRole);
 	}
 
 	if (!reqContext) {
 		return null;
 	}
 
-	for (index = 0, length = reqContext.length; index < length; index++) {
-		if (
-			includeElement &&
-			matchesSelector(virtualNode.actualNode, getSelector(reqContext[index]))
-		) {
-			return null;
+	for (let index = 0; index < reqContext.length; index++) {
+		let vNode = includeElement ? virtualNode : virtualNode.parent;
+
+		while (vNode) {
+			const parentRole = getRole(vNode);
+
+			if (reqContext[index].includes(parentRole)) {
+				return null;
+			}
+
+			vNode = vNode.parent;
 		}
-		if (findUpVirtual(virtualNode, getSelector(reqContext[index]))) {
-			//if one matches, it passes
-			return null;
-		} else {
-			missing.push(reqContext[index]);
-		}
+
+		missing.push(reqContext[index]);
 	}
 
 	return missing;

--- a/lib/commons/aria/implicit-nodes.js
+++ b/lib/commons/aria/implicit-nodes.js
@@ -5,6 +5,7 @@ import lookupTable from './lookup-table';
  * Get a list of CSS selectors of nodes that have an implicit role
  * @method implicitNodes
  * @memberof axe.commons.aria
+ * @deprecated
  * @instance
  * @param {String} role The role to check
  * @return {Mixed} Either an Array of CSS selectors or `null` if there are none

--- a/lib/commons/aria/required-context.js
+++ b/lib/commons/aria/required-context.js
@@ -15,7 +15,7 @@ function requiredContext(role) {
 		return null;
 	}
 
-	return roleDef.requiredContext;
+	return [...roleDef.requiredContext];
 }
 
 export default requiredContext;

--- a/lib/commons/aria/required-context.js
+++ b/lib/commons/aria/required-context.js
@@ -1,4 +1,4 @@
-import lookupTable from './lookup-table';
+import standards from '../../standards';
 
 /**
  * Get the required context (parent) roles for a given role
@@ -9,15 +9,13 @@ import lookupTable from './lookup-table';
  * @return {Mixed} Either an Array of required context elements or `null` if there are none
  */
 function requiredContext(role) {
-	'use strict';
-	let context = null;
-	const roles = lookupTable.role[role];
+	const roleDef = standards.ariaRoles[role];
 
-	if (roles) {
-		// TODO: es-module-utils.clone
-		context = axe.utils.clone(roles.context);
+	if (!roleDef || !roleDef.requiredContext) {
+		return null;
 	}
-	return context;
+
+	return roleDef.requiredContext;
 }
 
 export default requiredContext;

--- a/lib/commons/aria/required-context.js
+++ b/lib/commons/aria/required-context.js
@@ -11,7 +11,7 @@ import standards from '../../standards';
 function requiredContext(role) {
 	const roleDef = standards.ariaRoles[role];
 
-	if (!roleDef || !roleDef.requiredContext) {
+	if (!roleDef || !Array.isArray(roleDef.requiredContext)) {
 		return null;
 	}
 

--- a/test/commons/aria/required-context.js
+++ b/test/commons/aria/required-context.js
@@ -36,4 +36,21 @@ describe('aria.requiredContext', function() {
 
 		assert.isNull(result);
 	});
+
+	it('should return a unique copy of the context', function() {
+		var context = ['yes', 'no'];
+
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
+						requiredContext: context
+					}
+				}
+			}
+		});
+
+		var result = axe.commons.aria.requiredContext('cats');
+		assert.notEqual(result, context);
+	});
 });

--- a/test/commons/aria/required-context.js
+++ b/test/commons/aria/required-context.js
@@ -10,12 +10,25 @@ describe('aria.requiredContext', function() {
 			standards: {
 				ariaRoles: {
 					cats: {
+						requiredContext: ['yes']
+					}
+				}
+			}
+		});
+		assert.deepEqual(axe.commons.aria.requiredContext('cats'), ['yes']);
+	});
+
+	it('should returned null if the required context is not an array', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
 						requiredContext: 'yes'
 					}
 				}
 			}
 		});
-		assert.equal(axe.commons.aria.requiredContext('cats'), 'yes');
+		assert.isNull(axe.commons.aria.requiredContext('cats'));
 	});
 
 	it('should return null if there are no required context nodes', function() {

--- a/test/commons/aria/required-context.js
+++ b/test/commons/aria/required-context.js
@@ -1,0 +1,26 @@
+describe('aria.requiredContext', function() {
+	'use strict';
+
+	afterEach(function() {
+		axe.reset();
+	});
+
+	it('should returned the context property for the proper role', function() {
+		axe.configure({
+			standards: {
+				ariaRoles: {
+					cats: {
+						requiredContext: 'yes'
+					}
+				}
+			}
+		});
+		assert.equal(axe.commons.aria.requiredContext('cats'), 'yes');
+	});
+
+	it('should return null if there are no required context nodes', function() {
+		var result = axe.commons.aria.requiredContext('cats');
+
+		assert.isNull(result);
+	});
+});

--- a/test/commons/aria/roles.js
+++ b/test/commons/aria/roles.js
@@ -54,35 +54,6 @@ describe('aria.requiredOwned', function() {
 	});
 });
 
-describe('aria.requiredContext', function() {
-	'use strict';
-
-	var orig;
-	beforeEach(function() {
-		orig = axe.commons.aria.lookupTable.role;
-	});
-
-	afterEach(function() {
-		axe.commons.aria.lookupTable.role = orig;
-	});
-
-	it('should returned the context property for the proper role', function() {
-		axe.commons.aria.lookupTable.role = {
-			cats: {
-				context: 'yes'
-			}
-		};
-		assert.equal(axe.commons.aria.requiredContext('cats'), 'yes');
-	});
-
-	it('should return null if there are no required context nodes', function() {
-		axe.commons.aria.lookupTable.role = {};
-		var result = axe.commons.aria.requiredContext('cats');
-
-		assert.isNull(result);
-	});
-});
-
 describe('aria.implicitNodes', function() {
 	'use strict';
 


### PR DESCRIPTION
Implicit nodes is being deprecated in favor of just getting the role of the node in question. 

Part of issue #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
