### PR TITLE
ci: verify release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,7 @@ jobs:
   # Verify released package has all required files
   verify_release:
     <<: *defaults
+    <<: *unix_box
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
@@ -199,6 +200,7 @@ jobs:
   # Verify canary released package has all required files
   verify_next_release:
     <<: *defaults
+    <<: *unix_box
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,7 @@ jobs:
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache_unix
       - run: npm run next-release
+      - run: .circleci/verify-release.sh
       - run: npm publish --tag=next
 
   # Release a "production" version
@@ -170,6 +171,7 @@ jobs:
       - <<: *restore_dependency_cache_unix
       - run: npm run build
       - run: npm run sri-validate
+      - run: .circleci/verify-release.sh
       - run: npm publish
 
   # Create a GitHub release.
@@ -185,6 +187,23 @@ jobs:
             curl https://raw.githubusercontent.com/dequelabs/attest-release-scripts/develop/src/node-github-release.sh -s -o ./node-github-release.sh
             chmod +x ./node-github-release.sh
             ./node-github-release.sh
+
+  # Verify released package has all required files
+  verify_release:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *restore_dependency_cache_unix
+      - run: .circleci/verify-release.sh post
+
+  # Verify canary released package has all required files
+  verify_next_release:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *restore_dependency_cache_unix
+      - run: npm run next-release
+      - run: .circleci/verify-release.sh post
 
 workflows:
   version: 2
@@ -261,6 +280,19 @@ workflows:
           filters:
             branches:
               only: master
+      # Verify releases have all required files
+      - verify_release:
+          requires:
+            - release
+          filters:
+            branches:
+              only: master
+      - verify_next_release:
+          requires:
+            - next_release
+          filters:
+            branches:
+              only: develop
       - github_release:
           requires:
             - release

--- a/.circleci/verify-release.sh
+++ b/.circleci/verify-release.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+if [ -n "$1" ] && [ "$1" == "post" ]
+then
+  # verify the released npm package in another dir as we can't
+  # install a package with the same name
+  version=$(node -pe "require('./package.json').version")
+  name=$(node -pe "require('./package.json').name")
+
+  mkdir "verify-release-$version"
+  cd "verify-release-$version"
+  npm init -y
+  npm install "$name@$version"
+  node -pe "window={}; document={}; require('$name')"
+
+  cd "node_modules/${name}"
+else
+  # verify main file exists
+  main=$(node -pe "require('./package.json').main")
+  node -pe "window={}; document={}; require('./$main')"
+fi
+
+# Test if typescript file exists (if declared)
+#
+# Note: because we are using node to read the package.json, the
+# variable gets set to the string `undefined` if the property
+# does not exists, rather than an empty variable.
+types=$(node -pe "require('./package.json').types")
+if [ "$types" == "undefined" ]
+then
+  types=$(node -pe "require('./package.json').typings")
+fi
+
+if [ "$types" != "undefined" ] && [ ! -f "$types" ]
+then
+  echo "types file missing"
+  exit 1;
+fi


### PR DESCRIPTION
Copying over what we did in [react-axe](https://github.com/dequelabs/react-axe/pull/176) to verify releases before and after publish

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
