### PR TITLE
chore(named-from-contents): work with standards object

### DIFF
--- a/lib/commons/aria/named-from-contents.js
+++ b/lib/commons/aria/named-from-contents.js
@@ -1,5 +1,5 @@
 import getRole from './get-role';
-import lookupTable from './lookup-table';
+import standards from '../../standards';
 import { getNodeFromTree } from '../../core/utils';
 import AbstractVirtuaNode from '../../core/base/virtual-node/abstract-virtual-node';
 
@@ -18,9 +18,9 @@ function namedFromContents(vNode, { strict } = {}) {
 	}
 
 	const role = getRole(vNode);
-	const roleDef = lookupTable.role[role];
+	const roleDef = standards.ariaRoles[role];
 
-	if (roleDef && roleDef.nameFrom.includes('contents')) {
+	if (roleDef && roleDef.nameFromContent) {
 		return true;
 	}
 

--- a/test/commons/aria/named-from-contents.js
+++ b/test/commons/aria/named-from-contents.js
@@ -4,15 +4,8 @@ describe('aria.namedFromContents', function() {
 	var fixture = document.querySelector('#fixture');
 	var flatTreeSetup = axe.testUtils.flatTreeSetup;
 
-	beforeEach(function() {
-		aria.foo = { nameFrom: ['author', 'contents'] };
-		aria.bar = { nameFrom: ['author'] };
-	});
-
 	afterEach(function() {
 		fixture.innerHTML = '';
-		delete aria.lookupTable.role.foo;
-		delete aria.lookupTable.role.bar;
 	});
 
 	it('returns true when the element has an explicit role named from content', function() {
@@ -31,20 +24,12 @@ describe('aria.namedFromContents', function() {
 	it('returns true when the element has an implicit role named from content', function() {
 		fixture.innerHTML = '<h1>foo</h1>';
 		flatTreeSetup(fixture);
-		// Varify h1 is named from contents:
-		assert.equal(aria.getRole(fixture.firstChild), 'heading');
-		assert.include(aria.lookupTable.role.heading.nameFrom, 'contents');
-
 		assert.isTrue(namedFromContents(fixture.firstChild));
 	});
 
 	it('returns false when the element has a role not named from content', function() {
 		fixture.innerHTML = '<main role="main"></main>';
 		flatTreeSetup(fixture);
-		// Varify main is not named from contents:
-		assert.equal(aria.getRole(fixture.firstChild), 'main');
-		assert.notInclude(aria.lookupTable.role.main.nameFrom, 'contents');
-
 		assert.isFalse(namedFromContents(fixture.firstChild));
 	});
 


### PR DESCRIPTION
Part of issue #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
