### PR TITLE
chore: resolve most es-modules todo

### DIFF
--- a/lib/commons/aria/get-element-unallowed-roles.js
+++ b/lib/commons/aria/get-element-unallowed-roles.js
@@ -2,6 +2,7 @@ import isValidRole from './is-valid-role';
 import getImplicitRole from './implicit-role';
 import getRoleType from './get-role-type';
 import isAriaRoleAllowedOnElement from './is-aria-role-allowed-on-element';
+import { tokenList, isHtmlElement, matchesSelector } from '../../core/utils';
 
 // dpub roles which are subclassing roles that are implicit on some native
 // HTML elements (img, link, etc.)
@@ -32,22 +33,14 @@ function getRoleSegments(node) {
 	}
 
 	if (node.hasAttribute('role')) {
-		// TODO: es-module-utils.tokenList
-		const nodeRoles = axe.utils.tokenList(
-			node.getAttribute('role').toLowerCase()
-		);
+		const nodeRoles = tokenList(node.getAttribute('role').toLowerCase());
 		roles = roles.concat(nodeRoles);
 	}
 
 	if (node.hasAttributeNS('http://www.idpf.org/2007/ops', 'type')) {
-		// TODO: es-module-utils.tokenList
-		const epubRoles = axe.utils
-			.tokenList(
-				node
-					.getAttributeNS('http://www.idpf.org/2007/ops', 'type')
-					.toLowerCase()
-			)
-			.map(role => `doc-${role}`);
+		const epubRoles = tokenList(
+			node.getAttributeNS('http://www.idpf.org/2007/ops', 'type').toLowerCase()
+		).map(role => `doc-${role}`);
 
 		roles = roles.concat(epubRoles);
 	}
