### PR TITLE
feat(checks): deprecate role-none and role-presentation for presentational-role

### DIFF
--- a/build/configure.js
+++ b/build/configure.js
@@ -87,6 +87,7 @@ function buildRules(grunt, options, commons, callback) {
 		var tags = options.tags ? options.tags.split(/\s*,\s*/) : [];
 		var rules = result.rules;
 		var checks = result.checks;
+		parseChecks(checks);
 
 		// Translate checks
 		if (locale && locale.checks) {

--- a/lib/checks/shared/presentational-role-evaluate.js
+++ b/lib/checks/shared/presentational-role-evaluate.js
@@ -1,0 +1,42 @@
+import { getExplicitRole, getRole } from '../../commons/aria';
+import { getGlobalAriaAttrs } from '../../commons/standards';
+import { isFocusable } from '../../commons/dom';
+
+function presentationalRoleEvaluate(node, options, virtualNode) {
+	const role = getRole(virtualNode);
+	const explicitRole = getExplicitRole(virtualNode);
+
+	if (['presentation', 'none'].includes(role)) {
+		this.data({ role });
+		return true;
+	}
+
+	// if the user didn't intended to make this presentational we fail
+	if (!['presentation', 'none'].includes(explicitRole)) {
+		return false;
+	}
+
+	// user intended to make this presentational so inform them of
+	// problems caused by role conflict resolution
+	const hasGlobalAria = getGlobalAriaAttrs().some(attr =>
+		virtualNode.hasAttr(attr)
+	);
+	const focusable = isFocusable(virtualNode);
+	let messageKey;
+
+	if (hasGlobalAria && !focusable) {
+		messageKey = 'globalAria';
+	} else if (!hasGlobalAria && focusable) {
+		messageKey = 'focusable';
+	} else {
+		messageKey = 'both';
+	}
+
+	this.data({
+		messageKey,
+		role
+	});
+	return false;
+}
+
+export default presentationalRoleEvaluate;

--- a/lib/checks/shared/presentational-role.json
+++ b/lib/checks/shared/presentational-role.json
@@ -9,7 +9,7 @@
 				"default": "Element's default semantics were not overridden with role=\"none\" or role=\"presentation\"",
 				"globalAria": "Element's role is not presentational because it has a global ARIA attribute",
 				"focusable": "Element's role is not presentational because it is focusable",
-				"both": "Element's role is not presentational because it has a global aria attribute and is focusable"
+				"both": "Element's role is not presentational because it has a global ARIA attribute and is focusable"
 			}
 		}
 	}

--- a/lib/checks/shared/presentational-role.json
+++ b/lib/checks/shared/presentational-role.json
@@ -1,0 +1,16 @@
+{
+	"id": "presentational-role",
+	"evaluate": "presentational-role-evaluate",
+	"metadata": {
+		"impact": "minor",
+		"messages": {
+			"pass": "Element's default semantics were overriden with role=\"${data.role}\"",
+			"fail": {
+				"default": "Element's default semantics were not overridden with role=\"none\" or role=\"presentation\"",
+				"globalAria": "Element's role is not presentational because it has a global aria attribute",
+				"focusable": "Element's role is not presentational because it is focusable",
+				"both": "Element's role is not presentational because it has a global aria attribute and is focusable"
+			}
+		}
+	}
+}

--- a/lib/checks/shared/presentational-role.json
+++ b/lib/checks/shared/presentational-role.json
@@ -7,7 +7,7 @@
 			"pass": "Element's default semantics were overriden with role=\"${data.role}\"",
 			"fail": {
 				"default": "Element's default semantics were not overridden with role=\"none\" or role=\"presentation\"",
-				"globalAria": "Element's role is not presentational because it has a global aria attribute",
+				"globalAria": "Element's role is not presentational because it has a global ARIA attribute",
 				"focusable": "Element's role is not presentational because it is focusable",
 				"both": "Element's role is not presentational because it has a global aria attribute and is focusable"
 			}

