### PR TITLE
fix(object-alt): do not allow fallback content for objects

### DIFF
--- a/lib/rules/object-alt.json
+++ b/lib/rules/object-alt.json
@@ -14,7 +14,6 @@
 	},
 	"all": [],
 	"any": [
-		"has-visible-text",
 		"aria-label",
 		"aria-labelledby",
 		"non-empty-title",

--- a/test/integration/rules/object-alt/object-alt.html
+++ b/test/integration/rules/object-alt/object-alt.html
@@ -1,18 +1,13 @@
-<object id="pass1">This object has text.</object>
-<object id="pass2" title="This object has text"></object>
-<object id="pass3" aria-label="this object has text"></object>
+<object id="pass1" title="This object has text"></object>
+<object id="pass2" aria-label="this object has text"></object>
 <span id="label1">this object has text</span>
-<object id="pass4" aria-labelledby="label1"></object>
-<object id="pass5" role="presentation"></object>
-<object id="pass6" role="none"></object>
+<object id="pass3" aria-labelledby="label1"></object>
+<object id="pass4" role="presentation"></object>
+<object id="pass5" role="none"></object>
+
 <object id="violation1"></object>
 <object id="violation2"><div></div></object>
-<object id="violation3"
-	><p style="display: none;">This object has no text.</p></object
->
-<object id="pass7" role="none"></object>
-<object id="pass8" role="presentation"></object>
-
+<object id="violation3">This object has text.</object>
 <object id="violation4" role="none" tabindex="0"></object>
 <object id="violation5" role="presentation" tabindex="0"></object>
 <object id="violation6" role="none" aria-live="assertive"></object>

--- a/test/integration/rules/object-alt/object-alt.json
+++ b/test/integration/rules/object-alt/object-alt.json
@@ -10,14 +10,5 @@
 		["#violation6"],
 		["#violation7"]
 	],
-	"passes": [
-		["#pass1"],
-		["#pass2"],
-		["#pass3"],
-		["#pass4"],
-		["#pass5"],
-		["#pass6"],
-		["#pass7"],
-		["#pass8"]
-	]
+	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"]]
 }

--- a/test/integration/virtual-rules/object-alt.js
+++ b/test/integration/virtual-rules/object-alt.js
@@ -64,7 +64,7 @@ describe('object-alt', function() {
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should pass for visible text content', function() {
+	it('should fail for visible text content', function() {
 		var node = new axe.SerialVirtualNode({
 			nodeName: 'object'
 		});
@@ -77,20 +77,20 @@ describe('object-alt', function() {
 
 		var results = axe.runVirtualRule('object-alt', node);
 
-		assert.lengthOf(results.passes, 1);
-		assert.lengthOf(results.violations, 0);
+		assert.lengthOf(results.passes, 0);
+		assert.lengthOf(results.violations, 1);
 		assert.lengthOf(results.incomplete, 0);
 	});
 
-	it('should incomplete when alt and children are missing', function() {
+	it('should fail when alt and children are missing', function() {
 		var results = axe.runVirtualRule('object-alt', {
 			nodeName: 'object',
 			attributes: {}
 		});
 
 		assert.lengthOf(results.passes, 0);
-		assert.lengthOf(results.violations, 0);
-		assert.lengthOf(results.incomplete, 1);
+		assert.lengthOf(results.violations, 1);
+		assert.lengthOf(results.incomplete, 0);
 	});
 
 	it('should fail children contain no visible text', function() {


### PR DESCRIPTION
Fallback content can not be used to give an object an accessible name. Instead us aria-label(ledby) or title.

Closes issue: #2524

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
