### PR TITLE
fix(frame-tested): fail when iframe axe is configured differently

### DIFF
--- a/lib/checks/media/frame-tested-evaluate.js
+++ b/lib/checks/media/frame-tested-evaluate.js
@@ -17,9 +17,33 @@ function frameTestedEvaluate(node, options) {
 		}, 0);
 	}, timeout);
 
-	respondable(node.contentWindow, 'axe.ping', null, undefined, function() {
+	respondable(node.contentWindow, 'axe.ping', null, undefined, data => {
 		if (timer !== null) {
 			clearTimeout(timer);
+
+			// verify axe is configured the same (allow axe test version)
+			// TODO: es-modules-version
+			if (data.version !== 'x.y.z' && data.version !== axe.version) {
+				this.data({
+					messageKey: 'version',
+					version: axe.version,
+					iframeVersion: data.version
+				});
+				return resolve(false);
+			}
+
+			// TODO: es-modules-_audit
+			const config = JSON.stringify(axe._audit.spec || {});
+			const iframeConfig = JSON.stringify(data.spec || {});
+			if (config !== iframeConfig) {
+				this.data({
+					messageKey: 'configure',
+					config,
+					iframeConfig
+				});
+				return resolve(false);
+			}
+
 			resolve(true);
 		}
 	});

--- a/lib/checks/media/frame-tested.json
+++ b/lib/checks/media/frame-tested.json
@@ -8,7 +8,11 @@
 		"impact": "critical",
 		"messages": {
 			"pass": "The iframe was tested with axe-core",
-			"fail": "The iframe could not be tested with axe-core",
+			"fail": {
+				"default": "The iframe could not be tested with axe-core",
+				"version": "The iframe is using a different version of axe;\nprimary version: ${data.version}\niframe version: ${data.iframeVersion}",
+				"configure": "The iframe is using a different configuration of axe;\nprimary config: ${data.config}\niframe config: ${data.iframeConfig}"
+			},
 			"incomplete": "The iframe still has to be tested with axe-core"
 		}
 	}

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -10,6 +10,8 @@ function configure(spec) {
 		throw new Error('No audit configured');
 	}
 
+	audit.spec = spec;
+
 	if (spec.axeVersion || spec.ver) {
 		let specVersion = spec.axeVersion || spec.ver;
 		if (!/^\d+\.\d+\.\d+(-canary)?/.test(specVersion)) {

--- a/lib/core/public/load.js
+++ b/lib/core/public/load.js
@@ -58,7 +58,9 @@ function load(audit) {
 		respond
 	) {
 		respond({
-			axe: true
+			axe: true,
+			version: axe.version,
+			spec: axe._audit.spec
 		});
 	});
 

--- a/lib/core/public/reset.js
+++ b/lib/core/public/reset.js
@@ -7,6 +7,7 @@ function reset() {
 	if (!audit) {
 		throw new Error('No audit configured');
 	}
+	audit.spec = null;
 	audit.resetRulesAndChecks();
 	resetStandards();
 }

--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -13,47 +13,18 @@ const errorTypes = Object.freeze([
 ]);
 
 /**
- * get the unique string to be used to identify our instance of axe
- * @private
- */
-function _getSource() {
-	var application = 'axeAPI',
-		version = '',
-		src;
-	// TODO: es-modules_audit
-	if (typeof axe !== 'undefined' && axe._audit && axe._audit.application) {
-		application = axe._audit.application;
-	}
-	if (typeof axe !== 'undefined') {
-		// TODO: es-modules-version
-		version = axe.version;
-	}
-	src = application + '.' + version;
-	return src;
-}
-/**
  * Verify the received message is from the "respondable" module
  * @private
  * @param  {Object} postedMessage The message received via postMessage
  * @return {Boolean}              `true` if the message is verified from respondable
  */
 function verify(postedMessage) {
-	if (
+	return (
 		// Check incoming message is valid
 		typeof postedMessage === 'object' &&
 		typeof postedMessage.uuid === 'string' &&
 		postedMessage._respondable === true
-	) {
-		var messageSource = _getSource();
-		return (
-			// Check the version matches
-			postedMessage._source === messageSource ||
-			// Allow free communication with axe test
-			postedMessage._source === 'axeAPI.x.y.z' ||
-			messageSource === 'axeAPI.x.y.z'
-		);
-	}
-	return false;
+	);
 }
 
 /**
@@ -84,7 +55,6 @@ function post(win, topic, message, uuid, keepalive, callback) {
 		message: message,
 		error: error,
 		_respondable: true,
-		_source: _getSource(),
 		// TODO: es-modules_uuid
 		_axeuuid: axe._uuid,
 		_keepalive: keepalive

--- a/test/checks/media/frame-tested.js
+++ b/test/checks/media/frame-tested.js
@@ -66,4 +66,21 @@ describe('frame-tested', function() {
 			checkEvaluate.call(checkContext, iframe);
 		});
 	});
+
+	it('should fail if iframe uses a different config of axe', function(done) {
+		iframe.src = '/test/mock/frames/different-config.html';
+		iframe.addEventListener('load', function() {
+			checkContext._onAsync = function(result) {
+				assert.isFalse(result);
+				assert.deepEqual(checkContext._data, {
+					messageKey: 'configure',
+					config: '{}',
+					iframeConfig: JSON.stringify({ foo: 'bar' })
+				});
+				done();
+			};
+
+			checkEvaluate.call(checkContext, iframe);
+		});
+	});
 });

--- a/test/checks/media/frame-tested.js
+++ b/test/checks/media/frame-tested.js
@@ -13,8 +13,8 @@ describe('frame-tested', function() {
 		checkContext._onAsync = function() {};
 	});
 
-	after(function() {
-		fixture = '';
+	afterEach(function() {
+		fixture.innerHTML = '';
 	});
 
 	it('passes if the iframe contains axe-core', function(done) {
@@ -48,5 +48,22 @@ describe('frame-tested', function() {
 		};
 		// Timeout after 10ms
 		checkEvaluate.call(checkContext, iframe, { timeout: 10 });
+	});
+
+	it('should fail if iframe uses a different version of axe', function(done) {
+		iframe.src = '/test/mock/frames/different-version.html';
+		iframe.addEventListener('load', function() {
+			checkContext._onAsync = function(result) {
+				assert.isFalse(result);
+				assert.deepEqual(checkContext._data, {
+					messageKey: 'version',
+					version: axe.version,
+					iframeVersion: '1.0.0'
+				});
+				done();
+			};
+
+			checkEvaluate.call(checkContext, iframe);
+		});
 	});
 });

--- a/test/core/public/load.js
+++ b/test/core/public/load.js
@@ -41,7 +41,30 @@ describe('axe._load', function() {
 			var win = {
 				postMessage: function(message) {
 					var data = JSON.parse(message);
-					assert.deepEqual(data.message, { axe: true });
+					assert.deepEqual(data.message, { axe: true, version: axe.version });
+					done();
+				}
+			};
+
+			axe.utils.respondable._publish(win, { topic: 'axe.ping' });
+		});
+
+		it('should respond with axe configuration', function(done) {
+			var mockAudit = {
+				rules: [{ id: 'monkeys' }, { id: 'bananas' }]
+			};
+
+			axe._load({});
+			axe.configure(mockAudit);
+
+			var win = {
+				postMessage: function(message) {
+					var data = JSON.parse(message);
+					assert.deepEqual(data.message, {
+						axe: true,
+						version: axe.version,
+						spec: mockAudit
+					});
 					done();
 				}
 			};

--- a/test/core/public/reset.js
+++ b/test/core/public/reset.js
@@ -60,6 +60,7 @@ describe('axe.reset', function() {
 			],
 			reporter: 'raw'
 		});
+		assert.isNotNull(axe._audit.spec);
 		assert.lengthOf(axe._audit.rules, 1);
 		// assert.instanceOf(axe._audit.rules[0], Rule);
 		assert.equal(axe._audit.rules[0].id, 'bob');
@@ -69,6 +70,7 @@ describe('axe.reset', function() {
 
 		axe.reset();
 
+		assert.isNull(axe._audit.spec);
 		assert.lengthOf(axe._audit.rules, 1);
 		// assert.instanceOf(axe._audit.rules[0], Rule);
 		assert.equal(axe._audit.rules[0].id, 'bob');

--- a/test/core/utils/respondable.js
+++ b/test/core/utils/respondable.js
@@ -101,7 +101,6 @@ describe('axe.utils.respondable', function() {
 		it('should pass messages that have all required properties', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan',
 				_axeuuid: 'otherAxe'
 			};
@@ -110,59 +109,11 @@ describe('axe.utils.respondable', function() {
 				assert.equal(data, 'Help us Obi-Wan');
 				done();
 			});
-		});
-
-		it('should allow messages with _source axeAPI.x.y.z', function(done) {
-			eventData = {
-				_respondable: true,
-				_source: 'axeAPI.x.y.z',
-				message: 'Help us Obi-Wan',
-				_axeuuid: 'otherAxe'
-			};
-
-			axe.utils.respondable(win, 'Death star', null, true, function(data) {
-				assert.equal(data, 'Help us Obi-Wan');
-				done();
-			});
-		});
-
-		it('should allow messages if the axe version is x.y.z', function(done) {
-			axe.version = 'x.y.z';
-			eventData = {
-				_respondable: true,
-				_source: 'axeAPI.2.0.0',
-				message: 'Help us Obi-Wan',
-				_axeuuid: 'otherAxe'
-			};
-
-			axe.utils.respondable(win, 'Death star', null, true, function(data) {
-				assert.equal(data, 'Help us Obi-Wan');
-				done();
-			});
-		});
-
-		it('should reject messages if the axe version is different', function(done) {
-			axe.version = '1.0.0';
-			eventData = {
-				_respondable: true,
-				_source: 'axeAPI.2.0.0',
-				message: 'Help us Obi-Wan',
-				_axeuuid: 'otherAxe'
-			};
-
-			axe.utils.respondable(win, 'Death star', null, true, function() {
-				done(new Error('should not call callback'));
-			});
-
-			setTimeout(function() {
-				done();
-			}, 100);
 		});
 
 		it('should reject messages that are that are not strings', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan',
 				_axeuuid: 'otherAxe'
 			};
@@ -188,7 +139,6 @@ describe('axe.utils.respondable', function() {
 		it('should reject messages that are invalid stringified objects', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan',
 				_axeuuid: 'otherAxe'
 			};
@@ -214,7 +164,6 @@ describe('axe.utils.respondable', function() {
 		it('should reject messages that do not have a uuid', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan',
 				_axeuuid: 'otherAxe'
 			};
@@ -238,7 +187,6 @@ describe('axe.utils.respondable', function() {
 		it('should reject messages that do not have a matching uuid', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan',
 				_axeuuid: 'otherAxe'
 			};
@@ -263,7 +211,6 @@ describe('axe.utils.respondable', function() {
 
 		it('should reject messages that do not have `_respondable: true`', function(done) {
 			eventData = {
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan',
 				_axeuuid: 'otherAxe'
 			};
@@ -280,7 +227,6 @@ describe('axe.utils.respondable', function() {
 		it('should reject messages that do not have `_axeuuid`', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan'
 			};
 
@@ -296,7 +242,6 @@ describe('axe.utils.respondable', function() {
 		it('should reject messages from the same axe instance (`_axeuuid`)', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				message: 'Help us Obi-Wan'
 			};
 
@@ -322,7 +267,6 @@ describe('axe.utils.respondable', function() {
 		it('should throw if an error message was send', function(done) {
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				error: {
 					name: 'ReferenceError',
 					message: 'The exhaust port is open!',
@@ -343,7 +287,6 @@ describe('axe.utils.respondable', function() {
 
 			eventData = {
 				_respondable: true,
-				_source: 'axeAPI.2.0.0',
 				error: {
 					name: 'evil',
 					message: 'The exhaust port is open!',

--- a/test/mock/frames/different-config.html
+++ b/test/mock/frames/different-config.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Double responding frame</title>
+	</head>
+	<body>
+		<script>
+			var axe = {
+				version: 'x.y.z',
+				constants: {}
+			};
+		</script>
+		<script src="../../../tmp/core/core.js"></script>
+
+		<script>
+			axe.utils.respondable.subscribe('axe.ping', function(
+				data,
+				keepalive,
+				respond
+			) {
+				respond({
+					axe: true,
+					version: 'x.y.z',
+					spec: {
+						foo: 'bar'
+					}
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/mock/frames/different-version.html
+++ b/test/mock/frames/different-version.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Double responding frame</title>
+	</head>
+	<body>
+		<script>
+			var axe = {
+				version: '1.0.0',
+				constants: {}
+			};
+		</script>
+		<script src="../../../tmp/core/core.js"></script>
+
+		<script>
+			axe.utils.respondable.subscribe('axe.ping', function(
+				data,
+				keepalive,
+				respond
+			) {
+				respond({
+					axe: true,
+					version: '1.0.0'
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/mock/frames/responder.html
+++ b/test/mock/frames/responder.html
@@ -18,7 +18,10 @@
 				keepalive,
 				respond
 			) {
-				respond({ axe: true });
+				respond({
+					axe: true,
+					version: 'x.y.z'
+				});
 			});
 			axe.utils.respondable.subscribe('axe.start', function(
 				data,


### PR DESCRIPTION
Detecting a configuration error in axe required that we no longer silently fail when axe versions/branding were different in the iframe. With all `_uuid` checking we do in respondable I believe it's safe to remove the source checking. Doing this allows us to detect different versions/config in the `frame-tested` rule so users should see a failure if there is a mismatch.

Closes issue: #2340 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
