### PR TITLE
chore: don't rebuild axe when tests change

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,13 +234,14 @@ module.exports = function(grunt) {
 			}, [])
 		},
 		watch: {
-			files: [
-				'lib/**/*',
-				'test/**/*.js',
-				'test/integration/**/!(index).{html,json}',
-				'Gruntfile.js'
-			],
-			tasks: ['build', 'testconfig', 'fixture', 'notify']
+			axe: {
+				files: ['lib/**/*', 'Gruntfile.js'],
+				tasks: ['build', 'notify']
+			},
+			tests: {
+				files: ['test/**/*.js', 'test/integration/**/!(index).{html,json}'],
+				tasks: ['testconfig', 'fixture']
+			}
 		},
 		testconfig: {
 			test: {


### PR DESCRIPTION
I got tired of waiting for axe-core to fully build just because I changed a test file. Updated the Gruntfile to only build axe-core when the `lib` or `Gruntfile` changes and only build test files when the `test` changes.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
