### PR TITLE
chore: fix watch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,10 @@ module.exports = function(grunt) {
 			});
 			return driverTests;
 		})(),
-		clean: ['dist', 'tmp', 'axe.js', 'axe.*.js'],
+		clean: {
+			core: ['dist', 'tmp/core', 'tmp/rules.js', 'axe.js', 'axe.*.js'],
+			tests: ['tmp/integration-tests.js']
+		},
 		babel: {
 			options: {
 				compact: false
@@ -240,7 +243,7 @@ module.exports = function(grunt) {
 			},
 			tests: {
 				files: ['test/**/*.js', 'test/integration/**/!(index).{html,json}'],
-				tasks: ['testconfig', 'fixture']
+				tasks: ['clean:tests', 'testconfig', 'fixture']
 			}
 		},
 		testconfig: {
@@ -353,7 +356,7 @@ module.exports = function(grunt) {
 
 	grunt.registerTask('translate', ['validate', 'esbuild', 'add-locale']);
 	grunt.registerTask('build', [
-		'clean',
+		'clean:core',
 		'validate',
 		'esbuild',
 		'configure',


### PR DESCRIPTION
When a `lib` file was changed the `build` task would clean the entire `tmp` directory. However, the tests need the `tmp/integration-tests.js` file in order to run the integration tests. So I updated the clean task to not clean the integration test file unless the tests change.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
