### PR TITLE
fix(implilcit-role): use type property instead of attribute to resolve input role

### DIFF
--- a/lib/commons/standards/implicit-html-roles.js
+++ b/lib/commons/standards/implicit-html-roles.js
@@ -109,7 +109,7 @@ const implicitHtmlRoles = {
 				listElement && listElement.nodeName.toLowerCase() === 'datalist';
 		}
 
-		switch ((vNode.attr('type') || '').toLowerCase()) {
+		switch ((vNode.props.type || '').toLowerCase()) {
 			case 'button':
 			case 'image':
 			case 'reset':

--- a/lib/commons/standards/implicit-html-roles.js
+++ b/lib/commons/standards/implicit-html-roles.js
@@ -109,7 +109,7 @@ const implicitHtmlRoles = {
 				listElement && listElement.nodeName.toLowerCase() === 'datalist';
 		}
 
-		switch ((vNode.props.type || '').toLowerCase()) {
+		switch (vNode.props.type) {
 			case 'button':
 			case 'image':
 			case 'reset':

--- a/test/commons/aria/implicit-role.js
+++ b/test/commons/aria/implicit-role.js
@@ -301,6 +301,13 @@ describe('aria.implicitRole', function() {
 		assert.equal(implicitRole(node), 'combobox');
 	});
 
+	it('should return textbox for "input[type=invalid]"', function() {
+		fixture.innerHTML = '<input id="target" type="invalid"/>';
+		var node = fixture.querySelector('#target');
+		flatTreeSetup(fixture);
+		assert.equal(implicitRole(node), 'textbox');
+	});
+
 	it('should return region for "section" with accessible name aria-label', function() {
 		fixture.innerHTML = '<section id="target" aria-label="foo"></section>';
 		var node = fixture.querySelector('#target');


### PR DESCRIPTION
Closes issue: #2514 (axe should be aware of input type default of text )

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [X] Follows the commit message policy, appropriate for next version
- [X] Code is reviewed for security
