### PR TITLE
chore(required-children): work with standards object

### DIFF
--- a/lib/checks/aria/aria-required-children-evaluate.js
+++ b/lib/checks/aria/aria-required-children-evaluate.js
@@ -1,211 +1,104 @@
-import { requiredOwned, implicitNodes, getRole } from '../../commons/aria';
-import { hasContentVirtual, idrefs } from '../../commons/dom';
 import {
-	matchesSelector,
-	querySelectorAll,
-	getNodeFromTree
-} from '../../core/utils';
+	requiredOwned,
+	getRole,
+	getExplicitRole,
+	getOwnedVirtual
+} from '../../commons/aria';
+import { hasContentVirtual, idrefs } from '../../commons/dom';
+
+/**
+ * Get all owned roles of an element
+ */
+function getOwnedRoles(virtualNode) {
+	const ownedRoles = [];
+	const ownedElements = getOwnedVirtual(virtualNode);
+	for (let i = 0; i < ownedElements.length; i++) {
+		let ownedElement = ownedElements[i];
+		let role = getRole(ownedElement);
+
+		// if owned node has no role or is presentational we keep
+		// parsing the descendant tree. this means intermediate roles
+		// between a required parent and child will fail the check
+		if (['presentation', 'none', null].includes(role)) {
+			ownedElements.push(...ownedElement.children);
+		} else if (role) {
+			ownedRoles.push(role);
+		}
+	}
+
+	return ownedRoles;
+}
 
 /**
  * Get missing children roles
- * @param {HTMLElement} node node
- * @param {String[]} childRoles expected children roles
- * @param {Boolean} all should all child roles be present?
- * @param {String} role role of given node
  */
