### PR TITLE
feat(rule-matches): deprecate window-is-top-matches for is-initiator-matches

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,5 +1,6 @@
 {
 	"tags": {
+		"allowUnknownTags": true,
 		"dictionaries": ["jsdoc"]
 	},
 	"source": {
@@ -12,5 +13,6 @@
 		"encoding": "utf8",
 		"recurse": true,
 		"template": "./node_modules/minami"
-	}
+	},
+	"plugins": ["plugins/markdown"]
 }

--- a/doc/API.md
+++ b/doc/API.md
@@ -408,21 +408,22 @@ The options parameter is flexible way to configure how `axe.run` operates. The d
 
 Additionally, there are a number or properties that allow configuration of different options:
 
-| Property           | Default | Description                                                                                                                             |
-| ------------------ | :------ | :-------------------------------------------------------------------------------------------------------------------------------------- |
-| `runOnly`          | n/a     | Limit which rules are executed, based on names or tags                                                                                  |
-| `rules`            | n/a     | Enable or disable rules using the `enabled` property                                                                                    |
-| `reporter`         | `v1`    | Which reporter to use (see [Configuration](#api-name-axeconfigure))                                                                     |
-| `resultTypes`      | n/a     | Limit which result types are processed and aggregated                                                                                   |
-| `selectors`        | `true`  | Return CSS selector for elements, optimised for readability                                                                             |
-| `ancestry`         | `false` | Return CSS selector for elements, with all the element's ancestors                                                                      |
-| `xpath`            | `false` | Return xpath selectors for elements                                                                                                     |
-| `absolutePaths`    | `false` | Use absolute paths when creating element selectors                                                                                      |
-| `iframes`          | `true`  | Tell axe to run inside iframes                                                                                                          |
-| `elementRef`       | `false` | Return element references in addition to the target                                                                                     |
-| `frameWaitTime`    | `60000` | How long (in milliseconds) axe waits for a response from embedded frames before timing out                                              |
-| `preload`          | `true`  | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details) |
-| `performanceTimer` | `false` | Log rule performance metrics to the console                                                                                             |
+| Property           | Default | Description                                                                                                                                           |
+| ------------------ | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runOnly`          | n/a     | Limit which rules are executed, based on names or tags                                                                                                |
+| `rules`            | n/a     | Enable or disable rules using the `enabled` property                                                                                                  |
+| `reporter`         | `v1`    | Which reporter to use (see [Configuration](#api-name-axeconfigure))                                                                                   |
+| `resultTypes`      | n/a     | Limit which result types are processed and aggregated                                                                                                 |
+| `selectors`        | `true`  | Return CSS selector for elements, optimised for readability                                                                                           |
+| `ancestry`         | `false` | Return CSS selector for elements, with all the element's ancestors                                                                                    |
+| `xpath`            | `false` | Return xpath selectors for elements                                                                                                                   |
+| `absolutePaths`    | `false` | Use absolute paths when creating element selectors                                                                                                    |
+| `iframes`          | `true`  | Tell axe to run inside iframes                                                                                                                        |
+| `elementRef`       | `false` | Return element references in addition to the target                                                                                                   |
+| `frameWaitTime`    | `60000` | How long (in milliseconds) axe waits for a response from embedded frames before timing out                                                            |
+| `preload`          | `true`  | Any additional assets (eg: cssom) to preload before running rules. [See here for configuration details](#preload-configuration-details)               |
+| `performanceTimer` | `false` | Log rule performance metrics to the console                                                                                                           |
+| `isTopWindow`      | `false` | Force axe to consider the current iframe context as the top window, allowing rules such as `document-title` and `html-has-lang` to run for the iframe |
 
 ###### Options Parameter Examples
 

--- a/lib/checks/aria/abstractrole-evaluate.js
+++ b/lib/checks/aria/abstractrole-evaluate.js
@@ -1,6 +1,29 @@
 import { tokenList } from '../../core/utils';
 import { getRoleType } from '../../commons/aria';
-
+/**
+ * Check if an element's `role` attribute uses any abstract role values.
+ *
+ * Abstract roles are taken from the `ariaRoles` standards object from the roles `type` property.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all abstract roles</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if the element uses an `abstract` role. False otherwise.
+ */
 function abstractroleEvaluate(node, options, virtualNode) {
 	const abstractRoles = tokenList(virtualNode.attr('role')).filter(
 		role => getRoleType(role) === 'abstract'

--- a/lib/checks/aria/aria-allowed-attr-evaluate.js
+++ b/lib/checks/aria/aria-allowed-attr-evaluate.js
@@ -1,6 +1,30 @@
 import { getNodeAttributes, uniqueArray } from '../../core/utils';
 import { getRole, allowedAttr, validateAttr } from '../../commons/aria';
 
+/**
+ * Check if each ARIA attribute on an element is allowed for its semantic role.
+ *
+ * Allowed ARIA attributes are taken from the `ariaRoles` standards object combining the roles `requiredAttrs` and `allowedAttrs` properties, as well as any global ARIA attributes from the `ariaAttrs` standards object.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all unallowed aria attributes and their value</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if each aria attribute is allowed. False otherwise.
+ */
 function ariaAllowedAttrEvaluate(node, options) {
 	const invalid = [];
 

--- a/lib/checks/aria/aria-allowed-role-evaluate.js
+++ b/lib/checks/aria/aria-allowed-role-evaluate.js
@@ -1,6 +1,17 @@
 import { isVisible } from '../../commons/dom';
 import { getElementUnallowedRoles } from '../../commons/aria';
 
+/**
+ * Check if an element is allowed to have its explicit role value.
+ *
+ * Allowed ARIA roles are taken from the `htmlElms` standards object from the elements `allowedRoles` property.
+ *
+ * @memberof checks
+ * @param {Boolean} [options.allowImplicit=true] Allow the explicit role to match the implicit role of the element.
+ * @param {String[]} [options.ignoredTags=[]] Do not check for allowed roles in the provided HTML elements list.
+ * @data {String[]} List of all unallowed roles.
+ * @return {Boolean} True if the role is allowed on the element. False otherwise.
+ */
 function ariaAllowedRoledEvaluate(node, options = {}) {
 	/**
 	 * Implements allowed roles defined at:

--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -2,6 +2,28 @@ import standards from '../../standards';
 import { getRootNode } from '../../commons/dom';
 import { tokenList } from '../../core/utils';
 
+/**
+ * Check if an element with `aria-errormessage` also uses a technique to announce the message (aria-live, aria-describedby, etc.).
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>Boolean</code></td>
+ *       <td>The value of the `aria-errormessage` attribute</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if the element uses a supported technique. False otherwise.
+ */
 function ariaErrormessageEvaluate(node, options) {
 	options = Array.isArray(options) ? options : [];
 

--- a/lib/checks/aria/aria-hidden-body-evaluate.js
+++ b/lib/checks/aria/aria-hidden-body-evaluate.js
@@ -1,3 +1,9 @@
+/**
+ * Check that the element does not have the `aria-hidden` attribute.
+ *
+ * @memberof checks
+ * @return {Boolean} True if the `aria-hidden` attribute is not present. False otherwise.
+ */
 function ariaHiddenBodyEvaluate(node, options, virtualNode) {
 	return virtualNode.attr('aria-hidden') !== 'true';
 }

--- a/lib/checks/aria/aria-required-attr-evaluate.js
+++ b/lib/checks/aria/aria-required-attr-evaluate.js
@@ -2,6 +2,30 @@ import { requiredAttr } from '../../commons/aria';
 import { getElementSpec } from '../../commons/standards';
 import { uniqueArray, getNodeFromTree } from '../../core/utils';
 
+/**
+ * Check that the element has all required attributes for its explicit role.
+ *
+ * Required ARIA attributes are taken from the `ariaRoles` standards object from the roles `requiredAttrs` property.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all missing require attributes</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if all required attributes are present. False otherwise.
+ */
 function ariaRequiredAttrEvaluate(node, options = {}) {
 	const vNode = getNodeFromTree(node);
 	const missing = [];

--- a/lib/checks/aria/aria-required-children-evaluate.js
+++ b/lib/checks/aria/aria-required-children-evaluate.js
@@ -84,6 +84,16 @@ function missingRequiredChildren(virtualNode, role, required, ownedRoles) {
 	return null;
 }
 
+/**
+ * Check that an element owns all required children for its explicit role.
+ *
+ * Required roles are taken from the `ariaRoles` standards object from the roles `requiredOwned` property.
+ *
+ * @memberof checks
+ * @param {Boolean} options.reviewEmpty List of ARIA roles that should be flagged as "Needs Review" rather than a violation if the element has no owned children.
+ * @data {String[]} List of all missing owned roles.
+ * @returns {Mixed} True if the element owns all required roles. Undefined if `options.reviewEmpty=true` and the element has no owned children. False otherwise.
+ */
 function ariaRequiredChildrenEvaluate(node, options, virtualNode) {
 	const reviewEmpty =
 		options && Array.isArray(options.reviewEmpty) ? options.reviewEmpty : [];

--- a/lib/checks/aria/aria-required-parent-evaluate.js
+++ b/lib/checks/aria/aria-required-parent-evaluate.js
@@ -50,6 +50,30 @@ function getAriaOwners(element) {
 	return owners.length ? owners : null;
 }
 
+/**
+ * Check if the element has a parent with a required role.
+ *
+ * Required parent roles are taken from the `ariaRoles` standards object from the roles `requiredContext` property.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all missing required parent roles</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if the element has a parent with a required role. False otherwise.
+ */
 function ariaRequiredParentEvaluate(node, options, virtualNode) {
 	var missingParents = getMissingContext(virtualNode);
 

--- a/lib/checks/aria/aria-roledescription-evaluate.js
+++ b/lib/checks/aria/aria-roledescription-evaluate.js
@@ -1,5 +1,12 @@
 import { getRole } from '../../commons/aria';
 
+/**
+ * Check that `aria-roledescription` is used on a supported semantic role.
+ *
+ * @memberof checks
+ * @param {String[]} options.supportedRoles List of ARIA roles that support the `aria-roledescription` attribute
+ * @return {Mixed} True if the semantic role supports `aria-roledescription`. Undefined if the semantic role is `presentation` or `none`. False otherwise.
+ */
 function ariaRoledescriptionEvaluate(node, options = {}) {
 	const role = getRole(node);
 	const supportedRoles = options.supportedRoles || [];

--- a/lib/checks/aria/aria-unsupported-attr-evaluate.js
+++ b/lib/checks/aria/aria-unsupported-attr-evaluate.js
@@ -3,6 +3,30 @@ import standards from '../../standards';
 import matches from '../../commons/matches';
 import { getNodeAttributes } from '../../core/utils';
 
+/**
+ * Check that an element does not use any unsupported ARIA attributes.
+ *
+ * Unsupported attributes are taken from the `ariaAttrs` standards object from the attributes `unsupported` property.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all unsupported attributes</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if the element does not use any unsupported ARIA attributes. False otherwise.
+ */
 function ariaUnsupportedAttrEvaluate(node) {
 	const unsupportedAttrs = Array.from(getNodeAttributes(node))
 		.filter(({ name }) => {

--- a/lib/checks/aria/aria-valid-attr-evaluate.js
+++ b/lib/checks/aria/aria-valid-attr-evaluate.js
@@ -1,6 +1,30 @@
 import { validateAttr } from '../../commons/aria';
 import { getNodeAttributes } from '../../core/utils';
 
+/**
+ * Check that each `aria-` attribute on an element is a valid ARIA attribute.
+ *
+ * Valid ARIA attributes are listed in the `ariaAttrs` standards object.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all invalid attributes</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if all `aria-` attributes are valid. False otherwise.
+ */
 function ariaValidAttrEvaluate(node, options) {
 	options = Array.isArray(options.value) ? options.value : [];
 

--- a/lib/checks/aria/aria-valid-attr-value-evaluate.js
+++ b/lib/checks/aria/aria-valid-attr-value-evaluate.js
@@ -1,6 +1,30 @@
 import { validateAttrValue } from '../../commons/aria';
 import { getNodeAttributes } from '../../core/utils';
 
+/**
+ * Check that each ARIA attribute on an element has a valid value.
+ *
+ * Valid ARIA attribute values are taken from the `ariaAttrs` standards object from an attributes `type` property.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>Mixed</code></td>
+ *       <td>Object with Strings `messageKey` and `needsReview` if `aria-current` or `aria-describedby` are invalid. Otherwise a list of all invalid ARIA attributes and their value</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Mixed} True if all ARIA attributes have a valid value. Undefined for invalid `aria-current` or `aria-describedby` values. False otherwise.
+ */
 function ariaValidAttrValueEvaluate(node, options) {
 	options = Array.isArray(options.value) ? options.value : [];
 

--- a/lib/checks/aria/fallbackrole-evaluate.js
+++ b/lib/checks/aria/fallbackrole-evaluate.js
@@ -1,5 +1,11 @@
 import { tokenList } from '../../core/utils';
 
+/**
+ * Check that an element does not use more than one explicit role.
+ *
+ * @memberof checks
+ * @return {Boolean} True if the element uses more than one explicit role. False otherwise.
+ */
 function fallbackroleEvaluate(node, options, virtualNode) {
 	return tokenList(virtualNode.attr('role')).length > 1;
 }

--- a/lib/checks/aria/has-widget-role-evaluate.js
+++ b/lib/checks/aria/has-widget-role-evaluate.js
@@ -1,5 +1,13 @@
 import { getRoleType } from '../../commons/aria';
 
+/**
+ * Check if an elements `role` attribute uses any widget or composite role values.
+ *
+ * Widget roles are taken from the `ariaRoles` standards object from the roles `type` property.
+ *
+ * @memberof checks
+ * @return {Boolean} True if the element uses a `widget` or `composite` role. False otherwise.
+ */
 function hasWidgetRoleEvaluate(node) {
 	const role = node.getAttribute('role');
 	if (role === null) {

--- a/lib/checks/aria/invalidrole-evaluate.js
+++ b/lib/checks/aria/invalidrole-evaluate.js
@@ -1,6 +1,30 @@
 import { isValidRole } from '../../commons/aria';
 import { tokenList } from '../../core/utils';
 
+/**
+ * Check that each role on an element is a valid ARIA role.
+ *
+ * Valid ARIA roles are listed in the `ariaRoles` standards object.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all invalid roles</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean} True if the element uses an invalid role. False otherwise.
+ */
 function invalidroleEvaluate(node, options, virtualNode) {
 	const allRoles = tokenList(virtualNode.attr('role'));
 	const allInvalid = allRoles.every(

--- a/lib/checks/aria/no-implicit-explicit-label-evaluate.js
+++ b/lib/checks/aria/no-implicit-explicit-label-evaluate.js
@@ -1,6 +1,28 @@
 import { getRole } from '../../commons/aria';
 import { sanitize, labelText, accessibleTextVirtual } from '../../commons/text';
 
+/**
+ * Check that an elements explicit label matches its accessible name.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String</code></td>
+ *       <td>The elements explicit role</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Mixed} False if the element does not have an explicit label and accessible name or if there is no mismatch between them. Undefined if the element has an explicit label but no accessible name or if the accessible name does not include the label text.
+ */
 function noImplicitExplicitLabelEvaluate(node, options, virtualNode) {
 	const role = getRole(virtualNode, { noImplicit: true });
 	this.data(role);

--- a/lib/checks/aria/unsupportedrole-evaluate.js
+++ b/lib/checks/aria/unsupportedrole-evaluate.js
@@ -1,5 +1,13 @@
 import { isUnsupportedRole, getRole } from '../../commons/aria';
 
+/**
+ * Check that an elements semantic role is unsupported.
+ *
+ * Unsupported roles are taken from the `ariaRoles` standards object from the roles `unsupported` property.
+ *
+ * @memberof checks
+ * @return {Boolean} True if the elements semantic role is unsupported. False otherwise.
+ */
 function unsupportedroleEvaluate(node) {
 	return isUnsupportedRole(getRole(node));
 }

--- a/lib/checks/aria/valid-scrollable-semantics-evaluate.js
+++ b/lib/checks/aria/valid-scrollable-semantics-evaluate.js
@@ -51,9 +51,11 @@ function validScrollableRole(node) {
 }
 
 /**
+ * Check if the element has a valid scrollable role or tag.
+ *
+ * @memberof checks
  * @param {HTMLElement} node
- * @return {Boolean} Whether the element would have valid semantics if it were a
- *			scrollable region.
+ * @return {Boolean} True if the elements role or tag name is a valid scrollable region. False otherwise.
  */
 function validScrollableSemanticsEvaluate(node) {
 	return validScrollableRole(node) || validScrollableTagName(node);

--- a/lib/checks/index.js
+++ b/lib/checks/index.js
@@ -1,0 +1,11 @@
+/**
+ * Custom checks can use any of axe-cores internal checks by using the checks ID for the `evaluate` property in the metadata file. All check IDs can be found in the metadata-function-map.
+ *
+ * @example
+ * {
+ *   "id": "my-custom-check",
+ *   "evaluate": "abstractrole-evaluate"
+ * }
+ *
+ * @namespace checks
+ */

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -143,6 +143,7 @@ import headingMatches from '../../rules/heading-matches';
 import htmlNamespaceMatches from '../../rules/html-namespace-matches';
 import identicalLinksSamePurposeMatches from '../../rules/identical-links-same-purpose-matches';
 import insertedIntoFocusOrderMatches from '../../rules/inserted-into-focus-order-matches';
+import isInitiatorMatches from '../../rules/is-initiator-matches';
 import labelContentNameMismatchMatches from '../../rules/label-content-name-mismatch-matches';
 import labelMatches from '../../rules/label-matches';
 import landmarkHasBodyContextMatches from '../../rules/landmark-has-body-context-matches';
@@ -306,6 +307,7 @@ const metadataFunctionMap = {
 	'html-namespace-matches': htmlNamespaceMatches,
 	'identical-links-same-purpose-matches': identicalLinksSamePurposeMatches,
 	'inserted-into-focus-order-matches': insertedIntoFocusOrderMatches,
+	'is-initiator-matches': isInitiatorMatches,
 	'label-content-name-mismatch-matches': labelContentNameMismatchMatches,
 	'label-matches': labelMatches,
 	'landmark-has-body-context-matches': landmarkHasBodyContextMatches,

--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -144,6 +144,11 @@ function run(context, options, callback) {
 		return p;
 	}
 
+	// by setting the option here and not in runRules, we can ensure
+	// the option is only triggered in the top frame (as axe.run is
+	// not called by collectResultsFromFrames)
+	cache.set('isTopWindow', options.isTopWindow || false);
+
 	axe._running = true;
 	axe._runRules(
 		context,

--- a/lib/rules/bypass-matches.js
+++ b/lib/rules/bypass-matches.js
@@ -1,8 +1,8 @@
-import windowIsTopMatches from './window-is-top-matches';
+import isInitiatorMatches from './is-initiator-matches';
 
-function bypassMatches(node) {
+function bypassMatches(node, virtualNode, context) {
 	// the top level window should have an anchor
-	if (windowIsTopMatches(node)) {
+	if (isInitiatorMatches(node, virtualNode, context)) {
 		return !!node.querySelector('a[href]');
 	}
 

--- a/lib/rules/document-title.json
+++ b/lib/rules/document-title.json
@@ -1,7 +1,7 @@
 {
 	"id": "document-title",
 	"selector": "html",
-	"matches": "window-is-top-matches",
+	"matches": "is-initiator-matches",
 	"tags": ["cat.text-alternatives", "wcag2a", "wcag242", "ACT"],
 	"metadata": {
 		"description": "Ensures each HTML document contains a non-empty <title> element",

--- a/lib/rules/html-has-lang.json
+++ b/lib/rules/html-has-lang.json
@@ -1,7 +1,7 @@
 {
 	"id": "html-has-lang",
 	"selector": "html",
-	"matches": "window-is-top-matches",
+	"matches": "is-initiator-matches",
 	"tags": ["cat.language", "wcag2a", "wcag311", "ACT"],
 	"metadata": {
 		"description": "Ensures every HTML document has a lang attribute",

--- a/lib/rules/is-initiator-matches.js
+++ b/lib/rules/is-initiator-matches.js
@@ -1,0 +1,5 @@
+function isInitiatorMatches(node, virtualNode, context) {
+	return context.initiator;
+}
+
+export default isInitiatorMatches;

--- a/lib/rules/object-alt.json
+++ b/lib/rules/object-alt.json
@@ -14,7 +14,6 @@
 	},
 	"all": [],
 	"any": [
-		"has-visible-text",
 		"aria-label",
 		"aria-labelledby",
 		"non-empty-title",

--- a/lib/rules/window-is-top-matches.js
+++ b/lib/rules/window-is-top-matches.js
@@ -1,3 +1,4 @@
+// @deprecated
 function windowIsTopMatches(node) {
 	return (
 		node.ownerDocument.defaultView.self === node.ownerDocument.defaultView.top

--- a/test/core/public/run.js
+++ b/test/core/public/run.js
@@ -109,6 +109,15 @@ describe('axe.run', function() {
 		});
 	});
 
+	it('should set "isTopWindow" from options', function(done) {
+		axe._runRules = function() {
+			assert.isTrue(axe._cache.get('isTopWindow'));
+			done();
+		};
+
+		axe.run({ isTopWindow: true }, noop);
+	});
+
 	describe('callback', function() {
 		it('gives errors to the first argument on the callback', function(done) {
 			axe._runRules = function(ctxt, opt, resolve, reject) {

--- a/test/integration/rules/object-alt/object-alt.html
+++ b/test/integration/rules/object-alt/object-alt.html
@@ -1,18 +1,13 @@
-<object id="pass1">This object has text.</object>
-<object id="pass2" title="This object has text"></object>
-<object id="pass3" aria-label="this object has text"></object>
+<object id="pass1" title="This object has text"></object>
+<object id="pass2" aria-label="this object has text"></object>
 <span id="label1">this object has text</span>
-<object id="pass4" aria-labelledby="label1"></object>
-<object id="pass5" role="presentation"></object>
-<object id="pass6" role="none"></object>
+<object id="pass3" aria-labelledby="label1"></object>
+<object id="pass4" role="presentation"></object>
+<object id="pass5" role="none"></object>
+
 <object id="violation1"></object>
 <object id="violation2"><div></div></object>
-<object id="violation3"
-	><p style="display: none;">This object has no text.</p></object
->
-<object id="pass7" role="none"></object>
-<object id="pass8" role="presentation"></object>
-
+<object id="violation3">This object has text.</object>
 <object id="violation4" role="none" tabindex="0"></object>
 <object id="violation5" role="presentation" tabindex="0"></object>
 <object id="violation6" role="none" aria-live="assertive"></object>

--- a/test/integration/rules/object-alt/object-alt.json
+++ b/test/integration/rules/object-alt/object-alt.json
@@ -10,14 +10,5 @@
 		["#violation6"],
 		["#violation7"]
 	],
-	"passes": [
-		["#pass1"],
-		["#pass2"],
-		["#pass3"],
-		["#pass4"],
-		["#pass5"],
-		["#pass6"],
-		["#pass7"],
-		["#pass8"]
-	]
+	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"]]
 }

--- a/test/integration/virtual-rules/object-alt.js
+++ b/test/integration/virtual-rules/object-alt.js
@@ -64,7 +64,7 @@ describe('object-alt', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for visible text content', function() {
+	it('should fail for visible text content', function() {
 		var node = new axe.SerialVirtualNode({
 			nodeName: 'object'
 		});
@@ -77,20 +77,20 @@ describe('object-alt', function() {
 
 		var results = axe.runVirtualRule('object-alt', node);
 
-		assert.lengthOf(results.passes, 1);
-		assert.lengthOf(results.violations, 0);
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should incomplete when alt and children are missing', function() {
+	it('should fail when alt and children are missing', function() {
 		var results = axe.runVirtualRule('object-alt', {
 			nodeName: 'object',
 			attributes: {}
 		});
 
 		assert.lengthOf(results.passes, 0);
-		assert.lengthOf(results.violations, 0);
-		assert.lengthOf(results.incomplete, 1);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
 	});
 
 	it('should fail children contain no visible text', function() {

--- a/test/rule-matches/is-initiator-matches.js
+++ b/test/rule-matches/is-initiator-matches.js
@@ -1,0 +1,24 @@
+describe('is-initiator-matches', function() {
+	'use strict';
+
+	var rule;
+
+	beforeEach(function() {
+		rule = axe._audit.rules.find(function(rule) {
+			return rule.id === 'html-has-lang';
+		});
+	});
+
+	afterEach(function() {
+		var fixture = document.getElementById('fixture');
+		fixture.innerHTML = '';
+	});
+
+	it('should return true if the context is the initiator', function() {
+		assert.isTrue(rule.matches(null, null, { initiator: true }));
+	});
+
+	it('should return false if the context is not the initiator', function() {
+		assert.isFalse(rule.matches(null, null, { initiator: false }));
+	});
+});

--- a/test/rule-matches/window-is-top-matches.js
+++ b/test/rule-matches/window-is-top-matches.js
@@ -1,0 +1,41 @@
+describe('window-is-top-matches', function() {
+	var rule;
+	var fixture = document.getElementById('fixture');
+
+	beforeEach(function() {
+		rule = axe._audit.rules.find(function(rule) {
+			return rule.id === 'html-has-lang';
+		});
+	});
+
+	afterEach(function() {
+		fixture.innerHTML = '';
+	});
+
+	it('should return true when element is in the top window', function() {
+		assert.isTrue(rule.matches(fixture));
+	});
+
+	it('should return false when element is not in the top window', function() {
+		var frame = document.createElement('iframe');
+		fixture.appendChild(frame);
+
+		var doc = frame.contentDocument;
+		var div = doc.createElement('div');
+		doc.body.appendChild(div);
+
+		assert.isFalse(rule.matches(div));
+	});
+
+	it('should return true when "isTopWindow" has been set', function() {
+		var frame = document.createElement('iframe');
+		fixture.appendChild(frame);
+
+		var doc = frame.contentDocument;
+		var div = doc.createElement('div');
+		doc.body.appendChild(div);
+
+		axe._cache.set('isTopWindow', true);
+		assert.isTrue(rule.matches(div));
+	});
+});


### PR DESCRIPTION
This allows Cypress to run `document-title` and `html-has-lang` rules inside the iframe by making whichever context `axe.run` was called the "top-level" context (be it an iframe or the top-most window).

Closes issue: #1618 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
