### PR TITLE
fix(select-name): fix typo in accessible name help

### DIFF
--- a/lib/rules/select-name.json
+++ b/lib/rules/select-name.json
@@ -12,7 +12,7 @@
   ],
   "metadata": {
     "description": "Ensures select element has an accessible name",
-    "help": "Select element must have and accessible name"
+    "help": "Select element must have an accessible name"
   },
   "all": [],
   "any": [


### PR DESCRIPTION
I noticed this while testing some pages, just a minor typo fix.

Closes issue: N/A

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
