### PR TITLE
refactor: set default return for text.sanitize and utils.tokenList

### DIFF
--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -42,8 +42,7 @@ function ariaErrormessageEvaluate(node, options) {
 				idref.getAttribute('role') === 'alert' ||
 				idref.getAttribute('aria-live') === 'assertive' ||
 				idref.getAttribute('aria-live') === 'polite' ||
-				tokenList(node.getAttribute('aria-describedby') || '').indexOf(attr) >
-					-1
+				tokenList(node.getAttribute('aria-describedby')).indexOf(attr) > -1
 			);
 		}
 		return;

--- a/lib/checks/generic/attr-non-space-content-evaluate.js
+++ b/lib/checks/generic/attr-non-space-content-evaluate.js
@@ -14,8 +14,8 @@ function attrNonSpaceContentEvaluate(node, options = {}, vNode) {
 		return false;
 	}
 
-	const attribute = vNode.attr(options.attribute) || '';
-	const attributeIsEmpty = !sanitize(attribute.trim());
+	const attribute = vNode.attr(options.attribute);
+	const attributeIsEmpty = !sanitize(attribute);
 	if (attributeIsEmpty) {
 		this.data({
 			messageKey: 'emptyAttr'

--- a/lib/checks/navigation/unique-frame-title-evaluate.js
+++ b/lib/checks/navigation/unique-frame-title-evaluate.js
@@ -1,9 +1,7 @@
 import { sanitize } from '../../commons/text';
 
 function uniqueFrameTitleEvaluate(node, options, vNode) {
-	var title = sanitize(vNode.attr('title') || '')
-		.trim()
-		.toLowerCase();
+	var title = sanitize(vNode.attr('title')).toLowerCase();
 	this.data(title);
 	return true;
 }

--- a/lib/checks/shared/doc-has-title-evaluate.js
+++ b/lib/checks/shared/doc-has-title-evaluate.js
@@ -2,7 +2,7 @@ import { sanitize } from '../../commons/text';
 
 function docHasTitleEvaluate() {
 	var title = document.title;
-	return !!(title ? sanitize(title).trim() : '');
+	return !!sanitize(title);
 }
 
 export default docHasTitleEvaluate;

--- a/lib/commons/aria/implicit-nodes.js
+++ b/lib/commons/aria/implicit-nodes.js
@@ -11,8 +11,6 @@ import lookupTable from './lookup-table';
  * @return {Mixed} Either an Array of CSS selectors or `null` if there are none
  */
 function implicitNodes(role) {
-	'use strict';
-
 	let implicit = null;
 	const roles = lookupTable.role[role];
 

--- a/lib/commons/aria/label-virtual.js
+++ b/lib/commons/aria/label-virtual.js
@@ -34,7 +34,7 @@ function labelVirtual(virtualNode) {
 	// aria-label
 	candidate = virtualNode.attr('aria-label');
 	if (candidate) {
-		candidate = sanitize(candidate).trim();
+		candidate = sanitize(candidate);
 		if (candidate) {
 			return candidate;
 		}

--- a/lib/commons/aria/validate-attr-value.js
+++ b/lib/commons/aria/validate-attr-value.js
@@ -12,7 +12,6 @@ import { tokenList } from '../../core/utils';
  * @return {Boolean}
  */
 function validateAttrValue(node, attr) {
-	'use strict';
 	let matches;
 	let list;
 	const value = node.getAttribute(attr);

--- a/lib/commons/dom/get-element-coordinates.js
+++ b/lib/commons/dom/get-element-coordinates.js
@@ -20,8 +20,6 @@ import getScrollOffset from './get-scroll-offset';
  * @property {Number} height The height of the element
  */
 function getElementCoordinates(element) {
-	'use strict';
-
 	var scrollOffset = getScrollOffset(document),
 		xOffset = scrollOffset.left,
 		yOffset = scrollOffset.top,

--- a/lib/commons/dom/get-scroll-offset.js
+++ b/lib/commons/dom/get-scroll-offset.js
@@ -7,8 +7,6 @@
  * @return {Object} Contains the attributes `x` and `y` which contain the scroll offsets
  */
 function getScrollOffset(element) {
-	'use strict';
-
 	if (!element.nodeType && element.document) {
 		element = element.document;
 	}

--- a/lib/commons/dom/get-viewport-size.js
+++ b/lib/commons/dom/get-viewport-size.js
@@ -7,8 +7,6 @@
  * @return {Object}  Object with the `width` and `height` of the viewport
  */
 function getViewportSize(win) {
-	'use strict';
-
 	const doc = win.document;
 	const docElement = doc.documentElement;
 

--- a/lib/commons/dom/is-node.js
+++ b/lib/commons/dom/is-node.js
@@ -8,7 +8,6 @@
  * @return {Boolean}
  */
 function isNode(element) {
-	'use strict';
 	return element instanceof window.Node;
 }
 

--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -20,8 +20,6 @@ const clipPathRegex = /(\w+)\((\d+)/;
  * @return {Boolean}
  */
 function isClipped(style) {
-	'use strict';
-
 	const matchesClip = style.getPropertyValue('clip').match(clipRegex);
 	const matchesClipPath = style
 		.getPropertyValue('clip-path')

--- a/lib/commons/text/sanitize.js
+++ b/lib/commons/text/sanitize.js
@@ -7,7 +7,10 @@
  * @return {String} Sanitized string
  */
 function sanitize(str) {
-	'use strict';
+	if (!str) {
+		return '';
+	}
+
 	return str
 		.replace(/\r\n/g, '\n')
 		.replace(/\u00A0/g, ' ')

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -83,7 +83,6 @@ Check.prototype.enabled = true;
  * @param  {Function} callback Function to fire when check is complete
  */
 Check.prototype.run = function(node, options, context, resolve, reject) {
-	'use strict';
 	options = options || {};
 	const enabled = options.hasOwnProperty('enabled')
 		? options.enabled

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -8,7 +8,6 @@ axe.version = '<%= pkg.version %>';
 if (typeof define === 'function' && define.amd) {
 	// Explicitly naming the module to avoid mismatched anonymous define() modules when injected in a page
 	define('axe-core', [], function() {
-		'use strict';
 		return axe;
 	});
 }

--- a/lib/core/log.js
+++ b/lib/core/log.js
@@ -4,7 +4,6 @@
  * Logs a message to the developer console (if it exists and is active).
  */
 function log() {
-	'use strict';
 	if (typeof console === 'object' && console.log) {
 		// IE does not support console.log.apply
 		Function.prototype.apply.call(console.log, console, arguments);

--- a/lib/core/public/cleanup.js
+++ b/lib/core/public/cleanup.js
@@ -1,6 +1,4 @@
 function cleanup(resolve, reject) {
-	'use strict';
-
 	resolve = resolve || function() {};
 	reject = reject || axe.log;
 

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -2,7 +2,6 @@ import { hasReporter } from './reporter';
 import { configureStandards } from '../../standards';
 
 function configure(spec) {
-	'use strict';
 	var audit;
 
 	audit = axe._audit;

--- a/lib/core/public/get-rules.js
+++ b/lib/core/public/get-rules.js
@@ -4,8 +4,6 @@
  * @return {Array}  Array of rules
  */
 function getRules(tags) {
-	'use strict';
-
 	tags = tags || [];
 	var matchingRules = !tags.length
 		? axe._audit.rules

--- a/lib/core/public/load.js
+++ b/lib/core/public/load.js
@@ -3,7 +3,6 @@ import cleanup from './cleanup';
 import runRules from './run-rules';
 
 function runCommand(data, keepalive, callback) {
-	'use strict';
 	var resolve = callback;
 	var reject = function(err) {
 		if (err instanceof Error === false) {
@@ -50,8 +49,6 @@ function runCommand(data, keepalive, callback) {
  * @private
  */
 function load(audit) {
-	'use strict';
-
 	axe.utils.respondable.subscribe('axe.ping', function(
 		data,
 		keepalive,

--- a/lib/core/public/plugins.js
+++ b/lib/core/public/plugins.js
@@ -1,7 +1,6 @@
 /*eslint no-use-before-define:0 */
 
 function Plugin(spec) {
-	'use strict';
 	this._run = spec.run;
 	this._collect = spec.collect;
 	this._registry = {};
@@ -11,17 +10,14 @@ function Plugin(spec) {
 }
 
 Plugin.prototype.run = function() {
-	'use strict';
 	return this._run.apply(this, arguments);
 };
 
 Plugin.prototype.collect = function() {
-	'use strict';
 	return this._collect.apply(this, arguments);
 };
 
 Plugin.prototype.cleanup = function(done) {
-	'use strict';
 	var q = axe.utils.queue();
 	var that = this;
 	Object.keys(this._registry).forEach(function(key) {
@@ -35,12 +31,10 @@ Plugin.prototype.cleanup = function(done) {
 };
 
 Plugin.prototype.add = function(impl) {
-	'use strict';
 	this._registry[impl.id] = impl;
 };
 
 function registerPlugin(plugin) {
-	'use strict';
 	axe.plugins[plugin.id] = new Plugin(plugin);
 }
 

--- a/lib/core/public/reporter.js
+++ b/lib/core/public/reporter.js
@@ -6,7 +6,6 @@ export function hasReporter(reporterName) {
 }
 
 export function getReporter(reporter) {
-	'use strict';
 	if (typeof reporter === 'string' && reporters[reporter]) {
 		return reporters[reporter];
 	}
@@ -19,8 +18,6 @@ export function getReporter(reporter) {
 }
 
 export function addReporter(name, cb, isDefault) {
-	'use strict';
-
 	reporters[name] = cb;
 	if (isDefault) {
 		defaultReporter = cb;

--- a/lib/core/public/reset.js
+++ b/lib/core/public/reset.js
@@ -1,7 +1,6 @@
 import { resetStandards } from '../../standards';
 
 function reset() {
-	'use strict';
 	var audit = axe._audit;
 
 	if (!audit) {

--- a/lib/core/public/run-rules.js
+++ b/lib/core/public/run-rules.js
@@ -35,7 +35,6 @@ function cleanup() {
  * @param  {Function} reject   Called when execution failed, receives (err : Error)
  */
 function runRules(context, options, resolve, reject) {
-	'use strict';
 	try {
 		context = new Context(context);
 		axe._tree = context.flatTree;

--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -2,7 +2,6 @@ import { getReporter } from './reporter';
 import cache from '../base/cache';
 
 function isContext(potential) {
-	'use strict';
 	switch (true) {
 		case typeof potential === 'string':
 		case Array.isArray(potential):
@@ -33,7 +32,6 @@ var noop = function() {};
  * @return {object}            With 3 keys: context, options, callback
  */
 function normalizeRunParams(context, options, callback) {
-	'use strict';
 	let typeErr = new TypeError('axe.run arguments are invalid');
 
 	// Determine the context
@@ -83,7 +81,6 @@ function normalizeRunParams(context, options, callback) {
  * @return {Promise}           Resolves with the axe results. Only available when natively supported
  */
 function run(context, options, callback) {
-	'use strict';
 	if (!axe._audit) {
 		throw new Error('No audit configured');
 	}

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -87,7 +87,6 @@ DqElement.prototype = {
 	},
 
 	toJSON: function() {
-		'use strict';
 		return {
 			selector: this.selector,
 			source: this.source,

--- a/lib/core/utils/performance-timer.js
+++ b/lib/core/utils/performance-timer.js
@@ -8,8 +8,6 @@ import log from '../log';
  *
  */
 const performanceTimer = (function() {
-	'use strict';
-
 	/**
 	 * Get a time/date object using performance.now() if supported
 	 * @return {DOMTimeStamp}

--- a/lib/core/utils/token-list.js
+++ b/lib/core/utils/token-list.js
@@ -6,12 +6,10 @@
  * @return {Array}
  */
 function tokenList(str) {
-	const trimedStr = (str || '').trim();
-	if (!trimedStr) {
-		return [];
-	}
-
-	return trimedStr.replace(/\s{2,}/g, ' ').split(' ');
+	return (str || '')
+		.trim()
+		.replace(/\s{2,}/g, ' ')
+		.split(' ');
 }
 
 export default tokenList;

--- a/lib/core/utils/token-list.js
+++ b/lib/core/utils/token-list.js
@@ -6,10 +6,12 @@
  * @return {Array}
  */
 function tokenList(str) {
-	return str
-		.trim()
-		.replace(/\s{2,}/g, ' ')
-		.split(' ');
+	const trimedStr = (str || '').trim();
+	if (!trimedStr) {
+		return [];
+	}
+
+	return trimedStr.replace(/\s{2,}/g, ' ').split(' ');
 }
 
 export default tokenList;

--- a/lib/rules/frame-title-has-text-matches.js
+++ b/lib/rules/frame-title-has-text-matches.js
@@ -2,7 +2,7 @@ import { sanitize } from '../commons/text';
 
 function frameTitleHasTextMatches(node) {
 	var title = node.getAttribute('title');
-	return !!(title ? sanitize(title).trim() : '');
+	return !!sanitize(title);
 }
 
 export default frameTitleHasTextMatches;

--- a/test/commons/text/sanitize.js
+++ b/test/commons/text/sanitize.js
@@ -8,4 +8,8 @@ describe('text.sanitize', function() {
 		assert.equal(axe.commons.text.sanitize(' hi\r\nok'), 'hi\nok');
 		assert.equal(axe.commons.text.sanitize('hello\u00A0there'), 'hello there');
 	});
+
+	it('should accept null', function() {
+		assert.equal(axe.commons.text.sanitize(null), '');
+	});
 });

--- a/test/core/utils/token-list.js
+++ b/test/core/utils/token-list.js
@@ -25,7 +25,7 @@ describe('axe.utils.tokenList', function() {
 		]);
 	});
 
-	it('should return empty array for null value', function() {
-		assert.deepEqual(axe.utils.tokenList(null), []);
+	it('should return empty string array for null value', function() {
+		assert.deepEqual(axe.utils.tokenList(null), ['']);
 	});
 });

--- a/test/core/utils/token-list.js
+++ b/test/core/utils/token-list.js
@@ -24,4 +24,8 @@ describe('axe.utils.tokenList', function() {
 			'42'
 		]);
 	});
+
+	it('should return empty array for null value', function() {
+		assert.deepEqual(axe.utils.tokenList(null), []);
+	});
 });


### PR DESCRIPTION
Now we don't have to pass an empty string for these functions. Also removed `use strict` as it's not needed (especially if we want to use default parameters as the code will error on compile if it's there).

Closes issue: #2643 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
