### PR TITLE
tests: disable chrome-mobile testing, fix puppeteer example test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ win_box: &win_box
 
 orbs:
   win: circleci/windows@1.0.0
+  puppeteer: threetreeslight/puppeteer@0.1.2
+
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,13 +48,7 @@ module.exports = function(grunt) {
 		langs = [''];
 	}
 
-	var webDriverTestBrowsers = [
-		'firefox',
-		'chrome',
-		'ie',
-		'chrome-mobile',
-		'safari'
-	];
+	var webDriverTestBrowsers = ['firefox', 'chrome', 'ie', 'safari'];
 
 	process.env.NODE_NO_HTTP2 = 1; // to hide node warning - (node:18740) ExperimentalWarning: The http2 module is an experimental API.
 


### PR DESCRIPTION
Our tests are failing because of chrome-mobile. Turning off for now, created a [tech debt ticket for it](https://github.com/dequelabs/axe-core/issues/2497). Also [fixing our puppeteer example test](https://app.circleci.com/pipelines/github/dequelabs/axe-core/1125/workflows/793b36c0-0ddc-4507-adc7-ccb402918002/jobs/21505) by including the [circleci orb](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-on-circleci) that has all the required dependencies. 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
