### PR TITLE
fix(rule,check): allow function ids for matches property in rule.configure

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -1,6 +1,7 @@
 import Rule from './rule';
 import Check from './check';
 import standards from '../../standards';
+import metadataFunctionMap from './metadata-function-map';
 import RuleResult from './rule-result';
 import {
 	clone,
@@ -156,6 +157,7 @@ class Audit {
 		this.lang = 'en';
 		this.defaultConfig = audit;
 		this.standards = standards;
+		this.metadataFunctionMap = metadataFunctionMap;
 		this._init();
 		// A copy of the "default" locale. This will be set if the user
 		// provides a new locale to `axe.configure()` and used to undo

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -10,7 +10,7 @@ export function createExecutionContext(spec) {
 		}
 
 		// execution contexts can only be functions
-		if (spec.includes('function')) {
+		if (/^\s*function[\s\w]*\(/.test(spec)) {
 			return new Function('return ' + spec + ';')();
 		}
 

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -9,7 +9,14 @@ export function createExecutionContext(spec) {
 			return metadataFunctionMap[spec];
 		}
 
-		return new Function('return ' + spec + ';')();
+		// execution contexts can only be functions
+		if (spec.includes('function')) {
+			return new Function('return ' + spec + ';')();
+		}
+
+		throw new ReferenceError(
+			`Function ID does not exist in the metadata-function-map: ${spec}`
+		);
 	}
 	return spec;
 }

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -591,11 +591,7 @@ Rule.prototype.configure = function(spec) {
 	}
 
 	if (spec.hasOwnProperty('matches')) {
-		if (typeof spec.matches === 'string') {
-			this.matches = new Function('return ' + spec.matches + ';')();
-		} else {
-			this.matches = spec.matches;
-		}
+		this.matches = createExecutionContext(spec.matches);
 	}
 };
 

--- a/test/core/base/check.js
+++ b/test/core/base/check.js
@@ -98,6 +98,62 @@ describe('Check', function() {
 				assert.equal('fong', check.test());
 				delete Check.prototype.test;
 			});
+			it('should override evaluate as ID', function() {
+				axe._load({});
+				axe._audit.metadataFunctionMap['custom-evaluate'] = function() {
+					return 'fong';
+				};
+
+				Check.prototype.test = function() {
+					return this.evaluate();
+				};
+				var check = new Check({
+					evaluate: 'function () { return "foo"; }'
+				});
+				check.configure({ evaluate: 'custom-evaluate' });
+				assert.equal('fong', check.test());
+				delete Check.prototype.test;
+				delete axe._audit.metadataFunctionMap['custom-evaluate'];
+			});
+			it('should override after as ID', function() {
+				axe._load({});
+				axe._audit.metadataFunctionMap['custom-after'] = function() {
+					return 'fong';
+				};
+
+				Check.prototype.test = function() {
+					return this.after();
+				};
+				var check = new Check({
+					after: 'function () { return "foo"; }'
+				});
+				check.configure({ after: 'custom-after' });
+				assert.equal('fong', check.test());
+				delete Check.prototype.test;
+				delete axe._audit.metadataFunctionMap['custom-after'];
+			});
+			it('should error if evaluate does not match an ID', function() {
+				function fn() {
+					var check = new Check({});
+					check.configure({ evaluate: 'does-not-exist' });
+				}
+
+				assert.throws(
+					fn,
+					'Function ID does not exist in the metadata-function-map: does-not-exist'
+				);
+			});
+			it('should error if after does not match an ID', function() {
+				function fn() {
+					var check = new Check({});
+					check.configure({ after: 'does-not-exist' });
+				}
+
+				assert.throws(
+					fn,
+					'Function ID does not exist in the metadata-function-map: does-not-exist'
+				);
+			});
 			it('should override enabled', function() {
 				Check.prototype.test = function() {
 					return this.enabled;

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -1931,12 +1931,41 @@ describe('Rule', function() {
 			rule.configure({ tags: [] });
 			assert.deepEqual(rule._get('tags'), []);
 		});
-		it('should override matches', function() {
+		it('should override matches (doT.js function)', function() {
 			var rule = new Rule({ matches: 'function () {return "matches";}' });
 
 			assert.equal(rule._get('matches')(), 'matches');
 			rule.configure({ matches: 'function () {return "does not match";}' });
 			assert.equal(rule._get('matches')(), 'does not match');
+		});
+		it('should override matches (metadata function name)', function() {
+			axe._load({});
+			axe._audit.metadataFunctionMap['custom-matches'] = function() {
+				return 'custom-matches';
+			};
+			axe._audit.metadataFunctionMap['other-matches'] = function() {
+				return 'other-matches';
+			};
+
+			var rule = new Rule({ matches: 'custom-matches' });
+
+			assert.equal(rule._get('matches')(), 'custom-matches');
+			rule.configure({ matches: 'other-matches' });
+			assert.equal(rule._get('matches')(), 'other-matches');
+
+			delete axe._audit.metadataFunctionMap['custom-matches'];
+			delete axe._audit.metadataFunctionMap['other-matches'];
+		});
+		it('should error if matches does not match an ID', function() {
+			function fn() {
+				var rule = new Rule({});
+				rule.configure({ matches: 'does-not-exist' });
+			}
+
+			assert.throws(
+				fn,
+				'Function ID does not exist in the metadata-function-map: does-not-exist'
+			);
 		});
 	});
 });


### PR DESCRIPTION
@downzer0 discovered this one when trying to configure a rule with a `matches` function ID. I added tests to ensure this should work now as well as throw a more helpful message as the default was eval the string as code and you'd get a `thing is not defined` error which was super unhelpful. So now you should get an error with the name of the string you used.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
