### PR TITLE
fix(commons/get-text-element-stack): account for newline characters when text is larger than container

### DIFF
--- a/lib/commons/dom/get-text-element-stack.js
+++ b/lib/commons/dom/get-text-element-stack.js
@@ -45,7 +45,7 @@ function getTextElementStack(node) {
 			// text node (which can go off the screen)
 			// @see https://github.com/dequelabs/axe-core/issues/2178
 			// @see https://github.com/dequelabs/axe-core/issues/2483
-			if (rects[0] && rects[0].width > nodeRect.width) {
+			if (Array.from(rects).some(rect => rect.width > nodeRect.width)) {
 				return;
 			}
 

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -580,7 +580,7 @@ describe('dom.getElementStack', function() {
 		it('should handle text that is too large for the container', function() {
 			fixture.innerHTML =
 				'<pre id="1" style="width: 400px; overflow: auto;">' +
-				'<span id="target" style="display: flex; with: 400px;">' +
+				'<span id="target" style="display: flex; with: 400px;">\n\n' +
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed et sollicitudin quam. Fusce mi odio, egestas pulvinar erat eget, vehicula tempus est. Proin vitae ullamcorper velit. Donec sagittis est justo, mattis iaculis arcu facilisis id. Proin pulvinar ornare arcu a fermentum. Quisque et dignissim nulla, sit amet consectetur ipsum. Donec in libero porttitor, dapibus neque imperdiet, aliquam est. Vivamus blandit volutpat fringilla. In mi magna, mollis sit amet imperdiet eu, rutrum ut tellus. Mauris vel condimentum nibh, quis ultricies nisi. Vivamus accumsan quam mauris, id iaculis quam fringilla ac. Curabitur pulvinar dolor ac magna vehicula, non auctor ligula dignissim. Nam ac nibh porttitor, malesuada tortor varius, feugiat turpis. Mauris dapibus, tellus ut viverra porta, ipsum turpis bibendum ligula, at tempor felis ante non libero. Donec dapibus, diam sit amet posuere commodo, magna orci hendrerit ipsum, eu egestas mauris nulla ut ipsum. Sed luctus, orci in fringilla finibus, odio leo porta dolor, eu dignissim risus eros eget erat.' +
 				'</span>' +
 				'</pre>';


### PR DESCRIPTION
Padma found that if there was whitespace before the text my code didn't fix the issue. This change should address that.

Closes issue: #2483
 
## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
