### PR TITLE
feat(get-role): add noPresentational option

### DIFF
--- a/lib/commons/aria/get-role.js
+++ b/lib/commons/aria/get-role.js
@@ -110,22 +110,15 @@ function hasConflictResolution(vNode) {
 }
 
 /**
- * Return the semantic role of an element.
  *
- * @method getRole
- * @memberof axe.commons.aria
- * @instance
+ * @method resolveRole
  * @param {Element|VirtualNode} node
  * @param {Object} options
- * @param {boolean} options.noImplicit  Do not return the implicit role // @deprecated
- * @param {boolean} options.fallback  Allow fallback roles
- * @param {boolean} options.abstracts  Allow role to be abstract
- * @param {boolean} options.dpub  Allow role to be any (valid) doc-* roles
+ * @see getRole for option details
  * @returns {string|null} Role or null
- *
  * @deprecated noImplicit option is deprecated. Use aria.getExplicitRole instead.
  */
-function getRole(node, { noImplicit, ...explicitRoleOptions } = {}) {
+function resolveRole(node, { noImplicit, ...explicitRoleOptions } = {}) {
 	const vNode =
 		node instanceof AbstractVirtuaNode ? node : getNodeFromTree(node);
 	if (vNode.props.nodeType !== 1) {
@@ -150,6 +143,33 @@ function getRole(node, { noImplicit, ...explicitRoleOptions } = {}) {
 
 	// role presentation or none and no conflict resolution
 	return explicitRole;
+}
+
+/**
+ * Return the semantic role of an element.
+ *
+ * @method getRole
+ * @memberof axe.commons.aria
+ * @instance
+ * @param {Element|VirtualNode} node
+ * @param {Object} options
+ * @param {boolean} options.noImplicit  Do not return the implicit role // @deprecated
+ * @param {boolean} options.fallback  Allow fallback roles
+ * @param {boolean} options.abstracts  Allow role to be abstract
+ * @param {boolean} options.dpub  Allow role to be any (valid) doc-* roles
+ * @param {boolean} options.noPresentational return null if role is presentation or none
+ * @returns {string|null} Role or null
+ *
+ * @deprecated noImplicit option is deprecated. Use aria.getExplicitRole instead.
+ */
+function getRole(node, { noPresentational, ...options } = {}) {
+	const role = resolveRole(node, options);
+
+	if (noPresentational && ['presentation', 'none'].includes(role)) {
+		return null;
+	}
+
+	return role;
 }
 
 export default getRole;

--- a/test/commons/aria/get-role.js
+++ b/test/commons/aria/get-role.js
@@ -380,4 +380,36 @@ describe('aria.getRole', function() {
 			);
 		});
 	});
+
+	describe('noPresentational is honored', function() {
+		it('handles no inheritance role = presentation', function() {
+			fixture.innerHTML =
+				'<ul role="presentation" id="target"><li>foo</li></ul>';
+			flatTreeSetup(fixture);
+			var node = fixture.querySelector('#target');
+			assert.isNull(aria.getRole(node, { noPresentational: true }));
+		});
+
+		it('handles inheritance role = presentation', function() {
+			fixture.innerHTML =
+				'<ul role="presentation"><li id="target">foo</li></ul>';
+			flatTreeSetup(fixture);
+			var node = fixture.querySelector('#target');
+			assert.isNull(aria.getRole(node, { noPresentational: true }));
+		});
+
+		it('handles implicit role', function() {
+			var node = document.createElement('img');
+			node.setAttribute('alt', '');
+			flatTreeSetup(node);
+			assert.isNull(aria.getRole(node, { noPresentational: true }));
+		});
+
+		it('handles role = none', function() {
+			var node = document.createElement('div');
+			node.setAttribute('role', 'none');
+			flatTreeSetup(node);
+			assert.isNull(aria.getRole(node, { noPresentational: true }));
+		});
+	});
 });


### PR DESCRIPTION
Add option to getRole to return null if 'presentation' or 'none'
would be returned

Closes issue #1792

<< Describe the changes >>

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
