### PR TITLE
fix(color-contrast): mark elements with pseudo content as needs review

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -12,8 +12,9 @@ import {
 	getContrast,
 	getOwnBackgroundColor
 } from '../../commons/color';
+import { memoize } from '../../core/utils';
 
-function hasPsuedoElement(node, pseudo) {
+const hasPsuedoElement = memoize(function hasPsuedoElement(node, pseudo) {
 	const style = window.getComputedStyle(node, pseudo);
 	const backgroundColor = getOwnBackgroundColor(style);
 
@@ -27,7 +28,7 @@ function hasPsuedoElement(node, pseudo) {
 		(backgroundColor.alpha !== 0 ||
 			style.getPropertyValue('background-image') !== 'none')
 	);
-}
+});
 
 function colorContrastEvaluate(node, options, virtualNode) {
 	if (!isVisible(node, false)) {

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -9,8 +9,25 @@ import {
 	getBackgroundColor,
 	getForegroundColor,
 	incompleteData,
-	getContrast
+	getContrast,
+	getOwnBackgroundColor
 } from '../../commons/color';
+
+function hasPsuedoElement(node, pseudo) {
+	const style = window.getComputedStyle(node, pseudo);
+	const backgroundColor = getOwnBackgroundColor(style);
+
+	// element has a non-transparent color or image and has
+	// non-zero width
+	return (
+		style.getPropertyValue('content') !== 'none' &&
+		style.getPropertyValue('position') === 'absolute' &&
+		parseInt(style.getPropertyValue('width')) !== 0 &&
+		parseInt(style.getPropertyValue('height')) !== 0 &&
+		(backgroundColor.alpha !== 0 ||
+			style.getPropertyValue('background-image') !== 'none')
+	);
+}
 
 function colorContrastEvaluate(node, options, virtualNode) {
 	if (!isVisible(node, false)) {
@@ -60,6 +77,24 @@ function colorContrastEvaluate(node, options, virtualNode) {
 		? contrastRatio.normal
 		: contrastRatio.large;
 	const isValid = contrast > expected;
+
+	// if element or a parent has pseudo content then we need to mark
+	// as needs review
+	let parentNode = node.parentElement;
+	while (parentNode) {
+		if (
+			hasPsuedoElement(parentNode, 'before') ||
+			hasPsuedoElement(parentNode, 'after')
+		) {
+			this.data({
+				messageKey: 'pseudoContent'
+			});
+			this.relatedNodes(parentNode);
+			return undefined;
+		}
+
+		parentNode = parentNode.parentElement;
+	}
 
 	// ratio is outside range
 	if (

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -83,8 +83,8 @@ function colorContrastEvaluate(node, options, virtualNode) {
 	let parentNode = node.parentElement;
 	while (parentNode) {
 		if (
-			hasPsuedoElement(parentNode, 'before') ||
-			hasPsuedoElement(parentNode, 'after')
+			hasPsuedoElement(parentNode, ':before') ||
+			hasPsuedoElement(parentNode, ':after')
 		) {
 			this.data({
 				messageKey: 'pseudoContent'

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -33,7 +33,8 @@
 				"outsideViewport": "Element's background color could not be determined because it's outside the viewport",
 				"equalRatio": "Element has a 1:1 contrast ratio with the background",
 				"shortTextContent": "Element content is too short to determine if it is actual text content",
-				"nonBmp": "Element content contains only non-text characters"
+				"nonBmp": "Element content contains only non-text characters",
+				"pseudoContent": "Element's background color could not be determined due to a pseudo element"
 			}
 		}
 	}

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -356,6 +356,98 @@ describe('color-contrast', function() {
 		);
 	});
 
+	it('should return undefined if :before pseudo element has a background color', function() {
+		var params = checkSetup(
+			'<style>.foo { position: relative; } .foo:before { content: ""; position: absolute; width: 100%; height: 100%; background: red; }</style>' +
+				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
+		);
+
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._data, {
+			messageKey: 'pseudoContent'
+		});
+		assert.equal(
+			checkContext._relatedNodes[0],
+			document.querySelector('#background')
+		);
+	});
+
+	it('should return undefined if :after pseudo element has a background color', function() {
+		var params = checkSetup(
+			'<style>.foo { position: relative; } .foo:after { content: ""; position: absolute; width: 100%; height: 100%; background: red; }</style>' +
+				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
+		);
+
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._data, {
+			messageKey: 'pseudoContent'
+		});
+		assert.equal(
+			checkContext._relatedNodes[0],
+			document.querySelector('#background')
+		);
+	});
+
+	it('should return undefined if pseudo element has a background image', function() {
+		var dataURI =
+			'data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/' +
+			'XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkA' +
+			'ABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKU' +
+			'E1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7';
+
+		var params = checkSetup(
+			'<style>.foo { position: relative; } .foo:before { content: ""; position: absolute; width: 100%; height: 100%; background: url(' +
+				dataURI +
+				') no-repeat left center; }</style>' +
+				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
+		);
+
+		assert.isUndefined(contrastEvaluate.apply(checkContext, params));
+		assert.deepEqual(checkContext._data, {
+			messageKey: 'pseudoContent'
+		});
+		assert.equal(
+			checkContext._relatedNodes[0],
+			document.querySelector('#background')
+		);
+	});
+
+	it('should not return undefined if pseudo element has no content', function() {
+		var params = checkSetup(
+			'<style>.foo { position: relative; } .foo:before { position: absolute; width: 100%; height: 100%; background: red; }</style>' +
+				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
+		);
+
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
+	});
+
+	it('should not return undefined if pseudo element is not absolutely positioned no content', function() {
+		var params = checkSetup(
+			'<style>.foo { position: relative; } .foo:before { content: ""; width: 100%; height: 100%; background: red; }</style>' +
+				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
+		);
+
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
+	});
+
+	it('should not return undefined if pseudo element is has zero dimension', function() {
+		var params = checkSetup(
+			'<style>.foo { position: relative; } .foo:before { content: ""; position: absolute; height: 100%; background: red; }</style>' +
+				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
+		);
+
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
+	});
+
+	it("should not return undefined if pseudo element doesn't have a background", function() {
+		var params = checkSetup(
+			'<style>.foo { position: relative; } .foo:before { content: ""; position: absolute; width: 100%; height: 100%; }</style>' +
+				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
+		);
+
+		assert.isTrue(contrastEvaluate.apply(checkContext, params));
+	});
+
 	it('should return undefined for a single character text with insufficient contrast', function() {
 		var params = checkSetup(
 			'<div style="background-color: #FFF;">' +

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -432,7 +432,7 @@ describe('color-contrast', function() {
 
 	it('should not return undefined if pseudo element is has zero dimension', function() {
 		var params = checkSetup(
-			'<style>.foo { position: relative; } .foo:before { content: ""; position: absolute; height: 100%; background: red; }</style>' +
+			'<style>.foo { position: relative; } .foo:before { content: ""; position: absolute; width: 0; height: 100%; background: red; }</style>' +
 				'<div id="background" class="foo"><p id="target" style="#000">Content</p></div>'
 		);
 


### PR DESCRIPTION
Checking for pseudo content adds about 1 second on a [very large site](https://js.tensorflow.org/api/latest/) (26,678 nodes) to our color-contrast check:

| Branch | Time (ms) | 
| --------  | ---------------- |
| Develop | 8413.33 |
| Contrast-pseudo | 9649.56 |

Closes issue: #975 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
