### PR TITLE
feat(aria/lookupTable, aria-allowed-attr): deprecate aria.lookupTable and passing allowed attributes to aria-allowed-attr

### DIFF
--- a/lib/checks/aria/aria-allowed-attr-evaluate.js
+++ b/lib/checks/aria/aria-allowed-attr-evaluate.js
@@ -1,29 +1,23 @@
 import { getNodeAttributes, uniqueArray } from '../../core/utils';
-import { implicitRole, allowedAttr, validateAttr } from '../../commons/aria';
+import { getRole, allowedAttr, validateAttr } from '../../commons/aria';
 
-function ariaAllowedAttrEvaluate(node, options = {}) {
-	var invalid = [];
+function ariaAllowedAttrEvaluate(node, options) {
+	const invalid = [];
 
-	var attr,
-		attrName,
-		allowed,
-		role = node.getAttribute('role'),
-		attrs = getNodeAttributes(node);
+	const role = getRole(node);
+	const attrs = getNodeAttributes(node);
+	let allowed = allowedAttr(role);
 
-	if (!role) {
-		role = implicitRole(node);
-	}
-
-	allowed = allowedAttr(role);
-
+	// @deprecated: allowed attr options to pass more attrs.
+	// configure the standards spec instead
 	if (Array.isArray(options[role])) {
 		allowed = uniqueArray(options[role].concat(allowed));
 	}
 
 	if (role && allowed) {
-		for (var i = 0, l = attrs.length; i < l; i++) {
-			attr = attrs[i];
-			attrName = attr.name;
+		for (let i = 0; i < attrs.length; i++) {
+			const attr = attrs[i];
+			const attrName = attr.name;
 			if (validateAttr(attrName) && !allowed.includes(attrName)) {
 				invalid.push(attrName + '="' + attr.nodeValue + '"');
 			}

--- a/lib/commons/aria/lookup-table.js
+++ b/lib/commons/aria/lookup-table.js
@@ -1,3 +1,4 @@
+// @deprecated use standards object instead
 import implicitHtmlRoles from '../standards/implicit-html-roles';
 
 const isNull = value => value === null;

--- a/test/checks/aria/allowed-attr.js
+++ b/test/checks/aria/allowed-attr.js
@@ -8,6 +8,7 @@ describe('aria-allowed-attr', function() {
 	afterEach(function() {
 		fixture.innerHTML = '';
 		checkContext.reset();
+		axe.reset();
 	});
 
 	it('should detect incorrectly used attributes', function() {
@@ -114,15 +115,16 @@ describe('aria-allowed-attr', function() {
 
 	describe('options', function() {
 		it('should allow provided attribute names for a role', function() {
-			axe.commons.aria.lookupTable.role.mcheddarton = {
-				type: 'widget',
-				attributes: {
-					allowed: ['aria-checked']
-				},
-				owned: null,
-				nameFrom: ['author'],
-				context: null
-			};
+			axe.configure({
+				standards: {
+					ariaRoles: {
+						mcheddarton: {
+							allowedAttrs: ['aria-checked']
+						}
+					}
+				}
+			});
+
 			fixture.innerHTML =
 				'<div role="mccheddarton" id="target" aria-checked="true" aria-snuggles="true"></div>';
 			var target = fixture.children[0];
@@ -134,28 +136,22 @@ describe('aria-allowed-attr', function() {
 						mccheddarton: ['aria-checked', 'aria-snuggles']
 					})
 			);
-			delete axe.commons.aria.lookupTable.role.mccheddarton;
 		});
 
 		it('should handle multiple roles provided in options', function() {
-			axe.commons.aria.lookupTable.role.mcheddarton = {
-				type: 'widget',
-				attributes: {
-					allowed: ['aria-checked']
-				},
-				owned: null,
-				nameFrom: ['author'],
-				context: null
-			};
-			axe.commons.aria.lookupTable.role.bagley = {
-				type: 'widget',
-				attributes: {
-					allowed: ['aria-checked']
-				},
-				owned: null,
-				nameFrom: ['author'],
-				context: null
-			};
+			axe.configure({
+				standards: {
+					ariaRoles: {
+						mcheddarton: {
+							allowedAttrs: ['aria-checked']
+						},
+						bagley: {
+							allowedAttrs: ['aria-checked']
+						}
+					}
+				}
+			});
+
 			fixture.innerHTML =
 				'<div role="bagley" id="target" aria-snuggles2="true"></div>';
 			var target = fixture.children[0];
@@ -169,8 +165,6 @@ describe('aria-allowed-attr', function() {
 					.getCheckEvaluate('aria-allowed-attr')
 					.call(checkContext, target, options)
 			);
-			delete axe.commons.aria.lookupTable.role.mccheddarton;
-			delete axe.commons.aria.lookupTable.role.bagley;
 		});
 	});
 });

--- a/test/checks/aria/allowed-attr.js
+++ b/test/checks/aria/allowed-attr.js
@@ -118,7 +118,7 @@ describe('aria-allowed-attr', function() {
 			axe.configure({
 				standards: {
 					ariaRoles: {
-						mcheddarton: {
+						mccheddarton: {
 							allowedAttrs: ['aria-checked']
 						}
 					}
@@ -126,14 +126,21 @@ describe('aria-allowed-attr', function() {
 			});
 
 			fixture.innerHTML =
-				'<div role="mccheddarton" id="target" aria-checked="true" aria-snuggles="true"></div>';
+				'<div role="mccheddarton" id="target" aria-checked="true" aria-selected="true"></div>';
 			var target = fixture.children[0];
 			flatTreeSetup(fixture);
+
+			assert.isFalse(
+				axe.testUtils
+					.getCheckEvaluate('aria-allowed-attr')
+					.call(checkContext, target)
+			);
+
 			assert.isTrue(
 				axe.testUtils
 					.getCheckEvaluate('aria-allowed-attr')
 					.call(checkContext, target, {
-						mccheddarton: ['aria-checked', 'aria-snuggles']
+						mccheddarton: ['aria-checked', 'aria-selected']
 					})
 			);
 		});
@@ -153,13 +160,20 @@ describe('aria-allowed-attr', function() {
 			});
 
 			fixture.innerHTML =
-				'<div role="bagley" id="target" aria-snuggles2="true"></div>';
+				'<div role="bagley" id="target" aria-selected="true"></div>';
 			var target = fixture.children[0];
 			var options = {
-				mccheddarton: ['aria-snuggles'],
-				bagley: ['aria-snuggles2']
+				mccheddarton: ['aria-selected'],
+				bagley: ['aria-selected']
 			};
 			flatTreeSetup(fixture);
+
+			assert.isFalse(
+				axe.testUtils
+					.getCheckEvaluate('aria-allowed-attr')
+					.call(checkContext, target)
+			);
+
 			assert.isTrue(
 				axe.testUtils
 					.getCheckEvaluate('aria-allowed-attr')

--- a/test/commons/aria/get-explicit-role.js
+++ b/test/commons/aria/get-explicit-role.js
@@ -4,15 +4,6 @@ describe('aria.getExplicitRole', function() {
 	var roleDefinitions = aria.lookupTable.role;
 	var flatTreeSetup = axe.testUtils.flatTreeSetup;
 
-	var orig;
-	beforeEach(function() {
-		orig = axe.commons.aria.lookupTable.role;
-	});
-
-	afterEach(function() {
-		axe.commons.aria.lookupTable.role = orig;
-	});
-
 	it('returns valid roles', function() {
 		var node = document.createElement('div');
 		node.setAttribute('role', 'button');


### PR DESCRIPTION
This pr officially closes #2108 as it removes all lookup table references in our codebase expect where we still need it (mostly for `implicitNodes` which is deprecated as well and keeping `lookupTable` as a public API).

I noticed the `aria-allowed-attr` test still used the lookup table to configure the options test, which shouldn't have worked. Digging further I found multiple things wrong with that test that would cause it to never fail. 

First, without `mccheddarton` being configured into the standards object, the check would always pass as there was no allowed role data for an invalid role. Second, since `aria-snuggles` was not configured into the standards object, it would not be counted as a valid attribute so wouldn't fail on it either. Lastly, even if those were configured, since we pass the options to force the allowed attrs the test could never fail.

So to fix it I added an assert that proved that without the options the check should fail, which requires properly configured standards.

I also deprecated the options to ara-allowed-attrs as we had done with aria-required-attrs, and refactored the code while I was there to not use `var`.

Closes issue: #1682 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
