### PR TITLE
fix(link-name): pass landmark content as link text

### DIFF
--- a/lib/commons/text/subtree-text.js
+++ b/lib/commons/text/subtree-text.js
@@ -31,7 +31,7 @@ function subtreeText(virtualNode, context = {}) {
 	/**
 	 * Note: Strictly speaking if a child isn't named from content and it has no accessible name
 	 * accName says to ignore it. Browsers do this fairly consistently, but screen readers have
-	 * chosen to ignore this, but only for direct content, not for links.
+	 * chosen to ignore this, but only for direct content, not for labels / aria-labelledby.
 	 * That way in `a[href] > article > #text` the text is used for the accessible name,
 	 * See: https://github.com/dequelabs/axe-core/issues/1461
 	 */

--- a/lib/commons/text/subtree-text.js
+++ b/lib/commons/text/subtree-text.js
@@ -13,14 +13,32 @@ import getOwnedVirtual from '../aria/get-owned-virtual';
 function subtreeText(virtualNode, context = {}) {
 	const { alreadyProcessed } = accessibleTextVirtual;
 	context.startNode = context.startNode || virtualNode;
-	const { strict } = context;
+	const { strict, inControlContext, inLabelledByContext } = context;
 	if (
 		alreadyProcessed(virtualNode, context) ||
-		!namedFromContents(virtualNode, { strict })
+		virtualNode.props.nodeType !== 1
 	) {
 		return '';
 	}
 
+	if (
+		!namedFromContents(virtualNode, { strict }) &&
+		!context.subtreeDescendant
+	) {
+		return '';
+	}
+
+	/**
+	 * Note: Strictly speaking if a child isn't named from content and it has no accessible name
+	 * accName says to ignore it. Browsers do this fairly consistently, but screen readers have
+	 * chosen to ignore this, but only for direct content, not for links.
+	 * That way in `a[href] > article > #text` the text is used for the accessible name,
+	 * See: https://github.com/dequelabs/axe-core/issues/1461
+	 */
+	if (!strict) {
+		const subtreeDescendant = !inControlContext && !inLabelledByContext;
+		context = { subtreeDescendant, ...context };
+	}
 	return getOwnedVirtual(virtualNode).reduce((contentText, child) => {
 		return appendAccessibleText(contentText, child, context);
 	}, '');

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -257,12 +257,12 @@ describe('text.accessibleTextVirtual', function() {
 		axe.testUtils.flatTreeSetup(fixture);
 
 		var target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
-		// Chrome 72: This is This is a label of
-		// Firefox 62: This is ARIA Label
-		// Safari 12.0: This is This is a label of
+		// Chrome 86: This is This is a label of
+		// Firefox 82: This is ARIA Label everything
+		// Safari 14.0: This is This is a label of everything
 		assert.equal(
 			axe.commons.text.accessibleTextVirtual(target),
-			'This is This is a label of'
+			'This is This is a label of everything'
 		);
 	});
 

--- a/test/integration/rules/link-name/link-name.html
+++ b/test/integration/rules/link-name/link-name.html
@@ -2,6 +2,9 @@
 <a href="#" id="pass2" aria-label="link text"></a>
 <a href="#" id="pass3" aria-labelledby="linklabel"></a>
 <a href="#" id="pass4" title="title text"></a>
+<a href="#" id="pass5">
+	<article>Some sectioning content</article>
+</a>
 
 <div id="linklabel">Text</div>
 

--- a/test/integration/rules/link-name/link-name.json
+++ b/test/integration/rules/link-name/link-name.json
@@ -8,5 +8,5 @@
 		["#violation4"],
 		["#violation5"]
 	],
-	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"]]
+	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"]]
 }


### PR DESCRIPTION
To figure this one out I tested the following code:

```html
<label for="bar" id="foo">
	<a href="/" id="baz">
		<div role="alert" aria-label="Goodbye">Hello</div>
		<div role="textbox" aria-label="mars">earth</div>
		<div role="img">people</div>
	</a>
</label>
<input type="button" aria-labelledby="foo" id="bar" />
```

The surprising thing is that AT gave different names than the browsers do. The button works fairly consistently, but most AT seem to have something in place to deal with this `a[href] > article:not([aria-label])` scenario. Here are my test results:

(either aria-labelledby or explicit label)
| Browser (+AT)  | Link                | Button
|----------------|---------------------|-----------------
| Chrome name    | Goodbye mars        | Goodbye mars
| NVDA + Chrome  | Hello mars          | Goodbye mars
| JAWS + Chrome  | Hello slash         | Goodbye mars
| Firefox name   | Goodbye mars earth  | Goodbye mars earth
| NVDA + Firefox | Hello mars          | Goodbye mars
| Safari name    | Goodbye mars people | Goodbye mars
| VO + Safari    | Goodbye earth mars  | Goodbye mars
| JAWS + IE      | Hello earth people  | Goodbye mars

Versions: Firefox 82, Chrome 86, Safari 14, IE11, VO (MacOS) Catalina, JAWS 2020, NVDA 2020.3

Results are completely all over the place, so to avoid false positives what I've done is chosen the most optimistic scenario, which is that when looking for name from content of an element that isn't a label, all descendants should be considered, even elements that are named from author, except if the element that is named from author has an accessible name already through some other means.

**This PR does not guarantee the outcome will work everywhere.** Instead it avoids the false positive. I'm opening a ticket to look at this more closely when we're not days away from a code freeze.

Closes issue: #1461

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
