### PR TITLE
style(locales): proofreading of the french translations

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2,191 +2,191 @@
 	"lang": "fr",
 	"rules": {
 		"accesskeys": {
-			"description": "S’assure que chaque valeur de l’attribut accesskey soit unique",
+			"description": "Vérifier que chaque valeur de l’attribut accesskey est unique",
 			"help": "La valeur de l’attribut accesskey doit être unique"
 		},
 		"area-alt": {
-			"description": "S’assure que les éléments <area> d’une image réactive ont une alternative textuelle",
+			"description": "Vérifier que les éléments <area> d’une image réactive ont une alternative textuelle",
 			"help": "Les éléments <area> actifs doivent avoir une alternative textuelle"
 		},
 		"aria-allowed-attr": {
-			"description": "S’assure que les attributs ARIA sont autorisés pour le rôle d’un élément",
+			"description": "Vérifier que les attributs ARIA sont autorisés pour le rôle d’un élément",
 			"help": "Les éléments doivent seulement utiliser les attributs ARIA autorisés"
 		},
 		"aria-allowed-role": {
-			"description": "S’assure que l’attribut role a une valeur valide pour cet élément",
+			"description": "Vérifier que l’attribut role a une valeur valide pour cet élément",
 			"help": "Le rôle ARIA doit être valide pour cet élément"
 		},
 		"aria-hidden-body": {
-			"description": "S’assure que aria-hidden='true' n’est pas présent sur le corps du document (élément body)",
+			"description": "Vérifier qu’aria-hidden='true' n’est pas présent sur le corps du document (élément body)",
 			"help": "aria-hidden='true' ne doit pas être présent sur <body>"
 		},
 		"aria-hidden-focus": {
-			"description": "S'assure que aria-hidden n'est pas assigmé aux éléments qui recoivent le focus au clavier",
-			"help": "ARIA hidden n'est pas assigné aux éléments qui reçoivent le focus au clavier"
+			"description": "Vérifier qu’aria-hidden n’est pas assigné aux éléments qui reçoivent le focus au clavier",
+			"help": "aria-hidden n’est pas assigné aux éléments qui reçoivent le focus au clavier"
 		},
 		"aria-input-field-name": {
-			"description": "S'assure que chaque champ de formulaire avec ARIA est dôté d'un intitulé accessible",
+			"description": "Vérifier que chaque champ de formulaire avec ARIA est doté d’un intitulé accessible",
 			"help": "Les champs de formulaire ARIA ont un intitulé accessible"
 		},
 		"aria-required-attr": {
-			"description": "S’assure que les éléments avec des rôles ARIA ont les attributs ARIA requis",
+			"description": "Vérifier que les éléments avec des rôles ARIA ont les attributs ARIA requis",
 			"help": "Les attributs ARIA requis doivent être présents"
 		},
 		"aria-required-children": {
-			"description": "S’assure que les éléments avec un rôle ARIA comportent aussi des rôles pour les descendants directs",
+			"description": "Vérifier que les éléments avec un rôle ARIA comportent aussi des rôles pour les descendants directs",
 			"help": "Certains rôles ARIA doivent comporter des descendants directs spécifiques"
 		},
 		"aria-required-parent": {
-			"description": "S’assure que les éléments avec un rôle ARIA requérant des rôles parents y sont contenus",
+			"description": "Vérifier que les éléments avec un rôle ARIA requérant des rôles parents y sont contenus",
 			"help": "Certains rôles ARIA doivent être contenus par des parents spécifiques"
 		},
 		"aria-roledescription": {
-			"description": "S'assure que aria-roledescription n'est utilisé que sur des éléments qui ont un rôle implicite ou explicite",
+			"description": "Vérifier qu’aria-roledescription n’est utilisé que sur des éléments qui ont un rôle implicite ou explicite",
 			"help": "Utiliser aria-roledescription sur les éléments dont le rôle a une valeur sémantique"
 		},
 		"aria-roles": {
-			"description": "S’assure que les éléments avec un attribut role utilisent une valeur valide",
+			"description": "Vérifier que les éléments avec un attribut role utilisent une valeur valide",
 			"help": "Les rôles ARIA doivent se conformer aux valeurs valides"
 		},
 		"aria-toggle-field-name": {
-			"description": "S'assure que chaque champ de basculement ARIA a un libellé accessible",
+			"description": "Vérifier que chaque champ de basculement ARIA a un libellé accessible",
 			"help": "Les champs de basculement ARIA ont un libellé accessible"
 		},
 		"aria-valid-attr-value": {
-			"description": "S’assure que tous les attributs ARIA comportent des valeurs valides",
+			"description": "Vérifier que tous les attributs ARIA comportent des valeurs valides",
 			"help": "Les attributs ARIA doivent comporter des valeurs valides"
 		},
 		"aria-valid-attr": {
-			"description": "S’assure que les attributs commençant par aria- sont des attributs ARIA valides",
+			"description": "Vérifier que les attributs commençant par aria- sont des attributs ARIA valides",
 			"help": "Les attributs ARIA doivent se conformer aux noms valides"
 		},
 		"audio-caption": {
-			"description": "S’assure que les éléments <audio> ont des sous-titres",
-			"help": "Les éléments <audio> doivent avoir une psite de sous-titres"
+			"description": "Vérifier que les éléments <audio> ont des sous-titres",
+			"help": "Les éléments <audio> doivent avoir une piste de sous-titres"
 		},
 		"autocomplete-valid": {
-			"description": "S’assure que l’attribut autocomplete est correctement adapté au champ de formulaire",
+			"description": "Vérifier que l’attribut autocomplete est correctement adapté au champ de formulaire",
 			"help": "L’attribut autocomplete doit être utilisé correctement"
 		},
 		"avoid-inline-spacing": {
-			"description": "S'assure que l'espacement du texte défini à travers une attribution de styles peut être ajusté via une feuille de style personalisée",
-			"help": "L'espacement du texte inline peut être ajusté avec des feuilles de style personalisées"
+			"description": "Vérifier que l’espacement du texte défini à travers une attribution de styles peut être ajusté via une feuille de style personnalisée",
+			"help": "L’espacement du texte inline peut être ajusté avec des feuilles de style personnalisées"
 		},
 		"blink": {
-			"description": "S’assure que l’élément <blink> n’est pas utilisé",
+			"description": "Vérifier que l’élément <blink> n’est pas utilisé",
 			"help": "L’élément <blink> est déprécié et ne doit pas être utilisé"
 		},
 		"button-name": {
-			"description": "S’assure que les boutons ont un texte perceptible",
+			"description": "Vérifier que les boutons ont un texte perceptible",
 			"help": "Les boutons doivent avoir un texte perceptible"
 		},
 		"bypass": {
-			"description": "S’assure que chaque page dispose au minimum d’un mécanisme de contournement de la navigation pour accéder directement au contenu",
+			"description": "Vérifier que chaque page dispose au minimum d’un mécanisme de contournement de la navigation pour accéder directement au contenu",
 			"help": "Chaque page doit fournir des moyens de contourner les contenus répétés"
 		},
 		"color-contrast": {
-			"description": "S’assure que les contrastes entre le premier plan et l’arrière-plan rencontrent les seuils de contrastes exigés par les WCAG 2 AA",
+			"description": "Vérifier que les contrastes entre le premier plan et l’arrière-plan rencontrent les seuils de contrastes exigés par les WCAG 2 AA",
 			"help": "Les éléments doivent avoir un contraste de couleurs suffisant"
 		},
 		"css-orientation-lock": {
-			"description": "S'assure que les contenus ne sont pas limités à une orientation spécifique de l'écran, et que le contenu est utilisable sous toutes les orientations de l'écran",
-			"help": "Les CSS Media queries ne sont pas utilisées pour vérrouiller l'orientation de l'écran"
+			"description": "Vérifier que les contenus ne sont pas limités à une orientation spécifique de l’écran, et que le contenu est utilisable sous toutes les orientations de l’écran",
+			"help": "Les CSS Media queries ne sont pas utilisées pour verrouiller l’orientation de l’écran"
 		},
 		"definition-list": {
-			"description": "S’assure que les éléments <dl> sont correctement structurés",
+			"description": "Vérifier que les éléments <dl> sont correctement structurés",
 			"help": "Les éléments <dl> ne doivent contenir directement que des groupes d’éléments <dt> et <dd> correctement ordonnés, ou des éléments <script> ou <template>"
 		},
 		"dlitem": {
-			"description": "S’assure que les éléments <dt> et <dd> sont contenus dans un élément <dl>",
+			"description": "Vérifier que les éléments <dt> et <dd> sont contenus dans un élément <dl>",
 			"help": "Les éléments <dt> et <dd> doivent être contenus dans un élément <dl>"
 		},
 		"document-title": {
-			"description": "S’assure que chaque document HTML contient un élément <title> non vide",
+			"description": "Vérifier que chaque document HTML contient un élément <title> non vide",
 			"help": "Chaque document doit avoir un élément <title> pour aider à la navigation"
 		},
 		"duplicate-id-active": {
-			"description": "S'assure que la valeur d'attribut id de chaque élément actif est unique",
+			"description": "Vérifier que la valeur d’attribut id de chaque élément actif est unique",
 			"help": "Les IDs des éléments actifs doivent être uniques"
 		},
 		"duplicate-id-aria": {
-			"description": "S'assure que chaque valeur d'attribut id utilisée avec ARIA et dans les étiquettes est unique",
+			"description": "Vérifier que chaque valeur d’attribut id utilisée avec ARIA et dans les étiquettes est unique",
 			"help": "Les IDs utilisés avec ARIA et dans les étiquettes doivent être uniques"
 		},
 		"duplicate-id": {
-			"description": "S’assure que la valeur de chaque attribut id est unique",
+			"description": "Vérifier que la valeur de chaque attribut id est unique",
 			"help": "La valeur de l’attribut id doit être unique"
 		},
 		"empty-heading": {
-			"description": "S’assure que les niveaux de titre ont un texte perceptible",
+			"description": "Vérifier que les niveaux de titre ont un texte perceptible",
 			"help": "Les niveaux de titre ne doivent pas être vides"
 		},
 		"focus-order-semantics": {
-			"description": "S’assure que les éléments dans le parcours du focus onnt un rôle approprié",
+			"description": "Vérifier que les éléments dans le parcours du focus ont un rôle approprié",
 			"help": "Les éléments dans le parcours du focus doivent avoir un rôle approprié pour le contenu interactif"
 		},
 		"form-field-multiple-labels": {
-			"description": "S'assure que le champ de formulaire n'a pas plusieurs éléments d'étiquettes",
-			"help": "Le champ de formulaire ne devrait pas comporter plusieurs éléments d'étiquettes"
+			"description": "Vérifier que le champ de formulaire n’a pas plusieurs éléments d’étiquettes",
+			"help": "Le champ de formulaire ne devrait pas comporter plusieurs éléments d’étiquettes"
 		},
 		"frame-tested": {
-			"description": "S’assure que les éléments <iframe> et <frame> contiennent le script axe-core",
+			"description": "Vérifier que les éléments <iframe> et <frame> contiennent le script axe-core",
 			"help": "Les cadres doivent être testés avec axe-core"
 		},
 		"frame-title-unique": {
-			"description": "S’assure que les éléments <iframe> et <frame> ont un attribut title unique",
+			"description": "Vérifier que les éléments <iframe> et <frame> ont un attribut title unique",
 			"help": "Chaque cadre doit avoir un attribut title unique"
 		},
 		"frame-title": {
-			"description": "S’assure que les éléments <iframe> et <frame> ont un attribut title non vide",
+			"description": "Vérifier que les éléments <iframe> et <frame> ont un attribut title non vide",
 			"help": "Chaque cadre doit avoir un attribut title"
 		},
 		"heading-order": {
-			"description": "S’assure que la hiérarchie des niveaux de titre est sémantiquement correcte",
+			"description": "Vérifier que la hiérarchie des niveaux de titre est sémantiquement correcte",
 			"help": "Les niveaux de titre doivent s’incrémenter d’un seul niveau à la fois"
 		},
 		"hidden-content": {
-			"description": "Informe les utilisateurs sur les contenus cachés",
+			"description": "Informer les utilisateurs sur les contenus cachés",
 			"help": "Le contenu caché sur la page ne peut pas être analysé"
 		},
 		"html-has-lang": {
-			"description": "S’assure que chaque document HTML a un attribut lang",
+			"description": "Vérifier que chaque document HTML a un attribut lang",
 			"help": "L’élément <html> doit avoir un attribut lang"
 		},
 		"html-lang-valid": {
-			"description": "S’assure que l’attribut lang sur l’élément <html> a une valeur valide",
+			"description": "Vérifier que l’attribut lang sur l’élément <html> a une valeur valide",
 			"help": "L’élément <html> doit avoir une valeur valide pour l’attribut lang"
 		},
 		"html-xml-lang-mismatch": {
-			"description": "S’assure que les éléments HTML avec les attributs lang et xml:lang valides indiquent la même langue de base pour la page",
+			"description": "Vérifier que les éléments HTML avec les attributs lang et xml:lang valides indiquent la même langue de base pour la page",
 			"help": "Les éléments HTML avec les attributs lang et xml:lang doivent avoir la même langue de base"
 		},
 		"image-alt": {
-			"description": "S’assure que les éléments <img> ont une alternative textuelle, ou un rôle de type 'none' ou 'presentation'",
+			"description": "Vérifier que les éléments <img> ont une alternative textuelle, ou un rôle de type 'none' ou 'presentation'",
 			"help": "Les images doivent avoir une alternative textuelle"
 		},
 		"image-redundant-alt": {
-			"description": "S’assure que l’intitulé des liens et boutons n’est pas répété dans l’alternative de l’image",
+			"description": "Vérifier que l’intitulé des liens et boutons n’est pas répété dans l’alternative de l’image",
 			"help": "L’intitulé des liens et boutons ne doit pas être répété dans l’alternative de l’image"
 		},
 		"input-button-name": {
-			"description": "S'assure que la valeur textuelle des contrôles de boutons est perceptible",
+			"description": "Vérifier que la valeur textuelle des contrôles de boutons est perceptible",
 			"help": "La valeur textuelle des contrôles de boutons doit être perceptible"
 		},
 		"input-image-alt": {
-			"description": "S’assure que les éléments <input type=\"image\"> ont une alternative textuelle",
+			"description": "Vérifier que les éléments <input type=\"image\"> ont une alternative textuelle",
 			"help": "Les boutons images doivent avoir une alternative textuelle"
 		},
 		"label-content-name-mismatch": {
-			"description": "S'assure que dans le cas d'éléments identifiés par leur contenu textuel, le texte visible fait partie du intitulé accessible",
+			"description": "Vérifier que dans le cas d’éléments identifiés par leur contenu textuel, le texte visible fait partie de l’intitulé accessible",
 			"help": "Le contenu textuel des éléments doit aussi se retrouver dans leur intitulé accessible"
 		},
 		"label-title-only": {
-			"description": "S’assure que chaque élément de formulaire n’est pas labellisé uniquement par les attributs title ou aria-describedby",
+			"description": "Vérifier que chaque élément de formulaire n’est pas labellisé uniquement par les attributs title ou aria-describedby",
 			"help": "Chaque élément de formulaire doit avoir un label visible"
 		},
 		"label": {
-			"description": "S’assure que chaque élément de formulaire a une étiquette",
+			"description": "Vérifier que chaque élément de formulaire a une étiquette",
 			"help": "Chaque élément de formulaire doit avoir une étiquette"
 		},
 		"landmark-banner-is-top-level": {
@@ -194,7 +194,7 @@
 			"help": "La région banner doit être au niveau le plus haut"
 		},
 		"landmark-complementary-is-top-level": {
-			"description": "S'assure que les landmarks complementary ou aside se retrouvent au plus haut niveau",
+			"description": "Vérifier que les landmarks complementary ou aside se retrouvent au plus haut niveau",
 			"help": "Aside ne doit pas être contenu dans un autre landmark"
 		},
 		"landmark-contentinfo-is-top-level": {
@@ -206,23 +206,23 @@
 			"help": "La région main doit être au niveau le plus haut"
 		},
 		"landmark-no-duplicate-banner": {
-			"description": "S’assure que le document n’a pas plus d’une région banner",
+			"description": "Vérifier que le document n’a pas plus d’une région banner",
 			"help": "Le document contient au plus une région banner"
 		},
 		"landmark-no-duplicate-contentinfo": {
-			"description": "S’assure que le document n’a pas plus d’une région contentinfo",
+			"description": "Vérifier que le document n’a pas plus d’une région contentinfo",
 			"help": "Le document contient au plus une région contentinfo"
 		},
 		"landmark-no-duplicate-main": {
-			"description": "S'assure que le document a tout au plus, un seul landmark main",
-			"help": "Le document ne doit pas contenir plus d'un landmark main"
+			"description": "Vérifier que le document a tout au plus, un seul landmark main",
+			"help": "Le document ne doit pas contenir plus d’un landmark main"
 		},
 		"landmark-one-main": {
-			"description": "S’assure qu’une navigation pointe vers le contenu principal de la page. Si la page contient des iframes, chaque iframe ne doit contenir au plus qu’une région main",
+			"description": "Vérifier qu’une navigation pointe vers le contenu principal de la page. Si la page contient des iframes, chaque iframe ne doit contenir au plus qu’une région main",
 			"help": "La page doit contenir une région main"
 		},
 		"landmark-unique": {
-			"help": "S'assure que chaque landmark est unique",
+			"help": "Vérifier que chaque landmark est unique",
 			"description": "Les landmarks doivent comporter un rôle unique, ou une étiquette accessible par la combinaison de role/label/title"
 		},
 		"link-in-text-block": {
@@ -230,99 +230,99 @@
 			"help": "Les liens doivent pouvoir être distingués du texte environnant d’une façon qui ne repose pas sur la couleur"
 		},
 		"link-name": {
-			"description": "S’assure que les liens ont un texte perceptible",
+			"description": "Vérifier que les liens ont un texte perceptible",
 			"help": "Les liens doivent avoir un texte perceptible"
 		},
 		"list": {
-			"description": "S’assure que les listes sont structurées correctement",
-			"help": "<ul> et <ol> doivent ne contenir directement que des éléments <li>, <script> ou <template>"
+			"description": "Vérifier que les listes sont structurées correctement",
+			"help": "<ul> et <ol> ne doivent contenir directement que des éléments <li>, <script> ou <template>"
 		},
 		"listitem": {
-			"description": "S’assure que les éléments <li> sont utilisés sémantiquement",
+			"description": "Vérifier que les éléments <li> sont utilisés sémantiquement",
 			"help": "Les éléments <li> doivent être contenus dans un élément <ul> ou <ol>"
 		},
 		"marquee": {
-			"description": "S’assure que l’élément <marquee> n’est pas utilisé",
+			"description": "Vérifier que l’élément <marquee> n’est pas utilisé",
 			"help": "L’élément <marquee> est déprécié et ne doit pas être utilisé"
 		},
 		"meta-refresh": {
-			"description": "S’assure que <meta http-equiv=\"refresh\"> n’est pas utilisé",
+			"description": "Vérifier que <meta http-equiv=\"refresh\"> n’est pas utilisé",
 			"help": "La page HTML ne doit pas être actualisée automatiquement"
 		},
 		"meta-viewport-large": {
-			"description": "S’assure que <meta name=\"viewport\"> permet un agrandissement significatif",
+			"description": "Vérifier que <meta name=\"viewport\"> permet un agrandissement significatif",
 			"help": "Les utilisateurs devraient pouvoir zoomer et agrandir le texte jusqu’à 500%"
 		},
 		"meta-viewport": {
-			"description": "S’assure que <meta name=\"viewport\"> ne désactive pas le zoom ni l’agrandissement",
+			"description": "Vérifier que <meta name=\"viewport\"> ne désactive pas le zoom ni l’agrandissement",
 			"help": "Le zoom et l’agrandissement ne doivent pas être désactivés"
 		},
 		"object-alt": {
-			"description": "S’assure que les éléments <object> ont une alternative textuelle",
+			"description": "Vérifier que les éléments <object> ont une alternative textuelle",
 			"help": "Les éléments <object> doivent avoir une alternative textuelle"
 		},
 		"p-as-heading": {
-			"description": "S’assure que les éléments p ne sont pas utilisés pour styler des niveaux de titres",
+			"description": "Vérifier que les éléments p ne sont pas utilisés pour styler des niveaux de titres",
 			"help": "La graisse, le style et le corps du texte ne doivent pas être utilisés pour styler les éléments p comme des niveaux de titres"
 		},
 		"page-has-heading-one": {
-			"description": "S’assure que la page, ou au moins une de ses iframes, contient un titre de niveau un",
-			"help": "La page doit contenir un titre de niveau un"
+			"description": "Vérifier que la page, ou au moins une de ses iframes, contient un titre de niveau 1",
+			"help": "La page doit contenir un titre de niveau 1"
 		},
 		"region": {
-			"description": "S’assure que tout le contenu est localisé dans une région",
+			"description": "Vérifier que tout le contenu est localisé dans une région",
 			"help": "Le contenu doit être localisé dans une région"
 		},
 		"role-img-alt": {
-			"description": "S'assure que les éléments avec [role='img'] ont une équivalence textuelle",
+			"description": "Vérifier que les éléments avec [role='img'] ont une équivalence textuelle",
 			"help": "Les éléments avec [role='img'] ont une équivalence textuelle"
 		},
 		"scope-attr-valid": {
-			"description": "S’assure que l’attribut scope est utilisé correctement dans les tableaux",
+			"description": "Vérifier que l’attribut scope est utilisé correctement dans les tableaux",
 			"help": "L’attribut scope doit être utilisé correctement"
 		},
 		"scrollable-region-focusable": {
-			"description": "Les éléments dont le contenu défile devraient être accesibles au clavier",
-			"help": "S'assure que les régions défilantes sont accessibles au clavier"
+			"description": "Les éléments dont le contenu défile devraient être accessibles au clavier",
+			"help": "Vérifier que les régions défilantes sont accessibles au clavier"
 		},
 		"server-side-image-map": {
-			"description": "S’assure que les images réactives côté serveur ne sont pas utilisées",
+			"description": "Vérifier que les images réactives côté serveur ne sont pas utilisées",
 			"help": "Les images réactives côté serveur ne devraient pas être utilisées"
 		},
 		"skip-link": {
-			"description": "S’assure que tous les liens d’évitement ont une cible pouvant recevoir le focus",
+			"description": "Vérifier que tous les liens d’évitement ont une cible pouvant recevoir le focus",
 			"help": "La cible d’un lien d’évitement doit exister et pouvoir recevoir le focus"
 		},
 		"tabindex": {
-			"description": "S’assure que les valeurs de l’attribut tabindex ne sont pas supérieures à 0",
+			"description": "Vérifier que les valeurs de l’attribut tabindex ne sont pas supérieures à 0",
 			"help": "Aucun élément ne devrait avoir un tabindex avec une valeur supérieure à zéro"
 		},
 		"table-duplicate-name": {
-			"description": "S’assure que chaque tableau n’ait pas un summary et un caption identiques",
+			"description": "Vérifier que chaque tableau n’ait pas un summary et un caption identiques",
 			"help": "L’élément <caption> ne devrait pas contenir le même texte que l’attribut summary"
 		},
 		"table-fake-caption": {
-			"description": "S’assure que les tableaux avec une légende utilisent l’élément <caption>",
+			"description": "Vérifier que les tableaux avec une légende utilisent l’élément <caption>",
 			"help": "Les données ou les cellules d’entête ne devraient pas être utilisées pour légender un tableau de données"
 		},
 		"td-has-header": {
-			"description": "S’assure que chaque cellule de données non vide dans un tableau de données a une ou plusieurs cellules d’entête",
+			"description": "Vérifier que chaque cellule de données non vide dans un tableau de données a une ou plusieurs cellules d’entête",
 			"help": "Chaque élément td non vide dans un tableau plus grand que 3 × 3 doit avoir une cellule d’entête associée"
 		},
 		"td-headers-attr": {
-			"description": "S’assure que chaque cellule utilisant l’attribut headers fait référence à une autre cellule du même tableau",
+			"description": "Vérifier que chaque cellule utilisant l’attribut headers fait référence à une autre cellule du même tableau",
 			"help": "Les cellules utilisant l’attribut headers ne doivent faire référence qu’à d’autres cellules du même tableau"
 		},
 		"th-has-data-cells": {
-			"description": "S’assure que chaque cellule d’entête dans un tableau de données fait référence à des cellules de données",
+			"description": "Vérifier que chaque cellule d’entête dans un tableau de données fait référence à des cellules de données",
 			"help": "Tous les éléments th et ceux avec role=columnheader/rowheader doivent décrire des cellules de données"
 		},
 		"valid-lang": {
-			"description": "S’assure que les attributs lang ont des valeurs valides",
+			"description": "Vérifier que les attributs lang ont des valeurs valides",
 			"help": "L’attribut lang doit avoir une valeur valide"
 		},
 		"video-caption": {
-			"description": "S’assure que les éléments <video> ont des sous-titres",
+			"description": "Vérifier que les éléments <video> ont des sous-titres",
 			"help": "Les éléments <video> doivent avoir des sous-titres"
 		}
 	},