--- a/lib/checks/shared/role-none.json
+++ b/lib/checks/shared/role-none.json
@@ -1,6 +1,7 @@
 {
 	"id": "role-none",
 	"evaluate": "matches-definition-evaluate",
+	"deprecated": true,
 	"options": {
 		"matcher": {
 			"attributes": {

--- a/lib/checks/shared/role-presentation.json
+++ b/lib/checks/shared/role-presentation.json
@@ -1,6 +1,7 @@
 {
 	"id": "role-presentation",
 	"evaluate": "matches-definition-evaluate",
+	"deprecated": true,
 	"options": {
 		"matcher": {
 			"attributes": {

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -69,6 +69,7 @@ import existsEvaluate from '../../checks/shared/exists-evaluate';
 import hasAltEvaluate from '../../checks/shared/has-alt-evaluate';
 import isOnScreenEvaluate from '../../checks/shared/is-on-screen-evaluate';
 import nonEmptyIfPresentEvaluate from '../../checks/shared/non-empty-if-present-evaluate';
+import presentationalRoleEvaluate from '../../checks/shared/presentational-role-evaluate';
 import svgNonEmptyTitleEvaluate from '../../checks/shared/svg-non-empty-title-evaluate';
 
 // mobile
@@ -231,6 +232,7 @@ const metadataFunctionMap = {
 	'has-alt-evaluate': hasAltEvaluate,
 	'is-on-screen-evaluate': isOnScreenEvaluate,
 	'non-empty-if-present-evaluate': nonEmptyIfPresentEvaluate,
+	'presentational-role-evaluate': presentationalRoleEvaluate,
 	'svg-non-empty-title-evaluate': svgNonEmptyTitleEvaluate,
 
 	// mobile

--- a/lib/rules/button-name.json
+++ b/lib/rules/button-name.json
@@ -17,8 +17,7 @@
 		"button-has-visible-text",
 		"aria-label",
 		"aria-labelledby",
-		"role-presentation",
-		"role-none",
+		"presentational-role",
 		"non-empty-title"
 	],
 	"none": []

--- a/lib/rules/frame-title.json
+++ b/lib/rules/frame-title.json
@@ -18,8 +18,7 @@
 		"aria-label",
 		"aria-labelledby",
 		"non-empty-title",
-		"role-presentation",
-		"role-none"
+		"presentational-role"
 	],
 	"none": []
 }

--- a/lib/rules/image-alt.json
+++ b/lib/rules/image-alt.json
@@ -18,8 +18,7 @@
 		"aria-label",
 		"aria-labelledby",
 		"non-empty-title",
-		"role-presentation",
-		"role-none"
+		"presentational-role"
 	],
 	"none": ["alt-space-value"]
 }

--- a/lib/rules/input-button-name.json
+++ b/lib/rules/input-button-name.json
@@ -18,8 +18,7 @@
 		"non-empty-value",
 		"aria-label",
 		"aria-labelledby",
-		"role-presentation",
-		"role-none",
+		"presentational-role",
 		"non-empty-title"
 	],
 	"none": []

--- a/lib/rules/label.json
+++ b/lib/rules/label.json
@@ -22,8 +22,7 @@
 		"explicit-label",
 		"non-empty-title",
 		"non-empty-placeholder",
-		"role-none",
-		"role-presentation"
+		"presentational-role"
 	],
 	"none": ["help-same-as-label", "hidden-explicit-label"]
 }

--- a/lib/rules/link-name.json
+++ b/lib/rules/link-name.json
@@ -18,8 +18,6 @@
 		"has-visible-text",
 		"aria-label",
 		"aria-labelledby",
-		"role-presentation",
-		"role-none",
 		"non-empty-title"
 	],
 	"none": ["focusable-no-name"]

--- a/lib/rules/object-alt.json
+++ b/lib/rules/object-alt.json
@@ -18,8 +18,7 @@
 		"aria-label",
 		"aria-labelledby",
 		"non-empty-title",
-		"role-presentation",
-		"role-none"
+		"presentational-role"
 	],
 	"none": []
 }

--- a/lib/rules/select-name.json
+++ b/lib/rules/select-name.json
@@ -20,8 +20,7 @@
 		"implicit-label",
 		"explicit-label",
 		"non-empty-title",
-		"role-none",
-		"role-presentation"
+		"presentational-role"
 	],
 	"none": ["help-same-as-label", "hidden-explicit-label"]
 }

