### PR TITLE
chore(autocomplete/label-content-name-mismatch-matches): work with standards object

### DIFF
--- a/lib/rules/autocomplete-matches.js
+++ b/lib/rules/autocomplete-matches.js
@@ -1,5 +1,5 @@
 import { sanitize } from '../commons/text';
-import { lookupTable } from '../commons/aria';
+import standards from '../standards';
 import { isVisible } from '../commons/dom';
 
 function autocompleteMatches(node, virtualNode) {
@@ -36,7 +36,7 @@ function autocompleteMatches(node, virtualNode) {
 	const role = virtualNode.attr('role');
 	const tabIndex = virtualNode.attr('tabindex');
 	if (tabIndex === '-1' && role) {
-		const roleDef = lookupTable.role[role];
+		const roleDef = standards.ariaRoles[role];
 		if (roleDef === undefined || roleDef.type !== 'widget') {
 			return false;
 		}

--- a/lib/rules/label-content-name-mismatch-matches.js
+++ b/lib/rules/label-content-name-mismatch-matches.js
@@ -1,10 +1,8 @@
+import { getRole, arialabelText, arialabelledbyText } from '../commons/aria';
 import {
-	getRole,
-	lookupTable,
-	arialabelText,
-	arialabelledbyText
-} from '../commons/aria';
-import { getAriaRolesSupportingNameFromContent } from '../commons/standards';
+	getAriaRolesSupportingNameFromContent,
+	getAriaRolesByType
+} from '../commons/standards';
 import { sanitize, visibleVirtual } from '../commons/text';
 
 function labelContentNameMismatchMatches(node, virtualNode) {
@@ -20,9 +18,7 @@ function labelContentNameMismatchMatches(node, virtualNode) {
 		return false;
 	}
 
-	const widgetRoles = Object.keys(lookupTable.role).filter(
-		key => lookupTable.role[key].type === `widget`
-	);
+	const widgetRoles = getAriaRolesByType('widget');
 	const isWidgetType = widgetRoles.includes(role);
 	if (!isWidgetType) {
 		return false;


### PR DESCRIPTION
Part of issue #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
