### PR TITLE
chore: remove CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # axe-core
-
-[![CircleCI](https://circleci.com/gh/dequelabs/axe-core.svg?style=svg)](https://circleci.com/gh/dequelabs/axe-core)
-
 [![License](https://img.shields.io/npm/l/axe-core.svg)](LICENSE)
 [![Version](https://img.shields.io/npm/v/axe-core.svg)](https://www.npmjs.com/package/axe-core)
 [![Total npm downloads](https://img.shields.io/npm/dt/axe-core.svg)](https://www.npmjs.com/package/axe-core)


### PR DESCRIPTION
Remove the CircleCI badge because it is no longer needed now that we have Slack integration and it changes status multiple times over the day making us look bad on npm

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
