### PR TITLE
chore: update standard-version to v9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2649,13 +2649,13 @@
 			"dev": true
 		},
 		"compare-func": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
-			"integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
 			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
-				"dot-prop": "^3.0.0"
+				"dot-prop": "^5.1.0"
 			}
 		},
 		"component-emitter": {
@@ -2736,31 +2736,31 @@
 			"dev": true
 		},
 		"conventional-changelog": {
-			"version": "3.1.21",
-			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.21.tgz",
-			"integrity": "sha512-ZGecVZPEo3aC75VVE4nu85589dDhpMyqfqgUM5Myq6wfKWiNqhDJLSDMsc8qKXshZoY7dqs1hR0H/15kI/G2jQ==",
+			"version": "3.1.23",
+			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.23.tgz",
+			"integrity": "sha512-sScUu2NHusjRC1dPc5p8/b3kT78OYr95/Bx7Vl8CPB8tF2mG1xei5iylDTRjONV5hTlzt+Cn/tBWrKdd299b7A==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "^5.0.10",
+				"conventional-changelog-angular": "^5.0.11",
 				"conventional-changelog-atom": "^2.0.7",
 				"conventional-changelog-codemirror": "^2.0.7",
-				"conventional-changelog-conventionalcommits": "^4.3.0",
-				"conventional-changelog-core": "^4.1.7",
+				"conventional-changelog-conventionalcommits": "^4.4.0",
+				"conventional-changelog-core": "^4.2.0",
 				"conventional-changelog-ember": "^2.0.8",
 				"conventional-changelog-eslint": "^3.0.8",
 				"conventional-changelog-express": "^2.0.5",
 				"conventional-changelog-jquery": "^3.0.10",
-				"conventional-changelog-jshint": "^2.0.7",
+				"conventional-changelog-jshint": "^2.0.8",
 				"conventional-changelog-preset-loader": "^2.3.4"
 			}
 		},
 		"conventional-changelog-angular": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
-			"integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
+			"integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
+				"compare-func": "^2.0.0",
 				"q": "^1.5.1"
 			},
 			"dependencies": {
@@ -2813,12 +2813,12 @@
 			"dev": true
 		},
 		"conventional-changelog-conventionalcommits": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.3.0.tgz",
-			"integrity": "sha512-oYHydvZKU+bS8LnGqTMlNrrd7769EsuEHKy4fh1oMdvvDi7fem8U+nvfresJ1IDB8K00Mn4LpiA/lR+7Gs6rgg==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.4.0.tgz",
+			"integrity": "sha512-ybvx76jTh08tpaYrYn/yd0uJNLt5yMrb1BphDe4WBredMlvPisvMghfpnJb6RmRNcqXeuhR6LfGZGewbkRm9yA==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
+				"compare-func": "^2.0.0",
 				"lodash": "^4.17.15",
 				"q": "^1.5.1"
 			},
@@ -2832,19 +2832,19 @@
 			}
 		},
 		"conventional-changelog-core": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.1.7.tgz",
-			"integrity": "sha512-UBvSrQR2RdKbSQKh7RhueiiY4ZAIOW3+CSWdtKOwRv+KxIMNFKm1rOcGBFx0eA8AKhGkkmmacoTWJTqyz7Q0VA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.0.tgz",
+			"integrity": "sha512-8+xMvN6JvdDtPbGBqA7oRNyZD4od1h/SIzrWqHcKZjitbVXrFpozEeyn4iI4af1UwdrabQpiZMaV07fPUTGd4w==",
 			"dev": true,
 			"requires": {
 				"add-stream": "^1.0.0",
-				"conventional-changelog-writer": "^4.0.16",
+				"conventional-changelog-writer": "^4.0.17",
 				"conventional-commits-parser": "^3.1.0",
 				"dateformat": "^3.0.0",
 				"get-pkg-repo": "^1.0.0",
 				"git-raw-commits": "2.0.0",
 				"git-remote-origin-url": "^2.0.0",
-				"git-semver-tags": "^4.0.0",
+				"git-semver-tags": "^4.1.0",
 				"lodash": "^4.17.15",
 				"normalize-package-data": "^2.3.5",
 				"q": "^1.5.1",
@@ -2985,12 +2985,12 @@
 			}
 		},
 		"conventional-changelog-jshint": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.7.tgz",
