### PR TITLE
fix(attr-non-space-content-evaluate): Split no attribute and empty attribute message

### DIFF
--- a/lib/checks/generic/attr-non-space-content-evaluate.js
+++ b/lib/checks/generic/attr-non-space-content-evaluate.js
@@ -7,8 +7,22 @@ function attrNonSpaceContentEvaluate(node, options = {}, vNode) {
 		);
 	}
 
+	if (!vNode.hasAttr(options.attribute)) {
+		this.data({
+			messageKey: 'noAttr'
+		});
+		return false;
+	}
+
 	const attribute = vNode.attr(options.attribute) || '';
-	return !!sanitize(attribute.trim());
+	const attributeIsEmpty = !sanitize(attribute.trim());
+	if (attributeIsEmpty) {
+		this.data({
+			messageKey: 'emptyAttr'
+		});
+		return false;
+	}
+	return true;
 }
 
 export default attrNonSpaceContentEvaluate;

--- a/lib/checks/shared/non-empty-alt.json
+++ b/lib/checks/shared/non-empty-alt.json
@@ -8,7 +8,10 @@
 		"impact": "critical",
 		"messages": {
 			"pass": "Element has a non-empty alt attribute",
-			"fail": "Element has no alt attribute or the alt attribute is empty"
+			"fail": {
+				"noAttr": "Element has no alt attribute",
+				"emptyAttr": "Element has an empty alt attribute"
+			}
 		}
 	}
 }

--- a/lib/checks/shared/non-empty-placeholder.json
+++ b/lib/checks/shared/non-empty-placeholder.json
@@ -8,7 +8,10 @@
 		"impact": "serious",
 		"messages": {
 			"pass": "Element has a placeholder attribute",
-			"fail": "Element has no placeholder attribute or the placeholder attribute is empty"
+			"fail": {
+				"noAttr": "Element has no placeholder attribute",
+				"emptyAttr": "Element has an empty placeholder attribute"
+			}
 		}
 	}
 }

--- a/lib/checks/shared/non-empty-title.json
+++ b/lib/checks/shared/non-empty-title.json
@@ -8,7 +8,10 @@
 		"impact": "serious",
 		"messages": {
 			"pass": "Element has a title attribute",
-			"fail": "Element has no title attribute or the title attribute is empty"
+			"fail": {
+				"noAttr": "Element has no title attribute",
+				"emptyAttr": "Element has an empty title attribute"
+			}
 		}
 	}
 }

--- a/lib/checks/shared/non-empty-value.json
+++ b/lib/checks/shared/non-empty-value.json
@@ -8,7 +8,10 @@
 		"impact": "critical",
 		"messages": {
 			"pass": "Element has a non-empty value attribute",
-			"fail": "Element has no value attribute or the value attribute is empty"
+			"fail": {
+				"noAttr": "Element has no value attribute",
+				"emptyAttr": "Element has an empty value attribute"
+			}
 		}
 	}
 }