--- a/test/checks/shared/presentational-role.js
+++ b/test/checks/shared/presentational-role.js
@@ -1,0 +1,66 @@
+describe('presentational-role', function() {
+	'use strict';
+
+	var fixture = document.getElementById('fixture');
+	var queryFixture = axe.testUtils.queryFixture;
+	var checkEvaluate = axe.testUtils.getCheckEvaluate('presentational-role');
+	var checkContext = axe.testUtils.MockCheckContext();
+
+	afterEach(function() {
+		fixture.innerHTML = '';
+		checkContext.reset();
+	});
+
+	it('should detect role="none" on the element', function() {
+		var vNode = queryFixture('<div id="target" role="none"></div>');
+
+		assert.isTrue(checkEvaluate.call(checkContext, null, null, vNode));
+		assert.deepEqual(checkContext._data.role, 'none');
+	});
+
+	it('should detect role="presentation" on the element', function() {
+		var vNode = queryFixture('<div id="target" role="presentation"></div>');
+
+		assert.isTrue(checkEvaluate.call(checkContext, null, null, vNode));
+		assert.deepEqual(checkContext._data.role, 'presentation');
+	});
+
+	it('should return false when role !== none', function() {
+		var vNode = queryFixture('<div id="target" role="cats"></div>');
+
+		assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
+	});
+
+	it('should return false when there is no role attribute', function() {
+		var vNode = queryFixture('<div id="target"></div>');
+
+		assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
+	});
+
+	it('should return false when the element is focusable', function() {
+		var vNode = queryFixture(
+			'<button id="target" role="none">Still a button</button>'
+		);
+
+		assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
+		assert.deepEqual(checkContext._data.messageKey, 'focusable');
+	});
+
+	it('should return false when the element has global aria attributes', function() {
+		var vNode = queryFixture(
+			'<img id="target" role="none" aria-live="assertive" />'
+		);
+
+		assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
+		assert.deepEqual(checkContext._data.messageKey, 'globalAria');
+	});
+
+	it('should return false when the element has global aria attributes and is focusable', function() {
+		var vNode = queryFixture(
+			'<button id="target" role="none" aria-live="assertive">Still a button</button>'
+		);
+
+		assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
+		assert.deepEqual(checkContext._data.messageKey, 'both');
+	});
+});

--- a/test/integration/rules/button-name/button-name.html
+++ b/test/integration/rules/button-name/button-name.html
@@ -13,3 +13,9 @@
 <button id="buttonvalue" value="foo" tabindex="-1"></button>
 
 <input type="submit" value="submit" role="button" id="ignored" />
+
+<button id="fail1" role="presentation"></button>
+<button id="fail2" role="none"></button>
+
+<button id="pass1" role="presentation" disabled></button>
+<button id="pass2" role="none" disabled></button>

--- a/test/integration/rules/button-name/button-name.json
+++ b/test/integration/rules/button-name/button-name.json
@@ -7,7 +7,17 @@
 		["#alempty"],
 		["#albmissing"],
 		["#albempty"],
-		["#buttonvalue"]
+		["#buttonvalue"],
+		["#fail1"],
+		["#fail2"]
 	],
-	"passes": [["#text"], ["#al"], ["#alb"], ["#combo"], ["#buttonTitle"]]
+	"passes": [
+		["#text"],
+		["#al"],
+		["#alb"],
+		["#combo"],
+		["#buttonTitle"],
+		["#pass1"],
+		["#pass2"]
+	]
 }

--- a/test/integration/rules/frame-title/frame-title.html
+++ b/test/integration/rules/frame-title/frame-title.html
@@ -32,3 +32,28 @@
 	role="presentation"
 ></iframe>
 <iframe src="frame-title/frames/level1a.html" id="pass7" role="none"></iframe>
+
+<iframe
+	src="frame-title/frames/level1a.html"
+	id="violation4"
+	role="none"
+	aria-live="assertive"
+></iframe>
+<iframe
+	src="frame-title/frames/level1a.html"
+	id="violation5"
+	role="presentation"
+	aria-live="assertive"
+></iframe>
+<iframe
+	src="frame-title/frames/level1a.html"
+	id="violation6"
+	role="none"
+	tabindex="0"
+></iframe>
+<iframe
+	src="frame-title/frames/level1a.html"
+	id="violation7"
+	role="presentation"
+	tabindex="0"
+></iframe>