@@ -334,19 +334,19 @@
 		"aria-allowed-attr": {
 			"pass": "Les attributs ARIA sont utilisés correctement pour le rôle défini",
 			"fail": {
-				"singular": "L'attribut ARIA n'est pas autorisé: ${data.values}",
-				"plural": "Les attributs ARIA ne sont pas autorisés: ${data.values}"
+				"singular": "L’attribut ARIA n’est pas autorisé : ${data.values}",
+				"plural": "Les attributs ARIA ne sont pas autorisés : ${data.values}"
 			}
 		},
 		"aria-allowed-role": {
 			"pass": "Le rôle ARIA est autorisé pour l’élément donné",
 			"fail": {
-				"singular": "Le rôle ARIA ${data.values} n'est pas autorisé pour l'élément donné",
-				"plural": "Les rôles ARIA ${data.values} ne sont pas autorisés pour l'élément donné"
+				"singular": "Le rôle ARIA ${data.values} n’est pas autorisé pour l’élément donné",
+				"plural": "Les rôles ARIA ${data.values} ne sont pas autorisés pour l’élément donné"
 			},
 			"incomplete": {
-				"singular": "Le rôle ARIA ${data.values} doit être retiré lorsque l'élément est rendu visible, car il n'est pas autorisé pour cet élément",
-				"plural": "Les rôles ARIA ${data.values} doivent être retirés lorsque l'élément est rendu visible, car il nee sont pas autorisés pour cet élément"
+				"singular": "Le rôle ARIA ${data.values} doit être retiré lorsque l’élément est rendu visible, car il n’est pas autorisé pour cet élément",
+				"plural": "Les rôles ARIA ${data.values} doivent être retirés lorsque l’élément est rendu visible, car ils ne sont pas autorisés pour cet élément"
 			}
 		},
 		"aria-hidden-body": {
@@ -355,13 +355,13 @@
 		},
 		"aria-roledescription": {
 			"pass": "aria-roledescription utilisé sur un élément sémantique supporté",
-			"incomplete": "Vérifier que la valeur de aria-roledescription est annoncée par les lecteurs d'écran supportés",
-			"fail": "Attribuer à l'élément un role qui supporte aria-roledescription"
+			"incomplete": "Vérifier que la valeur d’aria-roledescription est annoncée par les lecteurs d’écran supportés",
+			"fail": "Attribuer à l’élément un role qui supporte aria-roledescription"
 		},
 		"aria-errormessage": {
-			"pass": "Utilise une technique prise en charge pour aria-errormessage",
+			"pass": "Utiliser une technique prise en charge pour aria-errormessage",
 			"fail": {
-				"singular": "La valeur de aria-errormessage `${data.values}` doit recourir à une technique pour annoncer le message (aria-live, aria-describedby, role=alert, etc.)",
+				"singular": "La valeur d’aria-errormessage `${data.values}` doit recourir à une technique pour annoncer le message (aria-live, aria-describedby, role=alert, etc.)",
 				"plural": "Les valeurs aria-errormessage `${data.values}` doivent recourir à une technique pour annoncer le message (aria-live, aria-describedby, role=alert, etc.)"
 			}
 		},
