### PR TITLE
fix(aria-hidden-body): Do not run on iframes

### DIFF
--- a/lib/rules/aria-hidden-body.json
+++ b/lib/rules/aria-hidden-body.json
@@ -2,6 +2,7 @@
 	"id": "aria-hidden-body",
 	"selector": "body",
 	"excludeHidden": false,
+	"matches": "is-initiator-matches",
 	"tags": ["cat.aria", "wcag2a", "wcag412"],
 	"metadata": {
 		"description": "Ensures aria-hidden='true' is not present on the document body.",

--- a/test/integration/full/aria-hidden-body/pass.html
+++ b/test/integration/full/aria-hidden-body/pass.html
@@ -26,5 +26,6 @@
 		<div id="mocha"></div>
 		<script src="pass.js"></script>
 		<script src="/test/integration/adapter.js"></script>
+		<iframe src="fail.html"></iframe>
 	</body>
 </html>


### PR DESCRIPTION
- Adding "is-initiator-matches" to aria-hidden-body.json
- Updating aria-hidden-body/pass.html integration test to include an iframe with aria-hidden='true' on the body

<< Describe the changes >>

Closes issue: https://github.com/dequelabs/axe-core/issues/1251

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
