### PR TITLE
core(cleanup): core/lib/imports: remove core-js and core-js-pure dependencies

### DIFF
--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -9,10 +9,6 @@ import es6promise from 'es6-promise';
 import { Uint32Array } from 'typedarray';
 import 'weakmap-polyfill';
 
-if (!('WeakMap' in window)) {
-	window.WeakMap = WeakMap;
-}
-
 if (!('Promise' in window)) {
 	es6promise.polyfill();
 }

--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -9,10 +9,12 @@ import es6promise from 'es6-promise';
 import { Uint32Array } from 'typedarray';
 import 'weakmap-polyfill';
 
-es6promise.polyfill();
-
 if (!('WeakMap' in window)) {
 	window.WeakMap = WeakMap;
+}
+
+if (!('Promise' in window)) {
+	es6promise.polyfill();
 }
 
 if (!('Uint32Array' in window)) {

--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -5,30 +5,16 @@ import doT from '@deque/dot';
 import emojiRegexText from 'emoji-regex';
 import memoize from 'memoizee';
 
-import Promise from 'core-js-pure/features/promise';
-import Uint32Array from 'core-js-pure/features/typed-array/uint32-array';
-import WeakMap from 'core-js-pure/es/weak-map';
+import es6promise from 'es6-promise';
+import { Uint32Array } from 'typedarray';
+import 'weakmap-polyfill';
 
-/**
- * Polyfill `WeakMap`
- * Reference https://github.com/zloirock/core-js/
- */
+es6promise.polyfill();
+
 if (!('WeakMap' in window)) {
 	window.WeakMap = WeakMap;
 }
 
-/**
- * Polyfill `Promise`
- * Reference https://github.com/zloirock/core-js/
- */
-if (!('Promise' in window)) {
-	window.Promise = Promise;
-}
-
-/**
- * Polyfill required TypedArray and functions
- * Reference https://github.com/zloirock/core-js/
- */
 if (!('Uint32Array' in window)) {
 	window.Uint32Array = Uint32Array;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2845,12 +2845,6 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-			"dev": true
-		},
 		"core-js-compat": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,6 @@
 		"chalk": "^4.1.0",
 		"clone": "~2.1.1",
 		"conventional-commits-parser": "^3.1.0",
-		"core-js": "^3.2.1",
-		"core-js-pure": "^3.6.5",
 		"css-selector-parser": "^1.3.0",
 		"derequire": "^2.1.1",
 		"emoji-regex": "8.0.0",
@@ -136,6 +134,7 @@
 		"sinon": "^7.5.0",
 		"sri-toolbox": "^0.2.0",
 		"standard-version": "^9.0.0",
+		"typedarray": "^0.0.6",
 		"typescript": "^3.5.3",
 		"uglify-js": "^3.4.4",
 		"weakmap-polyfill": "^2.0.0"


### PR DESCRIPTION
These polyfills, previously provided by `core-js` / `core-js-pure`, can also be fulfilled by existing bundled dependencies within `axe-core`.

In particular:

- `es6-promise` can provide `Promise`
- `typedarray` can provide `Uint32Array` (and was an implicit dependency, but is now added to `package.json` explicitly)
- `weakmap-polyfill` can provide `WeakMap`

This *might* provide an opportunity to remove `core-js` and `core-js-pure` completely from `axe-core`'s dependencies.

Unit tests pass **intermittently** locally, so additional verification would definitely help.  In particular, `UnhandledPromiseRejectionWarning` exceptions appear to be thrown unpredictably from the headless browser environment.

**Build Size Impact**

Before @ 3c2429b4032d29cdcfd3083e46e91854dccd733b
```sh
$ npm run-script build
...
./axe.min.js
Size:		419.95 Kb
Gzip Size:	108.92 Kb

Done.
```

After @ a9aebc21675611779b2a396ea50b7e07d36b9ec5 (this changeset)
```sh
$ npm run-script build
...
./axe.min.js
Size:		406.84 Kb
Gzip Size:	103.71 Kb

Done.
```

Relates to #1935

TODO:

- [ ] Investigate flaky tests due to unhandled promise rejections

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
