### PR TITLE
feat: add layout-table-matches method

### DIFF
--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -147,6 +147,7 @@ import labelContentNameMismatchMatches from '../../rules/label-content-name-mism
 import labelMatches from '../../rules/label-matches';
 import landmarkHasBodyContextMatches from '../../rules/landmark-has-body-context-matches';
 import landmarkUniqueMatches from '../../rules/landmark-unique-matches';
+import layoutTableMatches from '../../rules/layout-table-matches';
 import linkInTextBlockMatches from '../../rules/link-in-text-block-matches';
 import noAutoplayAudioMatches from '../../rules/no-autoplay-audio-matches';
 import noEmptyRoleMatches from '../../rules/no-empty-role-matches';
@@ -309,6 +310,7 @@ const metadataFunctionMap = {
 	'label-matches': labelMatches,
 	'landmark-has-body-context-matches': landmarkHasBodyContextMatches,
 	'landmark-unique-matches': landmarkUniqueMatches,
+	'layout-table-matches': layoutTableMatches,
 	'link-in-text-block-matches': linkInTextBlockMatches,
 	'no-autoplay-audio-matches': noAutoplayAudioMatches,
 	'no-empty-role-matches': noEmptyRoleMatches,

--- a/lib/rules/layout-table-matches.js
+++ b/lib/rules/layout-table-matches.js
@@ -1,6 +1,7 @@
 import { isDataTable } from '../commons/table';
 import { isFocusable } from '../commons/dom';
 
+// TODO: es-modules add tests. No way to access this on the `axe` object
 function dataTableMatches(node) {
 	return !isDataTable(node) && !isFocusable(node);
 }

--- a/lib/rules/layout-table-matches.js
+++ b/lib/rules/layout-table-matches.js
@@ -1,0 +1,8 @@
+import { isDataTable } from '../commons/table';
+import { isFocusable } from '../commons/dom';
+
+function dataTableMatches(node) {
+	return !isDataTable(node) && !isFocusable(node);
+}
+
+export default dataTableMatches;


### PR DESCRIPTION
TECH DEBT: There are no tests for this. Because this matches isn't used in any rule, it can't be accessed on the `axe` object. This can be solved once we have Babel enabled on our tests.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
