### PR TITLE
fix(aria-errormessage): allow aria-live="polite" on aria-errormessage target

### DIFF
--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -19,6 +19,7 @@ function ariaErrormessageEvaluate(node, options) {
 			return (
 				idref.getAttribute('role') === 'alert' ||
 				idref.getAttribute('aria-live') === 'assertive' ||
+				idref.getAttribute('aria-live') === 'polite' ||
 				tokenList(node.getAttribute('aria-describedby') || '').indexOf(attr) >
 					-1
 			);


### PR DESCRIPTION
Spec (https://www.w3.org/TR/wai-aria-1.1/#aria-errormessage) only states that "authors MAY use live regions for the error message element applying either an aria-live property or using one of the live region roles".

So we probably shouldn't enforce any role, unless we consider it a bad practice. In that case we should at least allow "polite" announcements, as "authors SHOULD NOT use the assertive value unless the interruption is imperative".

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