--- a/test/integration/rules/frame-title/frame-title.json
+++ b/test/integration/rules/frame-title/frame-title.json
@@ -4,7 +4,11 @@
 	"violations": [
 		["#violation1"],
 		["#violation1", "#violation2"],
-		["#violation3"]
+		["#violation3"],
+		["#violation4"],
+		["#violation5"],
+		["#violation6"],
+		["#violation7"]
 	],
 	"passes": [
 		["#violation1", "#pass1"],

--- a/test/integration/rules/image-alt/image-alt.html
+++ b/test/integration/rules/image-alt/image-alt.html
@@ -14,3 +14,8 @@
 <img src="img.jpg" id="pass7" role="none" />
 <img src="img.jpg" id="pass8" aria-labelledby="ninjamonkeys" />
 <img src="img.jpg" id="violation6" alt=" " />
+
+<img src="img.jpg" id="violation7" role="presentation" aria-live="assertive" />
+<img src="img.jpg" id="violation8" role="none" aria-live="assertive" />
+<img src="img.jpg" id="violation9" role="presentation" tabindex="0" />
+<img src="img.jpg" id="violation10" role="none" tabindex="0" />

--- a/test/integration/rules/image-alt/image-alt.json
+++ b/test/integration/rules/image-alt/image-alt.json
@@ -7,7 +7,11 @@
 		["#violation3"],
 		["#violation4"],
 		["#violation5"],
-		["#violation6"]
+		["#violation6"],
+		["#violation7"],
+		["#violation8"],
+		["#violation9"],
+		["#violation10"]
 	],
 	"passes": [
 		["#pass1"],

--- a/test/integration/rules/input-button-name/input-button-name.html
+++ b/test/integration/rules/input-button-name/input-button-name.html
@@ -18,4 +18,9 @@
 	<input type="button" title="Something" id="pass9" />
 	<input type="submit" title="Something" id="pass10" />
 	<input type="reset" title="Something" id="pass11" />
+
+	<input type="button" role="none" id="fail7" />
+	<input type="button" role="presentation" id="fail8" />
+	<input type="button" role="none" id="pass12" disabled />
+	<input type="button" role="presentation" id="pass13" disabled />
 </form>

--- a/test/integration/rules/input-button-name/input-button-name.json
+++ b/test/integration/rules/input-button-name/input-button-name.json
@@ -7,7 +7,9 @@
 		["#fail3"],
 		["#fail4"],
 		["#fail5"],
-		["#fail6"]
+		["#fail6"],
+		["#fail7"],
+		["#fail8"]
 	],
 	"passes": [
 		["#pass1"],
@@ -20,6 +22,8 @@
 		["#pass8"],
 		["#pass9"],
 		["#pass10"],
-		["#pass11"]
+		["#pass11"],
+		["#pass12"],
+		["#pass13"]
 	]
 }

--- a/test/integration/rules/link-name/link-name.html
+++ b/test/integration/rules/link-name/link-name.html
@@ -40,3 +40,6 @@
 <span role="link" href="#" tabindex="0" id="pass9" title="title text"></span>
 
 <a href="#" role="button">Does not apply</a>
+
+<a href="#" id="violation7" role="none"></a>
+<a href="#" id="violation8" role="presentation"></a>

--- a/test/integration/rules/link-name/link-name.json
+++ b/test/integration/rules/link-name/link-name.json
@@ -7,7 +7,9 @@
 		["#violation3"],
 		["#violation4"],
 		["#violation5"],
