### PR TITLE
chore: add file size to grunt output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-parallel');
 	grunt.loadNpmTasks('grunt-run');
+	grunt.loadNpmTasks('grunt-bytesize');
 	grunt.loadTasks('build/tasks');
 
 	var langs;
@@ -339,6 +340,13 @@ module.exports = function(grunt) {
 				sound: 'Pop',
 				timeout: 2
 			}
+		},
+		bytesize: {
+			all: {
+				src: langs.map(function(lang) {
+					return ['./axe' + lang + '.js', './axe' + lang + '.min.js'];
+				})
+			}
 		}
 	});
 
@@ -351,7 +359,8 @@ module.exports = function(grunt) {
 		'babel',
 		'concat:engine',
 		'uglify',
-		'aria-supported'
+		'aria-supported',
+		'bytesize'
 	]);
 	grunt.registerTask('prepare', [
 		'build',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,6 +1968,15 @@
 			"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
 			"dev": true
 		},
+		"bytesize": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/bytesize/-/bytesize-0.2.0.tgz",
+			"integrity": "sha1-blSXYmGR8vvpdkWS0k6Tpyz5lMU=",
+			"dev": true,
+			"requires": {
+				"humanize": "0.0.7"
+			}
+		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -5155,6 +5164,15 @@
 			"integrity": "sha512-WuiZFvGzcyzlEoPIcY1snI234ydDWeWWV5bpnB7PZsOLHcDsxWKnrR1rMWEUsbdVPPjvIirwFNsuo4CbJmsdFQ==",
 			"dev": true
 		},
+		"grunt-bytesize": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/grunt-bytesize/-/grunt-bytesize-0.2.0.tgz",
+			"integrity": "sha1-JvXeldUhxU53kKpqAlEEm6rWdHE=",
+			"dev": true,
+			"requires": {
+				"bytesize": "~0.2.0"
+			}
+		},
 		"grunt-contrib-clean": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-2.0.0.tgz",
@@ -5758,6 +5776,12 @@
 					}
 				}
 			}
+		},
+		"humanize": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.7.tgz",
+			"integrity": "sha1-Nx/FThqNNh6ou0DkcH5aCrR0E7M=",
+			"dev": true
 		},
 		"husky": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 		"globby": "^10.0.0",
 		"grunt": "^1.0.3",
 		"grunt-babel": "^8.0.0",
+		"grunt-bytesize": "^0.2.0",
 		"grunt-contrib-clean": "^2.0.0",
 		"grunt-contrib-concat": "^1.0.1",
 		"grunt-contrib-connect": "^2.0.0",


### PR DESCRIPTION
Just outputting the file size of `axe.js` and `axe.min.js`.

![image](https://user-images.githubusercontent.com/2433219/97888482-6a84a380-1ce8-11eb-970d-c5bf9d01082c.png)

**Note:** Based on these numbers, we've reduced axe-cores' minified file size (from our [4.0 release](https://github.com/dequelabs/axe-core/issues/2357)) by 135 kB and gzipped size by 30 kB. So far all we've done is changed the way we stored [valid-lang](https://github.com/dequelabs/axe-core/pull/2527) and switched from [webpack to esbuild](https://github.com/dequelabs/axe-core/pull/2579).

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
