### PR TITLE
fix(name-rules): ignore when explicit roles don't require a name

### DIFF
--- a/doc/standards-object.md
+++ b/doc/standards-object.md
@@ -72,8 +72,10 @@ The [`ariaRoles`](../lib/standards/aria-roles.js) object defines valid ARIA role
 - `requiredOwned` - array(optional). List of required owned roles.
 - `requiredAttrs` - array(optional). List of required attributes.
 - `allowedAttrs` - array(optional). List of allowed attributes (besides any required and global ARIA attributes).
+- `superclassRole` - array(optional). List of superclass roles.
+- `accessibleNameDrequired` - boolean(optional. Default `false`). If elements with this role require an accessible name.
 - `nameFromContent` - boolean(optional. Default `false`). If the role allows name from content when calculating the accessible name.
-- `unsupported` - boolean(optional. Default `false`). If the role role is unsupported. Use this property to disable a role.
+- `unsupported` - boolean(optional. Default `false`). If the role is unsupported. Use this property to disable a role.
 
 ### Dpub Roles
 

--- a/doc/standards-object.md
+++ b/doc/standards-object.md
@@ -73,7 +73,7 @@ The [`ariaRoles`](../lib/standards/aria-roles.js) object defines valid ARIA role
 - `requiredAttrs` - array(optional). List of required attributes.
 - `allowedAttrs` - array(optional). List of allowed attributes (besides any required and global ARIA attributes).
 - `superclassRole` - array(optional). List of superclass roles.
-- `accessibleNameDrequired` - boolean(optional. Default `false`). If elements with this role require an accessible name.
+- `accessibleNameRequired` - boolean(optional. Default `false`). If elements with this role require an accessible name.
 - `nameFromContent` - boolean(optional. Default `false`). If the role allows name from content when calculating the accessible name.
 - `unsupported` - boolean(optional. Default `false`). If the role is unsupported. Use this property to disable a role.
 

--- a/lib/core/base/metadata-function-map.js
+++ b/lib/core/base/metadata-function-map.js
@@ -153,6 +153,7 @@ import layoutTableMatches from '../../rules/layout-table-matches';
 import linkInTextBlockMatches from '../../rules/link-in-text-block-matches';
 import noAutoplayAudioMatches from '../../rules/no-autoplay-audio-matches';
 import noEmptyRoleMatches from '../../rules/no-empty-role-matches';
+import noExplicitNameRequiredMatches from '../../rules/no-explicit-name-required-matches';
 import noNamingMethodMatches from '../../rules/no-naming-method-matches';
 import noRoleMatches from '../../rules/no-role-matches';
 import notHtmlMatches from '../../rules/not-html-matches';