--- a/test/checks/shared/non-empty-alt.js
+++ b/test/checks/shared/non-empty-alt.js
@@ -4,28 +4,33 @@ describe('non-empty-alt', function() {
 	var fixture = document.getElementById('fixture');
 	var checkSetup = axe.testUtils.checkSetup;
 	var checkEvaluate = axe.testUtils.getCheckEvaluate('non-empty-alt');
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function() {
 		fixture.innerHTML = '';
+		checkContext.reset();
 	});
 
 	it('should return true if an alt is present', function() {
 		var params = checkSetup('<img id="target" alt="woohoo" />');
-		assert.isTrue(checkEvaluate.apply(null, params));
+		assert.isTrue(checkEvaluate.apply(checkContext, params));
 	});
 
 	it('should return false if an alt is not present', function() {
 		var params = checkSetup('<img id="target" />');
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'noAttr');
 	});
 
 	it('should return false if an alt is present, but empty', function() {
 		var params = checkSetup('<img id="target" alt=" " />');
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 
 	it('should collapse whitespace', function() {
 		var params = checkSetup('<img id="target" alt=" \t \n \r \t  \t\r\n " />');
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 });

--- a/test/checks/shared/non-empty-placeholder.js
+++ b/test/checks/shared/non-empty-placeholder.js
@@ -4,27 +4,31 @@ describe('non-empty-placeholder', function() {
 	var fixture = document.getElementById('fixture');
 	var checkSetup = axe.testUtils.checkSetup;
 	var checkEvaluate = axe.testUtils.getCheckEvaluate('non-empty-placeholder');
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function() {
 		fixture.innerHTML = '';
+		checkContext.reset();
 	});
 
 	it('should return true if a placeholder is present', function() {
 		var params = checkSetup('<input id="target" placeholder="woohoo" />');
 
-		assert.isTrue(checkEvaluate.apply(null, params));
+		assert.isTrue(checkEvaluate.apply(checkContext, params));
 	});
 
 	it('should return false if a placeholder is not present', function() {
 		var params = checkSetup('<input id="target" />');
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'noAttr');
 	});
 
 	it('should return false if a placeholder is present, but empty', function() {
 		var params = checkSetup('<input id="target" placeholder=" " />');
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 
 	it('should collapse whitespace', function() {
@@ -32,6 +36,7 @@ describe('non-empty-placeholder', function() {
 			'<input id="target" placeholder=" \t \n \r \t  \t\r\n " />'
 		);
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 });

--- a/test/checks/shared/non-empty-title.js
+++ b/test/checks/shared/non-empty-title.js
@@ -4,27 +4,31 @@ describe('non-empty-title', function() {
 	var fixture = document.getElementById('fixture');
 	var checkSetup = axe.testUtils.checkSetup;
 	var checkEvaluate = axe.testUtils.getCheckEvaluate('non-empty-title');
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function() {
 		fixture.innerHTML = '';
+		checkContext.reset();
 	});
 
 	it('should return true if a title is present', function() {
 		var params = checkSetup('<img id="target" title="woohoo" />');
 
-		assert.isTrue(checkEvaluate.apply(null, params));
+		assert.isTrue(checkEvaluate.apply(checkContext, params));
 	});
 
 	it('should return false if a title is not present', function() {
 		var params = checkSetup('<img id="target" />');
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'noAttr');
 	});
 
 	it('should return false if a title is present, but empty', function() {
 		var params = checkSetup('<img id="target" title=" " />');
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 
 	it('should collapse whitespace', function() {
@@ -32,6 +36,7 @@ describe('non-empty-title', function() {
 			'<img id="target" title=" \t \n \r \t  \t\r\n " />'
 		);
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 });

--- a/test/checks/shared/non-empty-value.js
+++ b/test/checks/shared/non-empty-value.js
@@ -4,6 +4,7 @@ describe('non-empty-value', function() {
 	var fixture = document.getElementById('fixture');
 	var checkSetup = axe.testUtils.checkSetup;
 	var checkEvaluate = axe.testUtils.getCheckEvaluate('non-empty-value');
+	var checkContext = axe.testUtils.MockCheckContext();
 
 	afterEach(function() {
 		fixture.innerHTML = '';
@@ -12,19 +13,21 @@ describe('non-empty-value', function() {
 	it('should return true if an value is present', function() {
 		var params = checkSetup('<input id="target" value="woohoo" />');
 
-		assert.isTrue(checkEvaluate.apply(null, params));
+		assert.isTrue(checkEvaluate.apply(checkContext, params));
 	});
 
 	it('should return false if an value is not present', function() {
 		var params = checkSetup('<input id="target" />');
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'noAttr');
 	});
 
 	it('should return false if an value is present, but empty', function() {
 		var params = checkSetup('<input id="target" value=" " />');
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 
 	it('should collapse whitespace', function() {
@@ -32,6 +35,7 @@ describe('non-empty-value', function() {
 			'<input id="target" value=" \t \n \r \t  \t\r\n " />'
 		);
 
-		assert.isFalse(checkEvaluate.apply(null, params));
+		assert.isFalse(checkEvaluate.apply(checkContext, params));
+		assert.equal(checkContext._data.messageKey, 'emptyAttr');
 	});
 });


### PR DESCRIPTION
 Split no attribute and empty attribute message

Closes issue: fixes #2451, fixes #2453

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