-function missingRequiredChildren(
-	/* eslint max-params: 0 */
-	node,
-	virtualNode,
-	childRoles,
-	all,
-	role,
-	ownedEls,
-	descRole
-) {
-	let missing = [];
-
-	for (let index = 0; index < childRoles.length; index++) {
-		const childRole = childRoles[index];
-		const ownsRole = owns(node, virtualNode, childRole);
-		const ariaOwnsRole = ariaOwns(ownedEls, childRole);
-		if (ownsRole || ariaOwnsRole) {
-			if (!all) {
-				return null;
-			}
-
-			/**
-			 * Verify if descendants contain one of the requested child roles & that a requested child role is not nested within an overriding role
-			 * Only handle when role is not `combobox`, given there is an exception/ different path for `combobox`
-			 * Eg:
-			 * `<div role="list"><div role="tabpanel"><div role="listitem">List item 1</div></div></div>`
-			 * should fail because `listitem` role not under `list` but has `tabpanel` between them, so although `listitem` is owned by `list` this is a failure.
-			 */
-			if (role !== 'combobox' && !descRole.includes(childRole)) {
-				missing.push(childRole);
-			}
-		} else {
-			if (all) {
-				missing.push(childRole);
-			}
-		}
-	}
+function missingRequiredChildren(virtualNode, role, required, ownedRoles) {
+	const isCombobox = role === 'combobox';
 
 	// combobox exceptions
-	if (role === 'combobox') {
-		// remove 'textbox' from missing roles if combobox is a native text-type input or owns a 'searchbox'
-		const textboxIndex = missing.indexOf('textbox');
+	if (isCombobox) {
+		// remove 'textbox' from missing roles if combobox is a native
+		// text-type input or owns a 'searchbox'
 		const textTypeInputs = ['text', 'search', 'email', 'url', 'tel'];
 		if (
-			(textboxIndex >= 0 &&
-				node.nodeName.toUpperCase() === 'INPUT' &&
-				textTypeInputs.includes(node.type)) ||
-			owns(node, virtualNode, 'searchbox') ||
-			ariaOwns(ownedEls, 'searchbox')
+			(virtualNode.props.nodeName === 'input' &&
+				textTypeInputs.includes(virtualNode.props.type)) ||
+			ownedRoles.includes('searchbox')
 		) {
-			missing.splice(textboxIndex, 1);
+			required = required.filter(requiredRole => requiredRole !== 'textbox');
 		}
 
+		// combobox only needs one of [listbox, tree, grid, dialog] and
+		// only the type that matches the aria-popup value. remove
+		// all the other popup roles from the list of required
 		const expandedChildRoles = ['listbox', 'tree', 'grid', 'dialog'];
-		const expandedValue = node.getAttribute('aria-expanded');
-		const expanded = expandedValue && expandedValue !== 'false';
+		const expandedValue = virtualNode.attr('aria-expanded');
+		const expanded = expandedValue && expandedValue.toLowerCase() !== 'false';
 		const popupRole = (
-			node.getAttribute('aria-haspopup') || 'listbox'
+			virtualNode.attr('aria-haspopup') || 'listbox'
 		).toLowerCase();
-
-		for (let index = 0; index < expandedChildRoles.length; index++) {
-			const expandedChildRole = expandedChildRoles[index];
-			// keep the specified popup type required if expanded
-			if (expanded && expandedChildRole === popupRole) {
-				continue;
-			}
-
-			// remove 'listbox' and company from missing roles if combobox is collapsed
-			const missingIndex = missing.indexOf(expandedChildRole);
-			if (missingIndex >= 0) {
-				missing.splice(missingIndex, 1);
-			}
-		}
-	}
-
-	if (missing.length) {
-		return missing;
-	}
-	if (!all && childRoles.length) {
-		return childRoles;
-	}
-	return null;
-}
-
-/**
- * Helper to check if a given node owns an element with a given role
- * @param {HTMLElement} node node
- * @param {Object} virtualTree virtual node
- * @param {String} role role
- * @param {Boolean} ariaOwned
- * @returns {Boolean}
- */
-function owns(node, virtualTree, role, ariaOwned) {
-	if (node === null) {
-		return false;
-	}
-	const implicit = implicitNodes(role);
-	let selector = ['[role="' + role + '"]'];
-
-	if (implicit) {
-		selector = selector.concat(
-			implicit.map(implicitSelector => implicitSelector + ':not([role])')
+		required = required.filter(
+			requiredRole =>
+				!expandedChildRoles.includes(requiredRole) ||
+				(expanded && requiredRole === popupRole)
 		);
 	}
 
-	selector = selector.join(',');
-	return ariaOwned
-		? matchesSelector(node, selector) ||
-				!!querySelectorAll(virtualTree, selector)[0]
-		: !!querySelectorAll(virtualTree, selector)[0];
-}
+	for (let i = 0; i < ownedRoles.length; i++) {
+		var ownedRole = ownedRoles[i];
 
-/**
- * Helper to check if a given node is `aria-owns` an element with a given role
- * @param {HTMLElement[]} nodes nodes
- * @param {String} role role
- * @returns {Boolean}
- */
-function ariaOwns(nodes, role) {
-	for (let index = 0; index < nodes.length; index++) {
-		const node = nodes[index];
-		if (node === null) {
-			continue;
-		}
+		if (required.includes(ownedRole)) {
+			required = required.filter(requiredRole => requiredRole !== ownedRole);
 
-		const virtualTree = getNodeFromTree(node);
-		if (owns(node, virtualTree, role, true)) {
-			return true;
+			// combobox requires all the roles not just any one of them
+			if (!isCombobox) {
+				return null;
+			}
 		}
 	}
-	return false;
-}
 
-/**
- * Get role (that is not presentation or none) of descendant
- * @param {HTMLElement} node node
- * @returns {String[]}
- */
-function getDescendantRole(node, ownedEls) {
-	const isOwns = ownedEls && ownedEls.length > 0;
-	const el = isOwns ? ownedEls[0] : node;
-
-	if (!el) {
-		return [];
+	if (required.length) {
+		return required;
 	}
 
-	const items = isOwns
-		? Array.from(el.children).reduce(
-				(out, child) => {
-					out.push(child);
-					return out;
-				},
-				[el]
-		  )
-		: Array.from(el.children);
-
-	return items.reduce((out, child) => {
-		const role = getRole(child);
-		if (['presentation', 'none', null].includes(role)) {
-			out = out.concat(getDescendantRole(child));
-		} else {
-			out.push(role);
-		}
-		return out;
-	}, []);
+	return null;
 }
 
 function ariaRequiredChildrenEvaluate(node, options, virtualNode) {
 	const reviewEmpty =
 		options && Array.isArray(options.reviewEmpty) ? options.reviewEmpty : [];
-	const role = node.getAttribute('role');
+	const role = getExplicitRole(virtualNode, { dpub: true });
 	const required = requiredOwned(role);
 	if (!required) {
 		return true;
 	}
 
-	let all = false;
-	let childRoles = required.one;
-	if (!childRoles) {
-		all = true;
-		childRoles = required.all;
-	}
-
-	const ownedElements = idrefs(node, 'aria-owns');
-	const descendantRole = getDescendantRole(node, ownedElements);
+	const ownedRoles = getOwnedRoles(virtualNode);
 	const missing = missingRequiredChildren(
-		node,
 		virtualNode,
-		childRoles,
-		all,
 		role,
-		ownedElements,
-		descendantRole
+		required,
+		ownedRoles
 	);
 	if (!missing) {
 		return true;
@@ -217,8 +110,8 @@ function ariaRequiredChildrenEvaluate(node, options, virtualNode) {
 	if (
 		reviewEmpty.includes(role) &&
 		!hasContentVirtual(virtualNode, false, true) &&
-		!descendantRole.length &&
-		idrefs(node, 'aria-owns').length === 0
+		!ownedRoles.length &&
+		(!virtualNode.hasAttr('aria-owns') || !idrefs(node, 'aria-owns').length)
 	) {
 		return undefined;
 	}

--- a/lib/commons/aria/required-owned.js
+++ b/lib/commons/aria/required-owned.js
@@ -11,11 +11,11 @@ import standards from '../../standards';
 function requiredOwned(role) {
 	const roleDef = standards.ariaRoles[role];
 
-  if (!roleDef || !Array.isArray(roleDef.requiredOwned)) {
-    return null;
-  }
+	 if (!roleDef || !Array.isArray(roleDef.requiredOwned)) {
+	 	 return null;
+	}
 
-  return [...roleDef.requiredOwned];
+	 return [...roleDef.requiredOwned];
 }
 
 export default requiredOwned;

--- a/lib/commons/aria/required-owned.js
+++ b/lib/commons/aria/required-owned.js
@@ -1,4 +1,4 @@
-import lookupTable from './lookup-table';
+import standards from '../../standards';
 
 /**
  * Get the required owned (children) roles for a given role
@@ -9,15 +9,13 @@ import lookupTable from './lookup-table';
  * @return {Mixed} Either an Array of required owned elements or `null` if there are none
  */
 function requiredOwned(role) {
-	'use strict';
-	let owned = null;
-	const roles = lookupTable.role[role];
+	const roleDef = standards.ariaRoles[role];
 
-	if (roles) {
-		// TODO: es-module-utils.clone
-		owned = axe.utils.clone(roles.owned);
-	}
-	return owned;
+  if (!roleDef || !Array.isArray(roleDef.requiredOwned)) {
+    return null;
+  }
+
+  return [...roleDef.requiredOwned];
 }
 
 export default requiredOwned;

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -85,7 +85,7 @@ const ariaRoles = {
 	},
 	combobox: {
 		type: 'composite',
-		requiredOwned: ['textbox', 'listbox', 'tree', 'grid', 'dialog'],
+		requiredOwned: ['listbox', 'tree', 'grid', 'dialog', 'textbox'],
 		requiredAttrs: ['aria-expanded'],
 		// Note: because aria-controls is not well supported we will not
 		// make it a required attribute even though it is required in the

--- a/test/commons/aria/required-owned.js
+++ b/test/commons/aria/required-owned.js
@@ -1,0 +1,56 @@
+describe('aria.requiredOwned', function() {
+  'use strict';
+
+  afterEach(function() {
+    axe.reset();
+  });
+
+  it('should returned the context property for the proper role', function() {
+    axe.configure({
+      standards: {
+        ariaRoles: {
+          cats: {
+            requiredOwned: ['yes']
+          }
+        }
+      }
+    });
+    assert.deepEqual(axe.commons.aria.requiredOwned('cats'), ['yes']);
+  });
+
+  it('should returned null if the required context is not an array', function() {
+    axe.configure({
+      standards: {
+        ariaRoles: {
+          cats: {
+            requiredOwned: 'yes'
+          }
+        }
+      }
+    });
+    assert.isNull(axe.commons.aria.requiredOwned('cats'));
+  });
+
+  it('should return null if there are no required context nodes', function() {
+    var result = axe.commons.aria.requiredOwned('cats');
+
+    assert.isNull(result);
+  });
+
+  it('should return a unique copy of the context', function() {
+    var context = ['yes', 'no'];
+
+    axe.configure({
+      standards: {
+        ariaRoles: {
+          cats: {
+            requiredOwned: context
+          }
+        }
+      }
+    });
+
+    var result = axe.commons.aria.requiredOwned('cats');
+    assert.notEqual(result, context);
+  });
+});

--- a/test/commons/aria/roles.js
+++ b/test/commons/aria/roles.js
@@ -1,32 +1,3 @@
-describe('aria.requiredOwned', function() {
-	'use strict';
-
-	var orig;
-	beforeEach(function() {
-		orig = axe.commons.aria.lookupTable.role;
-	});
-
-	afterEach(function() {
-		axe.commons.aria.lookupTable.role = orig;
-	});
-
-	it('should returned the owned property for the proper role', function() {
-		axe.commons.aria.lookupTable.role = {
-			cats: {
-				owned: 'yes'
-			}
-		};
-		assert.equal(axe.commons.aria.requiredOwned('cats'), 'yes');
-	});
-
-	it('should return null if there are no required owned nodes', function() {
-		axe.commons.aria.lookupTable.role = {};
-		var result = axe.commons.aria.requiredOwned('cats');
-
-		assert.isNull(result);
-	});
-});
-
 describe('aria.implicitNodes', function() {
 	'use strict';
 


### PR DESCRIPTION
Huge refactor of the code since we aren't using `implicitNodes` anymore. This is the last bit of code that uses the `lookupTable`

Part of issue #2108 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
