### PR TITLE
feat(standards/aria-roles): add presentational children property

### DIFF
--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -55,7 +55,8 @@ const ariaRoles = {
     allowedAttrs: ['aria-expanded', 'aria-pressed'],
     superclassRole: ['command'],
     accessibleNameRequired: true,
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   caption: {
     type: 'structure',
@@ -86,7 +87,8 @@ const ariaRoles = {
     allowedAttrs: ['aria-checked', 'aria-readonly', 'aria-required'],
     superclassRole: ['input'],
     accessibleNameRequired: true,
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   code: {
     type: 'structure',
@@ -246,7 +248,8 @@ const ariaRoles = {
     type: 'structure',
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
-    accessibleNameRequired: true
+    accessibleNameRequired: true,
+    childrenPresentational: true
   },
   input: {
     type: 'abstract',
@@ -318,7 +321,8 @@ const ariaRoles = {
   math: {
     type: 'structure',
     allowedAttrs: ['aria-expanded'],
-    superclassRole: ['section']
+    superclassRole: ['section'],
+    childrenPresentational: true
   },
   menu: {
     type: 'composite',
@@ -361,7 +365,8 @@ const ariaRoles = {
     ],
     superclassRole: ['checkbox', 'menuitem'],
     accessibleNameRequired: true,
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   menuitemradio: {
     type: 'widget',
@@ -374,14 +379,16 @@ const ariaRoles = {
     ],
     superclassRole: ['menuitemcheckbox', 'radio'],
     accessibleNameRequired: true,
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   meter: {
     type: 'structure',
     allowedAttrs: ['aria-valuetext'],
     requiredAttrs: ['aria-valuemax', 'aria-valuemin', 'aria-valuenow'],
     superclassRole: ['range'],
-    accessibleNameRequired: true
+    accessibleNameRequired: true,
+    childrenPresentational: true
   },
   navigation: {
     type: 'landmark',
@@ -411,7 +418,8 @@ const ariaRoles = {
     ],
     superclassRole: ['input'],
     accessibleNameRequired: true,
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   paragraph: {
     type: 'structure',
@@ -431,7 +439,8 @@ const ariaRoles = {
       'aria-valuetext'
     ],
     superclassRole: ['range'],
-    accessibleNameRequired: true
+    accessibleNameRequired: true,
+    childrenPresentational: true
   },
   radio: {
     type: 'widget',
@@ -449,7 +458,8 @@ const ariaRoles = {
     ],
     superclassRole: ['input'],
     accessibleNameRequired: true,
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   radiogroup: {
     type: 'composite',
@@ -538,7 +548,8 @@ const ariaRoles = {
       'aria-valuemin',
       'aria-valuetext'
     ],
-    superclassRole: ['range']
+    superclassRole: ['range'],
+    childrenPresentational: true
   },
   search: {
     type: 'landmark',
@@ -587,7 +598,8 @@ const ariaRoles = {
       'aria-orientation',
       'aria-valuetext'
     ],
-    superclassRole: ['structure', 'widget']
+    superclassRole: ['structure', 'widget'],
+    childrenPresentational: true
   },
   slider: {
     type: 'widget',
@@ -603,7 +615,8 @@ const ariaRoles = {
       'aria-valuetext'
     ],
     superclassRole: ['input', 'range'],
-    accessibleNameRequired: true
+    accessibleNameRequired: true,
+    childrenPresentational: true
   },
   spinbutton: {
     type: 'widget',
@@ -649,7 +662,8 @@ const ariaRoles = {
     allowedAttrs: ['aria-readonly'],
     superclassRole: ['checkbox'],
     accessibleNameRequired: true,
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   tab: {
     type: 'widget',
@@ -661,7 +675,8 @@ const ariaRoles = {
       'aria-expanded'
     ],
     superclassRole: ['sectionhead', 'widget'],
-    nameFromContent: true
+    nameFromContent: true,
+    childrenPresentational: true
   },
   table: {
     type: 'structure',

--- a/lib/standards/dpub-roles.js
+++ b/lib/standards/dpub-roles.js
@@ -167,7 +167,8 @@ const dpubRoles = {
   'doc-pagebreak': {
     type: 'separator',
     allowedAttrs: ['aria-expanded', 'aria-orientation'],
-    superclassRole: ['separator']
+    superclassRole: ['separator'],
+    childrenPresentational: true
   },
   'doc-pagelist': {
     type: 'navigation',


### PR DESCRIPTION
Required for #601. Using this we can do the following for the rule:

1. look for all `[role]` elements and match by any roles that have `childrenPresentational: true`
1. look at all descendants of said elements and return `false` if any element is focusable (using `dom.isFocusable`)
