### PR TITLE
feat: Add aria-structure-name rule

### DIFF
--- a/doc/rule-descriptions.md
+++ b/doc/rule-descriptions.md
@@ -62,10 +62,12 @@
 
 ## WCAG 2.1 Level A & AA Rules
 
-| Rule ID                                                                                                            | Description                                                                                   | Impact  | Tags                         | Issue Type |
-| :----------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- | :------ | :--------------------------- | :--------- |
-| [autocomplete-valid](https://dequeuniversity.com/rules/axe/3.5/autocomplete-valid?application=RuleDescription)     | Ensure the autocomplete attribute is correct and suitable for the form field                  | Serious | cat.forms, wcag21aa, wcag135 | failure    |
-| [avoid-inline-spacing](https://dequeuniversity.com/rules/axe/3.5/avoid-inline-spacing?application=RuleDescription) | Ensure that text spacing set through style attributes can be adjusted with custom stylesheets | Serious | wcag21aa, wcag1412           | failure    |
+| Rule ID                                                                                                            | Description                                                                                        | Impact  | Tags                         | Issue Type                 |
+| :----------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- | :------ | :--------------------------- | :------------------------- |
+| [autocomplete-valid](https://dequeuniversity.com/rules/axe/3.5/autocomplete-valid?application=RuleDescription)     | Ensure the autocomplete attribute is correct and suitable for the form field                       | Serious | cat.forms, wcag21aa, wcag135 | failure                    |
+| [avoid-inline-spacing](https://dequeuniversity.com/rules/axe/3.5/avoid-inline-spacing?application=RuleDescription) | Ensure that text spacing set through style attributes can be adjusted with custom stylesheets      | Serious | wcag21aa, wcag1412           | failure                    |
+| [name-author-contents](https://dequeuniversity.com/rules/axe/3.5/name-author-contents?application=RuleDescription) | Ensures elements with ARIA roles that require an accessible name have one from author or contents. | Serious |                              | failure, needs&nbsp;review |
+| [name-author](https://dequeuniversity.com/rules/axe/3.5/name-author?application=RuleDescription)                   | Ensures elements with ARIA roles that require an accessible name have one from author.             | Serious |                              | failure, needs&nbsp;review |
 
 ## Best Practices Rules
 

--- a/lib/rules/name-author-contents.json
+++ b/lib/rules/name-author-contents.json
@@ -1,0 +1,17 @@
+{
+	"id": "name-author-contents",
+	"selector": "[role=\"treeitem\"]",
+	"tags": [],
+	"metadata": {
+		"description": "Ensures elements with ARIA roles that require an accessible name have one from author or contents.",
+		"help": "Required accessible name must be present (author or contents)"
+	},
+	"all": [],
+	"any": [
+		"aria-label",
+		"aria-labelledby",
+		"has-visible-text",
+		"non-empty-title"
+	],
+	"none": []
+}

--- a/lib/rules/name-author.json
+++ b/lib/rules/name-author.json
@@ -1,0 +1,12 @@
+{
+	"id": "name-author",
+	"selector": "[role=\"tree\"]",
+	"tags": [],
+	"metadata": {
+		"description": "Ensures elements with ARIA roles that require an accessible name have one from author.",
+		"help": "Required accessible name must be present (author)"
+	},
+	"all": [],
+	"any": ["aria-label", "aria-labelledby", "non-empty-title"],
+	"none": []
+}

--- a/test/integration/rules/name-author-contents/name-author-contents.html
+++ b/test/integration/rules/name-author-contents/name-author-contents.html
@@ -1,0 +1,21 @@
+<div id="labeldiv">Some label</div>
+<div id="emptydiv"></div>
+
+<div role="treeitem" id="treeitem-empty"></div>
+<div role="treeitem" id="treeitem-text">Name</div>
+<div role="treeitem" id="treeitem-al" aria-label="Name"></div>
+<div role="treeitem" id="treeitem-alempty" aria-label=""></div>
+<div role="treeitem" id="treeitem-alb" aria-labelledby="labeldiv"></div>
+<div
+	role="treeitem"
+	id="treeitem-albmissing"
+	aria-labelledby="nonexistent"
+></div>
+<div role="treeitem" id="treeitem-albempty" aria-labelledby="emptydiv"></div>
+<div role="treeitem" id="treeitem-combo" aria-label="Aria Name">Name</div>
+<div role="treeitem" id="treeitem-title" title="Title"></div>
+
+<ul role="tree">
+	<li role="treeitem" id="treeitem-li-named">named</li>
+	<li role="treeitem" id="treeitem-li-unnamed"></li>
+</ul>

--- a/test/integration/rules/name-author-contents/name-author-contents.json
+++ b/test/integration/rules/name-author-contents/name-author-contents.json
@@ -1,0 +1,19 @@
+{
+	"description": "name-author-contents test",
+	"rule": "name-author-contents",
+	"violations": [
+		["#treeitem-empty"],
+		["#treeitem-alempty"],
+		["#treeitem-albmissing"],
+		["#treeitem-albempty"],
+		["#treeitem-li-unnamed"]
+	],
+	"passes": [
+		["#treeitem-text"],
+		["#treeitem-al"],
+		["#treeitem-alb"],
+		["#treeitem-combo"],
+		["#treeitem-title"],
+		["#treeitem-li-named"]
+	]
+}

--- a/test/integration/rules/name-author/name-author.html
+++ b/test/integration/rules/name-author/name-author.html
@@ -1,0 +1,15 @@
+<div id="labeldiv">Some label</div>
+<div id="emptydiv"></div>
+
+<div role="tree" id="tree-empty"></div>
+<div role="tree" id="tree-text">Name</div>
+<div role="tree" id="tree-al" aria-label="Name"></div>
+<div role="tree" id="tree-alempty" aria-label=""></div>
+<div role="tree" id="tree-alb" aria-labelledby="labeldiv"></div>
+<div role="tree" id="tree-albmissing" aria-labelledby="nonexistent"></div>
+<div role="tree" id="tree-albempty" aria-labelledby="emptydiv"></div>
+<div role="tree" id="tree-combo" aria-label="Aria Name">Name</div>
+<div role="tree" id="tree-title" title="Title"></div>
+
+<ul role="tree" id="tree-ul-unnamed"></ul>
+<ul role="tree" id="tree-ul-named" aria-label="named"></ul>

--- a/test/integration/rules/name-author/name-author.json
+++ b/test/integration/rules/name-author/name-author.json
@@ -1,0 +1,19 @@
+{
+	"description": "name-author test",
+	"rule": "name-author",
+	"violations": [
+		["#tree-empty"],
+		["#tree-alempty"],
+		["#tree-albmissing"],
+		["#tree-albempty"],
+		["#tree-ul-unnamed"],
+		["#tree-text"]
+	],
+	"passes": [
+		["#tree-al"],
+		["#tree-alb"],
+		["#tree-combo"],
+		["#tree-title"],
+		["#tree-ul-named"]
+	]
+}


### PR DESCRIPTION
Adds two new rules that catch elements which require an accessible name but are unnamed. Two separate rules since not every naming technique applies to all elements. If we can give actionable advise based on the role without having to create multiple rules then I'd be in favor of that.

Closes issue: None. But it is part of #2421.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