-			"integrity": "sha512-qHA8rmwUnLiIxANJbz650+NVzqDIwNtc0TcpIa0+uekbmKHttidvQ1dGximU3vEDdoJVKFgR3TXFqYuZmYy9ZQ==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.8.tgz",
+			"integrity": "sha512-hB/iI0IiZwnZ+seYI+qEQ4b+EMQSEC8jGIvhO2Vpz1E5p8FgLz75OX8oB1xJWl+s4xBMB6f8zJr0tC/BL7YOjw==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
+				"compare-func": "^2.0.0",
 				"q": "^1.5.1"
 			},
 			"dependencies": {
@@ -3009,12 +3009,12 @@
 			"dev": true
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
-			"integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+			"integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
+				"compare-func": "^2.0.0",
 				"conventional-commits-filter": "^2.0.6",
 				"dateformat": "^3.0.0",
 				"handlebars": "^4.7.6",
@@ -3082,9 +3082,9 @@
 			}
 		},
 		"conventional-recommended-bump": {
-			"version": "6.0.9",
-			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.0.9.tgz",
-			"integrity": "sha512-DpRmW1k8CpRrcsXHOPGgHgOd4BMGiq2gtXAveGM8B9pSd9b4r4WKnqp1Fd0vkDtk8l973mIk8KKKUYnKRr9SFw==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.0.10.tgz",
+			"integrity": "sha512-2ibrqAFMN3ZA369JgVoSbajdD/BHN6zjY7DZFKTHzyzuQejDUCjQ85S5KHxCRxNwsbDJhTPD5hOKcis/jQhRgg==",
 			"dev": true,
 			"requires": {
 				"concat-stream": "^2.0.0",
@@ -3092,7 +3092,7 @@
 				"conventional-commits-filter": "^2.0.6",
 				"conventional-commits-parser": "^3.1.0",
 				"git-raw-commits": "2.0.0",
-				"git-semver-tags": "^4.0.0",
+				"git-semver-tags": "^4.1.0",
 				"meow": "^7.0.0",
 				"q": "^1.5.1"
 			},
@@ -3725,12 +3725,20 @@
 			}
 		},
 		"dot-prop": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "^2.0.0"
+			},
+			"dependencies": {
+				"is-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+					"dev": true
+				}
 			}
 		},
 		"dotgitignore": {
@@ -5436,9 +5444,9 @@
 			}
 		},
 		"git-semver-tags": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.0.0.tgz",
-			"integrity": "sha512-LajaAWLYVBff+1NVircURJFL8TQ3EMIcLAfHisWYX/nPoMwnTYfWAznQDmMujlLqoD12VtLmoSrF1sQ5MhimEQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.0.tgz",
+			"integrity": "sha512-TcxAGeo03HdErzKzi4fDD+xEL7gi8r2Y5YSxH6N2XYdVSV5UkBwfrt7Gqo1b+uSHCjy/sa9Y6BBBxxFLxfbhTg==",
 			"dev": true,
 			"requires": {
 				"meow": "^7.0.0",
@@ -10966,16 +10974,16 @@
 			}
 		},
 		"standard-version": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/standard-version/-/standard-version-8.0.2.tgz",
-			"integrity": "sha512-L8X9KFq2SmVmaeZgUmWHFJMOsEWpjgFAwqic6yIIoveM1kdw1vH4Io03WWxUDjypjGqGU6qUtcJoR8UvOv5w3g==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.0.0.tgz",
+			"integrity": "sha512-eRR04IscMP3xW9MJTykwz13HFNYs8jS33AGuDiBKgfo5YrO0qX0Nxb4rjupVwT5HDYL/aR+MBEVLjlmVFmFEDQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
-				"conventional-changelog": "3.1.21",
+				"conventional-changelog": "3.1.23",
 				"conventional-changelog-config-spec": "2.1.0",
-				"conventional-changelog-conventionalcommits": "4.3.0",
-				"conventional-recommended-bump": "6.0.9",
+				"conventional-changelog-conventionalcommits": "4.4.0",
+				"conventional-recommended-bump": "6.0.10",
 				"detect-indent": "^6.0.0",
 				"detect-newline": "^3.1.0",
 				"dotgitignore": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
 		"selenium-webdriver": "~3.6.0",
 		"sinon": "^7.5.0",
 		"sri-toolbox": "^0.2.0",
-		"standard-version": "^8.0.0",
+		"standard-version": "^9.0.0",
 		"typescript": "^3.5.3",
 		"uglify-js": "^3.4.4",
 		"weakmap-polyfill": "^2.0.0",


### PR DESCRIPTION
Upgrades standard-version to v9.0.0, which has a security fix for dot-prop. The major change for v9 was that node 8 is no longer supported.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
