### PR TITLE
chore(region): work with standards object

### DIFF
--- a/lib/checks/navigation/region-evaluate.js
+++ b/lib/checks/navigation/region-evaluate.js
@@ -1,35 +1,29 @@
 import * as dom from '../../commons/dom';
 import * as aria from '../../commons/aria';
 import * as standards from '../../commons/standards';
-import * as text from '../../commons/text';
 import matches from '../../commons/matches';
-import { matchesSelector } from '../../core/utils';
 import cache from '../../core/base/cache';
 
 const landmarkRoles = standards.getAriaRolesByType('landmark');
 const implicitAriaLiveRoles = ['alert', 'log', 'status'];
 
-// Create a list of nodeNames that have a landmark as an implicit role
-const implicitLandmarks = landmarkRoles
-	.reduce((arr, role) => arr.concat(aria.implicitNodes(role)), [])
-	.filter(r => r !== null);
-
 // Check if the current element is a landmark
 function isRegion(virtualNode, options) {
 	const node = virtualNode.actualNode;
-	const explicitRole = aria.getExplicitRole(node);
+	const role = aria.getRole(virtualNode);
 	const ariaLive = (node.getAttribute('aria-live') || '').toLowerCase().trim();
 
 	// Ignore content inside of aria-live
 	if (
 		['assertive', 'polite'].includes(ariaLive) ||
-		implicitAriaLiveRoles.includes(explicitRole)
+		implicitAriaLiveRoles.includes(role)
 	) {
 		return true;
 	}
 
-	if (explicitRole) {
-		return explicitRole === 'dialog' || landmarkRoles.includes(explicitRole);
+	// Check if the node matches a landmark role
+	if (landmarkRoles.includes(role)) {
+		return true;
 	}
 
 	// Check if node matches an option
@@ -37,17 +31,7 @@ function isRegion(virtualNode, options) {
 		return true;
 	}
 
-	// Check if the node matches any of the CSS selectors of implicit landmarks
-	return implicitLandmarks.some(implicitSelector => {
-		let matches = matchesSelector(node, implicitSelector);
-		if (node.nodeName.toUpperCase() === 'FORM') {
-			let titleAttr = node.getAttribute('title');
-			let title =
-				titleAttr && titleAttr.trim() !== '' ? text.sanitize(titleAttr) : null;
-			return matches && (!!aria.labelVirtual(virtualNode) || !!title);
-		}
-		return matches;
-	});
+	return false;
 }
 
 /**

--- a/test/integration/full/region/region-fail.html
+++ b/test/integration/full/region/region-fail.html
@@ -35,6 +35,9 @@
 			<section>
 				<p>Content</p>
 			</section>
+			<section title="section 3">
+				<p>Content</p>
+			</section>
 		</div>
 
 		This should be ignored

--- a/test/integration/full/region/region-pass.html
+++ b/test/integration/full/region/region-pass.html
@@ -39,9 +39,6 @@
 		<section aria-label="section 2">
 			<p>Content</p>
 		</section>
-		<section title="section 3">
-			<p>Content</p>
-		</section>
 		<div id="mocha" role="complementary"></div>
 		<script src="region-pass.js"></script>
 		<script src="/test/integration/adapter.js"></script>


### PR DESCRIPTION
`title` no longer provides a `<section>` element an accessible name as we went with the [Safari implementation](https://github.com/dequelabs/axe-core/blob/develop/lib/commons/aria/lookup-table.js#L2117-L2125).

Part of issue #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
