### PR TITLE
chore: update all locales to new format

### DIFF
--- a/locales/da.json
+++ b/locales/da.json
@@ -329,12 +329,21 @@
 		},
 		"aria-allowed-attr": {
 			"pass": "ARIA-attribut er brugt korrekt for den angivede rolle",
-			"fail": "ARIA-attribut{{=it.data && it.data.length > 1 ? 'terne' : ''}} er ikke tilladt:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "ARIA-attributterne er ikke tilladt: ${data.values}",
+				"plural": "ARIA-attribut er ikke tilladt: ${data.values}"
+			}
 		},
 		"aria-allowed-role": {
 			"pass": "ARIA-rollen er tilladt for det givne element",
-			"fail": "ARIA-rolle{{=it.data && it.data.length > 1 ? 'rne' : 'n'}} {{=it.data.join(', ')}} er ikke tilladt for det givne element",
-			"incomplete": "ARIA-rolle{{=it.data && it.data.length > 1 ? 'rne' : 'n'}} {{=it.data.join(', ')}} skal være fjernet, når elementet er synligt, da {{=it.data && it.data.length > 1 ? 'de' : 'det'}} ikke er tilladt for elementet"
+			"fail": {
+				"singular": "ARIA-rollerne )}}', ')}} er ikke tilladt for det givne element",
+				"plural": "ARIA-rollen )}}', ')}} er ikke tilladt for det givne element"
+			},
+			"incomplete": {
+				"singular": "ARIA-rollerne )}}', ')}} skal være fjernet, når elementet er synligt, da de ikke er tilladt for elementet",
+				"plural": "ARIA-rollen )}}', ')}} skal være fjernet, når elementet er synligt, da det ikke er tilladt for elementet"
+			}
 		},
 		"aria-hidden-body": {
 			"pass": "Ingen 'aria-hidden'-attribut er at finde i dokumentets <body> element",
@@ -347,7 +356,10 @@
 		},
 		"aria-errormessage": {
 			"pass": "Bruger en understøttet 'aria-errormessage'-teknik",
-			"fail": "'aria-errormessage'-værdi{{=it.data && it.data.length > 1 ? 'er' : ''}} {{~it.data:value}} `{{=value}}{{~}}` bør bruge en teknik til at annoncere beskeden (fx 'aria-live', 'aria-describedby', 'role=alert', osv.)"
+			"fail": {
+				"singular": "'aria-errormessage'-værdier ${data.values}` bør bruge en teknik til at annoncere beskeden (fx 'aria-live', 'aria-describedby', 'role=alert', osv.)",
+				"plural": "'aria-errormessage'-værdi ${data.values}` bør bruge en teknik til at annoncere beskeden (fx 'aria-live', 'aria-describedby', 'role=alert', osv.)"
+			}
 		},
 		"has-widget-role": {
 			"pass": "Elementet har en 'widget'-rolle.",
@@ -359,45 +371,69 @@
 		},
 		"no-implicit-explicit-label": {
 			"pass": "Der er uoverensstemmelse mellem <label> og det tilgængelige navn",
-			"incomplete": "Tjek at <label> elementet ikke behøver være en del af {{=it.data}}-feltets navn"
+			"incomplete": "Tjek at <label> elementet ikke behøver være en del af ${data}-feltets navn"
 		},
 		"aria-required-attr": {
 			"pass": "Alle krævede ARIA-attributter er tilstede",
-			"fail": "Krævet ARIA-attribut{{=it.data && it.data.length > 1 ? 'ter' : ''}} er ikke til stede:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Krævet ARIA-attributter er ikke til stede: ${data.values}",
+				"plural": "Krævet ARIA-attribut er ikke til stede: ${data.values}"
+			}
 		},
 		"aria-required-children": {
 			"pass": "Krævet ARIA-under-elementer er til stede",
-			"fail": "Krævet ARIA-under-element{{=it.data && it.data.length > 1 ? 'er' : ''}}s rolle er ikke til stede:{{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "Forventer at ARIA under-element{{=it.data && it.data.length > 1 ? 'er' : ''}}s rolle bliver tilføjet:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Krævet ARIA-under-elementers rolle er ikke til stede: ${data.values}",
+				"plural": "Krævet ARIA-under-elements rolle er ikke til stede: ${data.values}"
+			},
+			"incomplete": {
+				"singular": "Forventer at ARIA under-elementers rolle bliver tilføjet: ${data.values}",
+				"plural": "Forventer at ARIA under-elements rolle bliver tilføjet: ${data.values}"
+			}
 		},
 		"aria-required-parent": {
 			"pass": "Krævet ARIA-over-elements rolle er til stede",
-			"fail": "Krævet ARIA-over-element{{=it.data && it.data.length > 1 ? 'er' : ''}}s rolle er ikke til stede:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Krævet ARIA-over-elementers rolle er ikke til stede: ${data.values}",
+				"plural": "Krævet ARIA-over-elements rolle er ikke til stede: ${data.values}"
+			}
 		},
 		"aria-unsupported-attr": {
 			"pass": "ARIA-attribut er understøttet",
-			"fail": "ARIA-attribut er ikke bredt understøttet i skærmlæsere og tilgængelighedsteknologier: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "ARIA-attribut er ikke bredt understøttet i skærmlæsere og tilgængelighedsteknologier:  ${data.values}"
 		},
 		"unsupportedrole": {
 			"pass": "ARIA rollen er understøttet",
-			"fail": "Den brugte rolle er ikke bredt understøttet i skærmlæsere og tilgængelighedsteknologier: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "Den brugte rolle er ikke bredt understøttet i skærmlæsere og tilgængelighedsteknologier:  ${data.values}"
 		},
 		"aria-valid-attr-value": {
 			"pass": "ARIA-attributværdien er valid",
-			"fail": "Ikke-korrekt ARIA-attributværdi{{=it.data && it.data.length > 1 ? 'er' : ''}}:{{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "ARIA-attribut{{=it.data && it.data.length > 1 ? 'ternes' : 'tens'}} element 'id' er ikke at finde på siden:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Ikke-korrekt ARIA-attributværdier: ${data.values}",
+				"plural": "Ikke-korrekt ARIA-attributværdi: ${data.values}"
+			},
+			"incomplete": {
+				"singular": "ARIA-attributternes element 'id' er ikke at finde på siden: ${data.values}",
+				"plural": "ARIA-attributtens element 'id' er ikke at finde på siden: ${data.values}"
+			}
 		},
 		"aria-valid-attr": {
-			"pass": "ARIA-attributnavn{{=it.data && it.data.length > 1 ? 'ene' : 'et'}} er korrekt",
-			"fail": "Ikke-korrekt ARIA-attributnavn{{=it.data && it.data.length > 1 ? 'e' : ''}}:{{~it.data:value}} {{=value}}{{~}}"
+			"pass": {
+				"singular": "ARIA-attributnavnene er korrekt",
+				"plural": "ARIA-attributnavnet er korrekt"
+			},
+			"fail": {
+				"singular": "Ikke-korrekt ARIA-attributnavne: ${data.values}",
+				"plural": "Ikke-korrekt ARIA-attributnavn: ${data.values}"
+			}
 		},
 		"valid-scrollable-semantics": {
 			"pass": "Elementet har korrekt semantik for et element i fokus-rækkefølgen.",
 			"fail": "Elementet har ikke korrekt semantik for et element i fokus-rækkefølgen."
 		},
 		"color-contrast": {
-			"pass": "Elementet har stor farvekontrast, den er {{=it.data.contrastRatio}}",
-			"fail": "Elementet har ikke nok farvekontrast, den er {{=it.data.contrastRatio}} (forgrundsfarve: {{=it.data.fgColor}}, baggrundsfarve: {{=it.data.bgColor}}, tekststørrelse: {{=it.data.fontSize}}, teksttykkelse: {{=it.data.fontWeight}}). Forventet kontrastforhold er {{=it.data.expectedContrastRatio}}",
+			"pass": "Elementet har stor farvekontrast, den er ${data.contrastRatio}",
+			"fail": "Elementet har ikke nok farvekontrast, den er ${data.contrastRatio} (forgrundsfarve: ${data.fgColor}, baggrundsfarve: ${data.bgColor}, tekststørrelse: ${data.fontSize}, teksttykkelse: ${data.fontWeight}). Forventet kontrastforhold er ${data.expectedContrastRatio}",
 			"incomplete": {
 				"bgImage": "Elementets baggrundsfarve kunne ikke detekteres på grund af et baggrundsbillede",
 				"bgGradient": "Elementets baggrundsfarve kunne ikke detekteres på grund af en baggrundsgradient",
@@ -457,8 +493,8 @@
 			"fail": "Fokuserbart indhold bør have tabindex='-1' eller fjernes fra sidens DOM"
 		},
 		"landmark-is-top-level": {
-			"pass": "{{=it.data.role }} landmark er på det øverste niveau.",
-			"fail": "{{=it.data.role }} landmark er indhold i et andet landmark."
+			"pass": "${data.role} landmark er på det øverste niveau.",
+			"fail": "${data.role} landmark er indhold i et andet landmark."
 		},
 		"page-has-heading-one": {
 			"pass": "Siden har mindst én overskrift på niveau 1",
@@ -576,7 +612,7 @@
 		},
 		"meta-viewport": {
 			"pass": "<meta>-tagget slår ikke zoom fra på mobile enheder",
-			"fail": "{{=it.data}} på <meta>-tagget slår zoom fra på mobile enheder"
+			"fail": "${data} på <meta>-tagget slår zoom fra på mobile enheder"
 		},
 		"header-present": {
 			"pass": "Siden har en overskrift (header)",
@@ -617,11 +653,11 @@
 		},
 		"duplicate-id-active": {
 			"pass": "Dokumentet har ingen aktive elementer, der deler den samme 'id'-attribut",
-			"fail": "Dokumentet har aktive elementer, der deler den samme 'id'-attribut: {{=it.data}}"
+			"fail": "Dokumentet har aktive elementer, der deler den samme 'id'-attribut: ${data}"
 		},
 		"duplicate-id-aria": {
 			"pass": "Dokumentet har ingen elementer refereret med ARIA eller labels, der deler den samme 'id'-attribut",
-			"fail": "Dokumentet har flere elementer refereret med ARIA med den samme 'id'-attribut: {{=it.data}}"
+			"fail": "Dokumentet har flere elementer refereret med ARIA med den samme 'id'-attribut: ${data}"
 		},
 		"duplicate-id": {
 			"pass": "Dokumentet har ingen statiske elementer, der deler den samme 'id'-attribut",
@@ -637,7 +673,10 @@
 		},
 		"avoid-inline-spacing": {
 			"pass": "Ingen inline styling med '!important', som påvirker tekst-mellemrums-afstand er specificeret",
-			"fail": "Fjern '!important' fra inline styling{{=it.data && it.data.length > 1 ? 's' : ''}} {{=it.data.join(', ')}}, da overskrivning af dette, ikke er understøttet i de fleste browsere"
+			"fail": {
+				"singular": "Fjern '!important' fra inline stylings )}}', ')}}, da overskrivning af dette, ikke er understøttet i de fleste browsere",
+				"plural": "Fjern '!important' fra inline styling )}}', ')}}, da overskrivning af dette, ikke er understøttet i de fleste browsere"
+			}
 		},
 		"button-has-visible-text": {
 			"pass": "Elementet har indre tekst, som er synlig for skærmlæsere",
@@ -668,7 +707,10 @@
 			"fail": "Elementet har ingen 'alt'-attribut, eller 'alt'-attributten er tom"
 		},
 		"non-empty-if-present": {
-			"pass": "Elementet {{?it.data}} har en 'værdi'-attribut med indhold{{??}} har ikke en 'value'-attribut{{?}}",
+			"pass": {
+				"default": "Elementet har ikke en 'value'-attribut",
+				"has-label": "Elementet har en 'værdi'-attribut med indhold"
+			},
 			"fail": "Elementet har en 'value'-attribut, og 'værdi'-attributten er tom"
 		},
 		"non-empty-title": {

--- a/locales/da.json
+++ b/locales/da.json
@@ -337,12 +337,12 @@
 		"aria-allowed-role": {
 			"pass": "ARIA-rollen er tilladt for det givne element",
 			"fail": {
-				"singular": "ARIA-rollerne )}}', ')}} er ikke tilladt for det givne element",
-				"plural": "ARIA-rollen )}}', ')}} er ikke tilladt for det givne element"
+				"singular": "ARIA-rollerne ${data.values} er ikke tilladt for det givne element",
+				"plural": "ARIA-rollen ${data.values} er ikke tilladt for det givne element"
 			},
 			"incomplete": {
-				"singular": "ARIA-rollerne )}}', ')}} skal være fjernet, når elementet er synligt, da de ikke er tilladt for elementet",
-				"plural": "ARIA-rollen )}}', ')}} skal være fjernet, når elementet er synligt, da det ikke er tilladt for elementet"
+				"singular": "ARIA-rollerne ${data.values} skal være fjernet, når elementet er synligt, da de ikke er tilladt for elementet",
+				"plural": "ARIA-rollen ${data.values} skal være fjernet, når elementet er synligt, da det ikke er tilladt for elementet"
 			}
 		},
 		"aria-hidden-body": {
@@ -674,8 +674,8 @@
 		"avoid-inline-spacing": {
 			"pass": "Ingen inline styling med '!important', som påvirker tekst-mellemrums-afstand er specificeret",
 			"fail": {
-				"singular": "Fjern '!important' fra inline stylings )}}', ')}}, da overskrivning af dette, ikke er understøttet i de fleste browsere",
-				"plural": "Fjern '!important' fra inline styling )}}', ')}}, da overskrivning af dette, ikke er understøttet i de fleste browsere"
+				"singular": "Fjern '!important' fra inline stylings ${data.values}, da overskrivning af dette, ikke er understøttet i de fleste browsere",
+				"plural": "Fjern '!important' fra inline styling ${data.values}, da overskrivning af dette, ikke er understøttet i de fleste browsere"
 			}
 		},
 		"button-has-visible-text": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -257,7 +257,7 @@
 		},
 		"aria-allowed-attr": {
 			"pass": "",
-			"fail": "Die folgenden ARIA-Attribute sind (für die ARIA-Rolle des Elementes) nicht erlaubt:{{~it.data:value}} {{=value}}{{~}}."
+			"fail": "Die folgenden ARIA-Attribute sind (für die ARIA-Rolle des Elementes) nicht erlaubt: ${data.values}."
 		},
 		"aria-hidden-body": {
 			"pass": "",
@@ -265,7 +265,7 @@
 		},
 		"aria-errormessage": {
 			"pass": "",
-			"fail": "Der Wert der aria-errormessage {{~it.data:value}} `{{=value}}{{~}}` muss eine Technik verwenden, um die Message anzukündigen (z. B., aria-live, aria-describedby, role=alert, etc.)."
+			"fail": "Der Wert der aria-errormessage  ${data.values}` muss eine Technik verwenden, um die Message anzukündigen (z. B., aria-live, aria-describedby, role=alert, etc.)."
 		},
 		"has-widget-role": {
 			"pass": "",
@@ -277,23 +277,23 @@
 		},
 		"aria-required-attr": {
 			"pass": "",
-			"fail": "Die folgenden erforderlichen ARIA-Attribute sind nicht vorhanden:{{~it.data:value}} {{=value}}{{~}}."
+			"fail": "Die folgenden erforderlichen ARIA-Attribute sind nicht vorhanden: ${data.values}."
 		},
 		"aria-required-children": {
 			"pass": "",
-			"fail": "Die folgenden erforderlichen untergeordneten ARIA-Rollen (ARIA-Kind-Rollen) sind nicht vorhanden:{{~it.data:value}} {{=value}}{{~}}."
+			"fail": "Die folgenden erforderlichen untergeordneten ARIA-Rollen (ARIA-Kind-Rollen) sind nicht vorhanden: ${data.values}."
 		},
 		"aria-required-parent": {
 			"pass": "",
-			"fail": "Die folgenden erforderlichen übergeordneten ARIA-Rollen (ARIA-Eltern-Rollen) sind nicht vorhanden:{{~it.data:value}} {{=value}}{{~}}."
+			"fail": "Die folgenden erforderlichen übergeordneten ARIA-Rollen (ARIA-Eltern-Rollen) sind nicht vorhanden: ${data.values}."
 		},
 		"aria-valid-attr-value": {
 			"pass": "",
-			"fail": "Folgende ARIA-Attributwerte sind nicht valide:{{~it.data:value}} {{=value}}{{~}}."
+			"fail": "Folgende ARIA-Attributwerte sind nicht valide: ${data.values}."
 		},
 		"aria-valid-attr": {
 			"pass": "",
-			"fail": "Folgende ARIA-Attributnamen sind nicht valide:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": "Folgende ARIA-Attributnamen sind nicht valide: ${data.values}"
 		},
 		"valid-scrollable-semantics": {
 			"pass": "",
@@ -301,7 +301,7 @@
 		},
 		"color-contrast": {
 			"pass": "",
-			"fail": "Das Element hat einen unzureichenden Kontrast von {{=it.data.contrastRatio}} (Vordergrundfarbe: {{=it.data.fgColor}}, Hintergrundfarbe: {{=it.data.bgColor}}, Schriftgröße: {{=it.data.fontSize}}, Schriftstärke: {{=it.data.fontWeight}}).",
+			"fail": "Das Element hat einen unzureichenden Kontrast von ${data.contrastRatio} (Vordergrundfarbe: ${data.fgColor}, Hintergrundfarbe: ${data.bgColor}, Schriftgröße: ${data.fontSize}, Schriftstärke: ${data.fontWeight}).",
 			"incomplete": {
 				"bgImage": "Die Hintergrundfarbe des Elementes konnte aufgrund eines Hintergrundbildes nicht bestimmt werden.",
 				"bgGradient": "Die Hintergrundfarbe des Elementes konnte aufgrund eines Hintergrundfarbverlaufes nicht bestimmt werden.",
@@ -335,7 +335,7 @@
 		},
 		"landmark-is-top-level": {
 			"pass": "",
-			"fail": "Die {{=it.data.role }} landmark befindet sich innerhalb einer anderen landmark."
+			"fail": "Die ${data.role} landmark befindet sich innerhalb einer anderen landmark."
 		},
 		"page-has-heading-one": {
 			"pass": "",
@@ -485,7 +485,7 @@
 		},
 		"duplicate-id": {
 			"pass": "",
-			"fail": "Das Dokument besitzt mehrere Elemente mit demselben id-Attributwert: {{=it.data}}."
+			"fail": "Das Dokument besitzt mehrere Elemente mit demselben id-Attributwert: ${data}."
 		},
 		"exists": {
 			"pass": "",

--- a/locales/es.json
+++ b/locales/es.json
@@ -333,12 +333,12 @@
 		"aria-allowed-role": {
 			"pass": "El rol ARIA está permitido para el elemento proporcionado",
 			"fail": {
-				"singular": "En ARIA, roles )}}', ')}} no están permitidos para el elemento proporcionado",
-				"plural": "En ARIA, role )}}', ')}}  no está permitido para el elemento proporcionado"
+				"singular": "En ARIA, roles ${data.values} no están permitidos para el elemento proporcionado",
+				"plural": "En ARIA, role ${data.values}  no está permitido para el elemento proporcionado"
 			},
 			"incomplete": {
-				"singular": "En ARIA, hay que eliminar roles )}}', ')}} cuando el elemento se haga visible, ya que no están permitidos para el elemento",
-				"plural": "En ARIA, hay que eliminar role )}}', ')}} cuando el elemento se haga visible, ya que no está permitido para el elemento"
+				"singular": "En ARIA, hay que eliminar roles ${data.values} cuando el elemento se haga visible, ya que no están permitidos para el elemento",
+				"plural": "En ARIA, hay que eliminar role ${data.values} cuando el elemento se haga visible, ya que no está permitido para el elemento"
 			}
 		},
 		"aria-hidden-body": {
@@ -665,8 +665,8 @@
 		"avoid-inline-spacing": {
 			"pass": "No se han especificado estilos 'inline' con '!important' que afecten al espaciado de texto",
 			"fail": {
-				"singular": "Eliminar '!important' de inline styles )}}', ')}}, porque su anulación no está admitida en la mayoría de navegadores",
-				"plural": "Eliminar '!important' de inline style )}}', ')}}, porque su anulación no está admitida en la mayoría de navegadores"
+				"singular": "Eliminar '!important' de inline styles ${data.values}, porque su anulación no está admitida en la mayoría de navegadores",
+				"plural": "Eliminar '!important' de inline style ${data.values}, porque su anulación no está admitida en la mayoría de navegadores"
 			}
 		},
 		"button-has-visible-text": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -325,12 +325,21 @@
 		},
 		"aria-allowed-attr": {
 			"pass": "Los atributos ARIA se usan correctamente para el rol definido",
-			"fail": "En ARIA, atributo{{=it.data && it.data.length > 1 ? 's no están permitidos' : 'no está permitido'}} :{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "En ARIA, atributos no están permitidos : ${data.values}",
+				"plural": "En ARIA, atributono está permitido : ${data.values}"
+			}
 		},
 		"aria-allowed-role": {
 			"pass": "El rol ARIA está permitido para el elemento proporcionado",
-			"fail": "En ARIA, role{{=it.data && it.data.length > 1 ? 's' : ''}} {{=it.data.join(', ')}} {{=it.data && it.data.length > 1 ? 'no están permitidos' : ' no está permitido'}} para el elemento proporcionado",
-			"incomplete": "En ARIA, hay que eliminar role{{=it.data && it.data.length > 1 ? 's' : ''}} {{=it.data.join(', ')}} cuando el elemento se haga visible, ya que {{=it.data && it.data.length > 1 ? 'no están permitidos' : 'no está permitido'}} para el elemento"
+			"fail": {
+				"singular": "En ARIA, roles )}}', ')}} no están permitidos para el elemento proporcionado",
+				"plural": "En ARIA, role )}}', ')}}  no está permitido para el elemento proporcionado"
+			},
+			"incomplete": {
+				"singular": "En ARIA, hay que eliminar roles )}}', ')}} cuando el elemento se haga visible, ya que no están permitidos para el elemento",
+				"plural": "En ARIA, hay que eliminar role )}}', ')}} cuando el elemento se haga visible, ya que no está permitido para el elemento"
+			}
 		},
 		"aria-hidden-body": {
 			"pass": "No hay ningún atributo aria-hidden presente en el 'body' del documento",
@@ -338,7 +347,10 @@
 		},
 		"aria-errormessage": {
 			"pass": "Usa una técnica admitida para aria-errormessage",
-			"fail": "En aria-errormessage, valor{{=it.data && it.data.length > 1 ? 'es' : ''}} {{~it.data:value}} `{{=value}}{{~}}`, se debe usar una técnica para anunciar el mensaje (p. ej., aria-live, aria-describedby, role=alert, etc.)"
+			"fail": {
+				"singular": "En aria-errormessage, valores  ${data.values}`, se debe usar una técnica para anunciar el mensaje (p. ej., aria-live, aria-describedby, role=alert, etc.)",
+				"plural": "En aria-errormessage, valor  ${data.values}`, se debe usar una técnica para anunciar el mensaje (p. ej., aria-live, aria-describedby, role=alert, etc.)"
+			}
 		},
 		"has-widget-role": {
 			"pass": "El elemento tiene un rol de widget.",
@@ -350,45 +362,69 @@
 		},
 		"no-implicit-explicit-label": {
 			"pass": "No hay discordancia entre un <label> y el nombre accesible",
-			"incomplete": "Comprobar que el <label> no necesita ser parte del ARIA {{=it.data}} para el nombre del campo"
+			"incomplete": "Comprobar que el <label> no necesita ser parte del ARIA ${data} para el nombre del campo"
 		},
 		"aria-required-attr": {
 			"pass": "Todos los atributos ARIA requeridos están presentes",
-			"fail": "Atributo{{=it.data && it.data.length > 1 ? 's requeridos no presentes' : ' requerido no presente'}}:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Atributos requeridos no presentes: ${data.values}",
+				"plural": "Atributo requerido no presente: ${data.values}"
+			}
 		},
 		"aria-required-children": {
 			"pass": "Los hijos ARIA requeridos están presentes",
-			"fail": "Rol de {{=it.data && it.data.length > 1 ? 'hijos' : 'hijo'}} requerido en ARIA no presente:{{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "Esperando que se añada rol ARIA para {{=it.data && it.data.length > 1 ? 'hijos' : 'hijo'}}:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Rol de hijos requerido en ARIA no presente: ${data.values}",
+				"plural": "Rol de hijo requerido en ARIA no presente: ${data.values}"
+			},
+			"incomplete": {
+				"singular": "Esperando que se añada rol ARIA para hijos: ${data.values}",
+				"plural": "Esperando que se añada rol ARIA para hijo: ${data.values}"
+			}
 		},
 		"aria-required-parent": {
 			"pass": "Rol de padre requerido en ARIA presente",
-			"fail": "Rol de ARIA requerido para padre {{=it.data && it.data.length > 1 ? 's' : ''}} no presente:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Rol de ARIA requerido para padre s no presente: ${data.values}",
+				"plural": "Rol de ARIA requerido para padre  no presente: ${data.values}"
+			}
 		},
 		"aria-unsupported-attr": {
 			"pass": "El atributo ARIA está admitido",
-			"fail": "El atributo ARIA no está ampliamente admitido en lectores de pantalla y tecnologías de apoyo: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "El atributo ARIA no está ampliamente admitido en lectores de pantalla y tecnologías de apoyo:  ${data.values}"
 		},
 		"unsupportedrole": {
 			"pass": "El rol ARIA está admitido",
-			"fail": "El rol usado no está ampliamente admitido en lectores de pantalla y tecnologías de apoyo: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "El rol usado no está ampliamente admitido en lectores de pantalla y tecnologías de apoyo:  ${data.values}"
 		},
 		"aria-valid-attr-value": {
 			"pass": "Los valores de los atributos ARIA son válidos",
-			"fail": "Valor{{=it.data && it.data.length > 1 ? 'es no válidos para atributo ARIA' : ' no válido para atributo ARIA'}}:{{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "Atributo{=it.data && it.data.length > 1 ? 's' : ''}} ARIA ID de elemento no existe en la página:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Valores no válidos para atributo ARIA: ${data.values}",
+				"plural": "Valor no válido para atributo ARIA: ${data.values}"
+			},
+			"incomplete": {
+				"singular": "Atributos ARIA ID de elemento no existe en la página: ${data.values}",
+				"plural": "Atributo ARIA ID de elemento no existe en la página: ${data.values}"
+			}
 		},
 		"aria-valid-attr": {
-			"pass": "Nombre{{=it.data && it.data.length > 1 ? 's de atributos ARIA válidos' : 'de atributo ARIA válido'}}",
-			"fail": "Nombre{{=it.data && it.data.length > 1 ? 's de atributos ARIA no válidos' : ' de atributo ARIA no válido'}}: {{~it.data:value}} {{=value}}{{~}}"
+			"pass": {
+				"singular": "Nombres de atributos ARIA válidos",
+				"plural": "Nombrede atributo ARIA válido"
+			},
+			"fail": {
+				"singular": "Nombres de atributos ARIA no válidos:  ${data.values}",
+				"plural": "Nombre de atributo ARIA no válido:  ${data.values}"
+			}
 		},
 		"valid-scrollable-semantics": {
 			"pass": "El elemento tiene una semántica válida para un elemento en orden de foco.",
 			"fail": "El elemento tiene una semántica no válida para un elemento en orden de foco."
 		},
 		"color-contrast": {
-			"pass": "El elemento tiene un contraste de color suficiente de {{=it.data.contrastRatio}}",
-			"fail": "El elemento tiene un contraste de color insuficiente de {{=it.data.contrastRatio}} (color de primer plano: {{=it.data.fgColor}}, color de fondo: {{=it.data.bgColor}}, tamaño de fuente: {{=it.data.fontSize}}, grosor de fuente: {{=it.data.fontWeight}}). Ratio de contraste esperado: {{=it.data.expectedContrastRatio}}",
+			"pass": "El elemento tiene un contraste de color suficiente de ${data.contrastRatio}",
+			"fail": "El elemento tiene un contraste de color insuficiente de ${data.contrastRatio} (color de primer plano: ${data.fgColor}, color de fondo: ${data.bgColor}, tamaño de fuente: ${data.fontSize}, grosor de fuente: ${data.fontWeight}). Ratio de contraste esperado: ${data.expectedContrastRatio}",
 			"incomplete": {
 				"bgImage": "El color de fondo del elemento no se pudo determinar debido a una imagen de fondo",
 				"bgGradient": "El color de fondo del elemento no se pudo determinar debido a un degradado de fondo",
@@ -448,8 +484,8 @@
 			"fail": "El contenido que admita el foco debería tener tabindex='-1' o ser eliminado del DOM"
 		},
 		"landmark-is-top-level": {
-			"pass": "El punto de referencia {{=it.data.role }} está en el nivel superior.",
-			"fail": "El punto de referencia {{=it.data.role }} está contenido en otro punto de referencia."
+			"pass": "El punto de referencia ${data.role} está en el nivel superior.",
+			"fail": "El punto de referencia ${data.role} está contenido en otro punto de referencia."
 		},
 		"page-has-heading-one": {
 			"pass": "La página tiene al menos un encabezado de nivel 1",
@@ -567,7 +603,7 @@
 		},
 		"meta-viewport": {
 			"pass": "La etiqueta <meta> no impide el zum en dispositivos móviles",
-			"fail": "{{=it.data}} en la etiqueta <meta> impide el zum en dispositivos móviles"
+			"fail": "${data} en la etiqueta <meta> impide el zum en dispositivos móviles"
 		},
 		"header-present": {
 			"pass": "La página tiene un 'header'",
@@ -608,11 +644,11 @@
 		},
 		"duplicate-id-active": {
 			"pass": "El documento no tiene elementos activos que compartan el mismo atributo id",
-			"fail": "El documento tiene elementos activos con el mismo atributo id: {{=it.data}}"
+			"fail": "El documento tiene elementos activos con el mismo atributo id: ${data}"
 		},
 		"duplicate-id-aria": {
 			"pass": "El documento no tiene elementos referidos con ARIA o etiquetas que compartan el mismo atributo id",
-			"fail": "El documento tiene múltiples elementos referidos con ARIA con el mismo atributo id: {{=it.data}}"
+			"fail": "El documento tiene múltiples elementos referidos con ARIA con el mismo atributo id: ${data}"
 		},
 		"duplicate-id": {
 			"pass": "El documento no tiene elementos estáticos que compartan el mismo atributo id",
@@ -628,7 +664,10 @@
 		},
 		"avoid-inline-spacing": {
 			"pass": "No se han especificado estilos 'inline' con '!important' que afecten al espaciado de texto",
-			"fail": "Eliminar '!important' de inline style{{=it.data && it.data.length > 1 ? 's' : ''}} {{=it.data.join(', ')}}, porque su anulación no está admitida en la mayoría de navegadores"
+			"fail": {
+				"singular": "Eliminar '!important' de inline styles )}}', ')}}, porque su anulación no está admitida en la mayoría de navegadores",
+				"plural": "Eliminar '!important' de inline style )}}', ')}}, porque su anulación no está admitida en la mayoría de navegadores"
+			}
 		},
 		"button-has-visible-text": {
 			"pass": "El elemento tiene texto interno visible para lectores de pantalla",
@@ -659,7 +698,10 @@
 			"fail": "El elemento no tiene atributo alt o el atributo alt está vacío"
 		},
 		"non-empty-if-present": {
-			"pass": "El elemento {{?it.data}}tiene un atributo de valor no vacío{{??}}no tiene un atributo de valor{{?}}",
+			"pass": {
+				"default": "El elemento no tiene un atributo de valor",
+				"has-label": "El elemento tiene un atributo de valor no vacío"
+			},
 			"fail": "El elemento tiene un atributo de valor y el atributo de valor está vacío"
 		},
 		"non-empty-title": {

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -333,12 +333,12 @@
 		"aria-allowed-role": {
 			"pass": "ARIA rola baimenduta dago emandako elementurako",
 			"fail": {
-				"singular": "ARIAn, rolak )}}', ')}} -ak ez daude baimenduta emandako elementurako",
-				"plural": "ARIAn, rola )}}', ')}} -a ez dago baimenduta emandako elementurako"
+				"singular": "ARIAn, rolak ${data.values} -ak ez daude baimenduta emandako elementurako",
+				"plural": "ARIAn, rola ${data.values} -a ez dago baimenduta emandako elementurako"
 			},
 			"incomplete": {
-				"singular": "AREAN, rolak kendu behar dira )}}', ')}} elementua ikusgai egiten denean, zeren elementurako  ez daude baimenduta",
-				"plural": "AREAN, rola kendu behar da )}}', ')}} elementua ikusgai egiten denean, zeren elementurako  ez dago baimenduta"
+				"singular": "AREAN, rolak kendu behar dira ${data.values} elementua ikusgai egiten denean, zeren elementurako  ez daude baimenduta",
+				"plural": "AREAN, rola kendu behar da ${data.values} elementua ikusgai egiten denean, zeren elementurako  ez dago baimenduta"
 			}
 		},
 		"aria-hidden-body": {
@@ -665,8 +665,8 @@
 		"avoid-inline-spacing": {
 			"pass": "Ez da testu-tarteari eragiten dion '!important' estilorik zehaztu.",
 			"fail": {
-				"singular": "Ezabatu '!important' inline styleetatik )}}', ')}}, nabigatzaile gehienetan ez delako onartzen baliogabetzea.",
-				"plural": "Ezabatu '!important' inline styletik )}}', ')}}, nabigatzaile gehienetan ez delako onartzen baliogabetzea."
+				"singular": "Ezabatu '!important' inline styleetatik ${data.values}, nabigatzaile gehienetan ez delako onartzen baliogabetzea.",
+				"plural": "Ezabatu '!important' inline styletik ${data.values}, nabigatzaile gehienetan ez delako onartzen baliogabetzea."
 			}
 		},
 		"button-has-visible-text": {

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -325,12 +325,21 @@
 		},
 		"aria-allowed-attr": {
 			"pass": "ARIA atributuak behar bezala erabiltzen dira zehaztutako rolerako",
-			"fail": "ARIAn, {{=it.data && it.data.length > 1 ? 'atributuak ez daude baimenduta' : 'atributua ez dago baimenduta'}} :{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "ARIAn, atributuak ez daude baimenduta : ${data.values}",
+				"plural": "ARIAn, atributua ez dago baimenduta : ${data.values}"
+			}
 		},
 		"aria-allowed-role": {
 			"pass": "ARIA rola baimenduta dago emandako elementurako",
-			"fail": "ARIAn, {{=it.data && it.data.length > 1 ? 'rolak' : 'rola'}} {{=it.data.join(', ')}} {{=it.data && it.data.length > 1 ? '-ak ez daude baimenduta' : '-a ez dago baimenduta'}} emandako elementurako",
-			"incomplete": "AREAN, {{=it.data && it.data.length > 1 ? 'rolak kendu behar dira' : 'rola kendu behar da'}} {{=it.data.join(', ')}} elementua ikusgai egiten denean, zeren elementurako {{=it.data && it.data.length > 1 ? ' ez daude baimenduta' : ' ez dago baimenduta'}} "
+			"fail": {
+				"singular": "ARIAn, rolak )}}', ')}} -ak ez daude baimenduta emandako elementurako",
+				"plural": "ARIAn, rola )}}', ')}} -a ez dago baimenduta emandako elementurako"
+			},
+			"incomplete": {
+				"singular": "AREAN, rolak kendu behar dira )}}', ')}} elementua ikusgai egiten denean, zeren elementurako  ez daude baimenduta",
+				"plural": "AREAN, rola kendu behar da )}}', ')}} elementua ikusgai egiten denean, zeren elementurako  ez dago baimenduta"
+			}
 		},
 		"aria-hidden-body": {
 			"pass": "Ez dago dokumentuko 'body'ean agertzen den aria-hidden atributurik",
@@ -338,7 +347,10 @@
 		},
 		"aria-errormessage": {
 			"pass": "Teknika onartu bat erabiltzen du aria-errormessagerako",
-			"fail": "aria-errormessagen, bailioa{{=it.data && it.data.length > 1 ? 'es' : ''}} {{~it.data:value}} `{{=value}}{{~}}`, mezua iragartzeko teknika bat erabili behar da (adibidez: aria-live, aria-describedby, role = alert, etab.)."
+			"fail": {
+				"singular": "aria-errormessagen, bailioaes  ${data.values}`, mezua iragartzeko teknika bat erabili behar da (adibidez: aria-live, aria-describedby, role = alert, etab.).",
+				"plural": "aria-errormessagen, bailioa  ${data.values}`, mezua iragartzeko teknika bat erabili behar da (adibidez: aria-live, aria-describedby, role = alert, etab.)."
+			}
 		},
 		"has-widget-role": {
 			"pass": "Elementuak widget rola du.",
@@ -350,45 +362,69 @@
 		},
 		"no-implicit-explicit-label": {
 			"pass": "Ez dago desadostasunik <label> baten eta izen irisgarriaren artean",
-			"incomplete": "Egiaztatu < label> zenbakiak ez duela zertan ARIAren {{=it.data}} parte izan eremuaren izenerako"
+			"incomplete": "Egiaztatu < label> zenbakiak ez duela zertan ARIAren ${data} parte izan eremuaren izenerako"
 		},
 		"aria-required-attr": {
 			"pass": "ARIA atributu guztiak daude",
-			"fail": "{{=it.data && it.data.length > 1 ? 'Eskatutako atributuak ez daude' : 'Eskatutako atributua ez dago'}}:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Eskatutako atributuak ez daude: ${data.values}",
+				"plural": "Eskatutako atributua ez dago: ${data.values}"
+			}
 		},
 		"aria-required-children": {
 			"pass": "Eskatutako ARIA semeak bertan daude",
-			"fail": "Esktatutako ARIARren {{=it.data && it.data.length > 1 ? 'semeak ez daude' : 'semeaez dago'}} :{{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "ARIA rola {{=it.data && it.data.length > 1 ? 'semeentzako' : 'semearentzako'}}:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Esktatutako ARIARren semeak ez daude : ${data.values}",
+				"plural": "Esktatutako ARIARren semeaez dago : ${data.values}"
+			},
+			"incomplete": {
+				"singular": "ARIA rola semeentzako: ${data.values}",
+				"plural": "ARIA rola semearentzako: ${data.values}"
+			}
 		},
 		"aria-required-parent": {
 			"pass": "ARIAn eskatzen den aitaren rola bertan dago",
-			"fail": "ARIAn eskatutako {{=it.data && it.data.length > 1 ? 'aitentzako rola ' : 'aitarentzako rola'}} ez dago:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "ARIAn eskatutako aitentzako rola  ez dago: ${data.values}",
+				"plural": "ARIAn eskatutako aitarentzako rola ez dago: ${data.values}"
+			}
 		},
 		"aria-unsupported-attr": {
 			"pass": "ARIA atributua onartuta dago",
-			"fail": "ARIA atributua ez dago oso onartuta pantaila-irakurgailuetan eta laguntza-teknologietan: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "ARIA atributua ez dago oso onartuta pantaila-irakurgailuetan eta laguntza-teknologietan:  ${data.values}"
 		},
 		"unsupportedrole": {
 			"pass": "ARIA rola onartuta dago",
-			"fail": "Erabilitako rola ez dago oso onartuta pantaila-irakurgailuetan eta laguntza-teknologietan: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "Erabilitako rola ez dago oso onartuta pantaila-irakurgailuetan eta laguntza-teknologietan:  ${data.values}"
 		},
 		"aria-valid-attr-value": {
 			"pass": "ARIA atributuen balioak baliozkoak dira",
-			"fail": "{{=it.data && it.data.length > 1 ? 'Balioak ez dira baliozkoak ARIA atributorako' : 'Balioa ez da baliozkoa ARIA atributorako'}}:{{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "{=it.data && it.data.length > 1 ? 'Elementuen atributua' : 'Elementuaren atributua}}  ARIA ID ez dago orrian:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": {
+				"singular": "Balioak ez dira baliozkoak ARIA atributorako: ${data.values}",
+				"plural": "Balioa ez da baliozkoa ARIA atributorako: ${data.values}"
+			},
+			"incomplete": {
+				"singular": "Elementuen atributua  ARIA ID ez dago orrian: ${data.values}",
+				"plural": "Elementuaren atributua  ARIA ID ez dago orrian: ${data.values}"
+			}
 		},
 		"aria-valid-attr": {
-			"pass": "{{=it.data && it.data.length > 1 ? 'Baliozko ARIA atributuen izenak' : 'Baliozko ARIA atributuen izena'}}",
-			"fail": "{{=it.data && it.data.length > 1 ? 'Baliogabeko ARIA atributuen izenak' : 'Baliogabeko ARIA atributuen izenak'}}: {{~it.data:value}} {{=value}}{{~}}"
+			"pass": {
+				"singular": "Baliozko ARIA atributuen izenak",
+				"plural": "Baliozko ARIA atributuen izena"
+			},
+			"fail": {
+				"singular": "Baliogabeko ARIA atributuen izenak:  ${data.values}",
+				"plural": "Baliogabeko ARIA atributuen izenak:  ${data.values}"
+			}
 		},
 		"valid-scrollable-semantics": {
 			"pass": "Elementuak semantika balioduna du foku-ordenan dagoen elementu batentzat.",
 			"fail": "Elementuak foku-ordenan dagoen elementu batentzat baliozkoa ez den semantika bat du.."
 		},
 		"color-contrast": {
-			"pass": "Elementuak {{=it.data.contrastRatio}}-ko kolore-kontraste nahikoa du",
-			"fail": "Elementuaren {{=it.data.contrastRatio}}-ko kolore-kontrastea ez da nahikoa (ehen planoaren kolorea: {{=it.data.fgColor}}, hondoaren kolorea: {{=it.data.bgColor}}, letra-iturriaren tamaina: {{=it.data.fontSize}}, letra-iturriaren lodiera: {{=it.data.fontWeight}}). Espero den kontraste-ratioa: {{=it.data.expectedContrastRatio}}",
+			"pass": "Elementuak ${data.contrastRatio}-ko kolore-kontraste nahikoa du",
+			"fail": "Elementuaren ${data.contrastRatio}-ko kolore-kontrastea ez da nahikoa (ehen planoaren kolorea: ${data.fgColor}, hondoaren kolorea: ${data.bgColor}, letra-iturriaren tamaina: ${data.fontSize}, letra-iturriaren lodiera: ${data.fontWeight}). Espero den kontraste-ratioa: ${data.expectedContrastRatio}",
 			"incomplete": {
 				"bgImage": "Elementuaren hondoko kolorea ezin izan da zehaztu, hondoko irudi batengatik",
 				"bgGradient": "Elementuaren hondoko kolorea ezin izan da zehaztu hondoko degradatu baten ondorioz",
@@ -448,8 +484,8 @@
 			"fail": "Fokuak onartzen duen edukiak tabindex = '-1' izan beharko luke edo DOMetik ezabatu beharko litzateke"
 		},
 		"landmark-is-top-level": {
-			"pass": "{{=it.data.role }} erreferentzia-puntua goiko mailan dago",
-			"fail": "{{=it.data.role }} erreferentzia-puntua beste erreferentzia-puntu batean dago."
+			"pass": "${data.role} erreferentzia-puntua goiko mailan dago",
+			"fail": "${data.role} erreferentzia-puntua beste erreferentzia-puntu batean dago."
 		},
 		"page-has-heading-one": {
 			"pass": "Orrialdeak 1. mailako goiburu bat du, gutxienez.",
@@ -567,7 +603,7 @@
 		},
 		"meta-viewport": {
 			"pass": "<meta> etiketak ez du zoom eragozten gailu mugikorretan",
-			"fail": "{{=it.data}} < meta> etiketan, gailu mugikorretan zoom-a eragozten du"
+			"fail": "${data} < meta> etiketan, gailu mugikorretan zoom-a eragozten du"
 		},
 		"header-present": {
 			"pass": "Orriak 'header' bat dauka",
@@ -608,11 +644,11 @@
 		},
 		"duplicate-id-active": {
 			"pass": "Dokumentuak ez dauka id atributu bera partekatzen duen elementu aktiborik",
-			"fail": "Dokumentuak elementu aktiboak ditu, id atributu berarekin: {{=it.data}}"
+			"fail": "Dokumentuak elementu aktiboak ditu, id atributu berarekin: ${data}"
 		},
 		"duplicate-id-aria": {
 			"pass": "Dokumentuak ez dauka id atributu bera partekatzen duen Aari edo etiketekin lotutako elementurik",
-			"fail": "Dokumentuak hainbat elementu ditu, id atributu bereko aria batekin lotuta: {{=it.data}}"
+			"fail": "Dokumentuak hainbat elementu ditu, id atributu bereko aria batekin lotuta: ${data}"
 		},
 		"duplicate-id": {
 			"pass": "Dokumentuak ez dauka id atributu bera partekatzen duen elementu estatikorik",
@@ -628,7 +664,10 @@
 		},
 		"avoid-inline-spacing": {
 			"pass": "Ez da testu-tarteari eragiten dion '!important' estilorik zehaztu.",
-			"fail": "Ezabatu '!important' inline style{{=it.data && it.data.length > 1 ? 'etatik' : 'tik'}} {{=it.data.join(', ')}}, nabigatzaile gehienetan ez delako onartzen baliogabetzea."
+			"fail": {
+				"singular": "Ezabatu '!important' inline styleetatik )}}', ')}}, nabigatzaile gehienetan ez delako onartzen baliogabetzea.",
+				"plural": "Ezabatu '!important' inline styletik )}}', ')}}, nabigatzaile gehienetan ez delako onartzen baliogabetzea."
+			}
 		},
 		"button-has-visible-text": {
 			"pass": "Elementuak pantaila-irakurgailuek ikusteko moduko barne-testua du.",
@@ -659,7 +698,10 @@
 			"fail": "Elementuak ez du alt atributurik edo alt atributua hutsik dago"
 		},
 		"non-empty-if-present": {
-			"pass": "{{?it.data}} elementuak hutsik ez dagoen balio-atributua du {??}}, eta ez du {{?}} balio-atributurik",
+			"pass": {
+				"default": ", eta ez du  balio-atributurik",
+				"has-label": "elementuak hutsik ez dagoen balio-atributua du  balio-atributurik"
+			},
 			"fail": "Elementuak balio-atributua du, eta balio-atributua hutsik dago"
 		},
 		"non-empty-title": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -422,7 +422,10 @@
 			}
 		},
 		"aria-valid-attr": {
-			"pass": "{{=it.data && it.data.length > 1 ? 'Les noms d’attributs ARIA sont valides' : 'Le nom d’attribut ARIA est valide'}}",
+			"pass": {
+				"singular": "Les noms d’attributs ARIA sont valides",
+				"plural": "Le nom d’attribut ARIA est valide"
+			},
 			"fail": {
 				"singular": "Le nom d’attribut ARIA est invalide: ${data.values}",
 				"plural": "Les noms d’attributs ARIA sont invalides: ${data.values}"
@@ -433,8 +436,8 @@
 			"fail": "L’élément n’a pas une sémantique valide pour un élément dans l’ordre de tabulation."
 		},
 		"color-contrast": {
-			"pass": "L’élément a un contraste de couleurs suffisant de {{=it.data.contrastRatio}}",
-			"fail": "L’élément a un contraste de couleurs insuffisant de {{=it.data.contrastRatio}} (couleur du texte : {{=it.data.fgColor}}, couleur d’arrière-plan : {{=it.data.bgColor}}, corps : {{=it.data.fontSize}}, graisse : {{=it.data.fontWeight}}). Le rapport de contraste attendu est {{=it.data.expectedContrastRatio}}",
+			"pass": "L’élément a un contraste de couleurs suffisant de ${data.contrastRatio}",
+			"fail": "L’élément a un contraste de couleurs insuffisant de ${data.contrastRatio} (couleur du texte : ${data.fgColor}, couleur d’arrière-plan : ${data.bgColor}, corps : ${data.fontSize}, graisse : ${data.fontWeight}). Le rapport de contraste attendu est ${data.expectedContrastRatio}",
 			"incomplete": {
 				"default": "Impossible de déterminer le rapport de contraste",
 				"bgImage": "La couleur d’arrière-plan de l’élément n’a pu être déterminée à cause d’une image d’arrière-plan",
@@ -494,8 +497,8 @@
 			"fail": "Le contenu focalisable devrait se voir assigné un tabindex='-1' ou être retiré du DOM"
 		},
 		"landmark-is-top-level": {
-			"pass": "La région {{=it.data.role }} est au niveau le plus haut.",
-			"fail": "La région {{=it.data.role }} est contenue dans une autre région."
+			"pass": "La région ${data.role} est au niveau le plus haut.",
+			"fail": "La région ${data.role} est contenue dans une autre région."
 		},
 		"page-has-heading-one": {
 			"pass": "La page a au moins un titre de niveau un",
@@ -668,7 +671,7 @@
 		},
 		"duplicate-id": {
 			"pass": "Le document n’a pas d’éléments qui partagent le même attribut id",
-			"fail": "Le document a plusieurs éléments avec le même attribut id : {{=it.data}}"
+			"fail": "Le document a plusieurs éléments avec le même attribut id : ${data}"
 		},
 		"aria-label": {
 			"pass": "L’attribut aria-label existe et n’est pas vide",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -397,7 +397,7 @@
 		},
 		"no-implicit-explicit-label": {
 			"pass": "<label> とアクセシブルな名前の間に不一致はありません",
-			"incomplete": "<label> が ARIA {{=it.data}} 欄の名前の一部である必要がないことを確認しましょう"
+			"incomplete": "<label> が ARIA ${data} 欄の名前の一部である必要がないことを確認しましょう"
 		},
 		"aria-required-attr": {
 			"pass": "すべての必須のARIA属性が存在しています",
@@ -426,11 +426,11 @@
 		},
 		"aria-unsupported-attr": {
 			"pass": "ARIA属性はサポートされています",
-			"fail": "ARIA属性はスクリーン・リーダーや支援技術に広くサポートされていません: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "ARIA属性はスクリーン・リーダーや支援技術に広くサポートされていません: ${data.values}"
 		},
 		"unsupportedrole": {
 			"pass": "ARIAロールはサポートされています",
-			"fail": "使用されているロールはスクリーン・リーダーや支援技術に広くサポートされていません: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "使用されているロールはスクリーン・リーダーや支援技術に広くサポートされていません: ${data.values}"
 		},
 		"aria-valid-attr-value": {
 			"pass": "ARIA属性値が有効です",
@@ -455,8 +455,8 @@
 			"fail": "要素はフォーカス順序に含まれる要素に対して無効なセマンティクスを持ちます"
 		},
 		"color-contrast": {
-			"pass": "要素には{{=it.data.contrastRatio}}の十分なコントラスト比があります",
-			"fail": "要素のコントラスト比が不十分です {{=it.data.contrastRatio}}（前景色: {{=it.data.fgColor}}、背景色: {{=it.data.bgColor}}、フォントサイズ: {{=it.data.fontSize}}、フォントの太さ: {{=it.data.fontWeight}}）。コントラスト比{{=it.data.expectedContrastRatio}}を必要とします",
+			"pass": "要素には${data.contrastRatio}の十分なコントラスト比があります",
+			"fail": "要素のコントラスト比が不十分です ${data.contrastRatio}（前景色: ${data.fgColor}、背景色: ${data.bgColor}、フォントサイズ: ${data.fontSize}、フォントの太さ: ${data.fontWeight}）。コントラスト比${data.expectedContrastRatio}を必要とします",
 			"incomplete": {
 				"default": "コントラスト比を判定できません",
 				"bgImage": "背景画像のため、要素の背景色を判定できません",
@@ -521,8 +521,8 @@
 			"fail": "フォーカス可能なコンテンツは tabindex='-1' を指定するか、DOMから削除するべきです"
 		},
 		"landmark-is-top-level": {
-			"pass": "{{=it.data.role }} ランドマークはトップレベルにあります",
-			"fail": "{{=it.data.role }} ランドマークが他のランドマークに含まれています"
+			"pass": "${data.role} ランドマークはトップレベルにあります",
+			"fail": "${data.role} ランドマークが他のランドマークに含まれています"
 		},
 		"page-has-heading-one": {
 			"pass": "ページには少なくとも1つのレベル1の見出しがあります",
@@ -651,7 +651,7 @@
 		},
 		"meta-viewport": {
 			"pass": "<meta>タグはモバイルデバイスでの拡大を無効にしません",
-			"fail": "<meta>タグの{{=it.data}}がモバイルデバイスでの拡大を無効にします"
+			"fail": "<meta>タグの${data}がモバイルデバイスでの拡大を無効にします"
 		},
 		"header-present": {
 			"pass": "ページにheaderが存在しています",
@@ -696,11 +696,11 @@
 		},
 		"duplicate-id-active": {
 			"pass": "ドキュメントに同じid属性を持つ有効な要素はありません",
-			"fail": "ドキュメントに同じid属性を持つ有効な要素があります: {{=it.data}}"
+			"fail": "ドキュメントに同じid属性を持つ有効な要素があります: ${data}"
 		},
 		"duplicate-id-aria": {
 			"pass": "ドキュメントに同じid属性を持つARIAまたはラベルに参照された要素はありません",
-			"fail": "ドキュメントに同じid属性を持つARIAに参照された複数の要素があります: {{=it.data}}"
+			"fail": "ドキュメントに同じid属性を持つARIAに参照された複数の要素があります: ${data}"
 		},
 		"duplicate-id": {
 			"pass": "ドキュメントに同じid属性を共有する静的な要素はありません",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -338,7 +338,7 @@
 		},
 		"aria-errormessage": {
 			"pass": "지원되고 있는 aria-errormessage 기술을 사용하고 있습니다.",
-			"fail": "aria-errormessage 값{{~it.data:value}} {=value}{{~}}는 메시지를 공지하는 방법을 사용해야 합니다.(예를 들어, aria-live, aria-describedby,role=alert 등)"
+			"fail": "aria-errormessage 값 ${data.values}는 메시지를 공지하는 방법을 사용해야 합니다.(예를 들어, aria-live, aria-describedby,role=alert 등)"
 		},
 		"has-widget-role": {
 			"pass": "요소에 widget 역할이 ​​있습니다.",
@@ -350,7 +350,7 @@
 		},
 		"no-implicit-explicit-label": {
 			"pass": "<label>과 접근 가능한 이름이 일치하지 않습니다.",
-			"incomplete": "<label>이 ARIA {{=it.data}} 필드 이름의 일부일 필요는 없는지 확인하세요."
+			"incomplete": "<label>이 ARIA ${data} 필드 이름의 일부일 필요는 없는지 확인하세요."
 		},
 		"aria-required-attr": {
 			"description": "ARIA 역할을 가진 요소가 모든 필수 ARIA 속성을 갖도록 합니다.",
@@ -358,37 +358,37 @@
 		},
 		"aria-required-children": {
 			"pass": "필수적인 ARIA 역할이 존재합니다.",
-			"fail": "필수적인 ARIA 역할이 제공되지 않고 있습니다: {{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "ARIA의 자손 역할이 추가되어야 합니다: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "필수적인 ARIA 역할이 제공되지 않고 있습니다:  ${data.values}",
+			"incomplete": "ARIA의 자손 역할이 추가되어야 합니다:  ${data.values}"
 		},
 		"aria-required-parent": {
 			"pass": "필수적인 ARIA 역할이 존재합니다.",
-			"fail": "필수적인 ARIA 역할이 제공되지 않고 있습니다: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "필수적인 ARIA 역할이 제공되지 않고 있습니다:  ${data.values}"
 		},
 		"aria-unsupported-attr": {
 			"pass": "사용된 ARIA 속성은 지원되고 있습니다.",
-			"fail": "사용된 ARIA 속성은 스크린 리더나 보조 기술에 널리 지원되지 않고 있습니다: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "사용된 ARIA 속성은 스크린 리더나 보조 기술에 널리 지원되지 않고 있습니다:  ${data.values}"
 		},
 		"unsupportedrole": {
 			"pass": "사용된 ARIA 역할이 지원됩니다.",
-			"fail": "사용된 ARIA 속성은 스크린 리더나 보조 기술에 널리 지원되지 않고 있습니다.: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "사용된 ARIA 속성은 스크린 리더나 보조 기술에 널리 지원되지 않고 있습니다.:  ${data.values}"
 		},
 		"aria-valid-attr-value": {
 			"pass": "ARIA 속성이 유효합니다.",
-			"fail": "무효인 ARIA 속성입니다:{{~it.data:value}} {{=value}}{{~}}",
-			"incomplete": "페이지에 ARIA 속성의 요소 ID가 존재하지 않습니다:{{~it.data:value}} {{=value}}{{~}}"
+			"fail": "무효인 ARIA 속성입니다: ${data.values}",
+			"incomplete": "페이지에 ARIA 속성의 요소 ID가 존재하지 않습니다: ${data.values}"
 		},
 		"aria-valid-attr": {
 			"pass": "ARIA 속성명이 유효합니다.",
-			"fail": "무효인 ARIA 속성명 입니다: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "무효인 ARIA 속성명 입니다:  ${data.values}"
 		},
 		"valid-scrollable-semantics": {
 			"pass": "요소는 포커스 순서에서 요소에 대한 유효한 의미를 갖습니다.",
 			"fail": "요소의 포커스 순서에서 요소에 대한 의미가 유효하지 않습니다."
 		},
 		"color-contrast": {
-			"pass": "{{=it.data.contrastRatio}} 요소의 색상 대비가 충분합니다.",
-			"fail": "{{=it.data.contrastRatio}} 요소의 색상 대비가 충분하지 않습니다. (foreground color: {{=it.data.fgColor}}, background color: {{=it.data.bgColor}}, font size: {{=it.data.fontSize}}, font weight: {{=it.data.fontWeight}}). {{=it.data.expectedContrastRatio}} 예상 대비 비율",
+			"pass": "${data.contrastRatio} 요소의 색상 대비가 충분합니다.",
+			"fail": "${data.contrastRatio} 요소의 색상 대비가 충분하지 않습니다. (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). ${data.expectedContrastRatio} 예상 대비 비율",
 			"incomplete": {
 				"bgImage": "배경 이미지로 인해 요소의 배경색을 확인할 수 없습니다.",
 				"bgGradient": "배경 그라데이션으로 인해 요소의 배경색을 결정할 수 없습니다.",
@@ -448,8 +448,8 @@
 			"fail": "포커스 가능 콘텐츠는 tabindex='-1' 이거나 DOM에서 제거 되어야 합니다."
 		},
 		"landmark-is-top-level": {
-			"pass": "{{=it.data.role }} 랜드마크가 최상위 레벨에 있습니다.",
-			"fail": "{{=it.data.role } 랜드마크는 다른 랜드마크에 포함되어 있습니다."
+			"pass": "${data.role} 랜드마크가 최상위 레벨에 있습니다.",
+			"fail": "${data.role} 랜드마크는 다른 랜드마크에 포함되어 있습니다."
 		},
 		"page-has-heading-one": {
 			"pass": "페이지에 하나 이상의 제목 레벨 1이 있습니다.",
@@ -567,7 +567,7 @@
 		},
 		"meta-viewport": {
 			"pass": "<meta> 태그는 모바일 장치에서 확대/축소를 비활성화하지 않습니다.",
-			"fail": "<meta> 태그의 {{= it.data}}는 모바일 장치에서 확대/축소를 사용하지 않습니다."
+			"fail": "<meta> 태그의 ${data}는 모바일 장치에서 확대/축소를 사용하지 않습니다."
 		},
 		"header-present": {
 			"pass": "페이지에 헤더가 있습니다.",
@@ -608,11 +608,11 @@
 		},
 		"duplicate-id-active": {
 			"pass": "문서에 같은 id 속성을 갖는 유효한 요소는 없습니다.",
-			"fail": "문서에 같은 id 속성을 갖는 유효한 요소가 있습니다: {{=it.data}}"
+			"fail": "문서에 같은 id 속성을 갖는 유효한 요소가 있습니다: ${data}"
 		},
 		"duplicate-id-aria": {
 			"pass": "문서에 ARIA로 참조된 요소나 동일한 id 속성을 공유하는 레이블이 없습니다.",
-			"fail": "동일한 id 속성을 가진 ARIA를 참조하는 여러 요소가 문서에 있습니다: {{=it.data}}"
+			"fail": "동일한 id 속성을 가진 ARIA를 참조하는 여러 요소가 문서에 있습니다: ${data}"
 		},
 		"duplicate-id": {
 			"pass": "문서에 동일한 id 속성을 공유하는 정적 요소가 없습니다.",
@@ -628,7 +628,10 @@
 		},
 		"avoid-inline-spacing": {
 			"pass": "텍스트 간격에 영향을 주는 '!important'를 가진 인라인 스타일이 지정되지 않았습니다.",
-			"fail": "인라인 스타일에서 '!important' 제거 {{=it.data && it.data.length > 1 ? 's' : ''}} {{=it.data.join(', ')}}, 이 항목을 재정의하는 것은 대부분의 브라우저에서 지원되지 않습니다."
+			"fail": {
+				"singular": "인라인 스타일에서 '!important' 제거 s )}}', ')}}, 이 항목을 재정의하는 것은 대부분의 브라우저에서 지원되지 않습니다.",
+				"plural": "인라인 스타일에서 '!important' 제거  )}}', ')}}, 이 항목을 재정의하는 것은 대부분의 브라우저에서 지원되지 않습니다."
+			}
 		},
 		"button-has-visible-text": {
 			"pass": "요소에는 스크린 리더에 표시되는 내부 텍스트가 있습니다.",
@@ -659,7 +662,10 @@
 			"fail": "요소에 alt 속성이 존재하지 않거나, alt 속성이 비어 있습니다."
 		},
 		"non-empty-if-present": {
-			"pass": "요소 {{?it.data}} 비어 있지 않은 값 속성이 있습니다{{??}}값 속성이 없습니다{{?}}",
+			"pass": {
+				"default": "요소 값 속성이 없습니다",
+				"has-label": "요소 비어 있지 않은 값 속성이 있습니다"
+			},
 			"fail": "요소에 value 속성이 존재하고, value 속성이 비어있습니다."
 		},
 		"non-empty-title": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -629,8 +629,8 @@
 		"avoid-inline-spacing": {
 			"pass": "텍스트 간격에 영향을 주는 '!important'를 가진 인라인 스타일이 지정되지 않았습니다.",
 			"fail": {
-				"singular": "인라인 스타일에서 '!important' 제거 s )}}', ')}}, 이 항목을 재정의하는 것은 대부분의 브라우저에서 지원되지 않습니다.",
-				"plural": "인라인 스타일에서 '!important' 제거  )}}', ')}}, 이 항목을 재정의하는 것은 대부분의 브라우저에서 지원되지 않습니다."
+				"singular": "인라인 스타일에서 '!important' 제거 s ${data.values}, 이 항목을 재정의하는 것은 대부분의 브라우저에서 지원되지 않습니다.",
+				"plural": "인라인 스타일에서 '!important' 제거  ${data.values}, 이 항목을 재정의하는 것은 대부분의 브라우저에서 지원되지 않습니다."
 			}
 		},
 		"button-has-visible-text": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -6,8 +6,8 @@
 			"fail": "Gebruik geen abstracte rollen (role)"
 		},
 		"color-contrast": {
-			"pass": "Element heeft voldoende contrast, namelijk {{=it.data.contrastRatio}}",
-			"fail": "Element heeft onvoldoende contrast, {{=it.data.contrastRatio}} (Voorgrondkleur: {{=it.data.fgColor}}, achtergrondkleur: {{=it.data.bgColor}}, tekstgrootte: {{=it.data.fontSize}}, tekstdikte: {{=it.data.fontWeight}})",
+			"pass": "Element heeft voldoende contrast, namelijk ${data.contrastRatio}",
+			"fail": "Element heeft onvoldoende contrast, ${data.contrastRatio} (Voorgrondkleur: ${data.fgColor}, achtergrondkleur: ${data.bgColor}, tekstgrootte: ${data.fontSize}, tekstdikte: ${data.fontWeight})",
 			"incomplete": {
 				"bgImage": "Element's achtergrondkleur kon niet worden bepaald vanwegen een achtergrondafbeelding",
 				"bgGradient": "Element's achtergrondkleur kon niet worden bepaald vanwegen een gradient kleur",

--- a/locales/pt_BR.json
+++ b/locales/pt_BR.json
@@ -397,7 +397,7 @@
 		},
 		"no-implicit-explicit-label": {
 			"pass": "Não há nenhuma divergência entre <label> e o nome acessível",
-			"incomplete": "Verifique se o <label> não precisa fazer parte do nome do campo ARIA {{=it.data}}"
+			"incomplete": "Verifique se o <label> não precisa fazer parte do nome do campo ARIA ${data}"
 		},
 		"aria-required-attr": {
 			"pass": "Todos os atributos ARIA necessários estão presentes",
@@ -426,11 +426,11 @@
 		},
 		"aria-unsupported-attr": {
 			"pass": "O atributo ARIA é suportado",
-			"fail": "O atributo ARIA não é amplamente suportado em leitores de tela e tecnologias assistivas: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "O atributo ARIA não é amplamente suportado em leitores de tela e tecnologias assistivas:  ${data.values}"
 		},
 		"unsupportedrole": {
 			"pass": "O ARIA 'role' é suportado",
-			"fail": "O 'role' usado não é amplamente suportado em leitores de tela e tecnologias assistivas: {{~it.data:value}} {{=value}}{{~}}"
+			"fail": "O 'role' usado não é amplamente suportado em leitores de tela e tecnologias assistivas:  ${data.values}"
 		},
 		"aria-valid-attr-value": {
 			"pass": "Os valores dos atributos ARIA são válidos",
@@ -444,7 +444,10 @@
 			}
 		},
 		"aria-valid-attr": {
-			"pass": "{{=it.data && it.data.length > 1 ? 'Os nomes dos atributos ARIA são válidos' : 'O nome do atributo ARIA é valido'}}",
+			"pass": {
+				"singular": "Os nomes dos atributos ARIA são válidos",
+				"plural": "O nome do atributo ARIA é valido"
+			},
 			"fail": {
 				"singular": "Nome de atributo ARIA inválido: ${data.values}",
 				"plural": "Nomes de atributos ARIA inválidos: ${data.values}"
@@ -455,8 +458,8 @@
 			"fail": "O elemento possui semântica inválida para um elemento na ordem de foco."
 		},
 		"color-contrast": {
-			"pass": "O elemento tem contraste suficiente no valor de {{=it.data.contrastRatio}}",
-			"fail": "O elemento tem contraste insuficiente no valor de {{=it.data.contrastRatio}} (cor do primeiro plano: {{=it.data.fgColor}}, cor de fundo: {{=it.data.bgColor}}, tamanho da fonte: {{=it.data.fontSize}}, normal/negrito: {{=it.data.fontWeight}}). Contraste esperado no valor de {{=it.data.expectedContrastRatio}}",
+			"pass": "O elemento tem contraste suficiente no valor de ${data.contrastRatio}",
+			"fail": "O elemento tem contraste insuficiente no valor de ${data.contrastRatio} (cor do primeiro plano: ${data.fgColor}, cor de fundo: ${data.bgColor}, tamanho da fonte: ${data.fontSize}, normal/negrito: ${data.fontWeight}). Contraste esperado no valor de ${data.expectedContrastRatio}",
 			"incomplete": {
 				"default": "Impossível determinar o contraste",
 				"bgImage": "A cor de fundo do elemento não pôde ser determinada devido a uma imagem de fundo",
@@ -521,8 +524,8 @@
 			"fail": "Conteúdo focalizável deve ter tabindex='-1' ou ser removido do DOM"
 		},
 		"landmark-is-top-level": {
-			"pass": "A região {{=it.data.role }} está no nível principal.",
-			"fail": "A região {{=it.data.role }} está contida em outra região."
+			"pass": "A região ${data.role} está no nível principal.",
+			"fail": "A região ${data.role} está contida em outra região."
 		},
 		"page-has-heading-one": {
 			"pass": "A página tem pelo menos um título de primeiro nível",
@@ -651,7 +654,7 @@
 		},
 		"meta-viewport": {
 			"pass": "A tag <meta> não desabilita o zoom em dispositivos móveis",
-			"fail": "{{=it.data}} na tag <meta> desabilita o zoom em dispositivos móveis"
+			"fail": "${data} na tag <meta> desabilita o zoom em dispositivos móveis"
 		},
 		"header-present": {
 			"pass": "A página tem um cabeçalho (header)",
@@ -696,11 +699,11 @@
 		},
 		"duplicate-id-active": {
 			"pass": "O documento não tem elementos ativos que compartilham o mesmo atributo 'id'",
-			"fail": "O documento tem elementos ativos com o mesmo atributo 'id': {{=it.data}}"
+			"fail": "O documento tem elementos ativos com o mesmo atributo 'id': ${data}"
 		},
 		"duplicate-id-aria": {
 			"pass": "O documento não tem elementos referenciados com ARIA ou rótulos que compartilham o mesmo atributo 'id'",
-			"fail": "O documento tem múltiplos elementos referenciados com ARIA com o mesmo atributo 'id': {{=it.data}}"
+			"fail": "O documento tem múltiplos elementos referenciados com ARIA com o mesmo atributo 'id': ${data}"
 		},
 		"duplicate-id": {
 			"pass": "O documento não tem elementos estáticos que compartilham o mesmo atributo 'id'",


### PR DESCRIPTION
Used a script to auto-convert each file. 

Note: the `failureSummaries` section is not converted as we didn't even do it in the English version. Looking at it I'm not sure what the appropriate value should be so we'll need to discuss that before we merge this in. Here's what it currently looks like:

```js
"failureMessage": "Fix any of the following:{{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}
```

Closes issue: #2190

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
