### PR TITLE
Updated axe.reset() to reset branding, application, and tagExcludes.

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -150,9 +150,6 @@ const mergeFallbackMessage = (a, b) => {
 class Audit {
 	constructor(audit) {
 		// defaults
-		this.brand = 'axe';
-		this.application = 'axeAPI';
-		this.tagExclude = ['experimental'];
 		this.lang = 'en';
 		this.defaultConfig = audit;
 		this.standards = standards;
@@ -298,6 +295,9 @@ class Audit {
 		this.commands = {};
 		this.rules = [];
 		this.checks = {};
+		this.brand = 'axe';
+		this.application = 'axeAPI';
+		this.tagExclude = ['experimental'];
 		unpackToObject(audit.rules, this, 'addRule');
 		unpackToObject(audit.checks, this, 'addCheck');
 		this.data = {};

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -417,7 +417,9 @@ describe('Audit', function() {
 		it('should reset brand tagExlcude', function() {
 			var audit = new Audit();
 			assert.equal(audit.tagExclude, ['experimental']);
-			// TODO: Find where tagExclude is set
+			axe.configure({
+				tagExclude: ['ninjas']
+			});			
 			audit.resetRulesAndChecks();
 			assert.equal(audit.application, ['experimental']);
 		});

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -394,6 +394,33 @@ describe('Audit', function() {
 			audit.resetRulesAndChecks();
 			assert.equal(audit.lang, 'en');
 		});
+		it('should reset brand', function() {
+			var audit = new Audit();
+			assert.equal(audit.brand, 'axe');
+			audit.setBranding({
+				brand: 'test'
+			});
+			assert.equal(audit.brand, 'test');
+			audit.resetRulesAndChecks();
+			assert.equal(audit.brand, 'axe');
+		});
+		it('should reset brand application', function() {
+			var audit = new Audit();
+			assert.equal(audit.application, 'axeAPI');
+			audit.setBranding({
+				application: 'test'
+			});
+			assert.equal(audit.application, 'test');
+			audit.resetRulesAndChecks();
+			assert.equal(audit.application, 'axeAPI');
+		});
+		it('should reset brand tagExlcude', function() {
+			var audit = new Audit();
+			assert.equal(audit.tagExclude, ['experimental']);
+			// TODO: Find where tagExclude is set
+			audit.resetRulesAndChecks();
+			assert.equal(audit.application, ['experimental']);
+		});
 	});
 
 	describe('Audit#addCheck', function() {


### PR DESCRIPTION
Updated the codebase to reset the brand, application, and tagExcludes properties in the audit.
Closes issue: #2530 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
