### PR TITLE
fix(color-contrast): properly handle scrolling text

### DIFF
--- a/lib/commons/dom/get-text-element-stack.js
+++ b/lib/commons/dom/get-text-element-stack.js
@@ -24,29 +24,30 @@ function getTextElementStack(node) {
 		return [];
 	}
 
-	// if the element is using text truncation we need to get the rect of
-	// the element rather than look at the text node rects as they will return
-	// the full width of the text node before truncation (which can go off the
-	// screen)
-	// @see https://github.com/dequelabs/axe-core/issues/2178
-	const whiteSpace = vNode.getComputedStylePropertyValue('white-space');
-	const overflow = vNode.getComputedStylePropertyValue('overflow');
-	if (whiteSpace === 'nowrap' && overflow === 'hidden') {
-		return [getElementStack(node)];
-	}
-
 	// for code blocks that use syntax highlighting, you can get a ton of client
 	// rects (See https://github.com/dequelabs/axe-core/issues/1985). they use
 	// a mixture of text nodes and other nodes (which will contain their own text
 	// nodes), but all we care about is checking the direct text nodes as the
 	// other nodes will have their own client rects checked. doing this speeds up
 	// color contrast significantly for large syntax highlighted code blocks
+	const nodeRect = vNode.boundingClientRect;
 	const clientRects = [];
 	Array.from(node.childNodes).forEach(elm => {
 		if (elm.nodeType === 3 && sanitize(elm.textContent) !== '') {
 			const range = document.createRange();
 			range.selectNodeContents(elm);
 			const rects = range.getClientRects();
+
+			// if the elements bounding rect is smaller than the text rects
+			// (for example, it's using text truncation or overflow) we
+			// need to get the rect of the element rather than look at the
+			// text node rects as they will return the full width of the
+			// text node (which can go off the screen)
+			// @see https://github.com/dequelabs/axe-core/issues/2178
+			// @see https://github.com/dequelabs/axe-core/issues/2483
+			if (rects[0].width > nodeRect.width) {
+				return;
+			}
 
 			for (let i = 0; i < rects.length; i++) {
 				const rect = rects[i];
@@ -60,6 +61,10 @@ function getTextElementStack(node) {
 			}
 		}
 	});
+
+	if (!clientRects.length) {
+		return [getElementStack(node)];
+	}
 
 	return clientRects.map(rect => {
 		return getRectStack(grid, rect);

--- a/lib/commons/dom/get-text-element-stack.js
+++ b/lib/commons/dom/get-text-element-stack.js
@@ -45,7 +45,7 @@ function getTextElementStack(node) {
 			// text node (which can go off the screen)
 			// @see https://github.com/dequelabs/axe-core/issues/2178
 			// @see https://github.com/dequelabs/axe-core/issues/2483
-			if (rects[0].width > nodeRect.width) {
+			if (rects[0] && rects[0].width > nodeRect.width) {
 				return;
 			}
 

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -576,5 +576,18 @@ describe('dom.getElementStack', function() {
 			var stacks = getTextElementStack(target).map(mapToIDs);
 			assert.deepEqual(stacks, [['target', '1', 'fixture']]);
 		});
+
+		it('should handle text that is too large for the container', function() {
+			fixture.innerHTML =
+				'<pre id="1" style="width: 400px; overflow: auto;">' +
+				'<span id="target" style="display: flex; with: 400px;">' +
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed et sollicitudin quam. Fusce mi odio, egestas pulvinar erat eget, vehicula tempus est. Proin vitae ullamcorper velit. Donec sagittis est justo, mattis iaculis arcu facilisis id. Proin pulvinar ornare arcu a fermentum. Quisque et dignissim nulla, sit amet consectetur ipsum. Donec in libero porttitor, dapibus neque imperdiet, aliquam est. Vivamus blandit volutpat fringilla. In mi magna, mollis sit amet imperdiet eu, rutrum ut tellus. Mauris vel condimentum nibh, quis ultricies nisi. Vivamus accumsan quam mauris, id iaculis quam fringilla ac. Curabitur pulvinar dolor ac magna vehicula, non auctor ligula dignissim. Nam ac nibh porttitor, malesuada tortor varius, feugiat turpis. Mauris dapibus, tellus ut viverra porta, ipsum turpis bibendum ligula, at tempor felis ante non libero. Donec dapibus, diam sit amet posuere commodo, magna orci hendrerit ipsum, eu egestas mauris nulla ut ipsum. Sed luctus, orci in fringilla finibus, odio leo porta dolor, eu dignissim risus eros eget erat.' +
+				'</span>' +
+				'</pre>';
+			axe.testUtils.flatTreeSetup(fixture);
+			var target = fixture.querySelector('#target');
+			var stacks = getTextElementStack(target).map(mapToIDs);
+			assert.deepEqual(stacks, [['target', '1', 'fixture']]);
+		});
 	});
 });


### PR DESCRIPTION
Text whose container was smaller than the text itself caused the same problems as [truncated text](https://github.com/dequelabs/axe-core/pull/2302). 

Closes issue: #2483

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
