### PR TITLE
tests: run ChromeHeadless for integration test 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5787,15 +5787,6 @@
       "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
-    "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
-    },
     "is-core-module": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "html-entities": "^1.2.0",
     "http-server": "^0.12.3",
     "husky": "^3.1.0",
-    "is-ci": "^2.0.0",
     "jquery": "^3.0.0",
     "jsdoc": "^3.5.5",
     "jsdom": "^16.3.0",

--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -134,7 +134,7 @@ function buildWebDriver(browser) {
     };
   }
 
-  // fix chrome DevToolsActivePort file doesn't exist
+  // fix chrome DevToolsActivePort file doesn't exist in CricleCI
   // @see https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t
   if (browser === 'chrome') {
     capabilities = WebDriver.Capabilities.chrome();

--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -136,8 +136,10 @@ function buildWebDriver(browser) {
     capabilities.set('chromeOptions', {
       args: [
         '--no-sandbox',
+        '--headless',
         '--disable-extensions',
         '--disable-dev-shm-usage',
+        '-disable-gpu',
         '--remote-debugging-port=9222'
       ]
     });

--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -126,7 +126,9 @@ function buildWebDriver(browser) {
     };
   }
 
-  // fix chrome DevToolsActivePort file doesn't exist in CricleCI
+  // fix chrome DevToolsActivePort file doesn't exist in CricleCI (as well as a
+  // host of other problems with starting Chrome). the only thing that seems to
+  // allow Chrome to start without problems consistently is using ChromeHeadless
   // @see https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t
   if (browser === 'chrome') {
     var service = new chrome.ServiceBuilder(chromedriver.path).build();
@@ -138,9 +140,7 @@ function buildWebDriver(browser) {
         '--no-sandbox',
         '--headless',
         '--disable-extensions',
-        '--disable-dev-shm-usage',
-        '-disable-gpu',
-        '--remote-debugging-port=9222'
+        '--disable-dev-shm-usage'
       ]
     });
   }

--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -4,7 +4,6 @@ var globby = require('globby');
 var WebDriver = require('selenium-webdriver');
 var chrome = require('selenium-webdriver/chrome');
 var chromedriver = require('chromedriver');
-var isCI = require('is-ci');
 
 var args = process.argv.slice(2);
 
@@ -18,13 +17,6 @@ args.forEach(function(arg) {
     browser = parts[1].toLowerCase();
   }
 });
-
-// circle has everything configured to run chrome but local install
-// may not
-if (browser === 'chrome' && !isCI) {
-  var service = new chrome.ServiceBuilder(chromedriver.path).build();
-  chrome.setDefaultService(service);
-}
 
 /**
  * Keep injecting scripts until window.mochaResults is set
@@ -137,6 +129,9 @@ function buildWebDriver(browser) {
   // fix chrome DevToolsActivePort file doesn't exist in CricleCI
   // @see https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t
   if (browser === 'chrome') {
+    var service = new chrome.ServiceBuilder(chromedriver.path).build();
+    chrome.setDefaultService(service);
+
     capabilities = WebDriver.Capabilities.chrome();
     capabilities.set('chromeOptions', {
       args: [

--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -140,10 +140,10 @@ function buildWebDriver(browser) {
     capabilities = WebDriver.Capabilities.chrome();
     capabilities.set('chromeOptions', {
       args: [
-        'disable-infobars',
+        '--no-sandbox',
         '--disable-extensions',
         '--disable-dev-shm-usage',
-        '--no-sandbox'
+        '--remote-debugging-port=9222'
       ]
     });
   }

--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -117,6 +117,7 @@ function runTestUrls(driver, isMobile, urls, errors) {
 function buildWebDriver(browser) {
   var capabilities;
   var mobileBrowser = browser.split('-mobile');
+
   if (mobileBrowser.length > 1) {
     browser = mobileBrowser[0];
     capabilities = {
@@ -131,6 +132,20 @@ function buildWebDriver(browser) {
         }
       }
     };
+  }
+
+  // fix chrome DevToolsActivePort file doesn't exist
+  // @see https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t
+  if (browser === 'chrome') {
+    capabilities = WebDriver.Capabilities.chrome();
+    capabilities.set('chromeOptions', {
+      args: [
+        'disable-infobars',
+        '--disable-extensions',
+        '--disable-dev-shm-usage',
+        '--no-sandbox'
+      ]
+    });
   }
 
   var webdriver = new WebDriver.Builder()


### PR DESCRIPTION
Chrome is [failing to start a lot](https://app.circleci.com/pipelines/github/dequelabs/axe-core/1479/workflows/c9511638-cba6-4217-b2b5-2a5efa5b1fa2/jobs/24819) and with no apparent reason as this was all working fine when running it as Grunt. This is a copied/pasted file that worked before but now fails. Trying this to see if it resolves the issues as suggested in various sites.


Going to cancel and rerun this build a couple of times to see if it's working consistently.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
