### PR TITLE
docs: add docs for check options

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -79,7 +79,7 @@ axe.configure({
         <code>reviewEmpty</code>
       </td>
       <td align="left">
-        <pre lang=css><code>[
+        <pre lang=js><code>[
   'doc-bibliography',
   'doc-endnotes',
   'grid',
@@ -89,7 +89,8 @@ axe.configure({
   'tablist',
   'tree',
   'treegrid',
-  'rowgroup']</code></pre>
+  'rowgroup'
+]</code></pre>
         </td>
       <td align="left">List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children</td>
     </tr>
@@ -98,34 +99,83 @@ axe.configure({
 
 ### aria-roledescription
 
-| Option           | Default                                                                                                    | Description                                                          |
-| ---------------- | :--------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------- |
-| `supportedRoles` | <pre lang=js>['button', 'img', 'checkbox', 'radio', 'combobox', 'menuitemcheckbox', 'menuitemradio']</pre> | List of ARIA roles that support the `aria-roledescription` attribute |
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>supportedRoles</code>
+      </td>
+      <td align="left">
+        <pre lang=js><code>[
+  'button',
+  'img',
+  'checkbox',
+  'radio',
+  'combobox',
+  'menuitemcheckbox',
+  'menuitemradio'
+]</code></pre>
+        </td>
+      <td align="left">List of ARIA roles that support the `aria-roledescription` attribute</td>
+    </tr>
+  </tbody>
+</table>
 
 ### color-contrast
 
-| Option                              | Default | Description                                                                                    |
-| ----------------------------------- | :------ | :--------------------------------------------------------------------------------------------- |
-| `ignoreUnicode`                     | `true`  | Do not check the color contrast of Unicode characters                                          |
-| `ignoreLength`                      | `false` | Do not check the color contrast of short text content                                          |
-| `boldValue`                         | `700`   | The minimum CSS `font-weight` value that designates bold text                                  |
-| `boldTextPt`                        | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                  |
-| `largeTextPt`                       | `18`    | The minimum CSS `font-size` pt value that designates text as being large                       |
-| `contrastRatio`                     | N/A     | Contrast ratio options                                                                         |
-| `contrastRatio.normal`              | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
-| `contrastRatio.normal.expected`     | `4.5`   | The expected contrast ratio for normal text                                                    |
-| `contrastRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
-| `contrastRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
-| `contrastRatio.large`               | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
-| `contrastRatio.large.expected`      | `4.5`   | The expected contrast ratio for large text                                                     |
-| `contrastRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
-| `contrastRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
+| Option                                                      | Default | Description                                                                                    |
+| ----------------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------- |
+| `ignoreUnicode`                                             | `true`  | Do not check the color contrast of Unicode characters                                          |
+| `ignoreLength`                                              | `false` | Do not check the color contrast of short text content                                          |
+| `boldValue`                                                 | `700`   | The minimum CSS `font-weight` value that designates bold text                                  |
+| `boldTextPt`                                                | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                  |
+| `largeTextPt`                                               | `18`    | The minimum CSS `font-size` pt value that designates text as being large                       |
+| `contrastRatio`                                             | N/A     | Contrast ratio options                                                                         |
+| &nbsp;&nbsp;`contrastRatio.normal`                          | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.expected`     | `4.5`   | The expected contrast ratio for normal text                                                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
+| &nbsp;&nbsp;`contrastRatio.large`                           | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.expected`      | `4.5`   | The expected contrast ratio for large text                                                     |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
 
 ### page-has-heading-one
 
-| Option     | Default                                                                                                                                                                                                                                                                | Description                                                  |
-| ---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
-| `selector` | <pre lang=css>h1:not([role]):not([aria-level]), h1:not([role])[aria-level=1], h2:not([role])[aria-level=1], h3:not([role])[aria-level=1], h4:not([role])[aria-level=1], h5:not([role])[aria-level=1], h6:not([role])[aria-level=1], [role=heading][aria-level=1]</pre> | Selector used to determine if a page has a level one heading |
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>selector</code>
+      </td>
+      <td align="left">
+        <pre lang=css><code>h1:not([role]):not([aria-level]), 
+h1:not([role])[aria-level=1], 
+h2:not([role])[aria-level=1], 
+h3:not([role])[aria-level=1], 
+h4:not([role])[aria-level=1], 
+h5:not([role])[aria-level=1], 
+h6:not([role])[aria-level=1], 
+[role=heading][aria-level=1]</code></pre>
+        </td>
+      <td align="left">Selector used to determine if a page has a level one heading</td>
+    </tr>
+  </tbody>
+</table>
 
 ### page-has-main
 
@@ -155,9 +205,32 @@ axe.configure({
 
 ### duplicate-img-label
 
-| Option           | Default                                                           | Description                                                                 |
-| ---------------- | :---------------------------------------------------------------- | :-------------------------------------------------------------------------- |
-| `parentSelector` | <pre lang=css>button, [role=button], a[href], p, li, td, th</pre> | Selector used to look at an image parent that may duplicate the image label |
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>parentSelector</code>
+      </td>
+      <td align="left">
+        <pre lang=css><code>button,
+[role=button],
+a[href],
+p,
+li,
+td,
+th</code></pre>
+        </td>
+      <td align="left">Selector used to look at an image parent that may duplicate the image label</td>
+    </tr>
+  </tbody>
+</table>
 
 ### label-content-name-mismatch
 
@@ -211,9 +284,32 @@ axe.configure({
 
 ### header-present
 
-| Option     | Default                                                                                                                            | Description                                        |
-| ---------- | :--------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- |
-| `selector` | <pre lang=css>h1:not([role]), h2:not([role]), h3:not([role]), h4:not([role]), h5:not([role]), h6:not([role]), [role=heading]</pre> | Selector used to determine if a page has a heading |
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>selector</code>
+      </td>
+      <td align="left">
+        <pre lang=css><code>h1:not([role]), 
+h2:not([role]), 
+h3:not([role]), 
+h4:not([role]), 
+h5:not([role]), 
+h6:not([role]), 
+[role=heading]</code></pre>
+        </td>
+      <td align="left">Selector used to determine if a page has a heading</td>
+    </tr>
+  </tbody>
+</table>
 
 ### landmark
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -247,9 +247,10 @@ th</code></pre>
 
 ### valid-lang
 
-| Option       | Default                                 | Description                               |
-| ------------ | :-------------------------------------- | :---------------------------------------- |
-| `attributes` | <pre lang=js>['lang', 'xml:lang']</pre> | Attributes to check for valid lang values |
+| Option       | Default                                                      | Description                               |
+| ------------ | :----------------------------------------------------------- | :---------------------------------------- |
+| `attributes` | <pre lang=js>['lang', 'xml:lang']</pre>                      | Attributes to check for valid lang values |
+| `value`      | [Array of all valid langs](../lib/core/utils/valid-langs.js) | List of valid lang values                 |
 
 ### frame-tested
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -61,13 +61,13 @@ axe.configure({
 | Option          | Default | Description                                                       |
 | --------------- | :------ | :---------------------------------------------------------------- |
 | `allowImplicit` | `true`  | Allow the explicit role to match the implicit role of the element |
-| `ignoredTags`   | `[]`    | Do not check for allowed roles in the provided HTML elements list        |
+| `ignoredTags`   | `[]`    | Do not check for allowed roles in the provided HTML elements list |
 
 ### aria-required-children
 
-| Option        | Default                                                                                                               | Description                                                                                                            |
-| ------------- | :-------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
-| `reviewEmpty` | `['doc-bibliography', 'doc-endnotes', 'grid', 'list', 'listbox', 'table', 'tablist', 'tree', 'treegrid', 'rowgroup']` | List of ARIA roles that should be flagged as Needs Review rather than a violation if the element has no owned children |
+| Option        | Default                                                                                                               | Description                                                                                                              |
+| ------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| `reviewEmpty` | `['doc-bibliography', 'doc-endnotes', 'grid', 'list', 'listbox', 'table', 'tablist', 'tree', 'treegrid', 'rowgroup']` | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
 
 ### aria-roledescription
 
@@ -77,60 +77,60 @@ axe.configure({
 
 ### color-contrast
 
-| Option                             | Default | Description                                                                                    |
-| ---------------------------------- | :------ | :--------------------------------------------------------------------------------------------- |
-| `ignoreUnicode`                    | `true`  | If unicode characters should not be checked for contrast                                       |
-| `ignoreLength`                     | `false` | If short text content should not be checked for color contrast                                 |
-| `boldValue`                        | `700`   | The minimum CSS `font-weight` value that designates bold text |
-| `boldTextPt`                       | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                  |
-| `largeTextPt`                      | `18`    | The minimum CSS `font-size` pt value that designates text as being large                       |
-| `contrastRatio`                    | N/A     | Contrast ratio options                                                                         |
-| `contrastRatio.normal`             | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
-| `contrastRatio.normal.expected`    | `4.5`   | The expected contrast ratio for normal text                                                    |
+| Option                              | Default | Description                                                                                    |
+| ----------------------------------- | :------ | :--------------------------------------------------------------------------------------------- |
+| `ignoreUnicode`                     | `true`  | Do not check the color contrast of Unicode characters                                          |
+| `ignoreLength`                      | `false` | Do not check the color contrast of short text content                                          |
+| `boldValue`                         | `700`   | The minimum CSS `font-weight` value that designates bold text                                  |
+| `boldTextPt`                        | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                  |
+| `largeTextPt`                       | `18`    | The minimum CSS `font-size` pt value that designates text as being large                       |
+| `contrastRatio`                     | N/A     | Contrast ratio options                                                                         |
+| `contrastRatio.normal`              | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
+| `contrastRatio.normal.expected`     | `4.5`   | The expected contrast ratio for normal text                                                    |
 | `contrastRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
 | `contrastRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
-| `contrastRatio.large`              | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
-| `contrastRatio.large.expected`     | `4.5`   | The expected contrast ratio for large text                                                     |
+| `contrastRatio.large`               | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
+| `contrastRatio.large.expected`      | `4.5`   | The expected contrast ratio for large text                                                     |
 | `contrastRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
 | `contrastRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
 
 ### page-has-heading-one
 
-| Option     | Default                                                                                                                                                                                                                                              | Description                                                  |
-| ---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
-| `selector` | `h1:not([role]):not([aria-level]), h1:not([role])[aria-level=1], h2:not([role])[aria-level=1], h3:not([role])[aria-level=1], h4:not([role])[aria-level=1], h5:not([role])[aria-level=1], h6:not([role])[aria-level=1], [role=heading][aria-level=1]` | Selector used to determine if a page has a level one heading |
+| Option     | Default                                                                                                                                                                                                                                                                | Description                                                  |
+| ---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
+| `selector` | <pre lang=css>h1:not([role]):not([aria-level]), h1:not([role])[aria-level=1], h2:not([role])[aria-level=1], h3:not([role])[aria-level=1], h4:not([role])[aria-level=1], h5:not([role])[aria-level=1], h6:not([role])[aria-level=1], [role=heading][aria-level=1]</pre> | Selector used to determine if a page has a level one heading |
 
 ### page-has-main
 
-| Option     | Default                           | Description                                              |
-| ---------- | :-------------------------------- | :------------------------------------------------------- |
-| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a main landmark |
+| Option     | Default                           | Description                                                |
+| ---------- | :-------------------------------- | :--------------------------------------------------------- |
+| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a `main` landmark |
 
 ### page-no-duplicate-banner
 
-| Option              | Default                              | Description                                                                           |
-| ------------------- | :----------------------------------- | :------------------------------------------------------------------------------------ |
-| `selector`          | `header:not([role]), [role=banner]`  | Selector used to determine if a page has a banner landmark                            |
-| `nativeScopeFilter` | `article, aside, main, nav, section` | Selector used to ignore banner landmarks that have a parent that matches the selector |
+| Option              | Default                              | Description                                                                             |
+| ------------------- | :----------------------------------- | :-------------------------------------------------------------------------------------- |
+| `selector`          | `header:not([role]), [role=banner]`  | Selector used to determine if a page has a `banner` landmark                            |
+| `nativeScopeFilter` | `article, aside, main, nav, section` | Selector used to ignore `banner` landmarks that have a parent that matches the selector |
 
 ### page-no-duplicate-contentinfo
 
-| Option              | Default                                  | Description                                                                                |
-| ------------------- | :--------------------------------------- | :----------------------------------------------------------------------------------------- |
-| `selector`          | `footer:not([role]), [role=contentinfo]` | Selector used to determine if a page has a contentinfo landmark                            |
-| `nativeScopeFilter` | `article, aside, main, nav, section`     | Option values used to ignore contentinfo landmarks that have a selector matching the parent element |
+| Option              | Default                                  | Description                                                                                           |
+| ------------------- | :--------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| `selector`          | `footer:not([role]), [role=contentinfo]` | Selector used to determine if a page has a `contentinfo` landmark                                     |
+| `nativeScopeFilter` | `article, aside, main, nav, section`     | Option values used to ignore `contentinfo` landmarks that have a selector matching the parent element |
 
 ### page-no-duplicate-main
 
-| Option     | Default                           | Description                                              |
-| ---------- | :-------------------------------- | :------------------------------------------------------- |
-| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a main landmark |
+| Option     | Default                           | Description                                                |
+| ---------- | :-------------------------------- | :--------------------------------------------------------- |
+| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a `main` landmark |
 
 ### duplicate-img-label
 
-| Option           | Default                                         | Description                                                                           |
-| ---------------- | :---------------------------------------------- | :------------------------------------------------------------------------------------ |
-| `parentSelector` | `button, [role=button], a[href], p, li, td, th` | Selector used to look for the parent of an image that could duplicate the image label |
+| Option           | Default                                         | Description                                                                 |
+| ---------------- | :---------------------------------------------- | :-------------------------------------------------------------------------- |
+| `parentSelector` | `button, [role=button], a[href], p, li, td, th` | Selector used to look at an image parent that may duplicate the image label |
 
 ### label-content-name-mismatch
 
@@ -153,40 +153,40 @@ axe.configure({
 
 ### frame-tested
 
-| Option        | Default | Description                                                |
-| ------------- | :------ | :--------------------------------------------------------- |
-| `isViolation` | `false` | If an iframe without axe should be reported as a violation |
+| Option        | Default | Description                                                                               |
+| ------------- | :------ | :---------------------------------------------------------------------------------------- |
+| `isViolation` | `false` | If an `iframe` that has not been injected with axe-core should be reported as a violation |
 
 ### no-autoplay-audio
 
-| Option            | Default | Description                                                                   |
-| ----------------- | :------ | :---------------------------------------------------------------------------- |
+| Option            | Default | Description                                                                         |
+| ----------------- | :------ | :---------------------------------------------------------------------------------- |
 | `allowedDuration` | `3`     | Maximum time in seconds an audio clip may autoplay before being marked as violation |
 
 ### css-orientation-lock
 
-| Option            | Default | Description                                                                                                                            |
-| ----------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------- |
-| `degreeThreshold` | `3`     | The difference of degrees from 180 and 90 that are considered orientation lock (for example, 93° is orientation locked but 94° is not) |
+| Option            | Default | Description                                                                                                                                                             |
+| ----------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `degreeThreshold` | `3`     | The difference of degrees from 180 and 90 that are considered locked to a specific display orientation (for example, 93° rotated is not considered locked while 94° is) |
 
 ### meta-viewport-large
 
-| Option         | Default | Description                                                                                                |
-| -------------- | :------ | :--------------------------------------------------------------------------------------------------------- |
+| Option         | Default | Description                                                                                     |
+| -------------- | :------ | :---------------------------------------------------------------------------------------------- |
 | `scaleMinimum` | `5`     | The `scale-maximum` CSS value of the check applies to. Values above this number will be ignored |
-| `lowerBound`   | `2`     | The `scale-minimum` CSS value the check applies to. Values below this number will be ignored |
+| `lowerBound`   | `2`     | The `scale-minimum` CSS value the check applies to. Values below this number will be ignored    |
 
 ### meta-viewport
 
-| Option         | Default | Description                                                                                                |
-| -------------- | :------ | :--------------------------------------------------------------------------------------------------------- |
+| Option         | Default | Description                                                                                  |
+| -------------- | :------ | :------------------------------------------------------------------------------------------- |
 | `scaleMinimum` | `2`     | The `scale-maximum` CSS value the check applies to. Values above this number will be ignored |
 
 ### header-present
 
-| Option     | Default                                                                                                          | Description                                        |
-| ---------- | :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- |
-| `selector` | `h1:not([role]), h2:not([role]), h3:not([role]), h4:not([role]), h5:not([role]), h6:not([role]), [role=heading]` | Selector used to determine if a page has a heading |
+| Option     | Default                                                                                                                            | Description                                        |
+| ---------- | :--------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- |
+| `selector` | <pre lang=css>h1:not([role]), h2:not([role]), h3:not([role]), h4:not([role]), h5:not([role]), h6:not([role]), [role=heading]</pre> | Selector used to determine if a page has a heading |
 
 ### landmark
 
@@ -196,16 +196,14 @@ axe.configure({
 
 ### p-as-heading
 
-| Option | Default | Description |
-| ------ | :------ | :---------- |
-
-
-???
+| Option    | Default                                                                                                                   | Description                                                                                                                    |
+| --------- | :------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------- |
+| `margins` | `[{ "weight": 150, "italic": true }, { "weight": 150, "size": 1.15 }, { "italic": true, "size": 1.15 }, { "size": 1.4 }]` | Common CSS values used to display `p` elements as `h1-h6` elements determining if a `p` element is being improperly repurposed |
 
 ### avoid-inline-spacing
 
-| Option          | Default                                             | Description                                      |
-| --------------- | :-------------------------------------------------- | :----------------------------------------------- |
+| Option          | Default                                             | Description                                   |
+| --------------- | :-------------------------------------------------- | :-------------------------------------------- |
 | `cssProperties` | `['line-height', 'letter-spacing', 'word-spacing']` | List of inline spacing CSS properties to flag |
 
 ### scope-value

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -206,7 +206,7 @@ axe.configure({
 
 | Option          | Default                                             | Description                                      |
 | --------------- | :-------------------------------------------------- | :----------------------------------------------- |
-| `cssProperties` | `['line-height', 'letter-spacing', 'word-spacing']` | List of CSS properties to flag as inline spacing |
+| `cssProperties` | `['line-height', 'letter-spacing', 'word-spacing']` | List of inline spacing CSS properties to flag |
 
 ### scope-value
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -38,7 +38,7 @@ Many checks allow you to change how they work through `options` properties. Thes
 
 For example, the check [has-lang](../lib/checks/language/has-lang.json) takes an `attributes` option which dictates which attributes to check for a lang value.
 
-To customize a checks options, you can use [`axe.configure`](./API.md#api-name-axeconfigure) to configure the check and modify the options as desired.
+To customize a check's options, you can use [`axe.configure`](./API.md#api-name-axeconfigure) to configure the check and modify the options as desired.
 
 ```js
 // configure has-lang check to look at the `hreflang` attribute as well

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -88,7 +88,7 @@ axe.configure({
 | `contrastRatio.normal`             | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
 | `contrastRatio.normal.expected`    | `4.5`   | The expected contrast ratio for normal text                                                    |
 | `contrastRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
-| `contratRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
+| `contrastRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
 | `contrastRatio.large`              | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
 | `contrastRatio.large.expected`     | `4.5`   | The expected contrast ratio for large text                                                     |
 | `contratRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -87,7 +87,7 @@ axe.configure({
 | `contrastRatio`                    | N/A     | Contrast ratio options                                                                         |
 | `contrastRatio.normal`             | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
 | `contrastRatio.normal.expected`    | `4.5`   | The expected contrast ratio for normal text                                                    |
-| `contratRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
+| `contrastRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
 | `contratRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
 | `contrastRatio.large`              | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
 | `contrastRatio.large.expected`     | `4.5`   | The expected contrast ratio for large text                                                     |

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -319,9 +319,31 @@ h6:not([role]),
 
 ### p-as-heading
 
-| Option    | Default                                                                                                                                    | Description                                                                                                                    |
-| --------- | :----------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
-| `margins` | <pre lang=js>[{ "weight": 150, "italic": true }, { "weight": 150, "size": 1.15 }, { "italic": true, "size": 1.15 }, { "size": 1.4 }]</pre> | Common CSS values used to display `p` elements as `h1-h6` elements determining if a `p` element is being improperly repurposed |
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>margins</code>
+      </td>
+      <td align="left">
+        <pre lang=js><code>[
+  { "weight": 150, "italic": true }, 
+  { "weight": 150, "size": 1.15 }, 
+  { "italic": true, "size": 1.15 }, 
+  { "size": 1.4 }
+]</code></pre>
+        </td>
+      <td align="left">Common CSS values used to display `p` elements as `h1-h6` elements determining if a `p` element is being improperly repurposed</td>
+    </tr>
+  </tbody>
+</table>
 
 ### avoid-inline-spacing
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -65,9 +65,21 @@ axe.configure({
 
 ### aria-required-children
 
-| Option        | Default                                                                                                                                                                                        | Description                                                                                                              |
-| ------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| `reviewEmpty` | <pre lang=js>[<br/> 'doc-bibliography',<br/> 'doc-endnotes',<br/> 'grid',<br/> 'list',<br/> 'listbox',<br/> 'table',<br/> 'tablist',<br/> 'tree',<br/> 'treegrid',<br/> 'rowgroup'<br/>]</pre> | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
+| Option        | Default              | Description |
+| ------------- | :------------------- | :---------- |
+| `reviewEmpty` | <pre lang=js><code>[ |
+
+'doc-bibliography',
+'doc-endnotes',
+'grid',
+'list',
+'listbox',
+'table',
+'tablist',
+'tree',
+'treegrid',
+'rowgroup'
+]</code></pre> | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
 
 ### aria-roledescription
 
@@ -128,9 +140,9 @@ axe.configure({
 
 ### duplicate-img-label
 
-| Option           | Default                                                            | Description                                                                 |
-| ---------------- | :----------------------------------------------------------------- | :-------------------------------------------------------------------------- |
-| `parentSelector` | <<pre lang=css>button, [role=button], a[href], p, li, td, th</pre> | Selector used to look at an image parent that may duplicate the image label |
+| Option           | Default                                                           | Description                                                                 |
+| ---------------- | :---------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| `parentSelector` | <pre lang=css>button, [role=button], a[href], p, li, td, th</pre> | Selector used to look at an image parent that may duplicate the image label |
 
 ### label-content-name-mismatch
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -61,7 +61,7 @@ axe.configure({
 | Option          | Default | Description                                                       |
 | --------------- | :------ | :---------------------------------------------------------------- |
 | `allowImplicit` | `true`  | Allow the explicit role to match the implicit role of the element |
-| `ignoredTags`   | `[]`    | List of HTML element names to not check for allowed roles         |
+| `ignoredTags`   | `[]`    | Do not check for allowed roles in the provided HTML elements list        |
 
 ### aria-required-children
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -65,9 +65,9 @@ axe.configure({
 
 ### aria-required-children
 
-| Option        | Default                                                                                                                                | Description                                                                                                              |
-| ------------- | :------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| `reviewEmpty` | <pre lang=js>['doc-bibliography', 'doc-endnotes', 'grid', 'list', 'listbox', 'table', 'tablist', 'tree', 'treegrid', 'rowgroup']</pre> | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
+| Option        | Default                                                                                                                                                                                        | Description                                                                                                              |
+| ------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| `reviewEmpty` | <pre lang=js>[<br/> 'doc-bibliography',<br/> 'doc-endnotes',<br/> 'grid',<br/> 'list',<br/> 'listbox',<br/> 'table',<br/> 'tablist',<br/> 'tree',<br/> 'treegrid',<br/> 'rowgroup'<br/>]</pre> | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
 
 ### aria-roledescription
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -65,15 +65,15 @@ axe.configure({
 
 ### aria-required-children
 
-| Option        | Default                                                                                                               | Description                                                                                                              |
-| ------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| `reviewEmpty` | `['doc-bibliography', 'doc-endnotes', 'grid', 'list', 'listbox', 'table', 'tablist', 'tree', 'treegrid', 'rowgroup']` | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
+| Option        | Default                                                                                                                                | Description                                                                                                              |
+| ------------- | :------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| `reviewEmpty` | <pre lang=js>['doc-bibliography', 'doc-endnotes', 'grid', 'list', 'listbox', 'table', 'tablist', 'tree', 'treegrid', 'rowgroup']</pre> | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
 
 ### aria-roledescription
 
-| Option           | Default                                                                                   | Description                                                          |
-| ---------------- | :---------------------------------------------------------------------------------------- | :------------------------------------------------------------------- |
-| `supportedRoles` | `['button', 'img', 'checkbox', 'radio', 'combobox', 'menuitemcheckbox', 'menuitemradio']` | List of ARIA roles that support the `aria-roledescription` attribute |
+| Option           | Default                                                                                                    | Description                                                          |
+| ---------------- | :--------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------- |
+| `supportedRoles` | <pre lang=js>['button', 'img', 'checkbox', 'radio', 'combobox', 'menuitemcheckbox', 'menuitemradio']</pre> | List of ARIA roles that support the `aria-roledescription` attribute |
 
 ### color-contrast
 
@@ -102,35 +102,35 @@ axe.configure({
 
 ### page-has-main
 
-| Option     | Default                           | Description                                                |
-| ---------- | :-------------------------------- | :--------------------------------------------------------- |
-| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a `main` landmark |
+| Option     | Default                                             | Description                                                |
+| ---------- | :-------------------------------------------------- | :--------------------------------------------------------- |
+| `selector` | <pre lang=css>main:not([role]), [role='main']</pre> | Selector used to determine if a page has a `main` landmark |
 
 ### page-no-duplicate-banner
 
-| Option              | Default                              | Description                                                                             |
-| ------------------- | :----------------------------------- | :-------------------------------------------------------------------------------------- |
-| `selector`          | `header:not([role]), [role=banner]`  | Selector used to determine if a page has a `banner` landmark                            |
-| `nativeScopeFilter` | `article, aside, main, nav, section` | Selector used to ignore `banner` landmarks that have a parent that matches the selector |
+| Option              | Default                                                | Description                                                                             |
+| ------------------- | :----------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| `selector`          | <pre lang=css>header:not([role]), [role=banner]</pre>  | Selector used to determine if a page has a `banner` landmark                            |
+| `nativeScopeFilter` | <pre lang=css>article, aside, main, nav, section</pre> | Selector used to ignore `banner` landmarks that have a parent that matches the selector |
 
 ### page-no-duplicate-contentinfo
 
-| Option              | Default                                  | Description                                                                                           |
-| ------------------- | :--------------------------------------- | :---------------------------------------------------------------------------------------------------- |
-| `selector`          | `footer:not([role]), [role=contentinfo]` | Selector used to determine if a page has a `contentinfo` landmark                                     |
-| `nativeScopeFilter` | `article, aside, main, nav, section`     | Option values used to ignore `contentinfo` landmarks that have a selector matching the parent element |
+| Option              | Default                                                    | Description                                                                                           |
+| ------------------- | :--------------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| `selector`          | <pre lang=css>footer:not([role]), [role=contentinfo]</pre> | Selector used to determine if a page has a `contentinfo` landmark                                     |
+| `nativeScopeFilter` | <pre lang=css>article, aside, main, nav, section</pre>     | Option values used to ignore `contentinfo` landmarks that have a selector matching the parent element |
 
 ### page-no-duplicate-main
 
-| Option     | Default                           | Description                                                |
-| ---------- | :-------------------------------- | :--------------------------------------------------------- |
-| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a `main` landmark |
+| Option     | Default                                             | Description                                                |
+| ---------- | :-------------------------------------------------- | :--------------------------------------------------------- |
+| `selector` | <pre lang=css>main:not([role]), [role='main']</pre> | Selector used to determine if a page has a `main` landmark |
 
 ### duplicate-img-label
 
-| Option           | Default                                         | Description                                                                 |
-| ---------------- | :---------------------------------------------- | :-------------------------------------------------------------------------- |
-| `parentSelector` | `button, [role=button], a[href], p, li, td, th` | Selector used to look at an image parent that may duplicate the image label |
+| Option           | Default                                                            | Description                                                                 |
+| ---------------- | :----------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| `parentSelector` | <<pre lang=css>button, [role=button], a[href], p, li, td, th</pre> | Selector used to look at an image parent that may duplicate the image label |
 
 ### label-content-name-mismatch
 
@@ -141,15 +141,15 @@ axe.configure({
 
 ### has-lang
 
-| Option       | Default                | Description                         |
-| ------------ | :--------------------- | :---------------------------------- |
-| `attributes` | `['lang', 'xml:lang']` | Attributes to check for lang values |
+| Option       | Default                                 | Description                         |
+| ------------ | :-------------------------------------- | :---------------------------------- |
+| `attributes` | <pre lang=js>['lang', 'xml:lang']</pre> | Attributes to check for lang values |
 
 ### valid-lang
 
-| Option       | Default                | Description                               |
-| ------------ | :--------------------- | :---------------------------------------- |
-| `attributes` | `['lang', 'xml:lang']` | Attributes to check for valid lang values |
+| Option       | Default                                 | Description                               |
+| ------------ | :-------------------------------------- | :---------------------------------------- |
+| `attributes` | <pre lang=js>['lang', 'xml:lang']</pre> | Attributes to check for valid lang values |
 
 ### frame-tested
 
@@ -190,24 +190,24 @@ axe.configure({
 
 ### landmark
 
-| Option     | Default             | Description                                                |
-| ---------- | :------------------ | :--------------------------------------------------------- |
-| `selector` | `main, [role=main]` | Selector used to determine if a page has a landmark region |
+| Option     | Default                               | Description                                                |
+| ---------- | :------------------------------------ | :--------------------------------------------------------- |
+| `selector` | <pre lang=css>main, [role=main]</pre> | Selector used to determine if a page has a landmark region |
 
 ### p-as-heading
 
-| Option    | Default                                                                                                                   | Description                                                                                                                    |
-| --------- | :------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------- |
-| `margins` | `[{ "weight": 150, "italic": true }, { "weight": 150, "size": 1.15 }, { "italic": true, "size": 1.15 }, { "size": 1.4 }]` | Common CSS values used to display `p` elements as `h1-h6` elements determining if a `p` element is being improperly repurposed |
+| Option    | Default                                                                                                                                    | Description                                                                                                                    |
+| --------- | :----------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| `margins` | <pre lang=js>[{ "weight": 150, "italic": true }, { "weight": 150, "size": 1.15 }, { "italic": true, "size": 1.15 }, { "size": 1.4 }]</pre> | Common CSS values used to display `p` elements as `h1-h6` elements determining if a `p` element is being improperly repurposed |
 
 ### avoid-inline-spacing
 
-| Option          | Default                                             | Description                                   |
-| --------------- | :-------------------------------------------------- | :-------------------------------------------- |
-| `cssProperties` | `['line-height', 'letter-spacing', 'word-spacing']` | List of inline spacing CSS properties to flag |
+| Option          | Default                                                              | Description                                   |
+| --------------- | :------------------------------------------------------------------- | :-------------------------------------------- |
+| `cssProperties` | <pre lang=js>['line-height', 'letter-spacing', 'word-spacing']</pre> | List of inline spacing CSS properties to flag |
 
 ### scope-value
 
-| Option   | Default                                  | Description                |
-| -------- | :--------------------------------------- | :------------------------- |
-| `values` | `['row', 'col', 'rowgroup', 'colgroup']` | List of valid scope values |
+| Option   | Default                                                   | Description                |
+| -------- | :-------------------------------------------------------- | :------------------------- |
+| `values` | <pre lang=js>['row', 'col', 'rowgroup', 'colgroup']</pre> | List of valid scope values |

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -161,7 +161,7 @@ axe.configure({
 
 | Option            | Default | Description                                                                   |
 | ----------------- | :------ | :---------------------------------------------------------------------------- |
-| `allowedDuration` | `3`     | Maximum time an audio is allowed to autoplay before being marked as violation |
+| `allowedDuration` | `3`     | Maximum time in seconds an audio clip may autoplay before being marked as violation |
 
 ### css-orientation-lock
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -30,7 +30,7 @@
 
 ## How Checks Work
 
-[Rules in axe-core](../lib/rules) are made up of individual checks that dictate how the rule works. Each check is typically designed to look for a specific requirement and report back its findings to the rule.
+[Rules in axe-core](../lib/rules) are made up of one or more individual checks that dictate how the rule works. Each check is typically designed to look for a specific requirement and report back its findings to the rule.
 
 For example, the rule [image-alt](../lib/rules/image-alt.json) uses the checks `has-alt`, `aria-label`, `aria-labelledby`, and `non-empty-title` to determine if the image has an accessible name from an `alt`, `aria-label`, `aria-labelledby`, or `title` attribute (respectively).
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -92,7 +92,7 @@ axe.configure({
 | `contrastRatio.large`              | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
 | `contrastRatio.large.expected`     | `4.5`   | The expected contrast ratio for large text                                                     |
 | `contrastRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
-| `contratRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
+| `contrastRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
 
 ### page-has-heading-one
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -81,7 +81,7 @@ axe.configure({
 | ---------------------------------- | :------ | :--------------------------------------------------------------------------------------------- |
 | `ignoreUnicode`                    | `true`  | If unicode characters should not be checked for contrast                                       |
 | `ignoreLength`                     | `false` | If short text content should not be checked for color contrast                                 |
-| `boldValue`                        | `700`   | The minimum CSS `font-weight` value that designates text as being bold                         |
+| `boldValue`                        | `700`   | The minimum CSS `font-weight` value that designates bold text |
 | `boldTextPt`                       | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                  |
 | `largeTextPt`                      | `18`    | The minimum CSS `font-size` pt value that designates text as being large                       |
 | `contrastRatio`                    | N/A     | Contrast ratio options                                                                         |

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -136,7 +136,7 @@ axe.configure({
 
 | Option               | Default | Description                                                                                                                                                               |
 | -------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `pixelThreshold`     | `0.1`   | Percent of differences in pixel data or pixel width needed to determine if a font is a ligature font (ligature fonts are ignored when comparing the label to the content) |
+| `pixelThreshold`     | `0.1`   | Percent of difference in pixel data or pixel width required to determine if a font is a ligature font. Ligature fonts are ignored when comparing the label to the content |
 | `occuranceThreshold` | `3`     | Number of times the font is encountered before auto-assigning the font as a ligature or not                                                                               |
 
 ### has-lang

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -3,7 +3,7 @@
 ## Table of Contents
 
 - [How Checks Work](#how-checks-work)
-- [Check Options](#check-optoins)
+- [Options](#optoins)
   - [aria-allowed-role](#aria-allowed-role)
   - [aria-required-children](#aria-required-children)
   - [aria-roledescription](#aria-roledescription)
@@ -54,7 +54,7 @@ axe.configure({
 });
 ```
 
-## Check Options
+## Options
 
 ### aria-allowed-role
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -174,7 +174,7 @@ axe.configure({
 | Option         | Default | Description                                                                                                |
 | -------------- | :------ | :--------------------------------------------------------------------------------------------------------- |
 | `scaleMinimum` | `5`     | The maximum CSS value of `scale-maximum` the check will apply to. Values above this number will be ignored |
-| `lowerBound`   | `2`     | The minimum CSS value of `scale-minimum` the check will apply to. Values below this number will be ignored |
+| `lowerBound`   | `2`     | The `scale-minimum` CSS value the check applies to. Values below this number will be ignored |
 
 ### meta-viewport
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -118,7 +118,7 @@ axe.configure({
 | Option              | Default                                  | Description                                                                                |
 | ------------------- | :--------------------------------------- | :----------------------------------------------------------------------------------------- |
 | `selector`          | `footer:not([role]), [role=contentinfo]` | Selector used to determine if a page has a contentinfo landmark                            |
-| `nativeScopeFilter` | `article, aside, main, nav, section`     | Selector used to ignore contentinfo landmarks that have a parent that matches the selector |
+| `nativeScopeFilter` | `article, aside, main, nav, section`     | Option values used to ignore contentinfo landmarks that have a selector matching the parent element |
 
 ### page-no-duplicate-main
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -173,7 +173,7 @@ axe.configure({
 
 | Option         | Default | Description                                                                                                |
 | -------------- | :------ | :--------------------------------------------------------------------------------------------------------- |
-| `scaleMinimum` | `5`     | The maximum CSS value of `scale-maximum` the check will apply to. Values above this number will be ignored |
+| `scaleMinimum` | `5`     | The `scale-maximum` CSS value of the check applies to. Values above this number will be ignored |
 | `lowerBound`   | `2`     | The `scale-minimum` CSS value the check applies to. Values below this number will be ignored |
 
 ### meta-viewport

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -3,7 +3,7 @@
 ## Table of Contents
 
 - [How Checks Work](#how-checks-work)
-- [Options](#optoins)
+- [Options](#options)
   - [aria-allowed-role](#aria-allowed-role)
   - [aria-required-children](#aria-required-children)
   - [aria-roledescription](#aria-roledescription)

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -91,7 +91,7 @@ axe.configure({
 | `contrastRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
 | `contrastRatio.large`              | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
 | `contrastRatio.large.expected`     | `4.5`   | The expected contrast ratio for large text                                                     |
-| `contratRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
+| `contrastRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
 | `contratRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
 
 ### page-has-heading-one

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -130,22 +130,22 @@ axe.configure({
 
 ### color-contrast
 
-| Option                                                      | Default | Description                                                                                    |
-| ----------------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------- |
-| `ignoreUnicode`                                             | `true`  | Do not check the color contrast of Unicode characters                                          |
-| `ignoreLength`                                              | `false` | Do not check the color contrast of short text content                                          |
-| `boldValue`                                                 | `700`   | The minimum CSS `font-weight` value that designates bold text                                  |
-| `boldTextPt`                                                | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                  |
-| `largeTextPt`                                               | `18`    | The minimum CSS `font-size` pt value that designates text as being large                       |
-| `contrastRatio`                                             | N/A     | Contrast ratio options                                                                         |
-| &nbsp;&nbsp;`contrastRatio.normal`                          | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
-| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.expected`     | `4.5`   | The expected contrast ratio for normal text                                                    |
-| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
-| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
-| &nbsp;&nbsp;`contrastRatio.large`                           | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
-| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.expected`      | `4.5`   | The expected contrast ratio for large text                                                     |
-| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
-| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
+| Option                                                      | Default | Description                                                                                                 |
+| ----------------------------------------------------------- | :------ | :---------------------------------------------------------------------------------------------------------- |
+| `ignoreUnicode`                                             | `true`  | Do not check the color contrast of Unicode characters                                                       |
+| `ignoreLength`                                              | `false` | Do not check the color contrast of short text content                                                       |
+| `boldValue`                                                 | `700`   | The minimum CSS `font-weight` value that designates bold text                                               |
+| `boldTextPt`                                                | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                               |
+| `largeTextPt`                                               | `18`    | The minimum CSS `font-size` pt value that designates text as being large                                    |
+| `contrastRatio`                                             | N/A     | Contrast ratio options                                                                                      |
+| &nbsp;&nbsp;`contrastRatio.normal`                          | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`)              |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.expected`     | `4.5`   | The expected contrast ratio for normal text                                                                 |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.minThreshold` | N/A     | The minimum contrast ratio the check will apply to. Contrast ratios less than this value will be ignored    |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.normal.maxThreshold` | N/A     | The maximum contrast ratio the check will apply to. Contrast ratios greater than this value will be ignored |
+| &nbsp;&nbsp;`contrastRatio.large`                           | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.expected`      | `4.5`   | The expected contrast contrast ratio for large text                                                         |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.minThreshold`  | N/A     | The minimum contrast ratio the check will apply to. Contrast ratios less than this value will be ignored    |
+| &nbsp;&nbsp;&nbsp;&nbsp;`contrastRatio.large.maxThreshold`  | N/A     | The maximum contrast ratio the check will apply to. Contrast ratios greater than this value will be ignored |
 
 ### page-has-heading-one
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -1,0 +1,215 @@
+# Check Options
+
+## Table of Contents
+
+- [How Checks Work](#how-checks-work)
+- [Check Options](#check-optoins)
+  - [aria-allowed-role](#aria-allowed-role)
+  - [aria-required-children](#aria-required-children)
+  - [aria-roledescription](#aria-roledescription)
+  - [color-contrast](#color-contrast)
+  - [page-has-heading-one](#page-has-heading-one)
+  - [page-has-main](#page-has-main)
+  - [page-no-duplicate-banner](#page-no-duplicate-banner)
+  - [page-no-duplicate-contentinfo](#page-no-duplicate-contentinfo)
+  - [page-no-duplicate-main](#page-no-duplicate-main)
+  - [duplicate-img-label](#duplicate-img-label)
+  - [label-content-name-mismatch](#label-content-name-mismatch)
+  - [has-lang](#has-lang)
+  - [valid-lang](#valid-lang)
+  - [frame-tested](#frame-tested)
+  - [no-autoplay-audio](#no-autoplay-audio)
+  - [css-orientation-lock](#css-orientation-lock)
+  - [meta-viewport-large](#meta-viewport-large)
+  - [meta-viewport](#meta-viewport)
+  - [header-present](#header-present)
+  - [landmark](#landmark)
+  - [p-as-heading](#p-as-heading)
+  - [avoid-inline-spacing](#avoid-inline-spacing)
+  - [scope-value](#scope-value)
+
+## How Checks Work
+
+[Rules in axe-core](../lib/rules) are made up of individual checks that dictate how the rule works. Each check is typically designed to look for a specific requirement and report back its findings to the rule.
+
+For example, the rule [image-alt](../lib/rules/image-alt.json) uses the checks `has-alt`, `aria-label`, `aria-labelledby`, and `non-empty-title` to determine if the image has an accessible name from an `alt`, `aria-label`, `aria-labelledby`, or `title` attribute (respectively).
+
+Many checks allow you to change how they work through `options` properties. These options can be found in the [checks metadata file](../lib/checks).
+
+For example, the check [has-lang](../lib/checks/language/has-lang.json) takes an `attributes` option which dictates which attributes to check for a lang value.
+
+To customize a checks options, you can use [`axe.configure`](./API.md#api-name-axeconfigure) to configure the check and modify the options as desired.
+
+```js
+// configure has-lang check to look at the `hreflang` attribute as well
+axe.configure({
+	checks: [
+		{
+			id: 'has-lang',
+			options: {
+				attributes: ['lang', 'xml:lang', 'hreflang']
+			}
+		}
+	]
+});
+```
+
+## Check Options
+
+### aria-allowed-role
+
+| Option          | Default | Description                                                       |
+| --------------- | :------ | :---------------------------------------------------------------- |
+| `allowImplicit` | `true`  | Allow the explicit role to match the implicit role of the element |
+| `ignoredTags`   | `[]`    | List of HTML element names to not check for allowed roles         |
+
+### aria-required-children
+
+| Option        | Default                                                                                                               | Description                                                                                                            |
+| ------------- | :-------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
+| `reviewEmpty` | `['doc-bibliography', 'doc-endnotes', 'grid', 'list', 'listbox', 'table', 'tablist', 'tree', 'treegrid', 'rowgroup']` | List of ARIA roles that should be flagged as Needs Review rather than a violation if the element has no owned children |
+
+### aria-roledescription
+
+| Option           | Default                                                                                   | Description                                                          |
+| ---------------- | :---------------------------------------------------------------------------------------- | :------------------------------------------------------------------- |
+| `supportedRoles` | `['button', 'img', 'checkbox', 'radio', 'combobox', 'menuitemcheckbox', 'menuitemradio']` | List of ARIA roles that support the `aria-roledescription` attribute |
+
+### color-contrast
+
+| Option                             | Default | Description                                                                                    |
+| ---------------------------------- | :------ | :--------------------------------------------------------------------------------------------- |
+| `ignoreUnicode`                    | `true`  | If unicode characters should not be checked for contrast                                       |
+| `ignoreLength`                     | `false` | If short text content should not be checked for color contrast                                 |
+| `boldValue`                        | `700`   | The minimum CSS `font-weight` value that designates text as being bold                         |
+| `boldTextPt`                       | `14`    | The minimum CSS `font-size` pt value that designates bold text as being large                  |
+| `largeTextPt`                      | `18`    | The minimum CSS `font-size` pt value that designates text as being large                       |
+| `contrastRatio`                    | N/A     | Contrast ratio options                                                                         |
+| `contrastRatio.normal`             | N/A     | Contrast ratio requirements for normal text (non-bold text or text smaller than `largeTextPt`) |
+| `contrastRatio.normal.expected`    | `4.5`   | The expected contrast ratio for normal text                                                    |
+| `contratRatio.normal.minThreshold` | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
+| `contratRatio.normal.maxThreshold` | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
+| `contrastRatio.large`              | N/A     | Contrast ratio requirements for large text (bold text or text larger than `largeTextPt`)       |
+| `contrastRatio.large.expected`     | `4.5`   | The expected contrast ratio for large text                                                     |
+| `contratRatio.large.minThreshold`  | N/A     | The minimum ratio the check will apply to. Ratios less than this number will be ignored        |
+| `contratRatio.large.maxThreshold`  | N/A     | The maximum ratio the check will apply to. Ratios greater than this number will be ignored     |
+
+### page-has-heading-one
+
+| Option     | Default                                                                                                                                                                                                                                              | Description                                                  |
+| ---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
+| `selector` | `h1:not([role]):not([aria-level]), h1:not([role])[aria-level=1], h2:not([role])[aria-level=1], h3:not([role])[aria-level=1], h4:not([role])[aria-level=1], h5:not([role])[aria-level=1], h6:not([role])[aria-level=1], [role=heading][aria-level=1]` | Selector used to determine if a page has a level one heading |
+
+### page-has-main
+
+| Option     | Default                           | Description                                              |
+| ---------- | :-------------------------------- | :------------------------------------------------------- |
+| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a main landmark |
+
+### page-no-duplicate-banner
+
+| Option              | Default                              | Description                                                                           |
+| ------------------- | :----------------------------------- | :------------------------------------------------------------------------------------ |
+| `selector`          | `header:not([role]), [role=banner]`  | Selector used to determine if a page has a banner landmark                            |
+| `nativeScopeFilter` | `article, aside, main, nav, section` | Selector used to ignore banner landmarks that have a parent that matches the selector |
+
+### page-no-duplicate-contentinfo
+
+| Option              | Default                                  | Description                                                                                |
+| ------------------- | :--------------------------------------- | :----------------------------------------------------------------------------------------- |
+| `selector`          | `footer:not([role]), [role=contentinfo]` | Selector used to determine if a page has a contentinfo landmark                            |
+| `nativeScopeFilter` | `article, aside, main, nav, section`     | Selector used to ignore contentinfo landmarks that have a parent that matches the selector |
+
+### page-no-duplicate-main
+
+| Option     | Default                           | Description                                              |
+| ---------- | :-------------------------------- | :------------------------------------------------------- |
+| `selector` | `main:not([role]), [role='main']` | Selector used to determine if a page has a main landmark |
+
+### duplicate-img-label
+
+| Option           | Default                                         | Description                                                                           |
+| ---------------- | :---------------------------------------------- | :------------------------------------------------------------------------------------ |
+| `parentSelector` | `button, [role=button], a[href], p, li, td, th` | Selector used to look for the parent of an image that could duplicate the image label |
+
+### label-content-name-mismatch
+
+| Option               | Default | Description                                                                                                                                                               |
+| -------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pixelThreshold`     | `0.1`   | Percent of differences in pixel data or pixel width needed to determine if a font is a ligature font (ligature fonts are ignored when comparing the label to the content) |
+| `occuranceThreshold` | `3`     | Number of times the font is encountered before auto-assigning the font as a ligature or not                                                                               |
+
+### has-lang
+
+| Option       | Default                | Description                         |
+| ------------ | :--------------------- | :---------------------------------- |
+| `attributes` | `['lang', 'xml:lang']` | Attributes to check for lang values |
+
+### valid-lang
+
+| Option       | Default                | Description                               |
+| ------------ | :--------------------- | :---------------------------------------- |
+| `attributes` | `['lang', 'xml:lang']` | Attributes to check for valid lang values |
+
+### frame-tested
+
+| Option        | Default | Description                                                |
+| ------------- | :------ | :--------------------------------------------------------- |
+| `isViolation` | `false` | If an iframe without axe should be reported as a violation |
+
+### no-autoplay-audio
+
+| Option            | Default | Description                                                                   |
+| ----------------- | :------ | :---------------------------------------------------------------------------- |
+| `allowedDuration` | `3`     | Maximum time an audio is allowed to autoplay before being marked as violation |
+
+### css-orientation-lock
+
+| Option            | Default | Description                                                                                                                            |
+| ----------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `degreeThreshold` | `3`     | The difference of degrees from 180 and 90 that are considered orientation lock (for example, 93° is orientation locked but 94° is not) |
+
+### meta-viewport-large
+
+| Option         | Default | Description                                                                                                |
+| -------------- | :------ | :--------------------------------------------------------------------------------------------------------- |
+| `scaleMinimum` | `5`     | The maximum CSS value of `scale-maximum` the check will apply to. Values above this number will be ignored |
+| `lowerBound`   | `2`     | The minimum CSS value of `scale-minimum` the check will apply to. Values below this number will be ignored |
+
+### meta-viewport
+
+| Option         | Default | Description                                                                                                |
+| -------------- | :------ | :--------------------------------------------------------------------------------------------------------- |
+| `scaleMinimum` | `2`     | The maximum CSS value of `scale-maximum` the check will apply to. Values above this number will be ignored |
+
+### header-present
+
+| Option     | Default                                                                                                          | Description                                        |
+| ---------- | :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- |
+| `selector` | `h1:not([role]), h2:not([role]), h3:not([role]), h4:not([role]), h5:not([role]), h6:not([role]), [role=heading]` | Selector used to determine if a page has a heading |
+
+### landmark
+
+| Option     | Default             | Description                                                |
+| ---------- | :------------------ | :--------------------------------------------------------- |
+| `selector` | `main, [role=main]` | Selector used to determine if a page has a landmark region |
+
+### p-as-heading
+
+| Option | Default | Description |
+| ------ | :------ | :---------- |
+
+
+???
+
+### avoid-inline-spacing
+
+| Option          | Default                                             | Description                                      |
+| --------------- | :-------------------------------------------------- | :----------------------------------------------- |
+| `cssProperties` | `['line-height', 'letter-spacing', 'word-spacing']` | List of CSS properties to flag as inline spacing |
+
+### scope-value
+
+| Option   | Default                                  | Description                |
+| -------- | :--------------------------------------- | :------------------------- |
+| `values` | `['row', 'col', 'rowgroup', 'colgroup']` | List of valid scope values |

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -180,7 +180,7 @@ axe.configure({
 
 | Option         | Default | Description                                                                                                |
 | -------------- | :------ | :--------------------------------------------------------------------------------------------------------- |
-| `scaleMinimum` | `2`     | The maximum CSS value of `scale-maximum` the check will apply to. Values above this number will be ignored |
+| `scaleMinimum` | `2`     | The `scale-maximum` CSS value the check applies to. Values above this number will be ignored |
 
 ### header-present
 

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -65,21 +65,36 @@ axe.configure({
 
 ### aria-required-children
 
-| Option        | Default              | Description |
-| ------------- | :------------------- | :---------- |
-| `reviewEmpty` | <pre lang=js><code>[ |
-
-'doc-bibliography',
-'doc-endnotes',
-'grid',
-'list',
-'listbox',
-'table',
-'tablist',
-'tree',
-'treegrid',
-'rowgroup'
-]</code></pre> | List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children |
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>reviewEmpty</code>
+      </td>
+      <td align="left">
+        <pre lang=css><code>[
+  'doc-bibliography',
+  'doc-endnotes',
+  'grid',
+  'list',
+  'listbox',
+  'table',
+  'tablist',
+  'tree',
+  'treegrid',
+  'rowgroup']</code></pre>
+        </td>
+      <td align="left">List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children</td>
+    </tr>
+  </tbody>
+</table>
 
 ### aria-roledescription
 


### PR DESCRIPTION
I only included checks whose options modified how the check behaved. Checks which used generic checks (such as `non-empty-title`) were not added to list as their options are not really there for the user to customize. Generic checks will be described in another doc about creating custom rules.

Note: I do not understand what all the options for `p-as-heading` do even from looking at the code. If anyone can provide that understanding that'd be great.

Rendered view https://github.com/dequelabs/axe-core/blob/62e559fd7c65b8f426d01d99803854b3b9dcef6c/doc/check-options.md

Closes issue: #2187 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