@@ -321,6 +322,7 @@ const metadataFunctionMap = {
 	'link-in-text-block-matches': linkInTextBlockMatches,
 	'no-autoplay-audio-matches': noAutoplayAudioMatches,
 	'no-empty-role-matches': noEmptyRoleMatches,
+	'no-explicit-name-required-matches': noExplicitNameRequiredMatches,
 	'no-naming-method-matches': noNamingMethodMatches,
 	'no-role-matches': noRoleMatches,
 	'not-html-matches': notHtmlMatches,

--- a/lib/rules/button-name.json
+++ b/lib/rules/button-name.json
@@ -1,6 +1,7 @@
 {
 	"id": "button-name",
 	"selector": "button",
+	"matches": "no-explicit-name-required-matches",
 	"tags": [
 		"cat.name-role-value",
 		"wcag2a",

--- a/lib/rules/image-alt.json
+++ b/lib/rules/image-alt.json
@@ -1,6 +1,7 @@
 {
 	"id": "image-alt",
 	"selector": "img",
+	"matches": "no-explicit-name-required-matches",
 	"tags": [
 		"cat.text-alternatives",
 		"wcag2a",

--- a/lib/rules/input-button-name.json
+++ b/lib/rules/input-button-name.json
@@ -1,6 +1,7 @@
 {
 	"id": "input-button-name",
 	"selector": "input[type=\"button\"], input[type=\"submit\"], input[type=\"reset\"]",
+	"matches": "no-explicit-name-required-matches",
 	"tags": [
 		"cat.name-role-value",
 		"wcag2a",

--- a/lib/rules/input-image-alt.json
+++ b/lib/rules/input-image-alt.json
@@ -1,6 +1,7 @@
 {
 	"id": "input-image-alt",
 	"selector": "input[type=\"image\"]",
+	"matches": "no-explicit-name-required-matches",
 	"tags": [
 		"cat.text-alternatives",
 		"wcag2a",

--- a/lib/rules/no-explicit-name-required-matches.js
+++ b/lib/rules/no-explicit-name-required-matches.js
@@ -1,0 +1,22 @@
+import { isFocusable } from '../commons/dom';
+import { getExplicitRole } from '../commons/aria';
+import ariaRoles from '../standards/aria-roles';
+
+/**
+ * Filter out elements with an explicit role that does not require an accessible name and is not focusable
+ */
+function noExplicitNameRequired(node, virtualNode) {
+	const role = getExplicitRole(virtualNode);
+	if (!role || ['none', 'presentation'].includes(role)) {
+		return true;
+	}
+
+	const { accessibleNameRequired } = ariaRoles[role] || {};
+	if (accessibleNameRequired || isFocusable(virtualNode)) {
+		return true;
+	}
+
+	return false;
+}
+
+export default noExplicitNameRequired;

--- a/lib/rules/object-alt.json
+++ b/lib/rules/object-alt.json
@@ -1,6 +1,7 @@
 {
 	"id": "object-alt",
 	"selector": "object",
+	"matches": "no-explicit-name-required-matches",
 	"tags": [
 		"cat.text-alternatives",
 		"wcag2a",

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -24,7 +24,8 @@ const ariaRoles = {
 	alertdialog: {
 		type: 'widget',
 		allowedAttrs: ['aria-expanded', 'aria-modal'],
-		superclassRole: ['alert', 'dialog']
+		superclassRole: ['alert', 'dialog'],
+		accessibleNameRequired: true
 	},
 	application: {
 		// Note: spec difference
@@ -32,7 +33,8 @@ const ariaRoles = {
 		// Note: aria-expanded is not in the 1.1 spec but is
 		// consistently supported in ATs and was added in 1.2
 		allowedAttrs: ['aria-activedescendant', 'aria-expanded'],
-		superclassRole: ['structure']
+		superclassRole: ['structure'],
+		accessibleNameRequired: true
 	},
 	article: {
 		type: 'structure',
@@ -52,6 +54,7 @@ const ariaRoles = {
 		type: 'widget',
 		allowedAttrs: ['aria-expanded', 'aria-pressed'],
 		superclassRole: ['command'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	caption: {
@@ -82,6 +85,7 @@ const ariaRoles = {
 		// consistently supported in ATs and was added in 1.2
 		allowedAttrs: ['aria-checked', 'aria-readonly', 'aria-required'],
 		superclassRole: ['input'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	code: {
@@ -103,6 +107,8 @@ const ariaRoles = {
 			'aria-selected'
 		],
 		superclassRole: ['cell', 'gridcell', 'sectionhead'],
+		// Note: spec difference
+		accessibleNameRequired: false,
 		nameFromContent: true
 	},
 	combobox: {
@@ -120,7 +126,8 @@ const ariaRoles = {
 			'aria-activedescendant',
 			'aria-orientation'
 		],
-		superclassRole: ['select']
+		superclassRole: ['select'],
+		accessibleNameRequired: true
 	},
 	command: {
 		type: 'abstract',
@@ -152,7 +159,8 @@ const ariaRoles = {
 	dialog: {
 		type: 'widget',
 		allowedAttrs: ['aria-expanded', 'aria-modal'],
-		superclassRole: ['window']
+		superclassRole: ['window'],
+		accessibleNameRequired: true
 	},
 	directory: {
 		type: 'structure',
@@ -200,7 +208,9 @@ const ariaRoles = {
 			'aria-expanded',
 			'aria-rowcount'
 		],
-		superclassRole: ['composite', 'table']
+		superclassRole: ['composite', 'table'],
+		// Note: spec difference
+		accessibleNameRequired: false
 	},
 	gridcell: {
 		type: 'widget',
@@ -228,12 +238,15 @@ const ariaRoles = {
 		requiredAttrs: ['aria-level'],
 		allowedAttrs: ['aria-expanded'],
 		superclassRole: ['sectionhead'],
+		// Note: spec difference
+		accessibleNameRequired: false,
 		nameFromContent: true
 	},
 	img: {
 		type: 'structure',
 		allowedAttrs: ['aria-expanded'],
-		superclassRole: ['section']
+		superclassRole: ['section'],
+		accessibleNameRequired: true
 	},
 	input: {
 		type: 'abstract',
@@ -251,6 +264,7 @@ const ariaRoles = {
 		type: 'widget',
 		allowedAttrs: ['aria-expanded'],
 		superclassRole: ['command'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	list: {
@@ -270,7 +284,8 @@ const ariaRoles = {
 			'aria-expanded',
 			'aria-orientation'
 		],
-		superclassRole: ['select']
+		superclassRole: ['select'],
+		accessibleNameRequired: true
 	},
 	listitem: {
 		type: 'structure',
@@ -332,6 +347,7 @@ const ariaRoles = {
 		// consistently supported in ATs and was added in 1.2
 		allowedAttrs: ['aria-posinset', 'aria-setsize', 'aria-expanded'],
 		superclassRole: ['command'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	menuitemcheckbox: {
@@ -344,6 +360,7 @@ const ariaRoles = {
 			'aria-setsize'
 		],
 		superclassRole: ['checkbox', 'menuitem'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	menuitemradio: {
@@ -356,13 +373,15 @@ const ariaRoles = {
 			'aria-setsize'
 		],
 		superclassRole: ['menuitemcheckbox', 'radio'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	meter: {
 		type: 'structure',
 		allowedAttrs: ['aria-valuetext'],
 		requiredAttrs: ['aria-valuemax', 'aria-valuemin', 'aria-valuenow'],
-		superclassRole: ['range']
+		superclassRole: ['range'],
+		accessibleNameRequired: true
 	},
 	navigation: {
 		type: 'landmark',
@@ -391,6 +410,7 @@ const ariaRoles = {
 			'aria-setsize'
 		],
 		superclassRole: ['input'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	paragraph: {
@@ -410,7 +430,8 @@ const ariaRoles = {
 			'aria-valuenow',
 			'aria-valuetext'
 		],
-		superclassRole: ['range']
+		superclassRole: ['range'],
+		accessibleNameRequired: true
 	},
 	radio: {
 		type: 'widget',
@@ -427,6 +448,7 @@ const ariaRoles = {
 			'aria-required'
 		],
 		superclassRole: ['input'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	radiogroup: {
@@ -439,7 +461,9 @@ const ariaRoles = {
 			'aria-expanded',
 			'aria-orientation'
 		],
-		superclassRole: ['select']
+		superclassRole: ['select'],
+		// Note: spec difference
+		accessibleNameRequired: false
 	},
 	range: {
 		type: 'abstract',
@@ -448,7 +472,9 @@ const ariaRoles = {
 	region: {
 		type: 'landmark',
 		allowedAttrs: ['aria-expanded'],
-		superclassRole: ['landmark']
+		superclassRole: ['landmark'],
+		// Note: spec difference
+		accessibleNameRequired: false
 	},
 	roletype: {
 		type: 'abstract',
@@ -491,6 +517,8 @@ const ariaRoles = {
 			'aria-selected'
 		],
 		superclassRole: ['cell', 'gridcell', 'sectionhead'],
+		// Note: spec difference
+		accessibleNameRequired: false,
 		nameFromContent: true
 	},
 	scrollbar: {
@@ -527,7 +555,8 @@ const ariaRoles = {
 			'aria-readonly',
 			'aria-required'
 		],
-		superclassRole: ['textbox']
+		superclassRole: ['textbox'],
+		accessibleNameRequired: true
 	},
 	section: {
 		type: 'abstract',
@@ -573,7 +602,8 @@ const ariaRoles = {
 			'aria-readonly',
 			'aria-valuetext'
 		],
-		superclassRole: ['input', 'range']
+		superclassRole: ['input', 'range'],
+		accessibleNameRequired: true
 	},
 	spinbutton: {
 		type: 'widget',
@@ -589,7 +619,8 @@ const ariaRoles = {
 			'aria-activedescendant',
 			'aria-valuetext'
 		],
-		superclassRole: ['composite', 'input', 'range']
+		superclassRole: ['composite', 'input', 'range'],
+		accessibleNameRequired: true
 	},
 	status: {
 		type: 'widget',
@@ -617,6 +648,7 @@ const ariaRoles = {
 		requiredAttrs: ['aria-checked'],
 		allowedAttrs: ['aria-readonly'],
 		superclassRole: ['checkbox'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	tab: {
@@ -640,6 +672,8 @@ const ariaRoles = {
 		// table be named from content (we even had to special case
 		// table in commons/aria/named-from-contents)
 		superclassRole: ['section'],
+		// Note: spec difference
+		accessibleNameRequired: false,
 		nameFromContent: true
 	},
 	tablist: {
@@ -659,7 +693,9 @@ const ariaRoles = {
 	tabpanel: {
 		type: 'widget',
 		allowedAttrs: ['aria-expanded'],
-		superclassRole: ['section']
+		superclassRole: ['section'],
+		// Note: spec difference
+		accessibleNameRequired: false
 	},
 	term: {
 		type: 'structure',
@@ -678,7 +714,8 @@ const ariaRoles = {
 			'aria-readonly',
 			'aria-required'
 		],
-		superclassRole: ['input']
+		superclassRole: ['input'],
+		accessibleNameRequired: true
 	},
 	time: {
 		type: 'structure',
@@ -696,7 +733,8 @@ const ariaRoles = {
 			'aria-activedescendant',
 			'aria-expanded'
 		],
-		superclassRole: ['group']
+		superclassRole: ['group'],
+		accessibleNameRequired: true
 	},
 	tooltip: {
 		type: 'structure',
@@ -714,7 +752,9 @@ const ariaRoles = {
 			'aria-expanded',
 			'aria-orientation'
 		],
-		superclassRole: ['select']
+		superclassRole: ['select'],
+		// Note: spec difference
+		accessibleNameRequired: false
 	},
 	treegrid: {
 		type: 'composite',
@@ -730,7 +770,9 @@ const ariaRoles = {
 			'aria-required',
 			'aria-rowcount'
 		],
-		superclassRole: ['grid', 'tree']
+		superclassRole: ['grid', 'tree'],
+		// Note: spec difference
+		accessibleNameRequired: false
 	},
 	treeitem: {
 		type: 'widget',
@@ -744,6 +786,7 @@ const ariaRoles = {
 			'aria-setsize'
 		],
 		superclassRole: ['listitem', 'option'],
+		accessibleNameRequired: true,
 		nameFromContent: true
 	},
 	widget: {

--- a/test/integration/rules/button-name/button-name.html
+++ b/test/integration/rules/button-name/button-name.html
@@ -14,9 +14,12 @@
 
 <button id="fail1" role="presentation"></button>
 <button id="fail2" role="none"></button>
+<button id="fail3" role="img" disabled></button>
+<button id="fail4" role="gridcell"></button>
 
 <button id="pass1" role="presentation" disabled></button>
 <button id="pass2" role="none" disabled></button>
 
 <span id="inapplicable1" role="button">Does not apply</span>
 <input type="submit" value="submit" role="button" id="inapplicable2" />
+<button id="inapplicable2" role="gridcell" disabled></button>

--- a/test/integration/rules/button-name/button-name.json
+++ b/test/integration/rules/button-name/button-name.json
@@ -9,7 +9,9 @@
 		["#albempty"],
 		["#buttonvalue"],
 		["#fail1"],
-		["#fail2"]
+		["#fail2"],
+		["#fail3"],
+		["#fail4"]
 	],
 	"passes": [
 		["#text"],

--- a/test/integration/rules/image-alt/image-alt.html
+++ b/test/integration/rules/image-alt/image-alt.html
@@ -19,3 +19,7 @@
 <img src="img.jpg" id="violation8" role="none" aria-live="assertive" />
 <img src="img.jpg" id="violation9" role="presentation" tabindex="0" />
 <img src="img.jpg" id="violation10" role="none" tabindex="0" />
+
+<img src="img.jpg" id="violation11" role="button" />
+<img src="img.jpg" id="violation12" role="separator" tabindex="0" />
+<img src="img.jpg" id="inapplicable1" role="separator" />

--- a/test/integration/rules/image-alt/image-alt.json
+++ b/test/integration/rules/image-alt/image-alt.json
@@ -11,7 +11,9 @@
 		["#violation7"],
 		["#violation8"],
 		["#violation9"],
-		["#violation10"]
+		["#violation10"],
+		["#violation11"],
+		["#violation12"]
 	],
 	"passes": [
 		["#pass1"],

--- a/test/integration/rules/input-button-name/input-button-name.html
+++ b/test/integration/rules/input-button-name/input-button-name.html
@@ -23,4 +23,8 @@
 	<input type="button" role="presentation" id="fail8" />
 	<input type="button" role="none" id="pass12" disabled />
 	<input type="button" role="presentation" id="pass13" disabled />
+
+	<input type="button" id="fail9" role="img" disabled />
+	<input type="button" id="fail10" role="gridcell" />
+	<input type="button" id="inapplicable1" role="gridcell" disabled />
 </form>

--- a/test/integration/rules/input-button-name/input-button-name.json
+++ b/test/integration/rules/input-button-name/input-button-name.json
@@ -9,7 +9,9 @@
 		["#fail5"],
 		["#fail6"],
 		["#fail7"],
-		["#fail8"]
+		["#fail8"],
+		["#fail9"],
+		["#fail10"]
 	],
 	"passes": [
 		["#pass1"],

--- a/test/integration/rules/input-image-alt/input-image-alt.html
+++ b/test/integration/rules/input-image-alt/input-image-alt.html
@@ -14,4 +14,14 @@
 	<input type="image" src="img.jpg" id="pass3" aria-labelledby="monkeys" />
 	<input type="image" src="img.jpg" id="pass4" title="monkeys" />
 	<input type="image" src="img.jpg" id="violation5" alt="" />
+
+	<input type="image" src="img.jpg" id="violation6" role="img" disabled />
+	<input type="image" src="img.jpg" id="violation7" role="gridcell" />
+	<input
+		type="image"
+		src="img.jpg"
+		id="inapplicable1"
+		role="gridcell"
+		disabled
+	/>
 </form>

--- a/test/integration/rules/input-image-alt/input-image-alt.json
+++ b/test/integration/rules/input-image-alt/input-image-alt.json
@@ -6,7 +6,9 @@
 		["#violation2"],
 		["#violation3"],
 		["#violation4"],
-		["#violation5"]
+		["#violation5"],
+		["#violation6"],
+		["#violation7"]
 	],
 	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"]]
 }

--- a/test/integration/rules/object-alt/object-alt.html
+++ b/test/integration/rules/object-alt/object-alt.html
@@ -12,3 +12,7 @@
 <object id="violation5" role="presentation" tabindex="0"></object>
 <object id="violation6" role="none" aria-live="assertive"></object>
 <object id="violation7" role="presentation" aria-live="assertive"></object>
+
+<object id="violation8" role="img"></object>
+<object id="violation9" role="separator" tabindex="0"></object>
+<object id="inapplicable1" role="separator"></object>

--- a/test/integration/rules/object-alt/object-alt.json
+++ b/test/integration/rules/object-alt/object-alt.json
@@ -8,7 +8,9 @@
 		["#violation4"],
 		["#violation5"],
 		["#violation6"],
-		["#violation7"]
+		["#violation7"],
+		["#violation8"],
+		["#violation9"]
 	],
 	"passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"], ["#pass5"]]
 }

--- a/test/rule-matches/no-explicit-name-required-matches.js
+++ b/test/rule-matches/no-explicit-name-required-matches.js
@@ -1,0 +1,67 @@
+describe('no-explicit-name-matches', function() {
+	'use strict';
+
+	var fixture = document.getElementById('fixture');
+	var queryFixture = axe.testUtils.queryFixture;
+	var rule;
+
+	beforeEach(function() {
+		rule = axe._audit.rules.find(function(rule) {
+			return rule.id === 'button-name';
+		});
+	});
+
+	afterEach(function() {
+		fixture.innerHTML = '';
+	});
+
+	it('returns true when element does not have `role` attribute', function() {
+		var vNode = queryFixture('<button id="target"></button>');
+		var actual = rule.matches(vNode.actualNode, vNode);
+		assert.isTrue(actual);
+	});
+
+	it('returns true when element has an explicit role of presentation', function() {
+		var vNode = queryFixture(
+			'<button id="target" role="presentation"></button>'
+		);
+		var actual = rule.matches(vNode.actualNode, vNode);
+		assert.isTrue(actual);
+	});
+
+	it('returns true when element has an explicit role of none', function() {
+		var vNode = queryFixture('<button id="target" role="none"></button>');
+		var actual = rule.matches(vNode.actualNode, vNode);
+		assert.isTrue(actual);
+	});
+
+	it('returns true when element has an invalid explicit role', function() {
+		var vNode = queryFixture('<button id="target" role="foo"></button>');
+		var actual = rule.matches(vNode.actualNode, vNode);
+		assert.isTrue(actual);
+	});
+
+	it('returns true when element has an explicit role that requires an accessible name', function() {
+		var vNode = queryFixture('<button id="target" role="button"></button>');
+		var actual = rule.matches(vNode.actualNode, vNode);
+		assert.isTrue(actual);
+	});
+
+	describe('with a role that does not require an accessible name', function() {
+		it('returns true when element is focusable', function() {
+			var vNode = queryFixture(
+				'<button id="target" role="separator"></button>'
+			);
+			var actual = rule.matches(vNode.actualNode, vNode);
+			assert.isTrue(actual);
+		});
+
+		it('returns false when element is not focusable', function() {
+			var vNode = queryFixture(
+				'<button id="target" role="separator" disabled></button>'
+			);
+			var actual = rule.matches(vNode.actualNode, vNode);
+			assert.isFalse(actual);
+		});
+	});
+});


### PR DESCRIPTION
Accessible name rules for native elements (image-alt, button-name, etc.) should be inapplicable if the role is changed to a role that does not require an accessible name, but only if that element is not focusable. This does not include link-name /area-alt because even with `tabindex="-1"`, these can be focused with click / touch.

Closes issue: #2578

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