@@ -374,37 +374,37 @@
 			"fail": "Le rôle doit être un des rôles ARIA valides"
 		},
 		"no-implicit-explicit-label": {
-			"pass": "Il n'y a pas de décalage entre le <label> et le intitulé accessible",
-			"incomplete": "Vérifier que le <label> n'a pas à faire partie du nom du champ de formulaire ARIA ${data}"
+			"pass": "Il n’y a pas de décalage entre le <label> et l’intitulé accessible",
+			"incomplete": "Vérifier que le <label> n’a pas à faire partie du nom du champ de formulaire ARIA ${data}"
 		},
 		"aria-required-attr": {
 			"pass": "Tous les attributs ARIA requis sont présents",
 			"fail": {
-				"singular": "L'attribut ARIA requis est manquant: ${data.values}",
-				"plural": "Les attributs ARIA requis sont manquants: ${data.values}"
+				"singular": "L’attribut ARIA requis est manquant : ${data.values}",
+				"plural": "Les attributs ARIA requis sont manquants : ${data.values}"
 			}
 		},
 		"aria-required-children": {
 			"pass": "Les descendants ARIA requis sont présents",
 			"fail": {
-				"singular": "Le descendant ARIA requis est manquant: ${data.values}",
-				"plural": "Les descendants ARIA requis sont manquants: ${data.values}"
+				"singular": "Le descendant ARIA requis est manquant : ${data.values}",
+				"plural": "Les descendants ARIA requis sont manquants : ${data.values}"
 			},
 			"incomplete": {
-				"singular": "Le rôle du descendant ARIA attendu doit être ajouté: ${data.values}",
-				"plural": "Les rôles des descendants ARIA attendus doivent être ajoutés: ${data.values}"
+				"singular": "Le rôle du descendant ARIA attendu doit être ajouté : ${data.values}",
+				"plural": "Les rôles des descendants ARIA attendus doivent être ajoutés : ${data.values}"
 			}
 		},
 		"aria-required-parent": {
 			"pass": "Les rôles parents ARIA requis sont présents",
 			"fail": {
-				"singular": "Le rôle parent ARIA requis est manquant: ${data.values}",
-				"plural": "Les rôles parents ARIA requis sont manquants: ${data.values}"
+				"singular": "Le rôle parent ARIA requis est manquant : ${data.values}",
+				"plural": "Les rôles parents ARIA requis sont manquants : ${data.values}"
 			}
 		},
 		"aria-unsupported-attr": {
-			"pass": "L'attribut ARIA est supporté",
-			"fail": "L'attribut ARIA n'est pas suffisamment supporté par les lecteurs d'écran et autres technologies d'assistance: ${data.values}"
+			"pass": "L’attribut ARIA est supporté",
+			"fail": "L’attribut ARIA n’est pas suffisamment supporté par les lecteurs d’écran et autres technologies d’assistance : ${data.values}"
 		},
 		"unsupportedrole": {
 			"pass": "Le rôle ARIA est supporté",
@@ -413,12 +413,12 @@
 		"aria-valid-attr-value": {
 			"pass": "Les valeurs d’attribut ARIA sont valides",
 			"fail": {
-				"singular": "La valeur d’attribut ARIA est invalide: ${data.values}",
-				"plural": "Les valeurs d’attribut ARIA sont invalides: ${data.values}"
+				"singular": "La valeur d’attribut ARIA est invalide : ${data.values}",
+				"plural": "Les valeurs d’attribut ARIA sont invalides : ${data.values}"
 			},
 			"incomplete": {
-				"singular": "Le id de l'attribut ARIA de l'élément n'existe pas dans cette page: ${data.values}",
-				"plural": "Le id de l'attribut ARIA des éléments n'existent pas dans cette page: ${data.values}"
+				"singular": "L’id de l’attribut ARIA de l’élément n’existe pas dans cette page : ${data.values}",
+				"plural": "L’id de l’attribut ARIA des éléments n’existent pas dans cette page : ${data.values}"
 			}
 		},
 		"aria-valid-attr": {
@@ -427,8 +427,8 @@
 				"plural": "Le nom d’attribut ARIA est valide"
 			},
 			"fail": {
-				"singular": "Le nom d’attribut ARIA est invalide: ${data.values}",
-				"plural": "Les noms d’attributs ARIA sont invalides: ${data.values}"
+				"singular": "Le nom d’attribut ARIA est invalide : ${data.values}",
+				"plural": "Les noms d’attributs ARIA sont invalides : ${data.values}"
 			}
 		},
 		"valid-scrollable-semantics": {
@@ -449,7 +449,7 @@
 				"elmPartiallyObscuring": "La couleur d’arrière-plan de l’élément n’a pu être déterminée, car il chevauche partiellement un autre élément",
 				"outsideViewport": "La couleur d’arrière-plan de l’élément n’a pu être déterminée, car il est à l’extérieur du viewport",
 				"equalRatio": "L’élément a un rapport de contraste de 1:1 avec son arrière-plan",
-				"shortTextContent": "Le contenu de l'élément est trop court pour déterminer S'il s'agit réellement de contenu textuel"
+				"shortTextContent": "Le contenu de l’élément est trop court pour déterminer s’il s’agit réellement d’un contenu textuel"
 			}
 		},
 		"link-in-text-block": {
@@ -470,30 +470,30 @@
 		},
 		"autocomplete-valid": {
 			"pass": "L’attribut autocomplete est formaté correctement",
-			"fail": "L’attribut autocomplete est formaté incorrectement"
+			"fail": "L’attribut autocomplete n’est pas formaté correctement"
 		},
 		"accesskeys": {
-			"pass": "La valeur de l'attribut accesskey est unique",
+			"pass": "La valeur de l’attribut accesskey est unique",
 			"fail": "Plusieurs éléments ont le même accesskey au sein du document"
 		},
 		"focusable-content": {
-			"pass": "L'élément contient des éléments focalisables",
-			"fail": "L'élément devrait avoir du contenu focalisable"
+			"pass": "L’élément contient des éléments focalisables",
+			"fail": "L’élément devrait avoir du contenu focalisable"
 		},
 		"focusable-disabled": {
-			"pass": "Aucun élément focalisable contenu dans l'élément",
+			"pass": "Aucun élément focalisable contenu dans l’élément",
 			"fail": "Le contenu focalisable devrait être désactivé ou retiré du DOM"
 		},
 		"focusable-element": {
-			"pass": "L'élément est focalisable",
-			"fail": "L'élément devrait être focalisable"
+			"pass": "L’élément est focalisable",
+			"fail": "L’élément devrait être focalisable"
 		},
 		"focusable-no-name": {
 			"pass": "L’élément n’est pas dans l’ordre de tabulation ou a un intitulé accessible",
 			"fail": "L’élément est dans l’ordre de tabulation et n’a pas d’intitulé accessible"
 		},
 		"focusable-not-tabbable": {
-			"pass": "Aucun élément focalisable contenu dans l'élément",
+			"pass": "Aucun élément focalisable contenu dans l’élément",
 			"fail": "Le contenu focalisable devrait se voir assigné un tabindex='-1' ou être retiré du DOM"
 		},
 		"landmark-is-top-level": {
@@ -525,8 +525,8 @@
 			"fail": "L’élément a un tabindex supérieur à 0"
 		},
 		"alt-space-value": {
-			"pass": "L'élément a une valeur d'attribut alt valide",
-			"fail": "L'élément a un attribut alt qui contient un caractères d'espacement, qui n'est pas ignoré par les lecteurs d'écran"
+			"pass": "L’élément a une valeur d’attribut alt valide",
+			"fail": "L’élément a un attribut alt qui contient un caractère d’espacement qui n’est pas ignoré par les lecteurs d’écran"
 		},
 		"duplicate-img-label": {
 			"pass": "L’élément ne duplique pas un texte existant dans l’alternative textuelle de l’élément <img>",
@@ -549,12 +549,12 @@
 			"fail": "L’élément de formulaire n’a pas de <label> implicite (imbriqué)"
 		},
 		"label-content-name-mismatch": {
-			"pass": "L'élément contient du texte visible qui n'est pas inclus dans l'intitulé accessible",
-			"fail": "Le texte contenu dans l'élément n'est pas inclus dans l'intitulé accessible"
+			"pass": "L’élément contient du texte visible qui n’est pas inclus dans l’intitulé accessible",
+			"fail": "Le texte contenu dans l’élément n’est pas inclus dans l’intitulé accessible"
 		},
 		"multiple-label": {
 			"pass": "L’élément de formulaire n’a pas plusieurs éléments <label>",
-			"incomplete": "Des éléments associés à plusieurs étiquettes ne sont pas suffisamment supportés par les teechnologies d'assistance. S'assurer que la première étiquette contient toute l'information nécessaire."
+			"incomplete": "Des éléments associés à plusieurs étiquettes ne sont pas suffisamment supportés par les technologies d’assistance. Vérifier que la première étiquette contient toute l’information nécessaire."
 		},
 		"title-only": {
 			"pass": "L’élément de formulaire n’a pas uniquement l’attribut title comme étiquette",
@@ -562,7 +562,7 @@
 		},
 		"landmark-is-unique": {
 			"pass": "Les landmarks doivent comporter un rôle unique, ou une étiquette accessible par la combinaison de role/label/title",
-			"fail": "L'attribut landmark doit comporter une valeur d'attribut aria-label, aria-labelledby, ou title unique pour rendre le landmark distinct"
+			"fail": "L’attribut landmark doit comporter une valeur d’attribut aria-label, aria-labelledby, ou title unique pour rendre le landmark distinct"
 		},
 		"has-lang": {
 			"pass": "L’élément <html> a un attribut lang",
@@ -583,8 +583,8 @@
 		"listitem": {
 			"pass": "L’item de liste a un élément <ul>, <ol> ou role=\"list\" parent",
 			"fail": {
-				"default": "L'item de liste n'a pas d'élément <ul> ou <ol> parent",
-				"roleNotValid": "L'item de liste n'a pas d'élément <ul> ou <ol> parent sans un role ou un role=\"list\""
+				"default": "L’item de liste n’a pas d’élément <ul> ou <ol> parent",
+				"roleNotValid": "L’item de liste n’a pas d’élément <ul> ou <ol> parent sans un role ou un role=\"list\""
 			}
 		},
 		"only-dlitems": {
@@ -594,8 +594,8 @@
 		"only-listitems": {
 			"pass": "L’élément de liste n’a que des descendants directs qui sont autorisés dans les éléments <li>",
 			"fail": {
-				"default": "L’élément de liste comporte des descendants directs qui ne sont pas autorisés à l'intérieur de l'élément <li>",
-				"roleNotValid": "L’élément de liste comporte des descendants directs avec un rôle qui n'est pas autorisé: ${data.roles}"
+				"default": "L’élément de liste comporte des descendants directs qui ne sont pas autorisés à l’intérieur de l’élément <li>",
+				"roleNotValid": "L’élément de liste comporte des descendants directs avec un rôle qui n’est pas autorisé : ${data.roles}"
 			}
 		},
 		"structured-dlitems": {
@@ -612,9 +612,9 @@
 			"incomplete": "L’iframe doit encore être testée avec axe-core"
 		},
 		"css-orientation-lock": {
-			"pass": "L'utilisation de l'écran est indépendant de l'orientation et n'est pas limitée à un mode d'affichage donné",
-			"fail": "L'utilisation de l'écran est limitée à une orientation donnée par CSS, rendant l'affichage inutilisable",
-			"incomplete": "Le verouillage de l'orientation d'affichage par CSS ne peut être déterminé"
+			"pass": "L’utilisation de l’écran est indépendante de l’orientation et n’est pas limitée à un mode d’affichage donné",
+			"fail": "L’utilisation de l’écran est limitée à une orientation donnée par CSS, rendant l’affichage inutilisable",
+			"incomplete": "Le verrouillage de l’orientation d’affichage par CSS ne peut être déterminé"
 		},
 		"meta-viewport-large": {
 			"pass": "La balise <meta> ne limite pas l’agrandissement sur les appareils mobiles",
@@ -662,12 +662,12 @@
 			"fail": "L’attribut title de l’élément n’est pas unique"
 		},
 		"duplicate-id-active": {
-			"pass": "Le document ne comporte aucun élément actif partageant la même valeur d'attribut id",
-			"fail": "Le document comporte ou un plusieurs éléments actifs partageant la même valeur d'attribut id: ${data}"
+			"pass": "Le document ne comporte aucun élément actif partageant la même valeur d’attribut id",
+			"fail": "Le document comporte ou un plusieurs éléments actifs partageant la même valeur d’attribut id : ${data}"
 		},
 		"duplicate-id-aria": {
-			"pass": "Le document ne comporte aucun élément référencés par ARIA ou étiquettes partageant la même valeur d'attribut id",
-			"fail": "Le document comporte un ou plusieurs éléments référencés par ARIA partageant la même valeur d'attribut id: ${data}"
+			"pass": "Le document ne comporte aucun élément référencé par ARIA ou étiquettes partageant la même valeur d’attribut id",
+			"fail": "Le document comporte un ou plusieurs éléments référencés par ARIA partageant la même valeur d’attribut id : ${data}"
 		},
 		"duplicate-id": {
 			"pass": "Le document n’a pas d’éléments qui partagent le même attribut id",
@@ -682,10 +682,10 @@
 			"fail": "L’attribut aria-labelledby n’existe pas, fait référence à des éléments qui n’existent pas ou à des éléments vides ou non visibles"
 		},
 		"avoid-inline-spacing": {
-			"pass": "Aucun style inline affectant l'espacement du texte avec '!important' n'a été spécifié",
+			"pass": "Aucun style inline affectant l’espacement du texte avec '!important' n’a été spécifié",
 			"fail": {
-				"singular": "Retirer '!important' du style inline ${data.values}, car le remplacement n'est pas pris en charge par la plupart des navigateurs",
-				"plural": "Retirer '!important' des styles inline ${data.values}, car le remplacement n'est pas pris en charge par la plupart des navigateurs"
+				"singular": "Retirer '!important' du style inline ${data.values}, car le remplacement n’est pas pris en charge par la plupart des navigateurs",
+				"plural": "Retirer '!important' des styles inline ${data.values}, car le remplacement n’est pas pris en charge par la plupart des navigateurs"
 			}
 		},
 		"button-has-visible-text": {
@@ -698,7 +698,7 @@
 		},
 		"exists": {
 			"pass": "L’élément n’existe pas",
-			"incomplete": "Element exists"
+			"incomplete": "L’élément existe"
 		},
 		"has-alt": {
 			"pass": "L’élément a un attribut alt",
@@ -714,12 +714,12 @@
 		},
 		"non-empty-alt": {
 			"pass": "L’élément a un attribut alt non vide",
-			"fail": "L’élément n’a pas d'attribut alt ou l’attribut alt est vide"
+			"fail": "L’élément n’a pas d’attribut alt ou l’attribut alt est vide"
 		},
 		"non-empty-if-present": {
 			"pass": {
-				"default": "L'élément n'a pas d'attribut value",
-				"has-label": "L'élément a un attribut value non-vide"
+				"default": "L’élément n’a pas d’attribut value",
+				"has-label": "L’élément a un attribut value non-vide"
 			},
 			"fail": "L’élément a un attribut value, et cet attribut est vide"
 		},
@@ -782,5 +782,5 @@
 			"failureMessage": "Corriger tous les éléments suivants : {{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
 		}
 	},
-	"incompleteFallbackMessage": "axe n'a pu en déterminer la raison. Il est temps de sortir l'inspecteur d'éléments!"
+	"incompleteFallbackMessage": "axe n’a pu en déterminer la raison. Il est temps de sortir l’inspecteur d’éléments !"
 }


### PR DESCRIPTION
- fixed basic typos
- replaced "s'assure que" by "vérifier que"
- removed subjunctive forms
- typography: homogenized apostrophes
- typography: added spaces before : and !
- fixed singular / plural
- fixed genders
- added some elisions of vowels

Closes issue #2484

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
