### PR TITLE
fix: remove axios import

### DIFF
--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -1,5 +1,3 @@
-// @deprecated (axios)
-import axios from 'axios';
 import { CssSelectorParser } from 'css-selector-parser';
 import doT from '@deque/dot';
 import emojiRegexText from 'emoji-regex';
@@ -38,4 +36,4 @@ if (window.Uint32Array) {
  * @namespace imports
  * @memberof axe
  */
-export { axios, CssSelectorParser, doT, emojiRegexText, memoize };
+export { CssSelectorParser, doT, emojiRegexText, memoize };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1539,15 +1539,6 @@
 			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
 			"dev": true
 		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"dev": true,
-			"requires": {
-				"follow-redirects": "1.5.10"
-			}
-		},
 		"babel-plugin-dynamic-import-node": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -4494,32 +4485,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
-		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"dev": true,
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
 		},
 		"for-in": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
 		"@babel/preset-env": "^7.5.4",
 		"@deque/dot": "^1.1.5",
 		"aria-query": "^3.0.0",
-		"axios": "^0.19.0",
 		"babelify": "^10.0.0",
 		"blanket": "~1.2.3",
 		"browserify": "^16.2.3",

--- a/test/integration/full/umd/umd-module-exports.js
+++ b/test/integration/full/umd/umd-module-exports.js
@@ -16,10 +16,6 @@ describe('UMD module.export', function() {
 		);
 	});
 
-	it('should ensure axe source includes axios', function() {
-		assert.isTrue(axe.source.includes(axe.imports.axios.toString()));
-	});
-
 	it('should include doT', function() {
 		var doT = axe.imports.doT;
 		assert(doT, 'doT is registered on axe.imports');

--- a/test/integration/full/umd/umd-window.js
+++ b/test/integration/full/umd/umd-window.js
@@ -49,16 +49,4 @@ describe('UMD window', function() {
 	it('should ensure axe has prototype chained keys', function() {
 		assert.hasAnyKeys(axe, ['utils', 'commons', 'core']);
 	});
-
-	it('should expose not expose axios as a property of window', function() {
-		assert.notProperty(window, 'axios');
-	});
-
-	it('should ensure axios is a mounted to axe.imports', function() {
-		assert.hasAnyKeys(axe.imports, ['axios']);
-	});
-
-	it('should ensure axios has prototype chained keys', function() {
-		assert.hasAnyKeys(axe.imports.axios, ['get', 'request', 'options', 'post']);
-	});
 });


### PR DESCRIPTION
For some reason switching from esbuild allowed axios to run which made navigator not defined. 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
