### PR TITLE
Remove duplicate definition, "disableOtherRules".

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -232,7 +232,6 @@ axe.configure({
   - `disableOtherRules` - Disables all rules not included in the `rules` property.
   - `locale` - A locale object to apply (at runtime) to all rules and checks, in the same shape as `/locales/*.json`.
   - `axeVersion` - Set the compatible version of a custom rule with the current axe version. Compatible versions are all patch and minor updates that are the same as, or newer than those of the `axeVersion` property.
-  - `disableOtherRules` - Disable all rules not listed in the `rules` parameter.
 
 **Returns:** Nothing
 


### PR DESCRIPTION
Removes a duplicate definition for the `disableOtherRules` property in API documentation.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