-		["#violation6"]
+		["#violation6"],
+		["#violation7"],
+		["#violation8"]
 	],
 	"passes": [
 		["#pass1"],

--- a/test/integration/rules/object-alt/object-alt.html
+++ b/test/integration/rules/object-alt/object-alt.html
@@ -10,3 +10,10 @@
 <object id="violation3"
 	><p style="display: none;">This object has no text.</p></object
 >
+<object id="pass7" role="none"></object>
+<object id="pass8" role="presentation"></object>
+
+<object id="violation4" role="none" tabindex="0"></object>
+<object id="violation5" role="presentation" tabindex="0"></object>
+<object id="violation6" role="none" aria-live="assertive"></object>
+<object id="violation7" role="presentation" aria-live="assertive"></object>

--- a/test/integration/rules/object-alt/object-alt.json
+++ b/test/integration/rules/object-alt/object-alt.json
@@ -1,13 +1,23 @@
 {
 	"description": "object-alt tests",
 	"rule": "object-alt",
-	"violations": [["#violation1"], ["#violation2"], ["#violation3"]],
+	"violations": [
+		["#violation1"],
+		["#violation2"],
+		["#violation3"],
+		["#violation4"],
+		["#violation5"],
+		["#violation6"],
+		["#violation7"]
+	],
 	"passes": [
 		["#pass1"],
 		["#pass2"],
 		["#pass3"],
 		["#pass4"],
 		["#pass5"],
-		["#pass6"]
+		["#pass6"],
+		["#pass7"],
+		["#pass8"]
 	]
 }

--- a/test/integration/rules/select-name/select-name.html
+++ b/test/integration/rules/select-name/select-name.html
@@ -19,9 +19,6 @@
 
 	<select id="pass5" title="Label"></select>
 
-	<select id="pass6" role="presentation"></select>
-	<select id="pass7" role="none"></select>
-
 	<div>
 		<label>
 			<select id="fail4">
@@ -30,4 +27,10 @@
 			</select>
 		</label>
 	</div>
+
+	<select id="fail5" role="presentation"></select>
+	<select id="fail6" role="none"></select>
+
+	<select id="pass6" role="presentation" disabled></select>
+	<select id="pass7" role="none" disabled></select>
 </form>

--- a/test/integration/rules/select-name/select-name.json
+++ b/test/integration/rules/select-name/select-name.json
@@ -1,7 +1,14 @@
 {
 	"description": "select-name test",
 	"rule": "select-name",
-	"violations": [["#fail1"], ["#fail2"], ["#fail3"], ["#fail4"]],
+	"violations": [
+		["#fail1"],
+		["#fail2"],
+		["#fail3"],
+		["#fail4"],
+		["#fail5"],
+		["#fail6"]
+	],
 	"passes": [
 		["#pass1"],
 		["#pass2"],

--- a/test/integration/virtual-rules/button-name.js
+++ b/test/integration/virtual-rules/button-name.js
@@ -38,11 +38,12 @@ describe('button-name', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=presentation', function() {
+	it('should pass for role=presentation when disabled', function() {
 		var results = axe.runVirtualRule('button-name', {
 			nodeName: 'button',
 			attributes: {
-				role: 'presentation'
+				role: 'presentation',
+				disabled: true
 			}
 		});
 
@@ -51,11 +52,12 @@ describe('button-name', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=none', function() {
+	it('should pass for role=none when disabled', function() {
 		var results = axe.runVirtualRule('button-name', {
 			nodeName: 'button',
 			attributes: {
-				role: 'none'
+				role: 'none',
+				disabled: true
 			}
 		});
 
@@ -143,6 +145,38 @@ describe('button-name', function() {
 			nodeName: 'button',
 			attributes: {
 				title: ''
+			}
+		});
+		node.children = [];
+
+		var results = axe.runVirtualRule('button-name', node);
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should fail for role=presentation', function() {
+		var node = new axe.SerialVirtualNode({
+			nodeName: 'button',
+			attributes: {
+				role: 'presentation'
+			}
+		});
+		node.children = [];
+
+		var results = axe.runVirtualRule('button-name', node);
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should fail for role=none', function() {
+		var node = new axe.SerialVirtualNode({
+			nodeName: 'button',
+			attributes: {
+				role: 'none'
 			}
 		});
 		node.children = [];

--- a/test/integration/virtual-rules/input-button-name.js
+++ b/test/integration/virtual-rules/input-button-name.js
@@ -68,12 +68,13 @@ describe('input-button-name', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=presentation', function() {
+	it('should pass for role=presentation when disabled', function() {
 		var results = axe.runVirtualRule('input-button-name', {
 			nodeName: 'input',
 			attributes: {
 				type: 'button',
-				role: 'presentation'
+				role: 'presentation',
+				disabled: true
 			}
 		});
 
@@ -82,12 +83,13 @@ describe('input-button-name', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=none', function() {
+	it('should pass for role=none when disabled', function() {
 		var results = axe.runVirtualRule('input-button-name', {
 			nodeName: 'input',
 			attributes: {
 				type: 'button',
-				role: 'none'
+				role: 'none',
+				disabled: true
 			}
 		});
 
@@ -157,6 +159,34 @@ describe('input-button-name', function() {
 			attributes: {
 				type: 'button',
 				title: ''
+			}
+		});
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should pass for role=presentation', function() {
+		var results = axe.runVirtualRule('input-button-name', {
+			nodeName: 'input',
+			attributes: {
+				type: 'button',
+				role: 'presentation'
+			}
+		});
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should pass for role=none', function() {
+		var results = axe.runVirtualRule('input-button-name', {
+			nodeName: 'input',
+			attributes: {
+				type: 'button',
+				role: 'none'
 			}
 		});
 

--- a/test/integration/virtual-rules/label.js
+++ b/test/integration/virtual-rules/label.js
@@ -102,11 +102,12 @@ describe('label', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=presentation', function() {
+	it('should pass for role=presentation when disabled', function() {
 		var results = axe.runVirtualRule('label', {
 			nodeName: 'input',
 			attributes: {
-				role: 'presentation'
+				role: 'presentation',
+				disabled: true
 			}
 		});
 
@@ -115,11 +116,12 @@ describe('label', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=none', function() {
+	it('should pass for role=none when disabled', function() {
 		var results = axe.runVirtualRule('label', {
 			nodeName: 'input',
 			attributes: {
-				role: 'none'
+				role: 'none',
+				disabled: true
 			}
 		});
 
@@ -178,6 +180,38 @@ describe('label', function() {
 			nodeName: 'input',
 			attributes: {
 				title: ''
+			}
+		});
+		node.parent = null;
+
+		var results = axe.runVirtualRule('label', node);
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should fail for role=presentation', function() {
+		var node = new axe.SerialVirtualNode({
+			nodeName: 'input',
+			attributes: {
+				role: 'presentation'
+			}
+		});
+		node.parent = null;
+
+		var results = axe.runVirtualRule('label', node);
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should fail for role=none', function() {
+		var node = new axe.SerialVirtualNode({
+			nodeName: 'input',
+			attributes: {
+				role: 'presentation'
 			}
 		});
 		node.parent = null;

--- a/test/integration/virtual-rules/link-name.js
+++ b/test/integration/virtual-rules/link-name.js
@@ -31,42 +31,6 @@ describe('link-name', function() {
 		assert.lengthOf(results.incomplete, 1);
 	});
 
-	it('should pass for role=presentation', function() {
-		var node = new axe.SerialVirtualNode({
-			nodeName: 'a',
-			attributes: {
-				href: '/foo.html',
-				tabindex: '-1',
-				role: 'presentation'
-			}
-		});
-		node.children = [];
-
-		var results = axe.runVirtualRule('link-name', node);
-
-		assert.lengthOf(results.passes, 1);
-		assert.lengthOf(results.violations, 0);
-		assert.lengthOf(results.incomplete, 0);
-	});
-
-	it('should pass for role=none', function() {
-		var node = new axe.SerialVirtualNode({
-			nodeName: 'a',
-			attributes: {
-				href: '/foo.html',
-				tabindex: '-1',
-				role: 'none'
-			}
-		});
-		node.children = [];
-
-		var results = axe.runVirtualRule('link-name', node);
-
-		assert.lengthOf(results.passes, 1);
-		assert.lengthOf(results.violations, 0);
-		assert.lengthOf(results.incomplete, 0);
-	});
-
 	it('should pass for visible text content', function() {
 		var node = new axe.SerialVirtualNode({
 			nodeName: 'span',

--- a/test/integration/virtual-rules/select-name.js
+++ b/test/integration/virtual-rules/select-name.js
@@ -75,11 +75,12 @@ describe('select-name', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=presentation', function() {
+	it('should pass for role=presentation when disabled', function() {
 		var results = axe.runVirtualRule('select-name', {
 			nodeName: 'select',
 			attributes: {
-				role: 'presentation'
+				role: 'presentation',
+				disabled: true
 			}
 		});
 
@@ -88,11 +89,12 @@ describe('select-name', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for role=none', function() {
+	it('should pass for role=none when disabled', function() {
 		var results = axe.runVirtualRule('select-name', {
 			nodeName: 'select',
 			attributes: {
-				role: 'none'
+				role: 'none',
+				disabled: true
 			}
 		});
 
@@ -151,6 +153,38 @@ describe('select-name', function() {
 			nodeName: 'select',
 			attributes: {
 				title: ''
+			}
+		});
+		node.parent = null;
+
+		var results = axe.runVirtualRule('select-name', node);
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should pass for role=presentation', function() {
+		var node = new axe.SerialVirtualNode({
+			nodeName: 'select',
+			attributes: {
+				role: 'presentation'
+			}
+		});
+		node.parent = null;
+
+		var results = axe.runVirtualRule('select-name', node);
+
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
+	});
+
+	it('should pass for role=none', function() {
+		var node = new axe.SerialVirtualNode({
+			nodeName: 'select',
+			attributes: {
+				role: 'none'
 			}
 		});
 		node.parent = null;


### PR DESCRIPTION
The `presentational-role` check is written in such a way that as long as the end role of the element is presentation/none the check will pass. This enables it to be used for things that don't use explicit role to make it presentation, such as an images empty `alt` attribute. That should help when fixing #2502 so we don't have to check the role in that check.

Also, I removed the presentational check on the `link-name` rule as there is no way to disable a link from being focusable without a) making it hidden which prevents the rule from running on it or b) removing the `href` attribute which goes against the `selector` of the rule.

Closes issue: #2454 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
