### PR TITLE
fix(rule): add check node to the check result object

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -479,6 +479,7 @@ function findCheckResults(nodes, checkID) {
 		var checks = getAllChecks(nodeResult);
 		checks.forEach(function(checkResult) {
 			if (checkResult.id === checkID) {
+				checkResult.node = nodeResult.node;
 				checkResults.push(checkResult);
 			}
 		});
@@ -534,6 +535,10 @@ Rule.prototype.after = function(result, options) {
 
 		var afterResults = check.after(beforeResults, option);
 		beforeResults.forEach(function(item) {
+			// only add the node property for the check.after so we can
+			// look at which iframe a check result came from, but we don't
+			// want it for the final results object
+			delete item.node;
 			if (afterResults.indexOf(item) === -1) {
 				item.filtered = true;
 			}

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -1518,6 +1518,52 @@ describe('Rule', function() {
 				assert.isTrue(success);
 			});
 
+			it('should add the check node to the check result', function() {
+				var success = false;
+
+				var rule = new Rule(
+					{
+						id: 'cats',
+						any: ['cats']
+					},
+					{
+						checks: {
+							cats: {
+								id: 'cats',
+								enabled: true,
+								after: function(results) {
+									assert.equal(results[0].node, 'customNode');
+									success = true;
+									return results;
+								}
+							}
+						}
+					}
+				);
+
+				rule.after(
+					{
+						id: 'cats',
+						nodes: [
+							{
+								all: [],
+								none: [],
+								any: [
+									{
+										id: 'cats',
+										result: true
+									}
+								],
+								node: 'customNode'
+							}
+						]
+					},
+					{ checks: { cats: { options: { dogs: true } } } }
+				);
+
+				assert.isTrue(success);
+			});
+
 			it('should filter removed checks', function() {
 				var rule = new Rule(
 					{


### PR DESCRIPTION
This was more difficult than I had hoped. The functions all mutate the original results through various passes, which meant that I couldn't return a new object as the final filter of `item.filtered === true` had to run on the original `result.nodes`. I'm not a fan of how we're doing it, but it would take a huge refactor to get it to work differently, and an even bigger understanding of why we are doing what we are doing.

I then tried to just add the `node` object directly to the check result, but that resulted in the final `results` object that axe returns having the node property for every check result. This wasn't ideal and frankly not needed as the parent check object has the node in question. 

So to get everything to work, I added the node to the object and then deleted it after we didn't need it any more. Is it a good solution? No. But I think it's probably the best we can do unless we want to refactor the entire function (which I would need some understanding first). 

Allows us to work on #728 and #2330 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
