### PR TITLE
fix(checks): do not normalize options for custom checks

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -1,7 +1,6 @@
 import Rule from './rule';
 import Check from './check';
 import standards from '../../standards';
-import metadataFunctionMap from './metadata-function-map';
 import RuleResult from './rule-result';
 import {
 	clone,
@@ -157,7 +156,6 @@ class Audit {
 		this.lang = 'en';
 		this.defaultConfig = audit;
 		this.standards = standards;
-		this.metadataFunctionMap = metadataFunctionMap;
 		this._init();
 		// A copy of the "default" locale. This will be set if the user
 		// provides a new locale to `axe.configure()` and used to undo

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -180,12 +180,23 @@ Check.prototype.runSync = function(node, options, context) {
  */
 
 Check.prototype.configure = function(spec) {
+	// allow test specs (without evaluate functions) to work as
+	// internal checks
+	if (!spec.evaluate || metadataFunctionMap[spec.evaluate]) {
+		this._internalCheck = true;
+	}
+
 	if (spec.hasOwnProperty('enabled')) {
 		this.enabled = spec.enabled;
 	}
 
 	if (spec.hasOwnProperty('options')) {
-		this.options = normalizeOptions(spec.options);
+		// only normalize options for internal checks
+		if (this._internalCheck) {
+			this.options = normalizeOptions(spec.options);
+		} else {
+			this.options = spec.options;
+		}
 	}
 
 	['evaluate', 'after']
@@ -193,8 +204,13 @@ Check.prototype.configure = function(spec) {
 		.forEach(prop => (this[prop] = createExecutionContext(spec[prop])));
 };
 
-Check.prototype.getOptions = function getOptions(options = {}) {
-	return deepMerge(this.options, normalizeOptions(options));
+Check.prototype.getOptions = function getOptions(options) {
+	// only merge and normalize options for internal checks
+	if (this._internalCheck) {
+		return deepMerge(this.options, normalizeOptions(options || {}));
+	} else {
+		return options || this.options;
+	}
 };
 
 export default Check;

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -10,6 +10,7 @@ import Audit from './base/audit';
 import CheckResult from './base/check-result';
 import Check from './base/check';
 import Context from './base/context';
+import metadataFunctionMap from './base/metadata-function-map';
 import RuleResult from './base/rule-result';
 import Rule from './base/rule';
 
@@ -53,7 +54,8 @@ axe._thisWillBeDeletedDoNotUse.base = {
 	Check,
 	Context,
 	RuleResult,
-	Rule
+	Rule,
+	metadataFunctionMap
 };
 
 axe.imports = imports;

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -3,6 +3,8 @@ describe('Rule', function() {
 
 	var Rule = axe._thisWillBeDeletedDoNotUse.base.Rule;
 	var Check = axe._thisWillBeDeletedDoNotUse.base.Check;
+	var metadataFunctionMap =
+		axe._thisWillBeDeletedDoNotUse.base.metadataFunctionMap;
 	var fixture = document.getElementById('fixture');
 	var noop = function() {};
 	var isNotCalled = function(err) {
@@ -1940,10 +1942,10 @@ describe('Rule', function() {
 		});
 		it('should override matches (metadata function name)', function() {
 			axe._load({});
-			axe._audit.metadataFunctionMap['custom-matches'] = function() {
+			metadataFunctionMap['custom-matches'] = function() {
 				return 'custom-matches';
 			};
-			axe._audit.metadataFunctionMap['other-matches'] = function() {
+			metadataFunctionMap['other-matches'] = function() {
 				return 'other-matches';
 			};
 
@@ -1953,8 +1955,8 @@ describe('Rule', function() {
 			rule.configure({ matches: 'other-matches' });
 			assert.equal(rule._get('matches')(), 'other-matches');
 
-			delete axe._audit.metadataFunctionMap['custom-matches'];
-			delete axe._audit.metadataFunctionMap['other-matches'];
+			delete metadataFunctionMap['custom-matches'];
+			delete metadataFunctionMap['other-matches'];
 		});
 		it('should error if matches does not match an ID', function() {
 			function fn() {

--- a/test/integration/full/configure-options/configure-options.js
+++ b/test/integration/full/configure-options/configure-options.js
@@ -34,6 +34,68 @@ describe('Configure Options', function() {
 					}
 				);
 			});
+
+			it('should not normalize external check options', function(done) {
+				target.setAttribute('lang', 'en');
+
+				axe.configure({
+					checks: [
+						{
+							id: 'dylang',
+							options: ['dylan'],
+							evaluate:
+								'function (node, options) {\n        var lang = (node.getAttribute("lang") || "").trim().toLowerCase();\n        var xmlLang = (node.getAttribute("xml:lang") || "").trim().toLowerCase();\n        var invalid = [];\n        (options || []).forEach(function(cc) {\n          cc = cc.toLowerCase();\n          if (lang && (lang === cc || lang.indexOf(cc.toLowerCase() + "-") === 0)) {\n            lang = null;\n          }\n          if (xmlLang && (xmlLang === cc || xmlLang.indexOf(cc.toLowerCase() + "-") === 0)) {\n            xmlLang = null;\n          }\n        });\n        if (xmlLang) {\n          invalid.push(\'xml:lang="\' + xmlLang + \'"\');\n        }\n        if (lang) {\n          invalid.push(\'lang="\' + lang + \'"\');\n        }\n        if (invalid.length) {\n          this.data(invalid);\n          return true;\n        }\n        return false;\n      }',
+							messages: {
+								pass: 'Good language',
+								fail: 'You mst use the DYLAN language'
+							}
+						}
+					],
+					rules: [
+						{
+							id: 'dylang',
+							metadata: {
+								description:
+									"Ensures lang attributes have the value of 'dylan'",
+								help: "lang attribute must have the value of 'dylan'"
+							},
+							selector: '#target',
+							any: [],
+							all: [],
+							none: ['dylang'],
+							tags: ['wcag2aa']
+						}
+					],
+					data: {
+						rules: {
+							dylang: {
+								description:
+									"Ensures lang attributes have the value of 'dylan'",
+								help: "lang attribute must have the value of 'dylan'"
+							}
+						}
+					}
+				});
+
+				axe.run(
+					'#target',
+					{
+						runOnly: {
+							type: 'rule',
+							values: ['dylang']
+						}
+					},
+					function(err, results) {
+						try {
+							assert.isNull(err);
+							assert.lengthOf(results.violations, 1, 'violations');
+							done();
+						} catch (e) {
+							done(e);
+						}
+					}
+				);
+			});
 		});
 
 		describe('aria-required-attr', function() {
@@ -67,8 +129,8 @@ describe('Configure Options', function() {
 		});
 	});
 
-	describe('disableOtherRules', function(done) {
-		it('disables rules that are not in the `rules` array', function() {
+	describe('disableOtherRules', function() {
+		it('disables rules that are not in the `rules` array', function(done) {
 			axe.configure({
 				disableOtherRules: true,
 				rules: [


### PR DESCRIPTION
Prevent breaking change to custom check options. Moved the `metadataFunctionMap` to the private test object as it was suppose to be there to begin with and not on the private `audit` object.

#Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
