### PR TITLE
feat(rule-matches): depreacte window-is-top-matches for is-intiator-matches

### DIFF
--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -143,6 +143,7 @@ import headingMatches from '../../rules/heading-matches';
 import htmlNamespaceMatches from '../../rules/html-namespace-matches';
 import identicalLinksSamePurposeMatches from '../../rules/identical-links-same-purpose-matches';
 import insertedIntoFocusOrderMatches from '../../rules/inserted-into-focus-order-matches';
+import isInitiatorMatches from '../../rules/is-initiator-matches';
 import labelContentNameMismatchMatches from '../../rules/label-content-name-mismatch-matches';
 import labelMatches from '../../rules/label-matches';
 import landmarkHasBodyContextMatches from '../../rules/landmark-has-body-context-matches';
@@ -306,6 +307,7 @@ const metadataFunctionMap = {
 	'html-namespace-matches': htmlNamespaceMatches,
 	'identical-links-same-purpose-matches': identicalLinksSamePurposeMatches,
 	'inserted-into-focus-order-matches': insertedIntoFocusOrderMatches,
+	'is-initiator-matches': isInitiatorMatches,
 	'label-content-name-mismatch-matches': labelContentNameMismatchMatches,
 	'label-matches': labelMatches,
 	'landmark-has-body-context-matches': landmarkHasBodyContextMatches,

--- a/lib/rules/bypass-matches.js
+++ b/lib/rules/bypass-matches.js
@@ -1,8 +1,8 @@
-import windowIsTopMatches from './window-is-top-matches';
+import isInitiatorMatches from './is-initiator-matches';
 
-function bypassMatches(node) {
+function bypassMatches(node, virtualNode, context) {
 	// the top level window should have an anchor
-	if (windowIsTopMatches(node)) {
+	if (isInitiatorMatches(node, virtualNode, context)) {
 		return !!node.querySelector('a[href]');
 	}
 

--- a/lib/rules/document-title.json
+++ b/lib/rules/document-title.json
@@ -1,7 +1,7 @@
 {
 	"id": "document-title",
 	"selector": "html",
-	"matches": "window-is-top-matches",
+	"matches": "is-initiator-matches",
 	"tags": ["cat.text-alternatives", "wcag2a", "wcag242", "ACT"],
 	"metadata": {
 		"description": "Ensures each HTML document contains a non-empty <title> element",

--- a/lib/rules/html-has-lang.json
+++ b/lib/rules/html-has-lang.json
@@ -1,7 +1,7 @@
 {
 	"id": "html-has-lang",
 	"selector": "html",
-	"matches": "window-is-top-matches",
+	"matches": "is-initiator-matches",
 	"tags": ["cat.language", "wcag2a", "wcag311", "ACT"],
 	"metadata": {
 		"description": "Ensures every HTML document has a lang attribute",

--- a/lib/rules/is-initiator-matches.js
+++ b/lib/rules/is-initiator-matches.js
@@ -1,0 +1,5 @@
+function isInitiatorMatches(node, virtualNode, context) {
+	return context.initiator;
+}
+
+export default isInitiatorMatches;

--- a/lib/rules/window-is-top-matches.js
+++ b/lib/rules/window-is-top-matches.js
@@ -1,3 +1,4 @@
+// @deprecated
 function windowIsTopMatches(node) {
 	return (
 		node.ownerDocument.defaultView.self === node.ownerDocument.defaultView.top

--- a/test/rule-matches/is-initiator-matches.js
+++ b/test/rule-matches/is-initiator-matches.js
@@ -1,0 +1,24 @@
+describe('is-initiator-matches', function() {
+	'use strict';
+
+	var rule;
+
+	beforeEach(function() {
+		rule = axe._audit.rules.find(function(rule) {
+			return rule.id === 'html-has-lang';
+		});
+	});
+
+	afterEach(function() {
+		var fixture = document.getElementById('fixture');
+		fixture.innerHTML = '';
+	});
+
+	it('should return true if the context is the initiator', function() {
+		assert.isTrue(rule.matches(null, null, { initiator: true }));
+	});
+
+	it('should return false if the context is not the initiator', function() {
+		assert.isFalse(rule.matches(null, null, { initiator: false }));
+	});
+});


### PR DESCRIPTION
This allows Cypress to run `document-title` and `html-has-lang` rules inside the iframe by making whichever context `axe.run` was called the "top-level" context (be it an iframe or the top-most window).

Closes issue: #1618 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
