### PR TITLE
chore: replace phrasing elements in subtree-text

### DIFF
--- a/lib/commons/text/subtree-text.js
+++ b/lib/commons/text/subtree-text.js
@@ -1,6 +1,7 @@
 import accessibleTextVirtual from './accessible-text-virtual';
 import namedFromContents from '../aria/named-from-contents';
 import getOwnedVirtual from '../aria/get-owned-virtual';
+import getElementsByContentType from '../standards/get-elements-by-content-type';
 
 /**
  * Get the accessible text for an element that can get its name from content
@@ -44,50 +45,7 @@ function subtreeText(virtualNode, context = {}) {
   }, '');
 }
 
-// TODO: Could do with an "HTML" lookup table, similar to ARIA,
-//  where this sort of stuff can live.
-const phrasingElements = [
-  '#text',
-  'a',
-  'abbr',
-  'area',
-  'b',
-  'bdi',
-  'bdo',
-  'button',
-  'canvas',
-  'cite',
-  'code',
-  'command',
-  'datalist',
-  'del',
-  'dfn',
-  'em',
-  'i',
-  'ins',
-  'kbd',
-  'keygen',
-  'label',
-  'map',
-  'mark',
-  'meter',
-  'noscript',
-  'output',
-  'progress',
-  'q',
-  'ruby',
-  's',
-  'samp',
-  'small',
-  'span',
-  'strong',
-  'sub',
-  'sup',
-  'time',
-  'u',
-  'var',
-  'wbr'
-];
+const phrasingElements = getElementsByContentType('phrasing').concat(['#text']);
 
 function appendAccessibleText(contentText, virtualNode, context) {
   const nodeName = virtualNode.props.nodeName;

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -449,7 +449,8 @@ const htmlElms = {
             type: 'hidden'
           }
         },
-        contentTypes: ['phrasing', 'flow'],
+        // Note: spec change (do not count as phrasing)
+        contentTypes: ['flow'],
         allowedRoles: false,
         noAriaAttrs: true
       },
@@ -499,7 +500,8 @@ const htmlElms = {
         allowedRoles: false
       },
       default: {
-        contentTypes: ['interactive', 'phrasing', 'flow'],
+        // Note: spec change (do not count as phrasing)
+        contentTypes: ['interactive', 'flow'],
         allowedRoles: ['combobox', 'searchbox', 'spinbutton'],
         implicitAttrs: {
           'aria-valuenow': ''

--- a/test/playground.html
+++ b/test/playground.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <title>O hai</title>
 
-  <div class="foo" id="foo">foo</div>
+  <label for="test">
+    foo
+    <input type="text" value="David" />
+  </label>
+  <input type="text" id="test" value="baz" />
 
   <script src="/axe.js"></script>
   <script>

--- a/test/playground.html
+++ b/test/playground.html
@@ -2,11 +2,7 @@
 <html lang="en">
   <title>O hai</title>
 
-  <label for="test">
-    foo
-    <input type="text" value="David" />
-  </label>
-  <input type="text" id="test" value="baz" />
+  <div class="foo" id="foo">foo</div>
 
   <script src="/axe.js"></script>
   <script>


### PR DESCRIPTION
Had to make `input` not a phrasing element in order to pass the accessible name acceptance tests. Also, should we add `#text` as an html element so we don't have to concat it to the end of the array?

Closes issue: #2632 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
