### PR TITLE
cli: wait before verifying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,8 +197,6 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
-      # Verifying the release keeps failing due to race condition
-      - run: sleep 10
       - run: .circleci/verify-release.sh post
 
   # Verify canary released package has all required files
@@ -208,8 +206,6 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
-      # Verifying the release keeps failing due to race condition
-      - run: sleep 10
       - run: npm run next-release
       - run: .circleci/verify-release.sh post
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       # Verifying the release keeps failing due to race condition
-      - run: sleep 10000
+      - run: sleep 10
       - run: .circleci/verify-release.sh post
 
   # Verify canary released package has all required files
@@ -209,7 +209,7 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       # Verifying the release keeps failing due to race condition
-      - run: sleep 10000
+      - run: sleep 10
       - run: npm run next-release
       - run: .circleci/verify-release.sh post
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,8 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
+      # Verifying the release keeps failing due to race condition
+      - run: sleep 10000
       - run: .circleci/verify-release.sh post
 
   # Verify canary released package has all required files
@@ -206,6 +208,8 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
+      # Verifying the release keeps failing due to race condition
+      - run: sleep 10000
       - run: npm run next-release
       - run: .circleci/verify-release.sh post
 


### PR DESCRIPTION
Our verify-next-release script keeps failing because of a race condition between npm having it and when our verify script tries to pull it down. Fixing the condition by putting in a sleep command to make the verify script wait before trying to pull it down from npm.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
