### PR TITLE
docs: ensure up-to-date

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -187,7 +187,8 @@ axe.configure({
 	checks: [Object],
 	rules: [Object],
 	locale: Object,
-	axeVersion: String
+	axeVersion: String,
+	disableOtherRules: Boolean
 });
 ```
 
@@ -228,6 +229,7 @@ axe.configure({
   - `disableOtherRules` - Disables all rules not included in the `rules` property.
   - `locale` - A locale object to apply (at runtime) to all rules and checks, in the same shape as `/locales/*.json`.
   - `axeVersion` - Set the compatible version of a custom rule with the current axe version. Compatible versions are all patch and minor updates that are the same as, or newer than those of the `axeVersion` property.
+  - `disableOtherRules` - Disable all rules not listed in the `rules` parameter.
 
 **Returns:** Nothing
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -410,7 +410,7 @@ Additionally, there are a number or properties that allow configuration of diffe
 | `rules`            | n/a     | Enable or disable rules using the `enabled` property                                                                                    |
 | `reporter`         | `v1`    | Which reporter to use (see [Configuration](#api-name-axeconfigure))                                                                     |
 | `resultTypes`      | n/a     | Limit which result types are processed and aggregated                                                                                   |
-| `selector`         | `true`  | Return CSS selector for elements, optimised for readability                                                                             |
+| `selectors`        | `true`  | Return CSS selector for elements, optimised for readability                                                                             |
 | `ancestry`         | `false` | Return CSS selector for elements, with all the element's ancestors                                                                      |
 | `xpath`            | `false` | Return xpath selectors for elements                                                                                                     |
 | `absolutePaths`    | `false` | Use absolute paths when creating element selectors                                                                                      |

--- a/doc/API.md
+++ b/doc/API.md
@@ -6,7 +6,6 @@
    1. [Get Started](#getting-started)
 1. [Section 2: API Reference](#section-2-api-reference)
    1. [Overview](#overview)
-   1. [Required Globals](#required-globals)
    1. [API Notes](#api-notes)
    1. [API Name: axe.getRules](#api-name-axegetrules)
    1. [API Name: axe.configure](#api-name-axeconfigure)
@@ -54,19 +53,7 @@ The axe API can be used as part of a broader process that is performed on many, 
 
 ### Overview
 
-The axe APIs are provided in the javascript file axe.js. It must be included in the web page under test. Parameters are sent as javascript function parameters. Results are returned in JSON format.
-
-### Required Globals
-
-Axe requires a handful of global variables and interfaces to be available in order to run. See the [jsdom example](https://github.com/dequelabs/axe-core/blob/develop/doc/examples/jsdom/test/a11y.js) for how to set these up in a non-browser environment.
-
-- `window`
-- `document`
-- [`navigator`](https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator)
-- [`Node`](https://developer.mozilla.org/en-US/docs/Web/API/Node)
-- [`NodeList`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList)
-- [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element)
-- [`Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document)
+The axe APIs are provided in the javascript file axe.js. It must be included in the web page under test, as well as each `iframe` under test. Parameters are sent as javascript function parameters. Results are returned in JSON format.
 
 ### Full API Reference for Developers
 
@@ -134,7 +121,7 @@ Returns a list of all rules with their ID and description
 
 - `tags` - **optional** Array of tags used to filter returned rules. If omitted, it will return all rules. See [axe-core tags](#axe-core-tags).
 
-**Returns:** Array of rules that match the input filter with each entry having a format of `{ruleId: <id>, description: <desc>}`
+**Returns:** Array of rules that match the input filter with each entry having a format of `{ruleId: <id>, description: <desc>, helpUrl: <url>, help: <help>, tags: <tags>}`
 
 #### Example 1
 
@@ -146,9 +133,32 @@ In this example, we pass in the WCAG 2 A and AA tags into `axe.getRules` to retr
 
 ```js
 [
-  { ruleId: "area-alt", description: "Checks the <area> elements of image…" },
-  { ruleId: "aria-allowed-attr", description: "Checks all attributes that start…" },
-  { ruleId: "aria-required-attr", description: "Checks all elements that contain…" },
+  {
+    description: "Ensures <area> elements of image maps have alternate text",
+    help: "Active <area> elements must have alternate text",
+    helpUrl: "https://dequeuniversity.com/rules/axe/3.5/area-alt?application=axeAPI",
+    ruleId: "area-alt",
+    tags: [
+      "cat.text-alternatives",
+      "wcag2a",
+      "wcag111",
+      "wcag244",
+      "wcag412",
+      "section508",
+      "section508.22.a"
+    ]
+  },
+  {
+    description: "Ensures ARIA attributes are allowed for an element's role",
+    help: "Elements must only use allowed ARIA attributes",
+    helpUrl: "https://dequeuniversity.com/rules/axe/3.5/aria-allowed-attr?application=axeAPI",
+    ruleId: "aria-allowed-attr",
+    tags: [
+      "cat.aria",
+      "wcag2a",
+      "wcag412"
+    ]
+  }
   …
 ]
 ```
@@ -622,6 +632,14 @@ The URL of the page that was tested.
 
 The date and time that analysis was completed.
 
+###### `testEngine`
+
+The application and version that ran the audit.
+
+###### `testEnvironment`
+
+Information about the current browser or node application that ran the audit.
+
 ###### result arrays
 
 The results of axe are grouped according to their outcome into the following arrays:
@@ -835,25 +853,6 @@ axe.commons.dom.getRootNode(node);
 ##### Returns
 
 The top-level document or shadow DOM document fragment
-
-#### axe.commons.dom.findUp
-
-Recursively walk up the DOM, checking for a node which matches a selector. Warning: this should be used sparingly for performance reasons.
-
-##### Synopsis
-
-```js
-axe.commons.dom.findUp(node, '.selector');
-```
-
-##### Parameters
-
-- `element` – HTMLElement. The starting element
-- `selector` – String. The target selector for the HTMLElement
-
-##### Returns
-
-Either the matching HTMLElement or `null` if there was no match.
 
 ## Section 3: Example Reference
 

--- a/doc/accessibility-supported.md
+++ b/doc/accessibility-supported.md
@@ -10,7 +10,7 @@ We currently test the following AT combinations for support
 
 1. VoiceOver and Safari on OS X
 1. VoiceOver and Safari on iOS
-1. JAWS and IE on Windows
+1. JAWS and IE11 on Windows
 1. NVDA and Firefox on Windows
 1. Talkback and Chrome on Android
 1. Dragon and Firefox on Windows
@@ -30,4 +30,4 @@ In addition, we disallow invalid attributes starting with `aria-` and invalid at
 
 We recognize that there are best practices that significantly improve the usability of application, even though they are not strictly required in order to conform with WCAG 2. We develop the best practice rules to help content developers to identify these and adhere to them.
 
-We recognize that this topic is somewhat controvertial and the rules we have represent Deque's opinion on what constitutes a best practice.
+We recognize that this topic is somewhat controversial and the rules we have represent Deque's opinion on what constitutes a best practice.

--- a/doc/code-submission-guidelines.md
+++ b/doc/code-submission-guidelines.md
@@ -37,8 +37,10 @@ perf(rule): improve speed of color contrast rules
 
 Use async process to compare elements without UI lockup
 
-Closes #1
+Closes issue #1
 ```
+
+**Note:** We do not link issues to be closed as we have our QA team verify the issue is resolved before closing. Instead use `Closes issue #` to link to the issue the pr resolves but won't close it once merged.
 
 > Commit messages should be 100 characters or less to make them easy to read on Github and
 > various git tools.
@@ -57,8 +59,8 @@ Must be one of the following:
 - **refactor:** A code change that neither fixes a bug nor adds a feature
 - **perf:** A code change that improves performance
 - **test:** Adding missing tests
-- **chore:** Changes to the build process or auxiliary tools and libraries such as documentation
-  generation
+- **chore:** Changes to the build process or auxiliary tools and libraries such as documentation generation
+- **ci:** Changes or fixes to CI configuration such as CircleCI
 
 #### Scope
 
@@ -66,9 +68,7 @@ The scope specifies the place of the commit change in the codebase along with th
 reference a rule, a commons file, or anything really. E.g. `feat(rule)` or
 `test(commons/aria)`. It would help us call to out rule changes in our changelog with `rule` used as the scope.
 
-If the scope is too broad to summarize, use the type only and leave off the parentheses. E.g.
-`type: some subject`. Keep in mind that a long scope often pushes your commit message over 100 characters.
-Brevity is helpful for everyone!
+If the scope is too broad to summarize, use the type only and leave off the parentheses. E.g. `type: some subject`. Keep in mind that a long scope often pushes your commit message over 100 characters. Brevity is helpful for everyone!
 
 #### Subject
 
@@ -80,17 +80,13 @@ The subject contains succinct description of the change:
 
 #### Body
 
-Use the imperative, present tense: "change" not "changed" nor "changes", just like the subject.
-Include the motivation for the change and contrast it with how the code worked before.
+Use the imperative, present tense: "change" not "changed" nor "changes", just like the subject. Include the motivation for the change and contrast it with how the code worked before.
 
 #### Footer
 
-Reference any issue that this commit closes with its fully qualified URL to support both
-Bitbucket and Github.
+Reference any issue that this commit closes with its fully qualified URL to support both Bitbucket and Github.
 
-If needed, the footer should contain any information about Breaking Changes. Deprecation notices or
-breaking changes in the Changelog should inform users if they'll need to modify their code after
-this commit.
+If needed, the footer should contain any information about Breaking Changes. Deprecation notices or breaking changes in the Changelog should inform users if they'll need to modify their code after this commit.
 
 ## Submitting a pull request
 
@@ -128,16 +124,13 @@ Run the following commands to apply all commits from that pull request on top of
 curl -L https://github.com/dequelabs/axe-core/pull/205.patch | git am -3
 ```
 
-If the merge succeeds, use `git diff origin/develop` to review all the changes that will happen
-post-merge.
+If the merge succeeds, use `git diff origin/develop` to review all the changes that will happen post-merge.
 
 ## Squashing everything into one commit
 
-Before merging a pull request with many commits into develop, make sure there is only one commit representing the
-changes in the pull request, so the git log stays lean. We particularly want to avoid merge messages and vague commits that don't follow our commit policy (like `Merged develop into featurebranch` or `fixed some stuff`).
+Before merging a pull request with many commits into develop, make sure there is only one commit representing the changes in the pull request, so the git log stays lean. We particularly want to avoid merge messages and vague commits that don't follow our commit policy (like `Merged develop into featurebranch` or `fixed some stuff`).
 
-You can use git's interactive rebase to manipulate, merge, and rename commits in your local
-history. If these steps are followed, a force push shouldn't be necessary.
+You can use git's interactive rebase to manipulate, merge, and rename commits in your local history. If these steps are followed, a force push shouldn't be necessary.
 
 **Do not force push to develop or master under any circumstances.**
 
@@ -147,14 +140,11 @@ To interactively rebase all of your commits on top of the latest in develop, run
 git rebase --interactive origin/develop
 ```
 
-This brings up an interactive dialog in your text editor. Follow the instructions to squash all
-of your commits into the top one. Rename the top one.
+This brings up an interactive dialog in your text editor. Follow the instructions to squash all of your commits into the top one. Rename the top one.
 
-Once this is done, run `git log` and you will see only one commit after develop, representing
-everything from the pull request.
+Once this is done, run `git log` and you will see only one commit after develop, representing everything from the pull request.
 
-Finally, pull from develop with `rebase` to put all of our local commits on top of the latest
-remote.
+Finally, pull from develop with `rebase` to put all of our local commits on top of the latest remote.
 
 ```sh
 git pull --rebase origin develop
@@ -168,11 +158,6 @@ git push origin develop
 
 ## Writing Integration Tests
 
-For each rule, axe-core needs to have integration tests. These tests are located in `tests/integration`.
-This directory contains two other directories. `rules`, which contains integration tests that can be run
-on a single page, and `full` which contains tests that can only be tested by running on multiple pages.
+For each rule, axe-core needs to have integration tests. These tests are located in `tests/integration`. This directory contains two other directories. `rules`, which contains integration tests that can be run on a single page, and `full` which contains tests that can only be tested by running on multiple pages.
 
-Ensure that for each check used in the rule, there is an integration test for both pass and fail results.
-Integration tests put in `rules` can be described using simple code snippets in an HTML file, and a JSON
-file that describes the expected outcome. For `full` tests, a complete Jasmine test should be created,
-including at least one HTML file that has the tested code, and a JS file that has the test statements.
+Ensure that for each check used in the rule, there is an integration test for both pass and fail results. Integration tests put in `rules` can be described using simple code snippets in an HTML file, and a JSON file that describes the expected outcome. For `full` tests, a complete Jasmine test should be created, including at least one HTML file that has the tested code, and a JS file that has the test statements.

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -31,24 +31,24 @@ Axe 3.0 supports open Shadow DOM: see our virtual DOM APIs and test utilities fo
 ### Environment Pre-requisites
 
 1. You must have NodeJS installed.
-2. Grunt must be installed globally. `npm install -g grunt-cli` (You may need to do this as `sudo npm install -g grunt-cli`)
-3. Install npm development dependencies. In the root folder of your axe-core repository, run `npm install`
+1. Install npm development dependencies. In the root folder of your axe-core repository, run `npm install`
 
 ### Building axe.js
 
-To build axe.js, simply run `grunt build` in the root folder of the axe-core repository. axe.js and axe.min.js are placed into the root folder.
+To build axe.js, simply run `npm run build` in the root folder of the axe-core repository. axe.js and axe.min.js are placed into the root folder.
 
 ### Running Tests
 
-To run all tests from the command line you can run `grunt test`, which will run all unit and integration tests using headless chrome and Selenium Webdriver.
+To run all tests from the command line you can run `npm test`, which will run all unit and integration tests using headless chrome and Selenium Webdriver.
 
-You can also load tests in any supported browser, which is helpful for debugging. Tests require a local server to run, you must first start a local server to serve files. You can use Grunt to start one by running `grunt dev`. Once your local server is running you can load the following pages in any browser to run tests:
+You can also load tests in any supported browser, which is helpful for debugging. Tests require a local server to run, you must first start a local server to serve files. You can use Grunt to start one by running `npm start`. Once your local server is running you can load the following pages in any browser to run tests:
 
 1. [Core Tests](../test/core/)
 2. [Commons Tests](../test/commons/)
 3. [Check Tests](../test/checks/)
-4. [Integration Tests](../test/integration/rules/)
-5. There are additional tests located in [test/integration/full/](../test/integration/full/) for tests that need to be run against their own document.
+4. [Rule Matches](../test/rule-matches/)
+5. [Integration Tests](../test/integration/rules/)
+6. There are additional tests located in [test/integration/full/](../test/integration/full/) for tests that need to be run against their own document.
 
 ### API Reference
 
@@ -69,7 +69,7 @@ Axe tests for accessibility using objects called Rules. Each Rule tests for a hi
 
 Upon execution, a Rule runs each of its Checks against all relevant nodes. Which nodes are relevant is determined by the Rule's `selector` property and `matches` function. If a Rule has no Checks that apply to a given node, the Rule will result in an inapplicable result.
 
-After execution, a Check will return `true` or `false` depending on whether or not the tested condition was satisfied. The result, as well as more information on what caused the Check to pass or fail, will be stored in either the `passes` array or the `violations` array.
+After execution, a Check will return `true`, `false`, or `undefined` depending on whether or not the tested condition was satisfied. The result, as well as more information on what caused the Check to pass or fail, will be stored in either the `passes`, `violations`, or `incomplete` arrays.
 
 ### Rules
 
@@ -80,7 +80,8 @@ Rules are defined by JSON files in the [lib/rules directory](../lib/rules). The 
 - `excludeHidden` - **optional** `Boolean` Whether the rule should exclude hidden elements. Defaults to `true`.
 - `enabled` - **optional** `Boolean` Whether the rule is enabled by default. Defaults to `true`.
 - `pageLevel` - **optional** `Boolean` Whether the rule is page level. Page level rules will only run if given an entire `document` as context.
-- `matches` - **optional** `String` Relative path to the JavaScript file of a custom matching function. See [matches function](#matches-function) for more information.
+- `matches` - **optional** `String` The ID of the filtering function that will exclude elements that match the `selector` property. See the [`metadata-function-map`](../lib/core/base/metadata-function-map.js) file for all defined IDs.
+- `impact` - **optional** `String` (one of `minor`, `moderate`, `serious`, or `critical`). Override the impact defined by checks.
 - `tags` - **optional** `Array` Strings of the accessibility guidelines of which the Rule applies.
 - `metadata` - `Object` Consisting of:
   - `description` - `String` Text string that describes what the rule does.
@@ -95,11 +96,11 @@ The `any`, `all` and `none` arrays must contain either a `String` which referenc
 - `id` - `String` The unique ID of the Check.
 - `options` - `Mixed` Any options the Check requires that are specific to the Rule.
 
-There is a Grunt target which will ensure each Rule has a valid format, which can be run with `grunt validate`.
+There is a Grunt target which will ensure each Rule has a valid format, which can be run with `npx grunt validate`.
 
 #### Matches Function
 
-Custom `matches` functions are executed against each node which matches the Rule's `selector` and receive two parameters:
+A Rule's `matches` function is executed against each node which matches the Rule's `selector` and receive two parameters:
 
 - `node` – node, the DOM Node to test
 - `virtualNode`– object, the virtual DOM representation of the node. See [virtualNode documentation](#virtual-nodes) for more.
@@ -111,9 +112,9 @@ The matches function must return either `true` or `false`. Common functions are 
 Similar to Rules, Checks are defined by JSON files in the [lib/checks directory](../lib/checks). The JSON object is used to seed the [Check object](../lib/core/base/check.js). A valid Check JSON consists of the following:
 
 - `id` - `String` A unique name of the Check
-- `evaluate` - `String` Relative path to the JavaScript file which contains the function body of the Check itself
-- `after` - **optional** `String` Relative path to the JavaScript file which contains the function body of a Check's after (or post-processing) function.f
-- `options` - **optional** `Mixed` Any information the Check needs that you might need to customize and/or is locale specific. Options can be overridden at runtime (with the options parameter) or config-time. For example, the [valid-lang](../lib/checks/language/valid-lang.json) Check defines what ISO 639-1 language codes it should accept as valid. Options do not need to follow any specific format or type; it is up to the author of a Check to determine the most appropriate format.
+- `evaluate` - `String` The ID of the function that implements the check's functionality. See the [`metadata-function-map`](../lib/core/base/metadata-function-map.js) file for all defined IDs.
+- `after` - **optional** `String` The ID of the function that gets called for checks that operate on a page-level basis, to process the results from the iframes.
+- `options` - **optional** `Object` Any information the Check needs that you might need to customize and/or is locale specific. Options can be overridden at runtime (with the options parameter) or config-time. For example, the [valid-lang](../lib/checks/language/valid-lang.json) Check defines what ISO 639-1 language codes it should accept as valid. Options do not need to follow any specific format or type; it is up to the author of a Check to determine the most appropriate format.
 - `metadata` - `Object` Consisting of:
   - `impact` - `String` (one of `minor`, `moderate`, `serious`, or `critical`)
   - `messages` - `Object` These messages are displayed when the Check passes or fails
@@ -132,7 +133,6 @@ The following variables are defined for `Check#evaluate`:
 - `virtualNode` – `Object` The virtualNode object for use with Shadow DOM. See [virtualNode documentation](#virtual-nodes).
 - `this.data()` - `Function` Free-form data that either the Check message requires or is presented as `data` in the CheckResult object. Subsequent calls to `this.data()` will overwrite previous. See [aria-valid-attr](../lib/checks/aria/valid-attr.js) for example usage.
 - `this.relatedNodes()` - `Function` Array or NodeList of elements that are related to this Check. For example the [duplicate-id](../lib/checks/shared/duplicate-id.js) Check will add all Elements which share the same ID.
-- `commons` - Common functions that may be used across multiple Checks. See [Common Functions](#common-functions) for more information.
 
 #### Check `after`
 
@@ -143,7 +143,6 @@ For example, the [duplicate-id](../lib/checks/shared/duplicate-id.json) Check in
 The following variables are defined for `Check#after`:
 
 - `results` - `Array` Contains [CheckResults](#checkresult) for every matching node.
-- `commons` - Common functions that may be used across multiple Checks. See [Common Functions](#common-functions) for more information.
 
 The after function must return an `Array` of CheckResults, due to this, it is a very common pattern to just use `Array#filter` to filter results:
 
@@ -160,14 +159,17 @@ return results.filter(function(r) {
 
 #### Pass, Fail and Incomplete Templates
 
-Occasionally, you may want to add additional information about why a Check passed, failed or returned undefined into its message. For example, the [aria-valid-attr](../lib/checks/aria/valid-attr.json) will add information about any invalid ARIA attributes to its fail message. The message uses the [doT.js](http://olado.github.io/doT/) and is compiled to a JavaScript function at build-time. In the Check message, you have access to the `CheckResult` as `it`.
+Occasionally, you may want to add additional information about why a Check passed, failed or returned undefined into its message. For example, the [aria-valid-attr](../lib/checks/aria/valid-attr.json) will add information about any invalid ARIA attributes to its fail message. The message use a [custom message format](./check-message-template.md). In the Check message, you have access to the `data` object as `data`.
 
 ```js
 // aria-valid-attr check
 "messages": {
   "pass": "ARIA attributes are used correctly for the defined role",
-  "fail": "ARIA attribute{{=it.data && it.data.length > 1 ? 's are' : ' is'}} not allowed:{{~it.data:value}} {{=value}}{{~}}",
-  "incomplete": "axe-core couldn't tell because of {{it.data.missingData}}"
+  "fail": {
+    "singular": "ARIA attribute is not allowed: ${data.values}",
+    "plural": "ARIA attributes are not allowed: ${data.values}"
+  },
+  "incomplete": "axe-core couldn't tell because of ${data.missingData}"
 }
 ```
 
@@ -187,72 +189,71 @@ A CheckResult has the following properties:
 
 ### Common Functions
 
-Common functions are an internal library used by the rules and checks. If you have code repeated across rules and checks, you can use these functions and contribute to them. They are made available to every function as `commons`. Documentation is available in [source code](../lib/commons/).
+Common functions are an internal library used by the rules and checks. If you have code repeated across rules and checks, you can use these functions and contribute to them. Documentation is available in [source code](../lib/commons/).
 
 #### Commons and Shadow DOM
 
-To support open Shadow DOM while maintaining backwards compatibility, commons functions that
-query DOM nodes must operate on an in-memory representation of the DOM using axe-core’s
-built-in [API methods and utility functions](./API.md#virtual-dom-utilities).
+To support open Shadow DOM while maintaining backwards compatibility, commons functions that query DOM nodes must operate on an in-memory representation of the DOM using axe-core’s built-in [API methods and utility functions](./API.md#virtual-dom-utilities).
 
-Commons functions should do the virtual tree lookup and call a `virtual` function
-including the rest of the commons code. The naming of this special function
-should contain the original commons function name with `Virtual` added to signify
-it expects to operate on a virtual DOM tree.
+Commons functions should do the virtual tree lookup and call a `virtual` function including the rest of the commons code. The naming of this special function should contain the original commons function name with `Virtual` added to signify it expects to operate on a virtual DOM tree.
 
 Let’s look at an example:
 
 ```js
-axe.commons.text.accessibleText = function(element, inLabelledbyContext) {
-	let virtualNode = axe.utils.getNodeFromTree(axe._tree[0], element); // throws an exception on purpose if axe._tree not correct
-	return axe.commons.text.accessibleTextVirtual(
-		virtualNode,
-		inLabelledbyContext
-	);
-};
+// lib/commons/text/accessible-text.js
+import { getNodeFromTree } from '../../core/utils';
+import accessibleTextVirtual from './accessible-text-virtual';
 
-axe.commons.text.accessibleTextVirtual = function(
-	element,
-	inLabelledbyContext
-) {
+function accessibleText(element, inLabelledbyContext) {
+	let virtualNode = getNodeFromTree(axe._tree[0], element); // throws an exception on purpose if axe._tree not correct
+	return accessibleTextVirtual(virtualNode, inLabelledbyContext);
+}
+
+export default accessibleText;
+
+// lib/commons/text/accessible-text-virtual.js
+function accessibleTextVirtual(element, inLabelledbyContext) {
 	// rest of the commons code minus the virtual tree lookup, since it’s passed in
-};
+}
 ```
 
-`accessibleTextVirtual` would only be called directly if you’ve got a virtual node
-you can use. If you don’t already have one, call the `accessibleText` lookup function,
-which passes on a virtual DOM node with both the light DOM and Shadow DOM (if applicable).
+`accessibleTextVirtual` would only be called directly if you’ve got a virtual node you can use. If you don’t already have one, call the `accessibleText` lookup function, which passes on a virtual DOM node with both the light DOM and Shadow DOM (if applicable).
 
 ### Virtual Nodes
 
-To support open Shadow DOM, axe-core has the ability to handle virtual nodes in [rule matches](#matches-function)
-and [check evaluate](#check-evaluate) functions. The full set of API methods for Shadow DOM can be
-found in the [API documentation](./API.md#virtual-dom-utilities), but the general
-structure for a virtualNode is as follows:
+To support open Shadow DOM, axe-core has the ability to handle virtual nodes in [rule matches](#matches-function) and [check evaluate](#check-evaluate) functions. The full set of API methods for Shadow DOM can be found in the [API documentation](./API.md#virtual-dom-utilities), but the general structure for a virtualNode is as follows:
 
 ```js
 {
   actualNode: <HTMLElement>,
   children: <Array>,
-  shadowId: <String>
+  parent: <VirtualNode>,
+  shadowId: <String>,
+  attr: <Function>,
+  hasAttr: <Function>,
+  props: <Object>,
 }
 ```
 
 - A virtualNode is an object containing an HTML DOM element (`actualNode`).
-- Children contains an array of child virtualNodes.
+- Children contains an array of child VirtualNodes.
+- Parent is the VirutalNode parent
 - The shadowID indicates whether the node is in an open shadow root and if it is, which one it is inside the boundary.
+- Attr is a function which returns the value of the passed in attribute, similar to `node.getAttribute()` (e.g. `vNode.attr('aria-label')`)
+- HasAttr is a function which returns true if the VirutalNode has the attribute, similar to `node.hasAttribute()` (e.g. `vNode.hasAttr('aria-label')`)
+- Props is an object of HTML DOM element properties. The general structure is as follows:
+  ```js
+  {
+    nodeName: <String>,
+    nodeType: <Number>,
+    id: <String>,
+    nodeValue: <String>
+  }
+  ```
 
 ### Core Utilities
 
 Core Utilities are an internal library that provides axe with functionality used throughout its core processes. Most notably among these are the queue function and the DqElement constructor.
-
-#### ARIA Lookup Tables
-
-axe.commons.aria provides a namespace for ARIA-related utilities, including a lookupTable for attributes and roles.
-
-- `axe.commons.aria.lookupTable.attributes`
-- `axe.commons.aria.lookupTable.globalAttributes`
-- `axe.commons.aria.lookupTable.role`
 
 #### Common Utility Functions
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -159,7 +159,7 @@ return results.filter(function(r) {
 
 #### Pass, Fail and Incomplete Templates
 
-Occasionally, you may want to add additional information about why a Check passed, failed or returned undefined into its message. For example, the [aria-valid-attr](../lib/checks/aria/valid-attr.json) will add information about any invalid ARIA attributes to its fail message. The message use a [custom message format](./check-message-template.md). In the Check message, you have access to the `data` object as `data`.
+Occasionally, you may want to add additional information about why a Check passed, failed or returned undefined into its message. For example, the [aria-valid-attr](../lib/checks/aria/valid-attr.json) will add information about any invalid ARIA attributes to its fail message. The message uses a [custom message format](./check-message-template.md). In the Check message, you have access to the `data` object as `data`.
 
 ```js
 // aria-valid-attr check

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -20,11 +20,11 @@ Axe 3.0 supports open Shadow DOM: see our virtual DOM APIs and test utilities fo
    1. [API Name: axe.utils.getFlattenedTree](#api-name-axeutilsgetflattenedtree)
    1. [API Name: axe.utils.getNodeFromTree](#api-name-axeutilsgetnodefromtree)
 1. [Test Utilities](#test-utilities)
-   1. [Test Util Name: axe.testUtils.MockCheckContext](#test-util-name-axetestutilsmockcheckcontext)
-   1. [Test Util Name: axe.testUtils.shadowSupport](#test-util-name-axetestutilsshadowsupport)
-   1. [Test Util Name: axe.testUtils.fixtureSetup](#test-util-name-axetestutilsfixturesetup)
-   1. [Test Util Name: axe.testUtils.checkSetup](#test-util-name-axetestutilschecksetup)
-1. [Using Rule Generation CLI](#axe-rule-generator)
+   1. [Test Util Name: axe.testUtils.MockCheckContext](#test-util-name-mockcheckcontext)
+   1. [Test Util Name: axe.testUtils.shadowSupport](#test-util-name-shadowsupport)
+   1. [Test Util Name: axe.testUtils.fixtureSetup](#test-util-name-fixturesetup)
+   1. [Test Util Name: axe.testUtils.checkSetup](#test-util-name-checksetup)
+1. [Using Rule Generation CLI](#using-rule-generation-cli)
 
 ## Getting Started
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -237,7 +237,7 @@ To support open Shadow DOM, axe-core has the ability to handle virtual nodes in 
 
 - A virtualNode is an object containing an HTML DOM element (`actualNode`).
 - Children contains an array of child VirtualNodes.
-- Parent is the VirutalNode parent
+- Parent is the VirtualNode parent
 - The shadowID indicates whether the node is in an open shadow root and if it is, which one it is inside the boundary.
 - Attr is a function which returns the value of the passed in attribute, similar to `node.getAttribute()` (e.g. `vNode.attr('aria-label')`)
 - HasAttr is a function which returns true if the VirutalNode has the attribute, similar to `node.hasAttribute()` (e.g. `vNode.hasAttr('aria-label')`)

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -240,7 +240,7 @@ To support open Shadow DOM, axe-core has the ability to handle virtual nodes in 
 - Parent is the VirtualNode parent
 - The shadowID indicates whether the node is in an open shadow root and if it is, which one it is inside the boundary.
 - Attr is a function which returns the value of the passed in attribute, similar to `node.getAttribute()` (e.g. `vNode.attr('aria-label')`)
-- HasAttr is a function which returns true if the VirutalNode has the attribute, similar to `node.hasAttribute()` (e.g. `vNode.hasAttr('aria-label')`)
+- HasAttr is a function which returns true if the VirtualNode has the attribute, similar to `node.hasAttribute()` (e.g. `vNode.hasAttr('aria-label')`)
 - Props is an object of HTML DOM element properties. The general structure is as follows:
   ```js
   {

--- a/doc/rule-development.md
+++ b/doc/rule-development.md
@@ -6,7 +6,7 @@ A rule is a JSON Object that defines a test for axe-core to run. At a high level
 
 ## Rule Select and Matches
 
-Each rule has a 'selector' and optionally a 'matches' property. The selector is a CSS selector. Each element matching this selector will be tested by the rule, unless the matches function says otherwise. The `matches` property is a reference to a function that returns a boolean, which indicates if the element should be tested.
+Each rule has a `selector` and optionally a `matches` property. The selector is a CSS selector. Each element matching this selector will be tested by the rule, unless the matches function says otherwise. The `matches` property is a reference to a function that returns a boolean, which indicates if the element should be tested.
 
 The last thing that may influence if an element is selected for testing in the rule is it's visibility. By default, hidden elements are ignored by the rule, unless the `excludeHidden` is set to 'false'.
 


### PR DESCRIPTION
The [API docs for standards](https://github.com/dequelabs/axe-core/pull/2417/files) has a few additional things I didn't pull over. Also, the formatting of newlines was a bit odd so I fixed some of that too where I saw it.

Closes issues: #2277, #1936, #2323, and #840

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
