### PR TITLE
chore: remove noScroll option from color-contrast

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -406,7 +406,6 @@ Additionally, there are a number or properties that allow configuration of diffe
 | `absolutePaths`    | `false` | Use absolute paths when creating element selectors                                                                                      |
 | `iframes`          | `true`  | Tell axe to run inside iframes                                                                                                          |
 | `elementRef`       | `false` | Return element references in addition to the target                                                                                     |
-| `restoreScroll`    | `false` | Scrolls elements back to before axe started                                                                                             |
 | `frameWaitTime`    | `60000` | How long (in milliseconds) axe waits for a response from embedded frames before timing out                                              |
 | `preload`          | `true`  | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
 | `performanceTimer` | `false` | Log rule performance metrics to the console                                                                                             |

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -43,7 +43,7 @@ function colorContrastEvaluate(node, options, virtualNode) {
 	}
 
 	const bgNodes = [];
-	const bgColor = getBackgroundColor(node, bgNodes, false);
+	const bgColor = getBackgroundColor(node, bgNodes);
 	const fgColor = getForegroundColor(node, false, bgColor);
 
 	const nodeStyle = window.getComputedStyle(node);

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -39,8 +39,10 @@ function getOpacity(node) {
  * @param {Boolean} noScroll (default false)
  * @param {Color} bgColor
  * @return {Color|null}
+ *
+ * @deprecated noScroll parameter
  */
-function getForegroundColor(node, noScroll, bgColor) {
+function getForegroundColor(node, _, bgColor) {
 	const nodeStyle = window.getComputedStyle(node);
 
 	const fgColor = new Color();
@@ -52,7 +54,7 @@ function getForegroundColor(node, noScroll, bgColor) {
 	}
 
 	if (!bgColor) {
-		bgColor = getBackgroundColor(node, [], noScroll);
+		bgColor = getBackgroundColor(node, []);
 	}
 
 	if (bgColor === null) {

--- a/lib/core/public/run-rules.js
+++ b/lib/core/public/run-rules.js
@@ -5,8 +5,6 @@ import {
 	queue,
 	performanceTimer,
 	collectResultsFromFrames,
-	getScrollState,
-	setScrollState,
 	mergeResults,
 	publishMetaData,
 	finalizeRuleResult
@@ -59,18 +57,11 @@ function runRules(context, options, resolve, reject) {
 			collectResultsFromFrames(context, options, 'rules', null, res, rej);
 		});
 	}
-	let scrollState;
 	q.defer(function(res, rej) {
-		if (options.restoreScroll) {
-			scrollState = getScrollState();
-		}
 		audit.run(context, options, res, rej);
 	});
 	q.then(function(data) {
 		try {
-			if (scrollState) {
-				setScrollState(scrollState);
-			}
 			if (options.performanceTimer) {
 				performanceTimer.auditEnd();
 			}

--- a/test/core/public/run.js
+++ b/test/core/public/run.js
@@ -385,53 +385,6 @@ describe('axe.run', function() {
 			);
 		});
 	});
-
-	describe.skip('option restoreScroll', function() {
-		it('does not change scroll when restoreScroll is not set', function(done) {
-			var calls = 0;
-			var _getSS = axe.utils.getScrollState;
-			var _setSS = axe.utils.setScrollState;
-			axe.utils.setScrollState = function() {
-				calls++;
-			};
-			axe.utils.getScrollState = axe.utils.setScrollState;
-
-			axe.run('#fixture', {}, function() {
-				assert.equal(calls, 0);
-				axe.utils.getScrollState = _getSS;
-				axe.utils.setScrollState = _setSS;
-				done();
-			});
-		});
-
-		it('resets scrolLState after running the audit', function(done) {
-			var scrollState = {};
-			var calls = 0;
-			var _getSS = axe.utils.getScrollState;
-			var _setSS = axe.utils.setScrollState;
-
-			axe.utils.setScrollState = function(arg) {
-				assert.equal(scrollState, arg);
-				calls++;
-			};
-			axe.utils.getScrollState = function() {
-				return scrollState;
-			};
-
-			axe.run(
-				'#fixture',
-				{
-					restoreScroll: true
-				},
-				function() {
-					assert.equal(calls, 1);
-					axe.utils.getScrollState = _getSS;
-					axe.utils.setScrollState = _setSS;
-					done();
-				}
-			);
-		});
-	});
 });
 
 describe('axe.run iframes', function() {


### PR DESCRIPTION
Note: the comment is more for us internally as a way to remind us to remove it at some point. The option is actually inert but the public API still accepts it as a parameter.

Closes issue: #2388

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
