### PR TITLE
chore: fix grunt develop

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,11 @@ module.exports = function(grunt) {
     langs = [''];
   }
 
+  // run tests only for affected files instead of all tests
+  grunt.event.on('watch', function(action, filepath) {
+    grunt.config.set('watch.file', filepath);
+  });
+
   process.env.NODE_NO_HTTP2 = 1; // to hide node warning - (node:18740) ExperimentalWarning: The http2 module is an experimental API.
 
   grunt.initConfig({
@@ -193,10 +198,16 @@ module.exports = function(grunt) {
         }
       }
     },
+    test: {
+      data: {
+        testFile: '<%= watch.file %>'
+      }
+    },
     watch: {
       axe: {
+        options: { spawn: false },
         files: ['lib/**/*', 'Gruntfile.js'],
-        tasks: ['build', 'notify']
+        tasks: ['build', 'notify', 'test']
       }
     },
     notify: {

--- a/build/tasks/test.js
+++ b/build/tasks/test.js
@@ -1,0 +1,20 @@
+const execSync = require('child_process').execSync;
+const chalk = require('chalk');
+
+/*eslint-env node */
+('use strict');
+
+module.exports = function(grunt) {
+  grunt.registerMultiTask(
+    'test',
+    'This task runs unit tests based on which file was changed',
+    function() {
+      const testFile = this.data.testFile;
+      console.log(`${chalk.green('>>')} File "${testFile}"`);
+
+      execSync(`npm run test:unit -- testFiles=${testFile}`, {
+        stdio: 'inherit'
+      });
+    }
+  );
+};

--- a/test/integration/api/external/index.js
+++ b/test/integration/api/external/index.js
@@ -123,7 +123,9 @@ var inTree = [];
 var walker = collectNodes();
 var next = walker.iterate().next();
 while (!next.done) {
-  inTree.push(next.value);
+  if (next.value.nodeType === 1) {
+    inTree.push(next.value);
+  }
   next = walker.iterate().next();
 }
 


### PR DESCRIPTION
This fixes `npm run develop` by running tests after a file has changed. The karma file then runs only the tests that are associated with the file that was changed (instead of all tests). 

It does this by looking at the passed in file path and matching it against known tests. For example, a file ending with `-matches.js` should run a rule by the same name in the `rule-matches` directory. This isn't guaranteed to find a file that matches (for example, there are some rule-matches that aren't tested, or some aria checks that don't have the same name of the test file), but karma will alert you if there isn't a test by that name. So you can either fix it (like we should with the aria checks) or ignore it.

This also fixes a test failure in the api tests that would happen very sporadically. It turns out that the tree walker was adding comment nodes to the list of elements to use for `randomNodeInTree()` and that would throw off our APIs as we don't expect a comment node to be passed in (so `getNodeFromTree` would fail to return anything).