@@ -70,8 +63,7 @@ function getElementUnallowedRoles(node, allowImplicit = true) {
 	const tagName = node.nodeName.toUpperCase();
 
 	// by pass custom elements
-	// TODO: es-module-utils.isHtmlElement
-	if (!axe.utils.isHtmlElement(node)) {
+	if (!isHtmlElement(node)) {
 		return [];
 	}
 
@@ -102,8 +94,7 @@ function getElementUnallowedRoles(node, allowImplicit = true) {
 			!(
 				role === 'row' &&
 				tagName === 'TR' &&
-				// TODO: es-module-utils.matchesSelector
-				axe.utils.matchesSelector(node, 'table[role="grid"] > tr')
+				matchesSelector(node, 'table[role="grid"] > tr')
 			)
 		) {
 			return true;

--- a/lib/commons/aria/is-accessible-ref.js
+++ b/lib/commons/aria/is-accessible-ref.js
@@ -1,12 +1,13 @@
 import standards from '../../standards';
 import getRootNode from '../dom/get-root-node';
+import cache from '../../core/base/cache';
+import { tokenList } from '../../core/utils';
 
 const idRefsRegex = /^idrefs?$/;
 
 function cacheIdRefs(node, refAttrs) {
 	if (node.hasAttribute) {
-		// TODO: es-module-_cache
-		const idRefs = axe._cache.get('idRefs');
+		const idRefs = cache.get('idRefs');
 
 		if (node.nodeName.toUpperCase() === 'LABEL' && node.hasAttribute('for')) {
 			idRefs[node.getAttribute('for')] = true;
@@ -21,8 +22,7 @@ function cacheIdRefs(node, refAttrs) {
 
 			const attrValue = node.getAttribute(attr);
 
-			// TODO: es-module-utils.tokenList
-			const tokens = axe.utils.tokenList(attrValue);
+			const tokens = tokenList(attrValue);
 
 			for (let k = 0; k < tokens.length; ++k) {
 				idRefs[tokens[k]] = true;
@@ -48,9 +48,8 @@ function isAccessibleRef(node) {
 
 	// because axe.commons is not available in axe.utils, we can't do
 	// this caching when we build up the virtual tree
-	// TODO: es-module-_cache
-	if (!axe._cache.get('idRefs')) {
-		axe._cache.set('idRefs', {});
+	if (!cache.get('idRefs')) {
+		cache.set('idRefs', {});
 		// Get all idref(s) attributes on the lookup table
 		const refAttrs = Object.keys(standards.ariaAttrs).filter(attr => {
 			const { type } = standards.ariaAttrs[attr];
@@ -60,8 +59,7 @@ function isAccessibleRef(node) {
 		cacheIdRefs(root, refAttrs);
 	}
 
-	// TODO: es-module-_cache
-	return axe._cache.get('idRefs')[id] === true;
+	return cache.get('idRefs')[id] === true;
 }
 
 export default isAccessibleRef;

--- a/lib/commons/aria/label-virtual.js
+++ b/lib/commons/aria/label-virtual.js
@@ -1,6 +1,7 @@
 import idrefs from '../dom/idrefs';
 import visibleVirtual from '../text/visible-virtual';
 import sanitize from '../text/sanitize';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Gets the accessible ARIA label text of a given element
@@ -19,8 +20,7 @@ function labelVirtual(virtualNode) {
 		ref = idrefs(virtualNode.actualNode, 'aria-labelledby');
 		candidate = ref
 			.map(function(thing) {
-				// TODO: es-module-utils.getNodeFromTree
-				const vNode = axe.utils.getNodeFromTree(thing);
+				const vNode = getNodeFromTree(thing);
 				return vNode ? visibleVirtual(vNode, true) : '';
 			})
 			.join(' ')

--- a/lib/commons/aria/label.js
+++ b/lib/commons/aria/label.js
@@ -1,4 +1,5 @@
 import labelVirtual from './label-virtual';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Gets the aria label for a given node
@@ -9,8 +10,7 @@ import labelVirtual from './label-virtual';
  * @return {Mixed} String of visible text, or `null` if no label is found
  */
 function label(node) {
-	// TODO: es-module-utils.getNodeFromTree
-	node = axe.utils.getNodeFromTree(node);
+	node = getNodeFromTree(node);
 	return labelVirtual(node);
 }
 

--- a/lib/commons/aria/validate-attr-value.js
+++ b/lib/commons/aria/validate-attr-value.js
@@ -1,5 +1,6 @@
 import standards from '../../standards';
 import getRootNode from '../dom/get-root-node';
+import { tokenList } from '../../core/utils';
 
 /**
  * Validate the value of an ARIA attribute
@@ -36,8 +37,7 @@ function validateAttrValue(node, attr) {
 			);
 
 		case 'nmtokens':
-			// TODO: es-module-utils.tokenList
-			list = axe.utils.tokenList(value);
+			list = tokenList(value);
 			// Check if any value isn't in the list of values
 			return list.reduce(function(result, token) {
 				return result && attrInfo.values.includes(token);
@@ -48,8 +48,7 @@ function validateAttrValue(node, attr) {
 			return !!(value && doc.getElementById(value));
 
 		case 'idrefs':
-			// TODO: es-module-utils.tokenList
-			list = axe.utils.tokenList(value);
+			list = tokenList(value);
 			return list.some(token => doc.getElementById(token));
 
 		case 'string':

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -2,14 +2,14 @@ import Color from './color';
 import getBackgroundColor from './get-background-color';
 import incompleteData from './incomplete-data';
 import flattenColors from './flatten-colors';
+import { getNodeFromTree } from '../../core/utils';
 
 function getOpacity(node) {
 	if (!node) {
 		return 1;
 	}
 
-	// TODO: es-module-utils.getNodeFromTree
-	const vNode = axe.utils.getNodeFromTree(node);
+	const vNode = getNodeFromTree(node);
 
 	if (vNode && vNode._opacity !== undefined && vNode._opacity !== null) {
 		return vNode._opacity;

--- a/lib/commons/dom/find-up-virtual.js
+++ b/lib/commons/dom/find-up-virtual.js
@@ -1,3 +1,5 @@
+import { matchesSelector } from '../../core/utils';
+
 /**
  * recusively walk up the DOM, checking for a node which matches a selector
  *
@@ -33,8 +35,7 @@ function findUpVirtual(element, target) {
 		}
 	} while (
 		parent &&
-		// TODO: es-module-utils.matchesSelector
-		!axe.utils.matchesSelector(parent, target) &&
+		!matchesSelector(parent, target) &&
 		parent !== document.documentElement
 	);
 
@@ -42,8 +43,7 @@ function findUpVirtual(element, target) {
 		return null;
 	}
 
-	// TODO: es-module-utils.matchesSelector
-	if (!axe.utils.matchesSelector(parent, target)) {
+	if (!matchesSelector(parent, target)) {
 		return null;
 	}
 	return parent;

--- a/lib/commons/dom/find-up.js
+++ b/lib/commons/dom/find-up.js
@@ -1,4 +1,5 @@
 import findUpVirtual from './find-up-virtual';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Find the virtual node and call dom.fundUpVirtual
@@ -13,8 +14,7 @@ import findUpVirtual from './find-up-virtual';
  * @return {HTMLElement|null} Either the matching HTMLElement or `null` if there was no match
  */
 function findUp(element, target) {
-	// TODO: es-module-utils.getNodeFromTree
-	return findUpVirtual(axe.utils.getNodeFromTree(element), target);
+	return findUpVirtual(getNodeFromTree(element), target);
 }
 
 export default findUp;

--- a/lib/commons/dom/get-element-stack.js
+++ b/lib/commons/dom/get-element-stack.js
@@ -1,5 +1,6 @@
 import { createGrid, getRectStack } from './get-rect-stack';
 import { getNodeFromTree } from '../../core/utils';
+import cache from '../../core/base/cache';
 
 /**
  * Return all elements that are at the center bounding rect of the passed in node.
@@ -9,10 +10,9 @@ import { getNodeFromTree } from '../../core/utils';
  * @return {Node[]}
  */
 function getElementStack(node) {
-	// TODO: es-module-_cache
-	if (!axe._cache.get('gridCreated')) {
+	if (!cache.get('gridCreated')) {
 		createGrid();
-		axe._cache.set('gridCreated', true);
+		cache.set('gridCreated', true);
 	}
 
 	const vNode = getNodeFromTree(node);

--- a/lib/commons/dom/get-tabbable-elements.js
+++ b/lib/commons/dom/get-tabbable-elements.js
@@ -1,3 +1,5 @@
+import { querySelectorAll } from '../../core/utils';
+
 /**
  * Get all elements (including given node) that are part of the tab order
  * @method getTabbableElements
@@ -7,8 +9,7 @@
  * @return {Boolean}
  */
 function getTabbableElements(virtualNode) {
-	// TODO: es-module-utils.querySelectorAll
-	const nodeAndDescendents = axe.utils.querySelectorAll(virtualNode, '*');
+	const nodeAndDescendents = querySelectorAll(virtualNode, '*');
 
 	const tabbableElements = nodeAndDescendents.filter(vNode => {
 		const isFocusable = vNode.isFocusable;

--- a/lib/commons/dom/get-text-element-stack.js
+++ b/lib/commons/dom/get-text-element-stack.js
@@ -1,6 +1,8 @@
 import getElementStack from './get-element-stack';
 import { createGrid, getRectStack } from './get-rect-stack';
 import sanitize from '../text/sanitize';
+import cache from '../../core/base/cache';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Return all elements that are at the center of each text client rect of the passed in node.
@@ -10,14 +12,12 @@ import sanitize from '../text/sanitize';
  * @return {Array<Node[]>}
  */
 function getTextElementStack(node) {
-	// TODO: es-module-_cache
-	if (!axe._cache.get('gridCreated')) {
+	if (!cache.get('gridCreated')) {
 		createGrid();
-		axe._cache.set('gridCreated', true);
+		cache.set('gridCreated', true);
 	}
 
-	// TODO: es-module-utils.getNodeFromTree
-	const vNode = axe.utils.getNodeFromTree(node);
+	const vNode = getNodeFromTree(node);
 	const grid = vNode._grid;
 
 	if (!grid) {

--- a/lib/commons/dom/has-content.js
+++ b/lib/commons/dom/has-content.js
@@ -1,4 +1,5 @@
 import hasContentVirtual from './has-content-virtual';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Find virtual node and call hasContentVirtual()
@@ -13,8 +14,7 @@ import hasContentVirtual from './has-content-virtual';
  * @return {Boolean}
  */
 function hasContent(elm, noRecursion, ignoreAria) {
-	// TODO: es-module-utils.getNodeFromTree
-	elm = axe.utils.getNodeFromTree(elm);
+	elm = getNodeFromTree(elm);
 	return hasContentVirtual(elm, noRecursion, ignoreAria);
 }
 

--- a/lib/commons/dom/idrefs.js
+++ b/lib/commons/dom/idrefs.js
@@ -1,4 +1,5 @@
 import getRootNode from './get-root-node';
+import { tokenList } from '../../core/utils';
 
 /**
  * Get elements referenced via a space-separated token attribute;
@@ -25,8 +26,7 @@ function idrefs(node, attr) {
 		let attrValue = node.getAttribute(attr);
 
 		if (attrValue) {
-			// TODO: es-module-utils.tokenList
-			attrValue = axe.utils.tokenList(attrValue);
+			attrValue = tokenList(attrValue);
 			for (let index = 0; index < attrValue.length; index++) {
 				result.push(doc.getElementById(attrValue[index]));
 			}

--- a/lib/commons/dom/is-hidden-with-css.js
+++ b/lib/commons/dom/is-hidden-with-css.js
@@ -1,4 +1,5 @@
 import getComposedParent from './get-composed-parent';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Determine whether an element is hidden based on css
@@ -10,8 +11,7 @@ import getComposedParent from './get-composed-parent';
  * @return {Boolean} the element's hidden status
  */
 function isHiddenWithCSS(el, descendentVisibilityValue) {
-	// TODO: es-module-utils.getNodeFromTree
-	const vNode = axe.utils.getNodeFromTree(el);
+	const vNode = getNodeFromTree(el);
 
 	if (!vNode) {
 		return _isHiddenWithCSS(el, descendentVisibilityValue);

--- a/lib/commons/dom/is-in-text-block.js
+++ b/lib/commons/dom/is-in-text-block.js
@@ -1,5 +1,6 @@
 import getComposedParent from './get-composed-parent';
 import sanitize from '../text/sanitize';
+import { getNodeFromTree } from '../../core/utils';
 
 function walkDomNode(node, functor) {
 	if (functor(node.actualNode) !== false) {
@@ -27,8 +28,7 @@ function getBlockParent(node) {
 		parentBlock = getComposedParent(parentBlock);
 	}
 
-	// TODO: es-module-utils.getNodeFromTree
-	return axe.utils.getNodeFromTree(parentBlock);
+	return getNodeFromTree(parentBlock);
 }
 
 /**

--- a/lib/commons/dom/is-modal-open.js
+++ b/lib/commons/dom/is-modal-open.js
@@ -1,5 +1,7 @@
 import isVisible from './is-visible';
 import getViewportSize from './get-viewport-size';
+import cache from '../../core/base/cache';
+import { querySelectorAllFilter } from '../../core/utils';
 
 /**
  * Determines if there is a modal currently open.
@@ -32,13 +34,11 @@ function isModalOpen(options) {
 	// in the viewport. since we aren't sure if it is or is not a modal this is
 	// just our best guess of being one based on convention.
 
-	// TODO: es-module-_cache
-	if (axe._cache.get('isModalOpen')) {
-		return axe._cache.get('isModalOpen');
+	if (cache.get('isModalOpen')) {
+		return cache.get('isModalOpen');
 	}
 
-	// TODO: es-module-utils.querySelectorAllFilter
-	const definiteModals = axe.utils.querySelectorAllFilter(
+	const definiteModals = querySelectorAllFilter(
 		// TODO: es-module-_tree
 		axe._tree[0],
 		'dialog, [role=dialog], [aria-modal=true]',
@@ -46,8 +46,7 @@ function isModalOpen(options) {
 	);
 
 	if (definiteModals.length) {
-		// TODO: es-module-_cache
-		axe._cache.set('isModalOpen', true);
+		cache.set('isModalOpen', true);
 		return true;
 	}
 
@@ -93,14 +92,12 @@ function isModalOpen(options) {
 		});
 
 		if (modalElement && stacks.every(stack => stack.includes(modalElement))) {
-			// TODO: es-module-_cache
-			axe._cache.set('isModalOpen', true);
+			cache.set('isModalOpen', true);
 			return true;
 		}
 	}
 
-	// TODO: es-module-_cache
-	axe._cache.set('isModalOpen', undefined);
+	cache.set('isModalOpen', undefined);
 	return undefined;
 }
 

--- a/lib/commons/dom/is-skip-link.js
+++ b/lib/commons/dom/is-skip-link.js
@@ -1,3 +1,6 @@
+import cache from '../../core/base/cache';
+import { querySelectorAll } from '../../core/utils';
+
 // test for hrefs that start with # or /# (for angular)
 const isInternalLinkRegex = /^\/?#[^/!]/;
 
@@ -15,23 +18,20 @@ function isSkipLink(element) {
 	}
 
 	let firstPageLink;
-	// TODO: es-module-_cache
-	if (typeof axe._cache.get('firstPageLink') !== 'undefined') {
-		firstPageLink = axe._cache.get('firstPageLink');
+	if (typeof cache.get('firstPageLink') !== 'undefined') {
+		firstPageLink = cache.get('firstPageLink');
 	} else {
 		// define a skip link as any anchor element whose href starts with `#...`
 		// and which precedes the first anchor element whose href doesn't start
 		// with  `#...` (that is, a link to a page)
-		// TODO: es-module-utils.querySelectorAll
-		firstPageLink = axe.utils.querySelectorAll(
+		firstPageLink = querySelectorAll(
 			// TODO: es-module-_tree
 			axe._tree,
 			'a:not([href^="#"]):not([href^="/#"]):not([href^="javascript"])'
 		)[0];
 
 		// null will signify no first page link
-		// TODO: es-module-_cache
-		axe._cache.set('firstPageLink', firstPageLink || null);
+		cache.set('firstPageLink', firstPageLink || null);
 	}
 
 	// if there are no page links then all all links will need to be

--- a/lib/commons/dom/shadow-elements-from-point.js
+++ b/lib/commons/dom/shadow-elements-from-point.js
@@ -1,5 +1,6 @@
 import getRootNode from './get-root-node';
 import visuallyContains from './visually-contains';
+import { isShadowRoot } from '../../core/utils';
 
 /**
  * Get elements from point across shadow dom boundaries
@@ -22,8 +23,7 @@ function shadowElementsFromPoint(nodeX, nodeY, root = document, i = 0) {
 			// We only want to touch each tree once, so we're filtering out nodes on other trees.
 			.filter(nodes => getRootNode(nodes) === root)
 			.reduce((stack, elm) => {
-				// TODO: es-module-utils.isShadowRoot
-				if (axe.utils.isShadowRoot(elm)) {
+				if (isShadowRoot(elm)) {
 					const shadowStack = shadowElementsFromPoint(
 						nodeX,
 						nodeY,

--- a/lib/commons/dom/visually-contains.js
+++ b/lib/commons/dom/visually-contains.js
@@ -1,16 +1,16 @@
+import { getNodeFromTree, getScroll } from '../../core/utils';
+
 /**
  * Return the ancestor node that is a scroll region.
  * @param {VirtualNode}
  * @return {VirtualNode|null}
  */
 function getScrollAncestor(node) {
-	// TODO: es-module-utils.getNodeFromTree
-	const vNode = axe.utils.getNodeFromTree(node);
+	const vNode = getNodeFromTree(node);
 	let ancestor = vNode.parent;
 
 	while (ancestor) {
-		// TODO: es-module-utils.getScroll
-		if (axe.utils.getScroll(ancestor.actualNode)) {
+		if (getScroll(ancestor.actualNode)) {
 			return ancestor.actualNode;
 		}
 

--- a/lib/commons/matches/from-definition.js
+++ b/lib/commons/matches/from-definition.js
@@ -6,7 +6,7 @@ import nodeName from './node-name';
 import properties from './properties';
 import semanticRole from './semantic-role';
 import AbstractVirtualNode from '../../core/base/virtual-node/abstract-virtual-node';
-import { getNodeFromTree } from '../../core/utils';
+import { getNodeFromTree, matches } from '../../core/utils';
 
 const matchers = {
 	attributes,
@@ -52,8 +52,7 @@ function fromDefinition(vNode, definition) {
 		);
 	}
 	if (typeof definition === 'string') {
-		// TODO: es-module-utils.matches
-		return axe.utils.matches(vNode, definition);
+		return matches(vNode, definition);
 	}
 
 	return Object.keys(definition).every(matcherName => {

--- a/lib/commons/table/is-header.js
+++ b/lib/commons/table/is-header.js
@@ -1,5 +1,6 @@
 import isColumnHeader from './is-column-header';
 import isRowHeader from './is-row-header';
+import { escapeSelector } from '../../core/utils';
 
 /**
  * Determine if a `HTMLTableCellElement` is a header
@@ -15,8 +16,7 @@ function isHeader(cell) {
 	}
 
 	if (cell.getAttribute('id')) {
-		// TODO: es-module-utils.escapeSelector
-		const id = axe.utils.escapeSelector(cell.getAttribute('id'));
+		const id = escapeSelector(cell.getAttribute('id'));
 		return !!document.querySelector(`[headers~="${id}"]`);
 	}
 

--- a/lib/commons/text/accessible-text.js
+++ b/lib/commons/text/accessible-text.js
@@ -1,4 +1,5 @@
 import accessibleTextVirtual from './accessible-text-virtual';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Finds virtual node and calls accessibleTextVirtual()
@@ -11,8 +12,7 @@ import accessibleTextVirtual from './accessible-text-virtual';
  * @return {string}
  */
 function accessibleText(element, context) {
-	// TODO: es-module-utils.getNodeFromTree
-	const virtualNode = axe.utils.getNodeFromTree(element); // throws an exception on purpose if axe._tree not correct
+	const virtualNode = getNodeFromTree(element); // throws an exception on purpose if axe._tree not correct
 	return accessibleTextVirtual(virtualNode, context);
 }
 

--- a/lib/commons/text/form-control-value.js
+++ b/lib/commons/text/form-control-value.js
@@ -12,6 +12,7 @@ import getOwnedVirtual from '../aria/get-owned-virtual';
 import isHiddenWithCSS from '../dom/is-hidden-with-css';
 import AbstractVirtualNode from '../../core/base/virtual-node/abstract-virtual-node';
 import { getNodeFromTree, querySelectorAll } from '../../core/utils';
+import log from '../../core/log';
 
 const controlValueRoles = [
 	'textbox',
@@ -69,8 +70,7 @@ function formControlValue(virtualNode, context = {}) {
 	}, '');
 
 	if (context.debug) {
-		// TODO: es-module-log
-		axe.log(valueString || '{empty-value}', actualNode, context);
+		log(valueString || '{empty-value}', actualNode, context);
 	}
 	return valueString;
 }

--- a/lib/commons/text/is-icon-ligature.js
+++ b/lib/commons/text/is-icon-ligature.js
@@ -1,5 +1,6 @@
 import sanitize from './sanitize';
 import hasUnicode from './has-unicode';
+import cache from '../../core/base/cache';
 
 /**
  * Determines if a given text node is an icon ligature
@@ -83,23 +84,21 @@ function isIconLigature(
 		return false;
 	}
 
-	// TODO: es-module-_cache
-	if (!axe._cache.get('canvasContext')) {
-		axe._cache.set(
+	if (!cache.get('canvasContext')) {
+		cache.set(
 			'canvasContext',
 			document.createElement('canvas').getContext('2d')
 		);
 	}
-	const canvasContext = axe._cache.get('canvasContext');
+	const canvasContext = cache.get('canvasContext');
 	const canvas = canvasContext.canvas;
 
 	// keep track of each font encountered and the number of times it shows up
 	// as a ligature.
-	// TODO: es-module-_cache
-	if (!axe._cache.get('fonts')) {
-		axe._cache.set('fonts', {});
+	if (!cache.get('fonts')) {
+		cache.set('fonts', {});
 	}
-	const fonts = axe._cache.get('fonts');
+	const fonts = cache.get('fonts');
 
 	const style = window.getComputedStyle(textVNode.parent.actualNode);
 	const fontFamily = style.getPropertyValue('font-family');

--- a/lib/commons/text/label.js
+++ b/lib/commons/text/label.js
@@ -1,4 +1,5 @@
 import labelVirtual from './label-virtual';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Finds virtual node and calls labelVirtual()
@@ -11,8 +12,7 @@ import labelVirtual from './label-virtual';
  * @return {Mixed} String of visible text, or `null` if no label is found
  */
 function label(node) {
-	// TODO: es-module-utils.getNodeFromTree
-	node = axe.utils.getNodeFromTree(node);
+	node = getNodeFromTree(node);
 	return labelVirtual(node);
 }
 

--- a/lib/commons/text/visible.js
+++ b/lib/commons/text/visible.js
@@ -1,4 +1,5 @@
 import visibleVirtual from './visible-virtual';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Finds virtual node and calls visibleVirtual()
@@ -10,8 +11,7 @@ import visibleVirtual from './visible-virtual';
  * @return {String}
  */
 function visible(element, screenReader, noRecursing) {
-	// TODO: es-module-utils.getNodeFromTree
-	element = axe.utils.getNodeFromTree(element);
+	element = getNodeFromTree(element);
 	return visibleVirtual(element, screenReader, noRecursing);
 }
 

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -11,6 +11,8 @@ import {
 	performanceTimer
 } from '../utils';
 import doT from '@deque/dot';
+import log from '../log';
+import constants from '../constants';
 
 const dotRegex = /\{\{.+?\}\}/g;
 
@@ -545,8 +547,7 @@ class Audit {
 				only.type = 'tag';
 				const unmatchedTags = only.values.filter(tag => !tags.includes(tag));
 				if (unmatchedTags.length !== 0) {
-					// TODO: es-modules-log
-					axe.log('Could not find tags `' + unmatchedTags.join('`, `') + '`');
+					log('Could not find tags `' + unmatchedTags.join('`, `') + '`');
 				}
 			} else {
 				throw new Error(`Unknown runOnly type '${only.type}'`);
@@ -683,8 +684,7 @@ function getDefferedRule(rule, context, options) {
 				// if debug - construct error details
 				if (!options.debug) {
 					const errResult = Object.assign(new RuleResult(rule), {
-						// TODO: es-modules-constants
-						result: axe.constants.CANTTELL,
+						result: constants.CANTTELL,
 						description: 'An error occured while running this rule',
 						message: err.message,
 						stack: err.stack,
@@ -709,7 +709,7 @@ function getDefferedRule(rule, context, options) {
  */
 function getHelpUrl({ brand, application, lang }, ruleId, version) {
 	return (
-		axe.constants.helpUrlBase +
+		constants.helpUrlBase +
 		brand +
 		'/' +
 		(version || axe.version.substring(0, axe.version.lastIndexOf('.'))) +

--- a/lib/core/base/rule-result.js
+++ b/lib/core/base/rule-result.js
@@ -1,3 +1,5 @@
+import constants from '../constants';
+
 /**
  * Constructor for the result of Rules
  * @param {Rule} rule
@@ -13,8 +15,7 @@ function RuleResult(rule) {
 	 * The calculated result of the Rule, either PASS, FAIL or NA
 	 * @type {String}
 	 */
-	// TODO: es-module-constants
-	this.result = axe.constants.NA;
+	this.result = constants.NA;
 
 	/**
 	 * Whether the Rule is a "pageLevel" rule

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -12,6 +12,7 @@ import {
 	assert
 } from '../utils';
 import constants from '../constants';
+import log from '../log';
 
 function Rule(spec, parentAudit) {
 	this._audit = parentAudit;
@@ -368,13 +369,7 @@ Rule.prototype._trackPerformance = function() {
  * @param {Array} nodes Result of rule.gather
  */
 Rule.prototype._logGatherPerformance = function(nodes) {
-	// TODO: es-modules-log
-	axe.log(
-		'gather (',
-		nodes.length,
-		'):',
-		performanceTimer.timeElapsed() + 'ms'
-	);
+	log('gather (', nodes.length, '):', performanceTimer.timeElapsed() + 'ms');
 	performanceTimer.mark(this._markChecksStart);
 };
 

--- a/lib/core/base/virtual-node/abstract-virtual-node.js
+++ b/lib/core/base/virtual-node/abstract-virtual-node.js
@@ -37,12 +37,3 @@ class AbstractVirtualNode {
 }
 
 export default AbstractVirtualNode;
-
-// hack to replace instanceof as webpack is making it two different
-// functions.
-// TODO: es-modules. remove this and use instanceof again
-export function isAbstractNode(vNode) {
-	return ['children', 'props', 'attr', 'hasAttr', 'hasClass'].every(prop => {
-		return !!vNode[prop];
-	});
-}

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -1,6 +1,7 @@
 import AbstractVirtualNode from './abstract-virtual-node';
 import { isXHTML, validInputTypes } from '../../utils';
 import { isFocusable, getTabbableElements } from '../../../commons/dom';
+import cache from '../cache';
 
 let isXHTMLGlobal;
 
@@ -40,9 +41,8 @@ class VirtualNode extends AbstractVirtualNode {
 			this._type = type;
 		}
 
-		// TODO: es-modules_cache
-		if (axe._cache.get('nodeMap')) {
-			axe._cache.get('nodeMap').set(node, this);
+		if (cache.get('nodeMap')) {
+			cache.get('nodeMap').set(node, this);
 		}
 	}
 

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -1,9 +1,7 @@
 import constants from './constants';
 import log from './log';
 
-import AbstractVirtualNode, {
-	isAbstractNode
-} from './base/virtual-node/abstract-virtual-node';
+import AbstractVirtualNode from './base/virtual-node/abstract-virtual-node';
 import SerialVirtualNode from './base/virtual-node/serial-virtual-node';
 import VirtualNode from './base/virtual-node/virtual-node';
 import cache from './base/cache';
@@ -45,9 +43,6 @@ axe.AbstractVirtualNode = AbstractVirtualNode;
 axe.SerialVirtualNode = SerialVirtualNode;
 axe.VirtualNode = VirtualNode;
 axe._cache = cache;
-
-// TODO: remove
-axe._isAbstractNode = isAbstractNode;
 
 // Setting up this private/temp namespace for the tests (which cannot yet `import/export` things).
 // TODO: remove `_thisWillBeDeletedDoNotUse`

--- a/lib/core/public/run-rules.js
+++ b/lib/core/public/run-rules.js
@@ -1,5 +1,17 @@
 import Context from '../base/context';
 import cache from '../base/cache';
+import {
+	getSelectorData,
+	queue,
+	performanceTimer,
+	collectResultsFromFrames,
+	getScrollState,
+	setScrollState,
+	mergeResults,
+	publishMetaData,
+	finalizeRuleResult
+} from '../utils';
+import log from '../log';
 
 // Clean up after resolve / reject
 function cleanup() {
@@ -29,49 +41,42 @@ function runRules(context, options, resolve, reject) {
 	try {
 		context = new Context(context);
 		axe._tree = context.flatTree;
-		axe._selectorData = axe.utils.getSelectorData(context.flatTree);
+		axe._selectorData = getSelectorData(context.flatTree);
 	} catch (e) {
 		cleanup();
 		return reject(e);
 	}
 
-	var q = axe.utils.queue();
+	var q = queue();
 	var audit = axe._audit;
 
 	if (options.performanceTimer) {
-		axe.utils.performanceTimer.auditStart();
+		performanceTimer.auditStart();
 	}
 
 	if (context.frames.length && options.iframes !== false) {
 		q.defer(function(res, rej) {
-			axe.utils.collectResultsFromFrames(
-				context,
-				options,
-				'rules',
-				null,
-				res,
-				rej
-			);
+			collectResultsFromFrames(context, options, 'rules', null, res, rej);
 		});
 	}
 	let scrollState;
 	q.defer(function(res, rej) {
 		if (options.restoreScroll) {
-			scrollState = axe.utils.getScrollState();
+			scrollState = getScrollState();
 		}
 		audit.run(context, options, res, rej);
 	});
 	q.then(function(data) {
 		try {
 			if (scrollState) {
-				axe.utils.setScrollState(scrollState);
+				setScrollState(scrollState);
 			}
 			if (options.performanceTimer) {
-				axe.utils.performanceTimer.auditEnd();
+				performanceTimer.auditEnd();
 			}
 
 			// Add wrapper object so that we may use the same "merge" function for results from inside and outside frames
-			var results = axe.utils.mergeResults(
+			var results = mergeResults(
 				data.map(function(results) {
 					return { results };
 				})
@@ -81,14 +86,14 @@ function runRules(context, options, resolve, reject) {
 			if (context.initiator) {
 				results = audit.after(results, options);
 
-				results.forEach(axe.utils.publishMetaData);
-				results = results.map(axe.utils.finalizeRuleResult);
+				results.forEach(publishMetaData);
+				results = results.map(finalizeRuleResult);
 			}
 			try {
 				resolve(results, cleanup);
 			} catch (e) {
 				cleanup();
-				axe.log(e);
+				log(e);
 			}
 		} catch (e) {
 			cleanup();

--- a/lib/core/public/run-virtual-rule.js
+++ b/lib/core/public/run-virtual-rule.js
@@ -1,7 +1,7 @@
-// TODO: es-module-tests: can't import directly as the instanceof is different (thanks webpack)
-// import SerialVirtualNode from '../base/virtual-node/serial-virtual-node';
-// import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
+import SerialVirtualNode from '../base/virtual-node/serial-virtual-node';
+import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
 import * as helpers from '../reporters/helpers';
+import { publishMetaData, finalizeRuleResult, aggregateResult } from '../utils';
 
 /**
  * Run a rule in a non-browser environment
@@ -11,11 +11,13 @@ import * as helpers from '../reporters/helpers';
  * @return {Object} axe results for the rule run
  */
 function runVirtualRule(ruleId, vNode, options = {}) {
+	// TODO: es-modules axe._audit
+	// TODO: es-modules axe._selectorData
 	options.reporter = options.reporter || axe._audit.reporter || 'v1';
 	axe._selectorData = {};
 
-	if (!(vNode instanceof axe.AbstractVirtualNode)) {
-		vNode = new axe.SerialVirtualNode(vNode);
+	if (!(vNode instanceof AbstractVirtualNode)) {
+		vNode = new SerialVirtualNode(vNode);
 	}
 
 	let rule = axe._audit.rules.find(rule => rule.id === ruleId);
@@ -35,9 +37,9 @@ function runVirtualRule(ruleId, vNode, options = {}) {
 	};
 
 	const rawResults = rule.runSync(context, options);
-	axe.utils.publishMetaData(rawResults);
-	axe.utils.finalizeRuleResult(rawResults);
-	const results = axe.utils.aggregateResult([rawResults]);
+	publishMetaData(rawResults);
+	finalizeRuleResult(rawResults);
+	const results = aggregateResult([rawResults]);
 
 	results.violations.forEach(result =>
 		result.nodes.forEach(nodeResult => {

--- a/lib/core/utils/aggregate-checks.js
+++ b/lib/core/utils/aggregate-checks.js
@@ -1,7 +1,6 @@
 import constants from '../constants';
 import aggregate from './aggregate';
 
-// TODO: es-modules-constants
 const { CANTTELL_PRIO, FAIL_PRIO } = constants;
 let checkMap = [];
 checkMap[constants.PASS_PRIO] = true;

--- a/lib/core/utils/aggregate-node-results.js
+++ b/lib/core/utils/aggregate-node-results.js
@@ -1,6 +1,7 @@
 import aggregateChecks from './aggregate-checks';
 import aggregate from './aggregate';
 import finalizeRuleResult from './finalize-result';
+import constants from '../constants';
 
 /**
  * Calculates the result of a Rule based on its types and the result of its child Checks
@@ -26,8 +27,7 @@ function aggregateNodeResults(nodeResults) {
 	if (nodeResults && nodeResults.length) {
 		let resultList = nodeResults.map(node => node.result);
 		ruleResult.result = aggregate(
-			// TODO: es-modules-constants
-			axe.constants.results,
+			constants.results,
 			resultList,
 			ruleResult.result
 		);
@@ -36,25 +36,25 @@ function aggregateNodeResults(nodeResults) {
 	}
 
 	// Create an array for each type
-	axe.constants.resultGroups.forEach(group => (ruleResult[group] = []));
+	constants.resultGroups.forEach(group => (ruleResult[group] = []));
 
 	// Fill the array with nodes
 	nodeResults.forEach(function(nodeResult) {
-		var groupName = axe.constants.resultGroupMap[nodeResult.result];
+		var groupName = constants.resultGroupMap[nodeResult.result];
 		ruleResult[groupName].push(nodeResult);
 	});
 
 	// Take the highest impact of failed or canttell rules
-	var impactGroup = axe.constants.FAIL_GROUP;
+	var impactGroup = constants.FAIL_GROUP;
 	if (ruleResult[impactGroup].length === 0) {
-		impactGroup = axe.constants.CANTTELL_GROUP;
+		impactGroup = constants.CANTTELL_GROUP;
 	}
 
 	if (ruleResult[impactGroup].length > 0) {
 		// Get the impact of all issues
 		let impactList = ruleResult[impactGroup].map(failure => failure.impact);
 
-		ruleResult.impact = aggregate(axe.constants.impact, impactList) || null;
+		ruleResult.impact = aggregate(constants.impact, impactList) || null;
 	} else {
 		ruleResult.impact = null;
 	}

--- a/lib/core/utils/aggregate-result.js
+++ b/lib/core/utils/aggregate-result.js
@@ -1,8 +1,9 @@
+import constants from '../constants';
+
 function copyToGroup(resultObject, subResult, group) {
 	var resultCopy = Object.assign({}, subResult);
 	resultCopy.nodes = (resultCopy[group] || []).concat();
-	// TODO: es-modules-constants
-	axe.constants.resultGroups.forEach(group => {
+	constants.resultGroups.forEach(group => {
 		delete resultCopy[group];
 	});
 	resultObject[group].push(resultCopy);
@@ -16,18 +17,16 @@ function aggregateResult(results) {
 	let resultObject = {};
 
 	// Create an array for each type
-	axe.constants.resultGroups.forEach(
-		groupName => (resultObject[groupName] = [])
-	);
+	constants.resultGroups.forEach(groupName => (resultObject[groupName] = []));
 
 	// Fill the array with nodes
 	results.forEach(function(subResult) {
 		if (subResult.error) {
-			copyToGroup(resultObject, subResult, axe.constants.CANTTELL_GROUP);
-		} else if (subResult.result === axe.constants.NA) {
-			copyToGroup(resultObject, subResult, axe.constants.NA_GROUP);
+			copyToGroup(resultObject, subResult, constants.CANTTELL_GROUP);
+		} else if (subResult.result === constants.NA) {
+			copyToGroup(resultObject, subResult, constants.NA_GROUP);
 		} else {
-			axe.constants.resultGroups.forEach(function(group) {
+			constants.resultGroups.forEach(function(group) {
 				if (Array.isArray(subResult[group]) && subResult[group].length > 0) {
 					copyToGroup(resultObject, subResult, group);
 				}

--- a/lib/core/utils/get-node-from-tree.js
+++ b/lib/core/utils/get-node-from-tree.js
@@ -1,3 +1,5 @@
+import cache from '../base/cache';
+
 /**
  * Return a single node from the virtual dom tree
  *
@@ -6,8 +8,7 @@
  */
 function getNodeFromTree(vNode, node) {
 	const el = node || vNode;
-	// TODO: es-modules_cache
-	return axe._cache.get('nodeMap') ? axe._cache.get('nodeMap').get(el) : null;
+	return cache.get('nodeMap') ? cache.get('nodeMap').get(el) : null;
 }
 
 export default getNodeFromTree;

--- a/lib/core/utils/parse-crossorigin-stylesheet.js
+++ b/lib/core/utils/parse-crossorigin-stylesheet.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import parseStylesheet from './parse-stylesheet';
+import constants from '../constants';
 
 /**
  * Parse cross-origin stylesheets
@@ -22,8 +23,7 @@ function parseCrossOriginStylesheet(
 ) {
 	const axiosOptions = {
 		method: 'get',
-		// TODO: es-modules-constants
-		timeout: axe.constants.preload.timeout,
+		timeout: constants.preload.timeout,
 		url
 	};
 

--- a/lib/core/utils/performance-timer.js
+++ b/lib/core/utils/performance-timer.js
@@ -1,3 +1,5 @@
+import log from '../log';
+
 /**
  * Performance measuring utility shimming the User Timing API
  *
@@ -81,9 +83,8 @@ const performanceTimer = (function() {
 		 * @member {Function} logMeasures Iterates through measures and logs any that exist
 		 */
 		logMeasures: function(measureName) {
-			function log(req) {
-				// TODO: es-modules-log
-				axe.log('Measure ' + req.name + ' took ' + req.duration + 'ms');
+			function logMeasure(req) {
+				log('Measure ' + req.name + ' took ' + req.duration + 'ms');
 			}
 			if (
 				window.performance &&
@@ -98,10 +99,10 @@ const performanceTimer = (function() {
 				for (var i = 0; i < measures.length; ++i) {
 					var req = measures[i];
 					if (req.name === measureName) {
-						log(req);
+						logMeasure(req);
 						return;
 					}
-					log(req);
+					logMeasure(req);
 				}
 			}
 		},

--- a/lib/core/utils/preload.js
+++ b/lib/core/utils/preload.js
@@ -1,6 +1,7 @@
 import preloadCssom from './preload-cssom';
 import preloadMedia from './preload-media';
 import uniqueArray from './unique-array';
+import constants from '../constants';
 
 /**
  * Validated the preload object
@@ -33,8 +34,7 @@ export function shouldPreload(options) {
  * @return {Object} configuration
  */
 export function getPreloadConfig(options) {
-	// TODO: es-modules-constants
-	const { assets, timeout } = axe.constants.preload;
+	const { assets, timeout } = constants.preload;
 	const config = {
 		assets,
 		timeout

--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -2,8 +2,8 @@ import processMessage from './process-message';
 import clone from './clone';
 import findBy from './find-by';
 import extendMetaData from './extend-meta-data';
+import incompleteFallbackMessage from '../reporters/helpers/incomplete-fallback-msg';
 
-/* global helpers */
 /**
  * Construct incomplete message from check.data
  * @param  {Object} checkData Check result with reason specified
@@ -17,8 +17,7 @@ function getIncompleteReason(checkData, messages) {
 			// fall back to the default message if no reason specified
 			return messages.incomplete.default;
 		} else {
-			// TODO: `helpers.incompleteFallbackMessage` should be imported from `lib/core/reporters/helpers`
-			return helpers.incompleteFallbackMessage();
+			return incompleteFallbackMessage();
 		}
 	}
 	if (checkData && checkData.missingData) {

--- a/lib/core/utils/queue.js
+++ b/lib/core/utils/queue.js
@@ -1,3 +1,5 @@
+import log from '../log';
+
 function noop() {}
 function funcGuard(f) {
 	if (typeof f !== 'function') {
@@ -23,8 +25,7 @@ function queue() {
 		err = e;
 		setTimeout(function() {
 			if (err !== undefined && err !== null) {
-				// TODO: es-modules-log
-				axe.log('Uncaught error (of queue)', err);
+				log('Uncaught error (of queue)', err);
 			}
 		}, 1);
 	};

--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -1,4 +1,5 @@
 import { v1 as uuid } from './uuid';
+import cache from '../base/cache';
 
 const messages = {};
 const subscribers = {};
@@ -89,11 +90,10 @@ function post(win, topic, message, uuid, keepalive, callback) {
 		_keepalive: keepalive
 	};
 
-	// TODO: es-modules_cache
-	var axeRespondables = axe._cache.get('axeRespondables');
+	var axeRespondables = cache.get('axeRespondables');
 	if (!axeRespondables) {
 		axeRespondables = {};
-		axe._cache.set('axeRespondables', axeRespondables);
+		cache.set('axeRespondables', axeRespondables);
 	}
 	axeRespondables[uuid] = true;
 	if (typeof callback === 'function') {
@@ -234,7 +234,7 @@ if (typeof window.addEventListener === 'function') {
 			 * handlers reflecting our messages.
 			 * @see https://github.com/dequelabs/axe-core/issues/1754
 			 */
-			var axeRespondables = axe._cache.get('axeRespondables') || {};
+			var axeRespondables = cache.get('axeRespondables') || {};
 			if (axeRespondables[uuid] && data._axeuuid === axe._uuid) {
 				return;
 			}

--- a/lib/core/utils/send-command-to-frame.js
+++ b/lib/core/utils/send-command-to-frame.js
@@ -1,5 +1,6 @@
 import getSelector from './get-selector';
 import respondable from './respondable';
+import log from '../log';
 
 function err(message, node) {
 	var selector;
@@ -19,8 +20,7 @@ function err(message, node) {
 function sendCommandToFrame(node, parameters, resolve, reject) {
 	var win = node.contentWindow;
 	if (!win) {
-		// TODO: es-modules-log
-		axe.log('Frame does not have a content window', node);
+		log('Frame does not have a content window', node);
 		resolve(null);
 		return;
 	}


### PR DESCRIPTION
Except for `axe._tree`, `axe._selectorData` and `axe._audit` which will need their own pr as those change code rather than just resolve imports.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
