### PR TITLE
feat(aria-toggle-field-name): add option role

### DIFF
--- a/lib/rules/aria-toggle-field-name.json
+++ b/lib/rules/aria-toggle-field-name.json
@@ -1,6 +1,6 @@
 {
 	"id": "aria-toggle-field-name",
-	"selector": "[role=\"checkbox\"], [role=\"menuitemcheckbox\"], [role=\"menuitemradio\"], [role=\"radio\"], [role=\"switch\"]",
+	"selector": "[role=\"checkbox\"], [role=\"menuitemcheckbox\"], [role=\"menuitemradio\"], [role=\"radio\"], [role=\"switch\"], [role=\"option\"]",
 	"matches": "no-naming-method-matches",
 	"tags": ["cat.aria", "wcag2a", "wcag412"],
 	"metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3705,7 +3705,8 @@
 		"esbuild": {
 			"version": "0.7.19",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.7.19.tgz",
-			"integrity": "sha512-0Ur8ZtuRPwJMj4+VjRLqn5z88WXf+2etZhe4dBA6eYFcdviQefb+Vrd59cTk0VXg08NU/BnAMkalCMHI8lig/A=="
+			"integrity": "sha512-0Ur8ZtuRPwJMj4+VjRLqn5z88WXf+2etZhe4dBA6eYFcdviQefb+Vrd59cTk0VXg08NU/BnAMkalCMHI8lig/A==",
+			"dev": true
 		},
 		"escalade": {
 			"version": "3.0.1",

--- a/test/integration/rules/aria-toggle-field-name/aria-toggle-field-name.html
+++ b/test/integration/rules/aria-toggle-field-name/aria-toggle-field-name.html
@@ -40,6 +40,9 @@
 	<span>off</span>
 	<span>on</span>
 </div>
+<div role="listbox" aria-label="Greeting">
+	<div role="option" id="pass6">Hello world</div>
+</div>
 
 <!-- FAIL -->
 <!-- checkbox -->
@@ -60,6 +63,15 @@
 <div id="fail5" role="switch" aria-checked="true">
 	<span></span>
 	<span></span>
+</div>
+<div role="listbox" aria-label="Greeting">
+	<div
+		role="option"
+		id="fail6"
+		title=""
+		aria-label=""
+		aria-labelledby="fake"
+	></div>
 </div>
 
 <!-- INAPPLICABLE -->

--- a/test/integration/rules/aria-toggle-field-name/aria-toggle-field-name.json
+++ b/test/integration/rules/aria-toggle-field-name/aria-toggle-field-name.json
@@ -1,7 +1,21 @@
 {
 	"description": "aria-toggle-field-name test",
 	"rule": "aria-toggle-field-name",
-	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"]],
-	"violations": [["#fail1"], ["#fail2"], ["#fail3"], ["#fail4"], ["#fail5"]],
+	"passes": [
+		["#pass1"],
+		["#pass2"],
+		["#pass3"],
+		["#pass4"],
+		["#pass5"],
+		["#pass6"]
+	],
+	"violations": [
+		["#fail1"],
+		["#fail2"],
+		["#fail3"],
+		["#fail4"],
+		["#fail5"],
+		["#fail6"]
+	],
 	"incomplete": [["#canttell1"], ["#canttell2"]]
 }

--- a/test/integration/virtual-rules/aria-toggle-field-name.js
+++ b/test/integration/virtual-rules/aria-toggle-field-name.js
@@ -89,7 +89,7 @@ describe('aria-toggle-field-name', function() {
 		var node = new axe.SerialVirtualNode({
 			nodeName: 'div',
 			attributes: {
-				role: 'menuitemcheckbox'
+				role: 'option'
 			}
 		});
 		node.children = [];


### PR DESCRIPTION
Test that elements with role=option have an accessible name. There's really no good reason for empty options to exist that I can think of, so those should be flag up.

Part of issue #2421

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
