### PR TITLE
fix(core): add proper UMD loader

### DIFF
--- a/doc/examples/puppeteer/axe-puppeteer.js
+++ b/doc/examples/puppeteer/axe-puppeteer.js
@@ -27,7 +27,7 @@ const main = async url => {
 		// Inject and run axe-core
 		const handle = await page.evaluateHandle(`
 			// Inject axe source code
-			${axeCore.source}
+			var axe = ${axeCore.source}
 			// Run axe
 			axe.run()
 		`);

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -5,13 +5,6 @@
 var axe = axe || {};
 axe.version = '<%= pkg.version %>';
 
-if (typeof define === 'function' && define.amd) {
-	// Explicitly naming the module to avoid mismatched anonymous define() modules when injected in a page
-	define('axe-core', [], function() {
-		'use strict';
-		return axe;
-	});
-}
 if (
 	typeof module === 'object' &&
 	module.exports &&
@@ -21,13 +14,7 @@ if (
 		'(' +
 		axeFunction.toString() +
 		')(typeof window === "object" ? window : this);';
-	module.exports = axe;
 }
-if (typeof window.getComputedStyle === 'function') {
-	window.axe = axe;
-}
-// local namespace for common functions
-var commons;
 
 function SupportError(error) {
 	this.name = 'SupportError';

--- a/lib/intro.stub
+++ b/lib/intro.stub
@@ -9,7 +9,24 @@
  * distribute or in any file that contains substantial portions of this source
  * code.
  */
-(function axeFunction (window) {
+(function(window) {
+
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD.
+        define('axe-core', [], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.axe = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, axeFunction));
+
+function axeFunction() {
   // A window reference is required to access the axe object in a "global".
   var global = window;
   var document = window.document;

--- a/lib/outro.stub
+++ b/lib/outro.stub
@@ -1,2 +1,4 @@
 
+  return axe;
+}
 }( typeof window === 'object' ? window : this ));

--- a/test/integration/full/umd/umd-define.js
+++ b/test/integration/full/umd/umd-define.js
@@ -9,7 +9,13 @@ describe('UMD define', function() {
 	it('calls define and passes it axe', function() {
 		var call = defineCalls[defineCalls.length - 1];
 		assert.isFunction(call[2]);
-		assert.strictEqual(call[2](), axe);
+
+		var axe = call[2]();
+
+		// test some public apis
+		assert.typeOf(axe.run, 'function');
+		assert.typeOf(axe.configure, 'function');
+		assert.typeOf(axe.reset, 'function');
 	});
 
 	it('defines module name as axe-core', function() {

--- a/test/integration/full/umd/umd-define.js
+++ b/test/integration/full/umd/umd-define.js
@@ -11,11 +11,7 @@ describe('UMD define', function() {
 		assert.isFunction(call[2]);
 
 		var axe = call[2]();
-
-		// test some public apis
-		assert.typeOf(axe.run, 'function');
-		assert.typeOf(axe.configure, 'function');
-		assert.typeOf(axe.reset, 'function');
+		assert.hasAnyKeys(axe, ['utils', 'commons', 'core']);
 	});
 
 	it('defines module name as axe-core', function() {

--- a/test/integration/full/umd/umd-module-exports.js
+++ b/test/integration/full/umd/umd-module-exports.js
@@ -2,8 +2,13 @@
 describe('UMD module.export', function() {
 	'use strict';
 
+	var axe;
+	beforeEach(function() {
+		axe = module.exports;
+	});
+
 	it('registers axe to module.exports', function() {
-		assert.strictEqual(module.exports, axe);
+		assert.hasAnyKeys(axe, ['utils', 'commons', 'core']);
 	});
 
 	it('does not use `require` functions', function() {
@@ -18,11 +23,5 @@ describe('UMD module.export', function() {
 
 	it('should ensure axe source includes axios', function() {
 		assert.isTrue(axe.source.includes(axe.imports.axios.toString()));
-	});
-
-	it('should include doT', function() {
-		var doT = axe.imports.doT;
-		assert(doT, 'doT is registered on axe.imports');
-		assert.equal(doT.name, 'doT');
 	});
 });

--- a/test/integration/full/umd/umd-module-exports.js
+++ b/test/integration/full/umd/umd-module-exports.js
@@ -24,4 +24,10 @@ describe('UMD module.export', function() {
 	it('should ensure axe source includes axios', function() {
 		assert.isTrue(axe.source.includes(axe.imports.axios.toString()));
 	});
+
+	it('should include doT', function() {
+		var doT = axe.imports.doT;
+		assert(doT, 'doT is registered on axe.imports');
+		assert.equal(doT.name, 'doT');
+	});
 });


### PR DESCRIPTION
Our UMD loader wasn't really a true UMD loader, so fixed it by using the template from https://github.com/umdjs/umd/blob/master/templates/returnExports.js. Due to our conditional loading of `axe.source` I had to do some additional wrapping of the UMD loader.

Note: this now prevents the `axe` object from going onto the global namespace if AMD or CommonJS are defined. This might be a breaking change, I'm not sure how to judge it based on the example puppeteer use. If so I can update it to always export, which means we close the linked issue as will not fix.

Closes issue: https://github.com/dequelabs/axe-core/issues/2052

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
