### PR TITLE
fix(checks/aria): mark elements missing from aria-errormessage for review

### DIFF
--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -3,7 +3,7 @@ import { getRootNode } from '../../commons/dom';
 import { tokenList } from '../../core/utils';
 
 /**
- * Check if an element with `aria-errormessage` also uses a technique to announce the message (aria-live, aria-describedby, etc.).
+ * Check if `aria-errormessage` references an element that also uses a technique to announce the message (aria-live, aria-describedby, etc.).
  *
  * ##### Data:
  * <table class="props">
@@ -15,14 +15,14 @@ import { tokenList } from '../../core/utils';
  *   </thead>
  *   <tbody>
  *     <tr>
- *       <td><code>Boolean</code></td>
+ *       <td><code>Mixed</code></td>
  *       <td>The value of the `aria-errormessage` attribute</td>
  *     </tr>
  *   </tbody>
  * </table>
  *
  * @memberof checks
- * @return {Boolean} True if the element uses a supported technique. False otherwise.
+ * @return {Mixed} True if aria-errormessage references an existing element that uses a supported technique. Undefined if it does not reference an existing element. False otherwise.
  */
 function ariaErrormessageEvaluate(node, options) {
 	options = Array.isArray(options) ? options : [];
@@ -45,14 +45,13 @@ function ariaErrormessageEvaluate(node, options) {
 					-1
 			);
 		}
+		return;
 	}
 
 	// limit results to elements that actually have this attribute
 	if (options.indexOf(attr) === -1 && hasAttr) {
-		if (!validateAttrValue(attr)) {
-			this.data(tokenList(attr));
-			return false;
-		}
+		this.data(tokenList(attr));
+		return validateAttrValue(attr);
 	}
 
 	return true;

--- a/lib/checks/aria/aria-errormessage.json
+++ b/lib/checks/aria/aria-errormessage.json
@@ -4,10 +4,14 @@
 	"metadata": {
 		"impact": "critical",
 		"messages": {
-			"pass": "Uses a supported aria-errormessage technique",
+			"pass": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
 			"fail": {
 				"singular": "aria-errormessage value `${data.values}` must use a technique to announce the message (e.g., aria-live, aria-describedby, role=alert, etc.)",
 				"plural": "aria-errormessage values `${data.values}` must use a technique to announce the message (e.g., aria-live, aria-describedby, role=alert, etc.)"
+			},
+			"incomplete": {
+				"singular": "ensure aria-errormessage value `${data.values}` references an existing element",
+				"plural": "ensure aria-errormessage values `${data.values}` reference existing elements"
 			}
 		}
 	}

--- a/test/checks/aria/errormessage.js
+++ b/test/checks/aria/errormessage.js
@@ -25,6 +25,18 @@ describe('aria-errormessage', function() {
 		);
 	});
 
+	it('should return undefined if aria-errormessage references an element that does not exist', function() {
+		var testHTML = '<div></div>';
+		fixture.innerHTML = testHTML;
+		var target = fixture.children[0];
+		target.setAttribute('aria-errormessage', 'plain');
+		assert.isUndefined(
+			axe.testUtils
+				.getCheckEvaluate('aria-errormessage')
+				.call(checkContext, target)
+		);
+	});
+
 	it('should return true if aria-errormessage id is alert', function() {
 		var testHTML = '<div></div>';
 		testHTML += '<div id="alert" role="alert"></div>';
@@ -114,11 +126,27 @@ describe('aria-errormessage', function() {
 	});
 
 	(shadowSupported ? it : xit)(
-		'should return false if aria-errormessage value crosses shadow boundary',
+		'should return undefined if aria-errormessage value crosses shadow boundary',
 		function() {
 			var params = shadowCheckSetup(
 				'<div id="target" aria-errormessage="live"></div>',
 				'<div id="live" aria-live="assertive"></div>'
+			);
+			assert.isUndefined(
+				axe.testUtils
+					.getCheckEvaluate('aria-errormessage')
+					.apply(checkContext, params)
+			);
+		}
+	);
+
+	(shadowSupported ? it : xit)(
+		'should return false if aria-errormessage and invalid reference are both inside shadow dom',
+		function() {
+			var params = shadowCheckSetup(
+				'<div></div>',
+				'<div id="target" aria-errormessage="live"</div>' +
+					'<div id="live"></div>'
 			);
 			assert.isFalse(
 				axe.testUtils
@@ -129,7 +157,7 @@ describe('aria-errormessage', function() {
 	);
 
 	(shadowSupported ? it : xit)(
-		'should return true if aria-errormessage and value are inside shadow dom',
+		'should return true if aria-errormessage and valid reference are both inside shadow dom',
 		function() {
 			var params = shadowCheckSetup(
 				'<div></div>',


### PR DESCRIPTION
If IDs in aria-errormessage do not correspond to existing elements, return undefined to mark for review.

Closes issue #2460

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
