### PR TITLE
chore: update eslint to include func-names and prefer-const

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     'no-cond-assign': 0,
     'no-debugger': 2,
     'no-eq-null': 0,
-    'no-eval': 0,
+    'no-eval': 2,
     'no-unused-expressions': 0,
     'block-scoped-var': 0,
     'no-iterator': 0,
@@ -79,6 +79,10 @@ module.exports = {
       globals: {
         window: true,
         document: true
+      },
+      rules: {
+        'func-names': [2, 'as-needed'],
+        'prefer-const': 2
       }
     },
     {

--- a/lib/checks/aria/aria-required-children-evaluate.js
+++ b/lib/checks/aria/aria-required-children-evaluate.js
@@ -13,8 +13,8 @@ function getOwnedRoles(virtualNode, required) {
   const ownedRoles = [];
   const ownedElements = getOwnedVirtual(virtualNode);
   for (let i = 0; i < ownedElements.length; i++) {
-    let ownedElement = ownedElements[i];
-    let role = getRole(ownedElement, { noPresentational: true });
+    const ownedElement = ownedElements[i];
+    const role = getRole(ownedElement, { noPresentational: true });
 
     // if owned node has no role or is presentational, or if role
     // allows group or rowgroup, we keep parsing the descendant tree.

--- a/lib/checks/aria/aria-required-parent-evaluate.js
+++ b/lib/checks/aria/aria-required-parent-evaluate.js
@@ -38,7 +38,7 @@ function getAriaOwners(element) {
   while (element) {
     if (element.getAttribute('id')) {
       const id = escapeSelector(element.getAttribute('id'));
-      let doc = getRootNode(element);
+      const doc = getRootNode(element);
       o = doc.querySelector(`[aria-owns~=${id}]`);
       if (o) {
         owners.push(o);

--- a/lib/checks/keyboard/accesskeys-after.js
+++ b/lib/checks/keyboard/accesskeys-after.js
@@ -1,7 +1,7 @@
 function accesskeysAfter(results) {
   var seen = {};
   return results
-    .filter(function(r) {
+    .filter(r => {
       if (!r.data) {
         return false;
       }
@@ -14,7 +14,7 @@ function accesskeysAfter(results) {
       seen[key].relatedNodes.push(r.relatedNodes[0]);
       return false;
     })
-    .map(function(r) {
+    .map(r => {
       r.result = !!r.relatedNodes.length;
       return r;
     });

--- a/lib/checks/label/help-same-as-label-evaluate.js
+++ b/lib/checks/label/help-same-as-label-evaluate.js
@@ -15,7 +15,7 @@ function helpSameAsLabelEvaluate(node, options, virtualNode) {
     if (node.getAttribute('aria-describedby')) {
       var ref = idrefs(node, 'aria-describedby');
       check = ref
-        .map(function(thing) {
+        .map(thing => {
           return thing ? accessibleText(thing) : '';
         })
         .join('');

--- a/lib/checks/lists/only-dlitems-evaluate.js
+++ b/lib/checks/lists/only-dlitems-evaluate.js
@@ -3,7 +3,7 @@ import { getRole, getExplicitRole } from '../../commons/aria';
 
 function onlyDlitemsEvaluate(node, options, virtualNode) {
   const ALLOWED_ROLES = ['definition', 'term', 'list'];
-  let base = {
+  const base = {
     badNodes: [],
     hasNonEmptyTextNode: false
   };

--- a/lib/checks/lists/only-listitems-evaluate.js
+++ b/lib/checks/lists/only-listitems-evaluate.js
@@ -5,9 +5,9 @@ function onlyListitemsEvaluate(node, options, virtualNode) {
   let hasNonEmptyTextNode = false;
   let atLeastOneListitem = false;
   let isEmpty = true;
-  let badNodes = [];
-  let badRoleNodes = [];
-  let badRoles = [];
+  const badNodes = [];
+  const badRoleNodes = [];
+  const badRoles = [];
 
   virtualNode.children.forEach(vNode => {
     const { actualNode } = vNode;

--- a/lib/checks/media/frame-tested-evaluate.js
+++ b/lib/checks/media/frame-tested-evaluate.js
@@ -8,16 +8,16 @@ function frameTestedEvaluate(node, options) {
   );
 
   // give the frame .5s to respond to 'axe.ping', else log failed response
-  let timer = setTimeout(function() {
+  let timer = setTimeout(() => {
     // This double timeout is important for allowing iframes to respond
     // DO NOT REMOVE
-    timer = setTimeout(function() {
+    timer = setTimeout(() => {
       timer = null;
       resolve(isViolation ? false : undefined);
     }, 0);
   }, timeout);
 
-  respondable(node.contentWindow, 'axe.ping', null, undefined, function() {
+  respondable(node.contentWindow, 'axe.ping', null, undefined, () => {
     if (timer !== null) {
       clearTimeout(timer);
       resolve(true);

--- a/lib/checks/media/no-autoplay-audio-evaluate.js
+++ b/lib/checks/media/no-autoplay-audio-evaluate.js
@@ -81,7 +81,7 @@ function noAutoplayAudioEvaluate(node, options) {
    * @param {String} hhMmSs time expressed in HH:MM:SS
    */
   function convertHourMinSecToSeconds(hhMmSs) {
-    let parts = hhMmSs.split(':');
+    const parts = hhMmSs.split(':');
     let secs = 0;
     let mins = 1;
 

--- a/lib/checks/navigation/p-as-heading-evaluate.js
+++ b/lib/checks/navigation/p-as-heading-evaluate.js
@@ -17,7 +17,7 @@ function normalizeFontWeight(weight) {
 
 function getTextContainer(elm) {
   let nextNode = elm;
-  let outerText = elm.textContent.trim();
+  const outerText = elm.textContent.trim();
   let innerText = outerText;
 
   while (innerText === outerText && nextNode !== undefined) {
@@ -39,7 +39,7 @@ function getTextContainer(elm) {
 }
 
 function getStyleValues(node) {
-  let style = window.getComputedStyle(getTextContainer(node));
+  const style = window.getComputedStyle(getTextContainer(node));
   return {
     fontWeight: normalizeFontWeight(style.getPropertyValue('font-weight')),
     fontSize: parseInt(style.getPropertyValue('font-size')),
@@ -60,17 +60,17 @@ function isHeaderStyle(styleA, styleB, margins) {
 }
 
 function pAsHeadingEvaluate(node, options, virtualNode) {
-  let siblings = Array.from(node.parentNode.children);
-  let currentIndex = siblings.indexOf(node);
+  const siblings = Array.from(node.parentNode.children);
+  const currentIndex = siblings.indexOf(node);
 
   options = options || {};
-  let margins = options.margins || [];
+  const margins = options.margins || [];
 
-  let nextSibling = siblings
+  const nextSibling = siblings
     .slice(currentIndex + 1)
     .find(elm => elm.nodeName.toUpperCase() === 'P');
 
-  let prevSibling = siblings
+  const prevSibling = siblings
     .slice(0, currentIndex)
     .reverse()
     .find(elm => elm.nodeName.toUpperCase() === 'P');
@@ -83,7 +83,7 @@ function pAsHeadingEvaluate(node, options, virtualNode) {
     return true;
   }
 
-  let blockquote = findUpVirtual(virtualNode, 'blockquote');
+  const blockquote = findUpVirtual(virtualNode, 'blockquote');
   if (blockquote && blockquote.nodeName.toUpperCase() === 'BLOCKQUOTE') {
     return undefined;
   }

--- a/lib/checks/navigation/unique-frame-title-after.js
+++ b/lib/checks/navigation/unique-frame-title-after.js
@@ -1,9 +1,9 @@
 function uniqueFrameTitleAfter(results) {
   var titles = {};
-  results.forEach(function(r) {
+  results.forEach(r => {
     titles[r.data] = titles[r.data] !== undefined ? ++titles[r.data] : 0;
   });
-  results.forEach(function(r) {
+  results.forEach(r => {
     r.result = !!titles[r.data];
   });
 

--- a/lib/checks/parsing/duplicate-id-after.js
+++ b/lib/checks/parsing/duplicate-id-after.js
@@ -1,6 +1,6 @@
 function duplicateIdAfter(results) {
   var uniqueIds = [];
-  return results.filter(function(r) {
+  return results.filter(r => {
     if (uniqueIds.indexOf(r.data) === -1) {
       uniqueIds.push(r.data);
       return true;

--- a/lib/checks/shared/non-empty-if-present-evaluate.js
+++ b/lib/checks/shared/non-empty-if-present-evaluate.js
@@ -1,8 +1,8 @@
 function nonEmptyIfPresentEvaluate(node, options, virtualNode) {
   // Check for 'default' names, which are given to reset and submit buttons
-  let nodeName = virtualNode.props.nodeName;
-  let type = (virtualNode.attr('type') || '').toLowerCase();
-  let label = virtualNode.attr('value');
+  const nodeName = virtualNode.props.nodeName;
+  const type = (virtualNode.attr('type') || '').toLowerCase();
+  const label = virtualNode.attr('value');
 
   if (label) {
     this.data({

--- a/lib/checks/tables/caption-faked-evaluate.js
+++ b/lib/checks/tables/caption-faked-evaluate.js
@@ -8,7 +8,7 @@ function captionFakedEvaluate(node) {
     return true;
   }
 
-  return firstRow.reduce(function(out, curr, i) {
+  return firstRow.reduce((out, curr, i) => {
     return out || (curr !== firstRow[i + 1] && firstRow[i + 1] !== undefined);
   }, false);
 }

--- a/lib/checks/tables/th-has-data-cells-evaluate.js
+++ b/lib/checks/tables/th-has-data-cells-evaluate.js
@@ -7,7 +7,7 @@ function thHasDataCellsEvaluate(node) {
 
   // Get a list of all headers reffed to in this rule
   let reffedHeaders = [];
-  cells.forEach(function(cell) {
+  cells.forEach(cell => {
     const headers = cell.getAttribute('headers');
     if (headers) {
       reffedHeaders = reffedHeaders.concat(headers.split(/\s+/));
@@ -20,7 +20,7 @@ function thHasDataCellsEvaluate(node) {
   });
 
   // Get all the headers
-  const headers = cells.filter(function(cell) {
+  const headers = cells.filter(cell => {
     if (sanitize(cell.textContent) === '') {
       return false;
     }

--- a/lib/commons/aria/label-virtual.js
+++ b/lib/commons/aria/label-virtual.js
@@ -19,7 +19,7 @@ function labelVirtual(virtualNode) {
     // aria-labelledby
     ref = idrefs(virtualNode.actualNode, 'aria-labelledby');
     candidate = ref
-      .map(function(thing) {
+      .map(thing => {
         const vNode = getNodeFromTree(thing);
         return vNode ? visibleVirtual(vNode, true) : '';
       })

--- a/lib/commons/aria/validate-attr-value.js
+++ b/lib/commons/aria/validate-attr-value.js
@@ -38,7 +38,7 @@ function validateAttrValue(node, attr) {
     case 'nmtokens':
       list = tokenList(value);
       // Check if any value isn't in the list of values
-      return list.reduce(function(result, token) {
+      return list.reduce((result, token) => {
         return result && attrInfo.values.includes(token);
         // Initial state, fail if the list is empty
       }, list.length !== 0);

--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -92,7 +92,7 @@ function Color(red, green, blue, alpha) {
    * @instance
    * @return {string}
    */
-  this.toHexString = function() {
+  this.toHexString = function toHexString() {
     var redString = Math.round(this.red).toString(16);
     var greenString = Math.round(this.green).toString(16);
     var blueString = Math.round(this.blue).toString(16);
@@ -113,7 +113,7 @@ function Color(red, green, blue, alpha) {
    * @memberof axe.commons.color.Color
    * @instance
    */
-  this.parseString = function(colorString) {
+  this.parseString = function parseString(colorString) {
     // IE occasionally returns named colors instead of RGB(A) values
     if (standards.cssColors[colorString] || colorString === 'transparent') {
       const [red, green, blue] = standards.cssColors[colorString] || [0, 0, 0];
@@ -144,7 +144,7 @@ function Color(red, green, blue, alpha) {
    * @instance
    * @param  {string}  rgb  The string value
    */
-  this.parseRgbString = function(colorString) {
+  this.parseRgbString = function parseRgbString(colorString) {
     // IE can pass transparent as value instead of rgba
     if (colorString === 'transparent') {
       this.red = 0;
@@ -164,7 +164,7 @@ function Color(red, green, blue, alpha) {
    * @instance
    * @param  {string}  rgb  The string value
    */
-  this.parseHexString = function(colorString) {
+  this.parseHexString = function parseHexString(colorString) {
     if (!colorString.match(hexRegex) || [6, 8].includes(colorString.length)) {
       return;
     }
@@ -231,7 +231,7 @@ function Color(red, green, blue, alpha) {
    * @instance
    * @return {number} The luminance value, ranges from 0 to 1
    */
-  this.getRelativeLuminance = function() {
+  this.getRelativeLuminance = function getRelativeLuminance() {
     var rSRGB = this.red / 255;
     var gSRGB = this.green / 255;
     var bSRGB = this.blue / 255;

--- a/lib/commons/color/element-is-distinct.js
+++ b/lib/commons/color/element-is-distinct.js
@@ -10,7 +10,7 @@ function _getFonts(style) {
   return style
     .getPropertyValue('font-family')
     .split(/[,;]/g)
-    .map(function(font) {
+    .map(font => {
       return font.trim().toLowerCase();
     });
 }
@@ -33,23 +33,22 @@ function elementIsDistinct(node, ancestorNode) {
   }
 
   // Check if the link has a border or outline
-  var hasBorder = ['border-bottom', 'border-top', 'outline'].reduce(function(
-    result,
-    edge
-  ) {
-    var borderClr = new Color();
-    borderClr.parseString(nodeStyle.getPropertyValue(edge + '-color'));
+  var hasBorder = ['border-bottom', 'border-top', 'outline'].reduce(
+    (result, edge) => {
+      var borderClr = new Color();
+      borderClr.parseString(nodeStyle.getPropertyValue(edge + '-color'));
 
-    // Check if a border/outline was specified
-    return (
-      result ||
-      // or if the current border edge / outline
-      (nodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
-        parseFloat(nodeStyle.getPropertyValue(edge + '-width')) > 0 &&
-        borderClr.alpha !== 0)
-    );
-  },
-  false);
+      // Check if a border/outline was specified
+      return (
+        result ||
+        // or if the current border edge / outline
+        (nodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
+          parseFloat(nodeStyle.getPropertyValue(edge + '-width')) > 0 &&
+          borderClr.alpha !== 0)
+      );
+    },
+    false
+  );
 
   if (hasBorder) {
     return true;
@@ -67,7 +66,7 @@ function elementIsDistinct(node, ancestorNode) {
     'font-weight',
     'font-style',
     'font-size'
-  ].reduce(function(result, cssProp) {
+  ].reduce((result, cssProp) => {
     return (
       result ||
       nodeStyle.getPropertyValue(cssProp) !==

--- a/lib/commons/color/filtered-rect-stack.js
+++ b/lib/commons/color/filtered-rect-stack.js
@@ -25,7 +25,7 @@ function filteredRectStack(elm) {
         return;
       }
       // if the stacks are the same, use the first one. otherwise, return null.
-      let rectA = rectStack[index - 1],
+      const rectA = rectStack[index - 1],
         rectB = rectStack[index];
 
       // if elements in clientRects are the same

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -38,14 +38,14 @@ function elmPartiallyObscured(elm, bgElm, bgColor) {
  */
 function getBackgroundColor(elm, bgElms = [], shadowOutlineEmMax = 0.1) {
   let bgColors = getTextShadowColors(elm, { minRatio: shadowOutlineEmMax });
-  let elmStack = getBackgroundStack(elm);
+  const elmStack = getBackgroundStack(elm);
 
   // Search the stack until we have an alpha === 1 background
   (elmStack || []).some(bgElm => {
     const bgElmStyle = window.getComputedStyle(bgElm);
 
     // Get the background color
-    let bgColor = getOwnBackgroundColor(bgElmStyle);
+    const bgColor = getOwnBackgroundColor(bgElmStyle);
 
     if (
       // abort if a node is partially obscured and obscuring element has a background

--- a/lib/commons/color/get-background-stack.js
+++ b/lib/commons/color/get-background-stack.js
@@ -45,7 +45,7 @@ function calculateObscuringElement(elmIndex, elmStack, originalElm) {
   if (elmIndex > 0) {
     // there are elements above our element, check if they contribute to the background
     for (var i = elmIndex - 1; i >= 0; i--) {
-      let bgElm = elmStack[i];
+      const bgElm = elmStack[i];
       if (contentOverlapping(originalElm, bgElm)) {
         return true;
       } else {
@@ -66,8 +66,8 @@ function calculateObscuringElement(elmIndex, elmStack, originalElm) {
  * @returns {Array}
  */
 function sortPageBackground(elmStack) {
-  let bodyIndex = elmStack.indexOf(document.body);
-  let bgNodes = elmStack;
+  const bodyIndex = elmStack.indexOf(document.body);
+  const bgNodes = elmStack;
 
   // Body can sometimes appear out of order in the stack:
   //   1) Body is not the first element due to negative z-index elements
@@ -76,7 +76,7 @@ function sortPageBackground(elmStack) {
   // In those instances we want to reinsert body back into the element stack
   // when not using the root document element as the html canvas for bgcolor
   // prettier-ignore
-  let sortBodyElement =
+  const sortBodyElement =
     bodyIndex > 1 || // negative z-index elements
     bodyIndex === -1; // element does not intersect with body
 
@@ -118,7 +118,7 @@ function getBackgroundStack(elm) {
   elmStack = sortPageBackground(elmStack);
 
   // Return all elements BELOW the current element, null if the element is undefined
-  let elmIndex = elmStack.indexOf(elm);
+  const elmIndex = elmStack.indexOf(elm);
   if (calculateObscuringElement(elmIndex, elmStack, elm)) {
     // if the total of the elements above our element results in total obscuring, return null
     incompleteData.set('bgColor', 'bgOverlap');

--- a/lib/commons/color/get-text-shadow-colors.js
+++ b/lib/commons/color/get-text-shadow-colors.js
@@ -58,11 +58,11 @@ function parseTextShadows(textShadow) {
   }
 
   while (str) {
-    let colorMatch =
+    const colorMatch =
       str.match(/^rgba?\([0-9,.\s]+\)/i) ||
       str.match(/^[a-z]+/i) ||
       str.match(/^#[0-9a-f]+/i);
-    let pixelMatch = str.match(/^([0-9.-]+)px/i) || str.match(/^(0)/);
+    const pixelMatch = str.match(/^([0-9.-]+)px/i) || str.match(/^(0)/);
 
     if (colorMatch) {
       assert(

--- a/lib/commons/dom/find-up-virtual.js
+++ b/lib/commons/dom/find-up-virtual.js
@@ -20,7 +20,7 @@ function findUpVirtual(element, target) {
   // slotted into a shadow DOM
   if (!element.shadowId && typeof element.actualNode.closest === 'function') {
     // non-shadow DOM elements
-    let match = element.actualNode.closest(target);
+    const match = element.actualNode.closest(target);
     if (match) {
       return match;
     }

--- a/lib/commons/dom/get-rect-stack.js
+++ b/lib/commons/dom/get-rect-stack.js
@@ -312,7 +312,7 @@ function getStackingOrder(vNode, parentVNode) {
  */
 function findScrollRegionParent(vNode, parentVNode) {
   let scrollRegionParent = null;
-  let checkedNodes = [vNode];
+  const checkedNodes = [vNode];
 
   while (parentVNode) {
     if (parentVNode._scrollRegionParent) {
@@ -464,8 +464,8 @@ export function createGrid(
 
 export function getRectStack(grid, rect, recursed = false) {
   // use center point of rect
-  let x = rect.left + rect.width / 2;
-  let y = rect.top + rect.height / 2;
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
 
   // NOTE: there is a very rare edge case in Chrome vs Firefox that can
   // return different results of `document.elementsFromPoint`. If the center
@@ -477,8 +477,8 @@ export function getRectStack(grid, rect, recursed = false) {
   const col = (x / gridSize) | 0;
   let stack = grid.cells[row][col].filter(gridCellNode => {
     return gridCellNode.clientRects.find(clientRect => {
-      let rectX = clientRect.left;
-      let rectY = clientRect.top;
+      const rectX = clientRect.left;
+      const rectY = clientRect.top;
 
       // perform an AABB (axis-aligned bounding box) collision check for the
       // point inside the rect

--- a/lib/commons/dom/inserted-into-focus-order.js
+++ b/lib/commons/dom/inserted-into-focus-order.js
@@ -12,7 +12,7 @@ import isNativelyFocusable from './is-natively-focusable';
  * if its tabindex were removed. Else, false.
  */
 function insertedIntoFocusOrder(el) {
-  let tabIndex = parseInt(el.getAttribute('tabindex'), 10);
+  const tabIndex = parseInt(el.getAttribute('tabindex'), 10);
 
   // an element that has an invalid tabindex will return 0 or -1 based on
   // if it is natively focusable or not, which will always be false for this

--- a/lib/commons/dom/is-in-text-block.js
+++ b/lib/commons/dom/is-in-text-block.js
@@ -50,7 +50,7 @@ function isInTextBlock(node) {
 
   // We want to ignore hidden text, and if br / hr is used, only use the section of the parent
   // that has the link we're looking at
-  walkDomNode(virtualParent, function(currNode) {
+  walkDomNode(virtualParent, currNode => {
     // We're already passed it, skip everything else
     if (inBrBlock === 2) {
       return false;

--- a/lib/commons/dom/is-modal-open.js
+++ b/lib/commons/dom/is-modal-open.js
@@ -12,7 +12,7 @@ import { querySelectorAllFilter } from '../../core/utils';
  */
 function isModalOpen(options) {
   options = options || {};
-  let modalPercent = options.modalPercent || 0.75;
+  const modalPercent = options.modalPercent || 0.75;
 
   // there is no "definitive" way to code a modal so detecting when one is open
   // is a bit of a guess. a modal won't always be accessible, so we can't rely

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -37,7 +37,7 @@ function accessibleTextVirtual(virtualNode, context = {}) {
   ];
 
   // Find the first step that returns a non-empty string
-  let accName = computationSteps.reduce((accName, step) => {
+  const accName = computationSteps.reduce((accName, step) => {
     if (context.startNode === virtualNode) {
       accName = sanitize(accName);
     }

--- a/lib/commons/text/form-control-value.js
+++ b/lib/commons/text/form-control-value.js
@@ -65,7 +65,7 @@ function formControlValue(virtualNode, context = {}) {
   );
 
   // Return the value of the first step that returns with text
-  let valueString = valueMethods.reduce((accName, step) => {
+  const valueString = valueMethods.reduce((accName, step) => {
     return accName || step(virtualNode, context);
   }, '');
 
@@ -126,7 +126,7 @@ function ariaTextboxValue(node) {
   const vNode =
     node instanceof AbstractVirtualNode ? node : getNodeFromTree(node);
 
-  let { actualNode } = vNode;
+  const { actualNode } = vNode;
   if (!isAriaTextbox(vNode)) {
     return '';
   }
@@ -182,13 +182,14 @@ function ariaListboxValue(node, context) {
 function ariaComboboxValue(node, context) {
   const vNode =
     node instanceof AbstractVirtualNode ? node : getNodeFromTree(node);
-  let listbox;
 
   // For combobox, find the first owned listbox:
   if (!isAriaCombobox(vNode)) {
     return '';
   }
-  listbox = getOwnedVirtual(vNode).filter(elm => getRole(elm) === 'listbox')[0];
+  const listbox = getOwnedVirtual(vNode).filter(
+    elm => getRole(elm) === 'listbox'
+  )[0];
 
   return listbox ? ariaListboxValue(listbox, context) : '';
 }

--- a/lib/commons/text/native-text-alternative.js
+++ b/lib/commons/text/native-text-alternative.js
@@ -20,7 +20,7 @@ function nativeTextAlternative(virtualNode, context = {}) {
 
   const textMethods = findTextMethods(virtualNode);
   // Find the first step that returns a non-empty string
-  let accName = textMethods.reduce((accName, step) => {
+  const accName = textMethods.reduce((accName, step) => {
     return accName || step(virtualNode, context);
   }, '');
 

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -323,7 +323,7 @@ class Audit {
     if (spec.metadata) {
       this.data.rules[spec.id] = spec.metadata;
     }
-    let rule = this.getRule(spec.id);
+    const rule = this.getRule(spec.id);
     if (rule) {
       rule.configure(spec);
     } else {
@@ -339,7 +339,7 @@ class Audit {
   addCheck(spec) {
     /*eslint no-eval: 0 */
 
-    let metadata = spec.metadata;
+    const metadata = spec.metadata;
     if (typeof metadata === 'object') {
       this.data.checks[spec.id] = metadata;
       // Transform messages into functions:
@@ -469,7 +469,7 @@ class Audit {
    */
   after(results, options) {
     var rules = this.rules;
-    return results.map(function(ruleResult) {
+    return results.map(ruleResult => {
       var rule = findBy(rules, 'id', ruleResult.id);
       if (!rule) {
         // If you see this, you're probably running the Mocha tests with the axe extension installed
@@ -537,7 +537,7 @@ class Audit {
       // Check if every value in options.runOnly is a known rule ID
       if (['rule', 'rules'].includes(only.type)) {
         only.type = 'rule';
-        only.values.forEach(function(ruleId) {
+        only.values.forEach(ruleId => {
           if (!ruleIds.includes(ruleId)) {
             throw new Error('unknown rule `' + ruleId + '` in options.runOnly');
           }
@@ -554,7 +554,7 @@ class Audit {
       }
     }
     if (typeof options.rules === 'object') {
-      Object.keys(options.rules).forEach(function(ruleId) {
+      Object.keys(options.rules).forEach(ruleId => {
         if (!ruleIds.includes(ruleId)) {
           throw new Error('unknown rule `' + ruleId + '` in options.rules');
         }
@@ -567,7 +567,7 @@ class Audit {
    * @param  {Mixed} options  Options object
    */
   setBranding(branding) {
-    let previous = {
+    const previous = {
       brand: this.brand,
       application: this.application
     };
@@ -596,7 +596,7 @@ class Audit {
       if (!this.data.rules[rule.id]) {
         this.data.rules[rule.id] = {};
       }
-      let metaData = this.data.rules[rule.id];
+      const metaData = this.data.rules[rule.id];
       if (
         typeof metaData.helpUrl !== 'string' ||
         (previous &&

--- a/lib/core/base/check.js
+++ b/lib/core/base/check.js
@@ -82,7 +82,7 @@ Check.prototype.enabled = true;
  *                             information for the check
  * @param  {Function} callback Function to fire when check is complete
  */
-Check.prototype.run = function(node, options, context, resolve, reject) {
+Check.prototype.run = function run(node, options, context, resolve, reject) {
   options = options || {};
   const enabled = options.hasOwnProperty('enabled')
     ? options.enabled
@@ -129,7 +129,7 @@ Check.prototype.run = function(node, options, context, resolve, reject) {
  * @param  {Object} options    The options that override the defaults and provide additional
  *                             information for the check
  */
-Check.prototype.runSync = function(node, options, context) {
+Check.prototype.runSync = function runSync(node, options, context) {
   options = options || {};
   const { enabled = this.enabled } = options;
 
@@ -142,7 +142,7 @@ Check.prototype.runSync = function(node, options, context) {
   const helper = checkHelper(checkResult, options);
 
   // throw error if a check is run that requires async behavior
-  helper.async = function() {
+  helper.async = function async() {
     throw new Error('Cannot run async check while in a synchronous run');
   };
 
@@ -178,7 +178,7 @@ Check.prototype.runSync = function(node, options, context) {
  * @param {Object} spec - the specification of the attributes to be changed
  */
 
-Check.prototype.configure = function(spec) {
+Check.prototype.configure = function configure(spec) {
   // allow test specs (without evaluate functions) to work as
   // internal checks
   if (!spec.evaluate || metadataFunctionMap[spec.evaluate]) {

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -165,9 +165,7 @@ function parseSelectorArray(context, type) {
   }
 
   // filter nulls
-  return result.filter(function(r) {
-    return r;
-  });
+  return result.filter(r => r);
 }
 
 /**
@@ -182,7 +180,7 @@ function validateContext(context) {
       var env = respondable.isInFrame() ? 'frame' : 'page';
       return new Error('No elements found for include in ' + env + ' Context');
     }
-    context.frames.forEach(function(frame, i) {
+    context.frames.forEach((frame, i) => {
       if (frame.include.length === 0) {
         return new Error(
           'No elements found for include in Context of frame ' + i

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -111,7 +111,7 @@ function Rule(spec, parentAudit) {
  * a given node.  Defaults to `true`.
  * @return {Boolean}    Whether the rule should run
  */
-Rule.prototype.matches = function() {
+Rule.prototype.matches = function matches() {
   return true;
 };
 
@@ -121,7 +121,7 @@ Rule.prototype.matches = function() {
  * @param  {Mixed}   options Options specific to this rule
  * @return {Array}           All matching `HTMLElement`s
  */
-Rule.prototype.gather = function(context, options = {}) {
+Rule.prototype.gather = function gather(context, options = {}) {
   const markStart = 'mark_gather_start_' + this.id;
   const markEnd = 'mark_gather_end_' + this.id;
   const markHiddenStart = 'mark_isHidden_start_' + this.id;
@@ -137,7 +137,7 @@ Rule.prototype.gather = function(context, options = {}) {
       performanceTimer.mark(markHiddenStart);
     }
 
-    elements = elements.filter(function(element) {
+    elements = elements.filter(element => {
       return !isHidden(element.actualNode);
     });
 
@@ -159,7 +159,7 @@ Rule.prototype.gather = function(context, options = {}) {
   return elements;
 };
 
-Rule.prototype.runChecks = function(
+Rule.prototype.runChecks = function runChecks(
   type,
   node,
   options,
@@ -171,19 +171,17 @@ Rule.prototype.runChecks = function(
 
   var checkQueue = queue();
 
-  this[type].forEach(function(c) {
+  this[type].forEach(c => {
     var check = self._audit.checks[c.id || c];
     var option = getCheckOption(check, self.id, options);
-    checkQueue.defer(function(res, rej) {
+    checkQueue.defer((res, rej) => {
       check.run(node, option, context, res, rej);
     });
   });
 
   checkQueue
-    .then(function(results) {
-      results = results.filter(function(check) {
-        return check;
-      });
+    .then(results => {
+      results = results.filter(check => check);
       resolve({ type: type, results: results });
     })
     .catch(reject);
@@ -192,19 +190,22 @@ Rule.prototype.runChecks = function(
 /**
  * Run a check for a rule synchronously.
  */
-Rule.prototype.runChecksSync = function(type, node, options, context) {
+Rule.prototype.runChecksSync = function runChecksSync(
+  type,
+  node,
+  options,
+  context
+) {
   const self = this;
   let results = [];
 
-  this[type].forEach(function(c) {
+  this[type].forEach(c => {
     const check = self._audit.checks[c.id || c];
     const option = getCheckOption(check, self.id, options);
     results.push(check.runSync(node, option, context));
   });
 
-  results = results.filter(function(check) {
-    return check;
-  });
+  results = results.filter(check => check);
 
   return { type: type, results: results };
 };
@@ -215,7 +216,7 @@ Rule.prototype.runChecksSync = function(type, node, options, context) {
  * @param  {Mixed}   options  Options specific to this rule
  * @param  {Function} callback Function to call when evaluate is complete; receives a RuleResult instance
  */
-Rule.prototype.run = function(context, options = {}, resolve, reject) {
+Rule.prototype.run = function run(context, options = {}, resolve, reject) {
   if (options.performanceTimer) {
     this._trackPerformance();
   }
@@ -293,7 +294,7 @@ Rule.prototype.run = function(context, options = {}, resolve, reject) {
  * @param  {Context}   context  The resolved Context object
  * @param  {Mixed}   options  Options specific to this rule
  */
-Rule.prototype.runSync = function(context, options = {}) {
+Rule.prototype.runSync = function runSync(context, options = {}) {
   if (options.performanceTimer) {
     this._trackPerformance();
   }
@@ -313,7 +314,7 @@ Rule.prototype.runSync = function(context, options = {}) {
   }
 
   nodes.forEach(node => {
-    let results = [];
+    const results = [];
     ['any', 'all', 'none'].forEach(type => {
       results.push(this.runChecksSync(type, node, options, context));
     });
@@ -355,7 +356,7 @@ Rule.prototype.runSync = function(context, options = {}) {
  * Add performance tracking properties to the rule
  * @private
  */
-Rule.prototype._trackPerformance = function() {
+Rule.prototype._trackPerformance = function _trackPerformance() {
   this._markStart = 'mark_rule_start_' + this.id;
   this._markEnd = 'mark_rule_end_' + this.id;
   this._markChecksStart = 'mark_runchecks_start_' + this.id;
@@ -368,7 +369,7 @@ Rule.prototype._trackPerformance = function() {
  * @param {Rule} rule The rule to log
  * @param {Array} nodes Result of rule.gather
  */
-Rule.prototype._logGatherPerformance = function(nodes) {
+Rule.prototype._logGatherPerformance = function _logGatherPerformance(nodes) {
   log('gather (', nodes.length, '):', performanceTimer.timeElapsed() + 'ms');
   performanceTimer.mark(this._markChecksStart);
 };
@@ -378,7 +379,7 @@ Rule.prototype._logGatherPerformance = function(nodes) {
  * @private
  * @param {Rule} rule The rule to log
  */
-Rule.prototype._logRulePerformance = function() {
+Rule.prototype._logRulePerformance = function _logRulePerformance() {
   performanceTimer.mark(this._markChecksEnd);
   performanceTimer.mark(this._markEnd);
   performanceTimer.measure(
@@ -399,12 +400,10 @@ Rule.prototype._logRulePerformance = function() {
  */
 function getResult(results) {
   if (results.length) {
-    let hasResults = false,
-      result = {};
-    results.forEach(function(r) {
-      const res = r.results.filter(function(result) {
-        return result;
-      });
+    let hasResults = false;
+    const result = {};
+    results.forEach(r => {
+      const res = r.results.filter(result => result);
       result[r.type] = res;
       if (res.length) {
         hasResults = true;
@@ -427,7 +426,10 @@ function getResult(results) {
  * @param  {Mixed}   options Options specific to this rule
  * @return {Array}           All matching `HTMLElement`s
  */
-Rule.prototype.gatherAndMatchNodes = function(context, options) {
+Rule.prototype.gatherAndMatchNodes = function gatherAndMatchNodes(
+  context,
+  options
+) {
   const markMatchesStart = 'mark_matches_start_' + this.id;
   const markMatchesEnd = 'mark_matches_end_' + this.id;
 
@@ -459,7 +461,7 @@ Rule.prototype.gatherAndMatchNodes = function(context, options) {
  */
 function findAfterChecks(rule) {
   return getAllChecks(rule)
-    .map(function(c) {
+    .map(c => {
       var check = rule._audit.checks[c.id || c];
       return check && typeof check.after === 'function' ? check : null;
     })
@@ -475,9 +477,9 @@ function findAfterChecks(rule) {
  */
 function findCheckResults(nodes, checkID) {
   var checkResults = [];
-  nodes.forEach(function(nodeResult) {
+  nodes.forEach(nodeResult => {
     var checks = getAllChecks(nodeResult);
-    checks.forEach(function(checkResult) {
+    checks.forEach(checkResult => {
       if (checkResult.id === checkID) {
         checkResult.node = nodeResult.node;
         checkResults.push(checkResult);
@@ -488,7 +490,7 @@ function findCheckResults(nodes, checkID) {
 }
 
 function filterChecks(checks) {
-  return checks.filter(function(check) {
+  return checks.filter(check => {
     return check.filtered !== true;
   });
 }
@@ -496,9 +498,9 @@ function filterChecks(checks) {
 function sanitizeNodes(result) {
   var checkTypes = ['any', 'all', 'none'];
 
-  var nodes = result.nodes.filter(function(detail) {
+  var nodes = result.nodes.filter(detail => {
     var length = 0;
-    checkTypes.forEach(function(type) {
+    checkTypes.forEach(type => {
       detail[type] = filterChecks(detail[type]);
       length += detail[type].length;
     });
@@ -507,9 +509,9 @@ function sanitizeNodes(result) {
 
   if (result.pageLevel && nodes.length) {
     nodes = [
-      nodes.reduce(function(a, b) {
+      nodes.reduce((a, b) => {
         if (a) {
-          checkTypes.forEach(function(type) {
+          checkTypes.forEach(type => {
             a[type].push.apply(a[type], b[type]);
           });
           return a;
@@ -526,15 +528,15 @@ function sanitizeNodes(result) {
  * @param  {Mixed} options Options specific to the rule
  * @return {RuleResult}         The RuleResult as filtered by after functions
  */
-Rule.prototype.after = function(result, options) {
+Rule.prototype.after = function after(result, options) {
   var afterChecks = findAfterChecks(this);
   var ruleID = this.id;
-  afterChecks.forEach(function(check) {
+  afterChecks.forEach(check => {
     var beforeResults = findCheckResults(result.nodes, check.id);
     var option = getCheckOption(check, ruleID, options);
 
     var afterResults = check.after(beforeResults, option);
-    beforeResults.forEach(function(item) {
+    beforeResults.forEach(item => {
       // only add the node property for the check.after so we can
       // look at which iframe a check result came from, but we don't
       // want it for the final results object
@@ -553,7 +555,7 @@ Rule.prototype.after = function(result, options) {
  * Reconfigure a rule after it has been added
  * @param {Object} spec - the attributes to be reconfigured
  */
-Rule.prototype.configure = function(spec) {
+Rule.prototype.configure = function configure(spec) {
   /*eslint no-eval:0 */
 
   if (spec.hasOwnProperty('selector')) {

--- a/lib/core/base/virtual-node/abstract-virtual-node.js
+++ b/lib/core/base/virtual-node/abstract-virtual-node.js
@@ -23,12 +23,12 @@ class AbstractVirtualNode {
   hasClass(className) {
     // get the value of the class attribute as svgs return a SVGAnimatedString
     // if you access the className property
-    let classAttr = this.attr('class');
+    const classAttr = this.attr('class');
     if (!classAttr) {
       return false;
     }
 
-    let selector = ' ' + className + ' ';
+    const selector = ' ' + className + ' ';
     return (
       (' ' + classAttr + ' ').replace(whitespaceRegex, ' ').indexOf(selector) >=
       0

--- a/lib/core/base/virtual-node/serial-virtual-node.js
+++ b/lib/core/base/virtual-node/serial-virtual-node.js
@@ -42,7 +42,8 @@ class SerialVirtualNode extends AbstractVirtualNode {
  * @return {Object} normalProperties
  */
 function normaliseProps(serialNode) {
-  let { nodeName, nodeType = 1 } = serialNode;
+  let { nodeName } = serialNode;
+  const { nodeType = 1 } = serialNode;
   assert(
     typeof nodeType === 'number',
     `nodeType has to be a number, got '${nodeType}'`

--- a/lib/core/constants.js
+++ b/lib/core/constants.js
@@ -43,7 +43,7 @@ const constants = {
   })
 };
 
-definitions.forEach(function(definition) {
+definitions.forEach(definition => {
   const name = definition.name;
   const value = definition.value;
   const priority = definition.priority;

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -7,9 +7,7 @@ axe.version = '<%= pkg.version %>';
 
 if (typeof define === 'function' && define.amd) {
   // Explicitly naming the module to avoid mismatched anonymous define() modules when injected in a page
-  define('axe-core', [], function() {
-    return axe;
-  });
+  define('axe-core', [], () => axe);
 }
 if (
   typeof module === 'object' &&

--- a/lib/core/public/cleanup.js
+++ b/lib/core/public/cleanup.js
@@ -1,5 +1,5 @@
 function cleanup(resolve, reject) {
-  resolve = resolve || function() {};
+  resolve = resolve || function res() {};
   reject = reject || axe.log;
 
   if (!axe._audit) {
@@ -10,9 +10,9 @@ function cleanup(resolve, reject) {
   // If a plugin fails it's cleanup, we still want the others to run
   var cleanupErrors = [];
 
-  Object.keys(axe.plugins).forEach(function(key) {
-    q.defer(function(res) {
-      var rej = function(err) {
+  Object.keys(axe.plugins).forEach(key => {
+    q.defer(res => {
+      var rej = function rej(err) {
         cleanupErrors.push(err);
         res();
       };
@@ -26,22 +26,20 @@ function cleanup(resolve, reject) {
 
   var flattenedTree = axe.utils.getFlattenedTree(document.body);
 
-  axe.utils
-    .querySelectorAll(flattenedTree, 'iframe, frame')
-    .forEach(function(node) {
-      q.defer(function(res, rej) {
-        return axe.utils.sendCommandToFrame(
-          node.actualNode,
-          {
-            command: 'cleanup-plugin'
-          },
-          res,
-          rej
-        );
-      });
+  axe.utils.querySelectorAll(flattenedTree, 'iframe, frame').forEach(node => {
+    q.defer((res, rej) => {
+      return axe.utils.sendCommandToFrame(
+        node.actualNode,
+        {
+          command: 'cleanup-plugin'
+        },
+        res,
+        rej
+      );
     });
+  });
 
-  q.then(function(results) {
+  q.then(results => {
     if (cleanupErrors.length === 0) {
       resolve(results);
     } else {

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -10,16 +10,16 @@ function configure(spec) {
   }
 
   if (spec.axeVersion || spec.ver) {
-    let specVersion = spec.axeVersion || spec.ver;
+    const specVersion = spec.axeVersion || spec.ver;
     if (!/^\d+\.\d+\.\d+(-canary)?/.test(specVersion)) {
       throw new Error(`Invalid configured version ${specVersion}`);
     }
 
-    let [version, canary] = specVersion.split('-');
-    let [major, minor, patch] = version.split('.').map(Number);
+    const [version, canary] = specVersion.split('-');
+    const [major, minor, patch] = version.split('.').map(Number);
 
-    let [axeVersion, axeCanary] = axe.version.split('-');
-    let [axeMajor, axeMinor, axePatch] = axeVersion.split('.').map(Number);
+    const [axeVersion, axeCanary] = axe.version.split('-');
+    const [axeMajor, axeMinor, axePatch] = axeVersion.split('.').map(Number);
 
     if (
       major !== axeMajor ||
@@ -49,7 +49,7 @@ function configure(spec) {
       throw new TypeError('Checks property must be an array');
     }
 
-    spec.checks.forEach(function(check) {
+    spec.checks.forEach(check => {
       if (!check.id) {
         throw new TypeError(
           // eslint-disable-next-line max-len
@@ -69,7 +69,7 @@ function configure(spec) {
       throw new TypeError('Rules property must be an array');
     }
 
-    spec.rules.forEach(function(rule) {
+    spec.rules.forEach(rule => {
       if (!rule.id) {
         throw new TypeError(
           // eslint-disable-next-line max-len

--- a/lib/core/public/get-rules.js
+++ b/lib/core/public/get-rules.js
@@ -7,14 +7,14 @@ function getRules(tags) {
   tags = tags || [];
   var matchingRules = !tags.length
     ? axe._audit.rules
-    : axe._audit.rules.filter(function(item) {
-        return !!tags.filter(function(tag) {
+    : axe._audit.rules.filter(item => {
+        return !!tags.filter(tag => {
           return item.tags.indexOf(tag) !== -1;
         }).length;
       });
 
   var ruleData = axe._audit.data.rules || {};
-  return matchingRules.map(function(matchingRule) {
+  return matchingRules.map(matchingRule => {
     var rd = ruleData[matchingRule.id] || {};
     return {
       ruleId: matchingRule.id,

--- a/lib/core/public/load.js
+++ b/lib/core/public/load.js
@@ -4,7 +4,7 @@ import runRules from './run-rules';
 
 function runCommand(data, keepalive, callback) {
   var resolve = callback;
-  var reject = function(err) {
+  var reject = function reject(err) {
     if (err instanceof Error === false) {
       err = new Error(err);
     }
@@ -22,7 +22,7 @@ function runCommand(data, keepalive, callback) {
       return runRules(
         context,
         options,
-        function(results, cleanup) {
+        (results, cleanup) => {
           resolve(results);
           // Cleanup AFTER resolve so that selectors can be generated
           cleanup();
@@ -49,11 +49,7 @@ function runCommand(data, keepalive, callback) {
  * @private
  */
 function load(audit) {
-  axe.utils.respondable.subscribe('axe.ping', function(
-    data,
-    keepalive,
-    respond
-  ) {
+  axe.utils.respondable.subscribe('axe.ping', (data, keepalive, respond) => {
     respond({
       axe: true
     });

--- a/lib/core/public/plugins.js
+++ b/lib/core/public/plugins.js
@@ -4,33 +4,31 @@ function Plugin(spec) {
   this._run = spec.run;
   this._collect = spec.collect;
   this._registry = {};
-  spec.commands.forEach(function(command) {
+  spec.commands.forEach(command => {
     axe._audit.registerCommand(command);
   });
 }
 
-Plugin.prototype.run = function() {
+Plugin.prototype.run = function run() {
   return this._run.apply(this, arguments);
 };
 
-Plugin.prototype.collect = function() {
+Plugin.prototype.collect = function collect() {
   return this._collect.apply(this, arguments);
 };
 
-Plugin.prototype.cleanup = function(done) {
+Plugin.prototype.cleanup = function cleanup(done) {
   var q = axe.utils.queue();
   var that = this;
-  Object.keys(this._registry).forEach(function(key) {
-    q.defer(function(done) {
-      that._registry[key].cleanup(done);
+  Object.keys(this._registry).forEach(key => {
+    q.defer(_done => {
+      that._registry[key].cleanup(_done);
     });
   });
-  q.then(function() {
-    done();
-  });
+  q.then(done);
 };
 
-Plugin.prototype.add = function(impl) {
+Plugin.prototype.add = function add(impl) {
   this._registry[impl.id] = impl;
 };
 

--- a/lib/core/public/run-rules.js
+++ b/lib/core/public/run-rules.js
@@ -52,14 +52,14 @@ function runRules(context, options, resolve, reject) {
   }
 
   if (context.frames.length && options.iframes !== false) {
-    q.defer(function(res, rej) {
+    q.defer((res, rej) => {
       collectResultsFromFrames(context, options, 'rules', null, res, rej);
     });
   }
-  q.defer(function(res, rej) {
+  q.defer((res, rej) => {
     audit.run(context, options, res, rej);
   });
-  q.then(function(data) {
+  q.then(data => {
     try {
       if (options.performanceTimer) {
         performanceTimer.auditEnd();
@@ -67,7 +67,7 @@ function runRules(context, options, resolve, reject) {
 
       // Add wrapper object so that we may use the same "merge" function for results from inside and outside frames
       var results = mergeResults(
-        data.map(function(results) {
+        data.map(results => {
           return { results };
         })
       );

--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -22,7 +22,7 @@ function isContext(potential) {
   }
 }
 
-var noop = function() {};
+var noop = function noop() {};
 
 /**
  * Normalize the optional params of axe.run()
@@ -32,7 +32,7 @@ var noop = function() {};
  * @return {object}            With 3 keys: context, options, callback
  */
 function normalizeRunParams(context, options, callback) {
-  let typeErr = new TypeError('axe.run arguments are invalid');
+  const typeErr = new TypeError('axe.run arguments are invalid');
 
   // Determine the context
   if (!isContext(context)) {
@@ -110,7 +110,7 @@ function run(context, options, callback) {
     }
   }
 
-  let args = normalizeRunParams(context, options, callback);
+  const args = normalizeRunParams(context, options, callback);
   context = args.context;
   options = args.options;
   callback = args.callback;
@@ -126,7 +126,7 @@ function run(context, options, callback) {
   let resolve = noop;
 
   if (typeof Promise === 'function' && callback === noop) {
-    p = new Promise(function(_resolve, _reject) {
+    p = new Promise((_resolve, _reject) => {
       reject = _reject;
       resolve = _resolve;
     });
@@ -145,8 +145,8 @@ function run(context, options, callback) {
   axe._runRules(
     context,
     options,
-    function(rawResults, cleanup) {
-      let respond = function(results) {
+    (rawResults, cleanup) => {
+      const respond = results => {
         axe._running = false;
         cleanup();
         try {
@@ -161,8 +161,8 @@ function run(context, options, callback) {
       }
 
       try {
-        let reporter = getReporter(options.reporter);
-        let results = reporter(rawResults, options, respond);
+        const reporter = getReporter(options.reporter);
+        const results = reporter(rawResults, options, respond);
         if (results !== undefined) {
           respond(results);
         }
@@ -173,7 +173,7 @@ function run(context, options, callback) {
         reject(err);
       }
     },
-    function(err) {
+    err => {
       axe._running = false;
       callback(err);
       reject(err);

--- a/lib/core/reporters/helpers/failure-summary.js
+++ b/lib/core/reporters/helpers/failure-summary.js
@@ -10,7 +10,7 @@ function failureSummary(nodeData) {
   failingChecks.any = nodeData.any;
 
   return Object.keys(failingChecks)
-    .map(function(key) {
+    .map(key => {
       if (!failingChecks[key].length) {
         return;
       }
@@ -18,13 +18,13 @@ function failureSummary(nodeData) {
       var sum = axe._audit.data.failureSummaries[key];
       if (sum && typeof sum.failureMessage === 'function') {
         return sum.failureMessage(
-          failingChecks[key].map(function(check) {
+          failingChecks[key].map(check => {
             return check.message || '';
           })
         );
       }
     })
-    .filter(function(i) {
+    .filter(i => {
       return i !== undefined;
     })
     .join('\n\n');

--- a/lib/core/reporters/helpers/process-aggregate.js
+++ b/lib/core/reporters/helpers/process-aggregate.js
@@ -58,20 +58,20 @@ var resultKeys = constants.resultGroups;
 function processAggregate(results, options) {
   var resultObject = axe.utils.aggregateResult(results);
 
-  resultKeys.forEach(function(key) {
+  resultKeys.forEach(key => {
     if (options.resultTypes && !options.resultTypes.includes(key)) {
       // If the user asks us to, truncate certain finding types to maximum one finding
-      (resultObject[key] || []).forEach(function(ruleResult) {
+      (resultObject[key] || []).forEach(ruleResult => {
         if (Array.isArray(ruleResult.nodes) && ruleResult.nodes.length > 0) {
           ruleResult.nodes = [ruleResult.nodes[0]];
         }
       });
     }
-    resultObject[key] = (resultObject[key] || []).map(function(ruleResult) {
+    resultObject[key] = (resultObject[key] || []).map(ruleResult => {
       ruleResult = Object.assign({}, ruleResult);
 
       if (Array.isArray(ruleResult.nodes) && ruleResult.nodes.length > 0) {
-        ruleResult.nodes = ruleResult.nodes.map(function(subResult) {
+        ruleResult.nodes = ruleResult.nodes.map(subResult => {
           if (typeof subResult.node === 'object') {
             subResult.html = subResult.node.source;
             if (options.elementRef && !subResult.node.fromFrame) {

--- a/lib/core/utils/aggregate-checks.js
+++ b/lib/core/utils/aggregate-checks.js
@@ -2,7 +2,7 @@ import constants from '../constants';
 import aggregate from './aggregate';
 
 const { CANTTELL_PRIO, FAIL_PRIO } = constants;
-let checkMap = [];
+const checkMap = [];
 checkMap[constants.PASS_PRIO] = true;
 checkMap[constants.CANTTELL_PRIO] = null;
 checkMap[constants.FAIL_PRIO] = false;
@@ -10,9 +10,9 @@ checkMap[constants.FAIL_PRIO] = false;
 /**
  * Map over the any / all / none properties
  */
-let checkTypes = ['any', 'all', 'none'];
+const checkTypes = ['any', 'all', 'none'];
 function anyAllNone(obj, functor) {
-  return checkTypes.reduce(function(out, type) {
+  return checkTypes.reduce((out, type) => {
     out[type] = (obj[type] || []).map(val => functor(val, type));
     return out;
   }, {});
@@ -20,11 +20,11 @@ function anyAllNone(obj, functor) {
 
 function aggregateChecks(nodeResOriginal) {
   // Create a copy
-  let nodeResult = Object.assign({}, nodeResOriginal);
+  const nodeResult = Object.assign({}, nodeResOriginal);
 
   // map each result value to a priority
-  anyAllNone(nodeResult, function(check, type) {
-    let i =
+  anyAllNone(nodeResult, (check, type) => {
+    const i =
       typeof check.result === 'undefined' ? -1 : checkMap.indexOf(check.result);
     // default to cantTell
     check.priority = i !== -1 ? i : constants.CANTTELL_PRIO;
@@ -56,7 +56,7 @@ function aggregateChecks(nodeResOriginal) {
   );
 
   // Of each type, filter out all results not matching the final priority
-  let impacts = [];
+  const impacts = [];
   checkTypes.forEach(type => {
     nodeResult[type] = nodeResult[type].filter(check => {
       return (

--- a/lib/core/utils/aggregate-node-results.js
+++ b/lib/core/utils/aggregate-node-results.js
@@ -8,10 +8,10 @@ import constants from '../constants';
  * @param	{Array} nodeResults The array of nodes tested by the Rule
  */
 function aggregateNodeResults(nodeResults) {
-  let ruleResult = {};
+  const ruleResult = {};
 
   // For each node, retrieve the result and impact
-  nodeResults = nodeResults.map(function(nodeResult) {
+  nodeResults = nodeResults.map(nodeResult => {
     // Known result
     if (nodeResult.any && nodeResult.all && nodeResult.none) {
       return aggregateChecks(nodeResult);
@@ -25,7 +25,7 @@ function aggregateNodeResults(nodeResults) {
   // Aggregate the result
   // If there were no nodes passed in, mark the test as inapplicable
   if (nodeResults && nodeResults.length) {
-    let resultList = nodeResults.map(node => node.result);
+    const resultList = nodeResults.map(node => node.result);
     ruleResult.result = aggregate(
       constants.results,
       resultList,
@@ -39,7 +39,7 @@ function aggregateNodeResults(nodeResults) {
   constants.resultGroups.forEach(group => (ruleResult[group] = []));
 
   // Fill the array with nodes
-  nodeResults.forEach(function(nodeResult) {
+  nodeResults.forEach(nodeResult => {
     var groupName = constants.resultGroupMap[nodeResult.result];
     ruleResult[groupName].push(nodeResult);
   });
@@ -52,7 +52,7 @@ function aggregateNodeResults(nodeResults) {
 
   if (ruleResult[impactGroup].length > 0) {
     // Get the impact of all issues
-    let impactList = ruleResult[impactGroup].map(failure => failure.impact);
+    const impactList = ruleResult[impactGroup].map(failure => failure.impact);
 
     ruleResult.impact = aggregate(constants.impact, impactList) || null;
   } else {

--- a/lib/core/utils/aggregate-result.js
+++ b/lib/core/utils/aggregate-result.js
@@ -14,19 +14,19 @@ function copyToGroup(resultObject, subResult, group) {
  * @param  {RuleResult} ruleResult The RuleResult to calculate the result of
  */
 function aggregateResult(results) {
-  let resultObject = {};
+  const resultObject = {};
 
   // Create an array for each type
   constants.resultGroups.forEach(groupName => (resultObject[groupName] = []));
 
   // Fill the array with nodes
-  results.forEach(function(subResult) {
+  results.forEach(subResult => {
     if (subResult.error) {
       copyToGroup(resultObject, subResult, constants.CANTTELL_GROUP);
     } else if (subResult.result === constants.NA) {
       copyToGroup(resultObject, subResult, constants.NA_GROUP);
     } else {
-      constants.resultGroups.forEach(function(group) {
+      constants.resultGroups.forEach(group => {
         if (Array.isArray(subResult[group]) && subResult[group].length > 0) {
           copyToGroup(resultObject, subResult, group);
         }

--- a/lib/core/utils/check-helper.js
+++ b/lib/core/utils/check-helper.js
@@ -10,9 +10,9 @@ import DqElement from './dq-element';
 function checkHelper(checkResult, options, resolve, reject) {
   return {
     isAsync: false,
-    async: function() {
+    async() {
       this.isAsync = true;
-      return function(result) {
+      return result => {
         if (result instanceof Error === false) {
           checkResult.result = result;
           resolve(checkResult);
@@ -21,12 +21,12 @@ function checkHelper(checkResult, options, resolve, reject) {
         }
       };
     },
-    data: function(data) {
+    data(data) {
       checkResult.data = data;
     },
-    relatedNodes: function(nodes) {
+    relatedNodes(nodes) {
       nodes = nodes instanceof window.Node ? [nodes] : toArray(nodes);
-      checkResult.relatedNodes = nodes.map(function(element) {
+      checkResult.relatedNodes = nodes.map(element => {
         return new DqElement(element, options);
       });
     }

--- a/lib/core/utils/collect-results-from-frames.js
+++ b/lib/core/utils/collect-results-from-frames.js
@@ -24,7 +24,7 @@ function collectResultsFromFrames(
   var frames = context.frames;
 
   // Tell each axe running in each frame to collect results
-  frames.forEach(function(frame) {
+  frames.forEach(frame => {
     var params = {
       options: options,
       command: command,
@@ -37,12 +37,12 @@ function collectResultsFromFrames(
       }
     };
 
-    q.defer(function(res, rej) {
+    q.defer((res, rej) => {
       var node = frame.node;
       sendCommandToFrame(
         node,
         params,
-        function(data) {
+        data => {
           if (data) {
             return res({
               results: data,
@@ -58,7 +58,7 @@ function collectResultsFromFrames(
   });
 
   // Combine results from all frames and give it back
-  q.then(function(data) {
+  q.then(data => {
     resolve(mergeResults(data, options));
   }).catch(reject);
 }

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -86,7 +86,7 @@ DqElement.prototype = {
     return this._fromFrame;
   },
 
-  toJSON: function() {
+  toJSON() {
     return {
       selector: this.selector,
       source: this.source,
@@ -96,7 +96,7 @@ DqElement.prototype = {
   }
 };
 
-DqElement.fromFrame = function(node, options, frame) {
+DqElement.fromFrame = function fromFrame(node, options, frame) {
   const spec = {
     ...node,
     selector: [...frame.selector, ...node.selector],

--- a/lib/core/utils/element-matches.js
+++ b/lib/core/utils/element-matches.js
@@ -4,7 +4,7 @@
  * @param {String} selector The selector to test element against
  * @return {Boolean}
  */
-const matchesSelector = (function() {
+const matchesSelector = (() => {
   var method;
 
   function getMethod(node) {
@@ -27,7 +27,7 @@ const matchesSelector = (function() {
     }
   }
 
-  return function(node, selector) {
+  return (node, selector) => {
     if (!method || !node[method]) {
       method = getMethod(node);
     }

--- a/lib/core/utils/get-friendly-uri-end.js
+++ b/lib/core/utils/get-friendly-uri-end.js
@@ -35,7 +35,7 @@ function trimRight(str) {
  *	 .hash			Hash / internal reference, e.g. '#footer'
  */
 function uriParser(url) {
-  let original = url;
+  const original = url;
   let protocol = '',
     domain = '',
     port = '',

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -38,9 +38,9 @@ function getAttributeNameValue(node, at) {
   let atnv;
 
   if (name.indexOf('href') !== -1 || name.indexOf('src') !== -1) {
-    let friendly = getFriendlyUriEnd(node.getAttribute(name));
+    const friendly = getFriendlyUriEnd(node.getAttribute(name));
     if (friendly) {
-      let value = encodeURI(friendly);
+      const value = encodeURI(friendly);
       if (value) {
         atnv = escapeSelector(at.name) + '$="' + escapeSelector(value) + '"';
       } else {
@@ -88,7 +88,7 @@ export function getSelectorData(domTree) {
   /* eslint no-loop-func:0*/
 
   // Initialize the return structure with the three maps
-  let data = {
+  const data = {
     classes: {},
     tags: {},
     attributes: {}
@@ -96,16 +96,16 @@ export function getSelectorData(domTree) {
 
   domTree = Array.isArray(domTree) ? domTree : [domTree];
   let currentLevel = domTree.slice();
-  let stack = [];
+  const stack = [];
   while (currentLevel.length) {
-    let current = currentLevel.pop();
-    let node = current.actualNode;
+    const current = currentLevel.pop();
+    const node = current.actualNode;
 
     if (!!node.querySelectorAll) {
       // ignore #text nodes
 
       // count the tag
-      let tag = node.nodeName;
+      const tag = node.nodeName;
       if (data.tags[tag]) {
         data.tags[tag]++;
       } else {
@@ -129,7 +129,7 @@ export function getSelectorData(domTree) {
         Array.from(getNodeAttributes(node))
           .filter(filterAttributes)
           .forEach(at => {
-            let atnv = getAttributeNameValue(node, at);
+            const atnv = getAttributeNameValue(node, at);
             if (atnv) {
               if (data.attributes[atnv]) {
                 data.attributes[atnv]++;
@@ -161,13 +161,13 @@ export function getSelectorData(domTree) {
  */
 function uncommonClasses(node, selectorData) {
   // eslint no-loop-func:false
-  let retVal = [];
-  let classData = selectorData.classes;
-  let tagData = selectorData.tags;
+  const retVal = [];
+  const classData = selectorData.classes;
+  const tagData = selectorData.tags;
 
   if (node.classList) {
     Array.from(node.classList).forEach(cl => {
-      let ind = escapeSelector(cl);
+      const ind = escapeSelector(cl);
       if (classData[ind] < tagData[node.nodeName]) {
         retVal.push({
           name: ind,
@@ -208,7 +208,7 @@ function getElmId(elm) {
   if (!elm.getAttribute('id')) {
     return;
   }
-  let doc = (elm.getRootNode && elm.getRootNode()) || document;
+  const doc = (elm.getRootNode && elm.getRootNode()) || document;
   const id = '#' + escapeSelector(elm.getAttribute('id') || '');
   if (
     // Don't include youtube's uid values, they change	on reload
@@ -240,9 +240,9 @@ function getBaseSelector(elm) {
  * @return {Array}						The sorted array of uncommon attribute data
  */
 function uncommonAttributes(node, selectorData) {
-  let retVal = [];
-  let attData = selectorData.attributes;
-  let tagData = selectorData.tags;
+  const retVal = [];
+  const attData = selectorData.attributes;
+  const tagData = selectorData.tags;
 
   if (node.hasAttributes()) {
     Array.from(getNodeAttributes(node))
@@ -279,8 +279,8 @@ function uncommonAttributes(node, selectorData) {
 function getThreeLeastCommonFeatures(elm, selectorData) {
   let selector = '';
   let features;
-  let clss = uncommonClasses(elm, selectorData);
-  let atts = uncommonAttributes(elm, selectorData);
+  const clss = uncommonClasses(elm, selectorData);
+  const atts = uncommonAttributes(elm, selectorData);
 
   if (clss.length && clss[0].count === 1) {
     // only use the unique class

--- a/lib/core/utils/get-shadow-selector.js
+++ b/lib/core/utils/get-shadow-selector.js
@@ -14,7 +14,7 @@ function getShadowSelector(generateSelector, elm, options = {}) {
     return generateSelector(elm, options, doc);
   }
 
-  let stack = [];
+  const stack = [];
   while (doc.nodeType === 11) {
     if (!doc.host) {
       return '';

--- a/lib/core/utils/is-node-in-context.js
+++ b/lib/core/utils/is-node-in-context.js
@@ -7,7 +7,7 @@ import contains from './contains';
  * @return {Node}             The deepest node
  */
 function getDeepest(collection) {
-  return collection.sort(function(a, b) {
+  return collection.sort((a, b) => {
     if (contains(a, b)) {
       return 1;
     }
@@ -26,14 +26,14 @@ function isNodeInContext(node, context) {
   const include =
     context.include &&
     getDeepest(
-      context.include.filter(function(candidate) {
+      context.include.filter(candidate => {
         return contains(candidate, node);
       })
     );
   const exclude =
     context.exclude &&
     getDeepest(
-      context.exclude.filter(function(candidate) {
+      context.exclude.filter(candidate => {
         return contains(candidate, node);
       })
     );

--- a/lib/core/utils/matches.js
+++ b/lib/core/utils/matches.js
@@ -52,11 +52,11 @@ function matchExpression(vNode, expression) {
   );
 }
 
-var escapeRegExp = (function() {
+var escapeRegExp = (() => {
   /*! Credit: XRegExp 0.6.1 (c) 2007-2008 Steven Levithan <http://stevenlevithan.com/regex/xregexp/> MIT License */
   var from = /(?=[\-\[\]{}()*+?.\\\^$|,#\s])/g;
   var to = '\\';
-  return function(string) {
+  return string => {
     return string.replace(from, to);
   };
 })();
@@ -88,34 +88,34 @@ function convertAttributes(atts) {
         regexp = new RegExp('^' + escapeRegExp(attributeValue) + '(-|$)');
         break;
       case '=':
-        test = function(value) {
+        test = value => {
           return attributeValue === value;
         };
         break;
       case '*=':
-        test = function(value) {
+        test = value => {
           return value && value.includes(attributeValue);
         };
         break;
       case '!=':
-        test = function(value) {
+        test = value => {
           return attributeValue !== value;
         };
         break;
       default:
-        test = function(value) {
+        test = value => {
           return !!value;
         };
     }
 
     if (attributeValue === '' && /^[*$^]=$/.test(att.operator)) {
-      test = function() {
+      test = () => {
         return false;
       };
     }
 
     if (!test) {
-      test = function(value) {
+      test = value => {
         return value && regexp.test(value);
       };
     }
@@ -215,8 +215,8 @@ export function convertSelector(selector) {
  * @returns {Boolean}
  */
 export function matchesExpression(vNode, expressions, matchAnyParent) {
-  let exps = [].concat(expressions);
-  let expression = exps.pop();
+  const exps = [].concat(expressions);
+  const expression = exps.pop();
   let matches = matchExpression(vNode, expression);
 
   while (!matches && matchAnyParent && vNode.parent) {
@@ -250,7 +250,7 @@ export function matchesExpression(vNode, expressions, matchAnyParent) {
  * @return {Boolean}
  */
 function matches(vNode, selector) {
-  let expressions = convertSelector(selector);
+  const expressions = convertSelector(selector);
   return expressions.some(expression => matchesExpression(vNode, expression));
 }
 

--- a/lib/core/utils/performance-timer.js
+++ b/lib/core/utils/performance-timer.js
@@ -7,7 +7,7 @@ import log from '../log';
  * http://caniuse.com/#search=User%20Timing
  *
  */
-const performanceTimer = (function() {
+const performanceTimer = (() => {
   /**
    * Get a time/date object using performance.now() if supported
    * @return {DOMTimeStamp}
@@ -27,13 +27,13 @@ const performanceTimer = (function() {
     /**
      * @member {Function} start Kicks off performance timing for overall axe audit
      */
-    start: function() {
+    start() {
       this.mark('mark_axe_start');
     },
     /**
      * @member {Function} end Concludes performance timing, compares start/end marks
      */
-    end: function() {
+    end() {
       this.mark('mark_axe_end');
       this.measure('axe', 'mark_axe_start', 'mark_axe_end');
 
@@ -42,13 +42,13 @@ const performanceTimer = (function() {
     /**
      * @member {Function} auditStart Starts an audit for a page or frame
      */
-    auditStart: function() {
+    auditStart() {
       this.mark('mark_audit_start');
     },
     /**
      * @member {Function} auditEnd Ends an audit for a page or frame, logs measurement of start/end marks
      */
-    auditEnd: function() {
+    auditEnd() {
       this.mark('mark_audit_end');
       this.measure('audit_start_to_end', 'mark_audit_start', 'mark_audit_end');
       // log audit/rule measures
@@ -60,7 +60,7 @@ const performanceTimer = (function() {
      * A mark that already exists will be overwritten.
      *
      */
-    mark: function(markName) {
+    mark(markName) {
       if (window.performance && window.performance.mark !== undefined) {
         window.performance.mark(markName);
       }
@@ -72,7 +72,7 @@ const performanceTimer = (function() {
      * @param {String} startMark String name of mark to start measuring
      * @param {String} endMark String name of mark to end measuring
      */
-    measure: function(measureName, startMark, endMark) {
+    measure(measureName, startMark, endMark) {
       if (window.performance && window.performance.measure !== undefined) {
         window.performance.measure(measureName, startMark, endMark);
       }
@@ -80,7 +80,7 @@ const performanceTimer = (function() {
     /**
      * @member {Function} logMeasures Iterates through measures and logs any that exist
      */
-    logMeasures: function(measureName) {
+    logMeasures(measureName) {
       function logMeasure(req) {
         log('Measure ' + req.name + ' took ' + req.duration + 'ms');
       }
@@ -108,13 +108,13 @@ const performanceTimer = (function() {
      * @member {Function} timeElapsed Records time since last audit
      * @return {DOMTimeStamp}
      */
-    timeElapsed: function() {
+    timeElapsed() {
       return now() - lastRecordedTime;
     },
     /**
      * @member {Function} reset Resets the time for a new audit
      */
-    reset: function() {
+    reset() {
       if (!originalTime) {
         originalTime = now();
       }

--- a/lib/core/utils/preload-cssom.js
+++ b/lib/core/utils/preload-cssom.js
@@ -49,7 +49,7 @@ export default preloadCssom;
  * @returns {Array<Object>} array of objects, which each object containing a root and an optional `shadowId`
  */
 function getAllRootNodesInTree(tree) {
-  let ids = [];
+  const ids = [];
 
   const rootNodes = querySelectorAllFilter(tree, '*', node => {
     if (ids.includes(node.shadowId)) {
@@ -233,7 +233,7 @@ function filterMediaIsPrint(media) {
  * @returns {Array<Object>}
  */
 function filterStylesheetsWithSameHref(sheets) {
-  let hrefs = [];
+  const hrefs = [];
   return sheets.filter(sheet => {
     if (!sheet.href) {
       // include sheets without `href`

--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -50,7 +50,7 @@ function getIncompleteReason(checkData, messages) {
  * @private
  */
 function extender(checksData, shouldBeTrue) {
-  return function(check) {
+  return check => {
     var sourceData = checksData[check.id] || {};
     var messages = sourceData.messages || {};
     var data = Object.assign({}, sourceData);
@@ -97,7 +97,7 @@ function publishMetaData(ruleResult) {
 
   var shouldBeTrue = extender(checksData, true);
   var shouldBeFalse = extender(checksData, false);
-  ruleResult.nodes.forEach(function(detail) {
+  ruleResult.nodes.forEach(detail => {
     detail.any.forEach(shouldBeTrue);
     detail.all.forEach(shouldBeTrue);
     detail.none.forEach(shouldBeFalse);

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -1,7 +1,7 @@
 import { matchesExpression, convertSelector } from './matches';
 
 function createLocalVariables(vNodes, anyLevel, thisLevel, parentShadowId) {
-  let retVal = {
+  const retVal = {
     vNodes: vNodes.slice(),
     anyLevel: anyLevel,
     thisLevel: thisLevel,
@@ -12,25 +12,27 @@ function createLocalVariables(vNodes, anyLevel, thisLevel, parentShadowId) {
 }
 
 function matchExpressions(domTree, expressions, filter) {
-  let stack = [];
-  let vNodes = Array.isArray(domTree) ? domTree : [domTree];
+  const stack = [];
+  const vNodes = Array.isArray(domTree) ? domTree : [domTree];
   let currentLevel = createLocalVariables(
     vNodes,
     expressions,
     [],
     domTree[0].shadowId
   );
-  let result = [];
+  const result = [];
 
   while (currentLevel.vNodes.length) {
-    let vNode = currentLevel.vNodes.pop();
-    let childOnly = []; // we will add hierarchical '>' selectors here
-    let childAny = [];
-    let combined = currentLevel.anyLevel.slice().concat(currentLevel.thisLevel);
+    const vNode = currentLevel.vNodes.pop();
+    const childOnly = []; // we will add hierarchical '>' selectors here
+    const childAny = [];
+    const combined = currentLevel.anyLevel
+      .slice()
+      .concat(currentLevel.thisLevel);
     let added = false;
     // see if node matches
     for (let i = 0; i < combined.length; i++) {
-      let exp = combined[i];
+      const exp = combined[i];
       if (
         (!exp[0].id || vNode.shadowId === currentLevel.parentShadowId) &&
         matchesExpression(vNode, exp[0])
@@ -41,7 +43,7 @@ function matchExpressions(domTree, expressions, filter) {
             added = true;
           }
         } else {
-          let rest = exp.slice(1);
+          const rest = exp.slice(1);
           if ([' ', '>'].includes(rest[0].combinator) === false) {
             throw new Error(
               'axe.utils.querySelectorAll does not support the combinator: ' +

--- a/lib/core/utils/queue.js
+++ b/lib/core/utils/queue.js
@@ -21,9 +21,9 @@ function queue() {
 
   // By default, wait until the next tick,
   // if no catch was set, throw to console.
-  var defaultFail = function(e) {
+  var defaultFail = e => {
     err = e;
-    setTimeout(function() {
+    setTimeout(() => {
       if (err !== undefined && err !== null) {
         log('Uncaught error (of queue)', err);
       }
@@ -32,7 +32,7 @@ function queue() {
   var failed = defaultFail;
 
   function createResolve(i) {
-    return function(r) {
+    return r => {
       tasks[i] = r;
       remaining -= 1;
       if (!remaining && completeQueue !== noop) {
@@ -72,10 +72,10 @@ function queue() {
      * First parameter should be the function to execute with subsequent
      * parameters being passed as arguments to that function
      */
-    defer: function(fn) {
+    defer(fn) {
       if (typeof fn === 'object' && fn.then && fn.catch) {
         var defer = fn;
-        fn = function(resolve, reject) {
+        fn = (resolve, reject) => {
           defer.then(resolve).catch(reject);
         };
       }
@@ -97,7 +97,7 @@ function queue() {
      * @param  {Function} f The callback, receives an array of the return/callbacked
      * values of each of the "deferred" functions
      */
-    then: function(fn) {
+    then(fn) {
       funcGuard(fn);
       if (completeQueue !== noop) {
         throw new Error('queue `then` already set');

--- a/lib/core/utils/respondable.js
+++ b/lib/core/utils/respondable.js
@@ -146,7 +146,7 @@ respondable.isInFrame = function isInFrame(win) {
  * @return {Function}      A function that may be invoked to respond to the message
  */
 function createResponder(source, topic, uuid) {
-  return function(message, keepalive, callback) {
+  return (message, keepalive, callback) => {
     post(source, topic, message, uuid, keepalive, callback);
   };
 }
@@ -219,7 +219,7 @@ function parseMessage(dataString) {
 if (typeof window.addEventListener === 'function') {
   window.addEventListener(
     'message',
-    function(e) {
+    e => {
       var data = parseMessage(e.data);
       if (!data || !data._axeuuid) {
         return;

--- a/lib/core/utils/rule-should-run.js
+++ b/lib/core/utils/rule-should-run.js
@@ -21,7 +21,7 @@ function matchTags(rule, runOnly) {
     exclude = Array.isArray(exclude) ? exclude : [exclude];
     // add defaults, unless mentioned in include
     exclude = exclude.concat(
-      defaultExclude.filter(function(tag) {
+      defaultExclude.filter(tag => {
         return include.indexOf(tag) === -1;
       })
     );
@@ -30,16 +30,16 @@ function matchTags(rule, runOnly) {
   } else {
     include = Array.isArray(runOnly) ? runOnly : [runOnly];
     // exclude the defaults not included
-    exclude = defaultExclude.filter(function(tag) {
+    exclude = defaultExclude.filter(tag => {
       return include.indexOf(tag) === -1;
     });
   }
 
-  matching = include.some(function(tag) {
+  matching = include.some(tag => {
     return rule.tags.indexOf(tag) !== -1;
   });
   if (matching || (include.length === 0 && rule.enabled !== false)) {
-    return exclude.every(function(tag) {
+    return exclude.every(tag => {
       return rule.tags.indexOf(tag) === -1;
     });
   } else {

--- a/lib/core/utils/select.js
+++ b/lib/core/utils/select.js
@@ -62,8 +62,8 @@ function select(selector, context) {
       }
     }
   }
-  const curried = (function(context) {
-    return function(node) {
+  const curried = (context => {
+    return node => {
       return isNodeInContext(node, context);
     };
   })(context);

--- a/lib/core/utils/send-command-to-frame.js
+++ b/lib/core/utils/send-command-to-frame.js
@@ -26,10 +26,10 @@ function sendCommandToFrame(node, parameters, resolve, reject) {
   }
 
   // give the frame .5s to respond to 'axe.ping', else log failed response
-  var timeout = setTimeout(function() {
+  var timeout = setTimeout(() => {
     // This double timeout is important for allowing iframes to respond
     // DO NOT REMOVE
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       if (!parameters.debug) {
         resolve(null);
       } else {
@@ -39,7 +39,7 @@ function sendCommandToFrame(node, parameters, resolve, reject) {
   }, 500);
 
   // send 'axe.ping' to the frame
-  respondable(win, 'axe.ping', null, undefined, function() {
+  respondable(win, 'axe.ping', null, undefined, () => {
     clearTimeout(timeout);
 
     // Give axe 60s (or user-supplied value) to respond to 'axe.start'
@@ -51,7 +51,7 @@ function sendCommandToFrame(node, parameters, resolve, reject) {
     }, frameWaitTime);
 
     // send 'axe.start' and send the callback if it responded
-    respondable(win, 'axe.start', parameters, undefined, function(data) {
+    respondable(win, 'axe.start', parameters, undefined, data => {
       clearTimeout(timeout);
       if (data instanceof Error === false) {
         resolve(data);

--- a/lib/core/utils/uuid.js
+++ b/lib/core/utils/uuid.js
@@ -29,7 +29,7 @@ if (!_rng) {
   // If all else fails, use Math.random().	It's fast, but is of unspecified
   // quality.
   var _rnds = new Array(16);
-  _rng = function() {
+  _rng = () => {
     for (var i = 0, r; i < 16; i++) {
       if ((i & 0x03) === 0) r = Math.random() * 0x100000000;
       _rnds[i] = (r >>> ((i & 0x03) << 3)) & 0xff;
@@ -56,7 +56,7 @@ function parse(s, buf, offset) {
     ii = 0;
 
   buf = buf || [];
-  s.toLowerCase().replace(/[0-9a-f]{2}/g, function(oct) {
+  s.toLowerCase().replace(/[0-9a-f]{2}/g, oct => {
     if (ii < 16) {
       // Don't overflow!
       buf[i + ii++] = _hexToByte[oct];

--- a/lib/rules/aria-allowed-attr-matches.js
+++ b/lib/rules/aria-allowed-attr-matches.js
@@ -3,7 +3,7 @@ import { getNodeAttributes } from '../core/utils';
 function ariaAllowedAttrMatches(node) {
   const aria = /^aria-/;
   if (node.hasAttributes()) {
-    let attrs = getNodeAttributes(node);
+    const attrs = getNodeAttributes(node);
     for (let i = 0, l = attrs.length; i < l; i++) {
       if (aria.test(attrs[i].name)) {
         return true;

--- a/lib/rules/color-contrast-matches.js
+++ b/lib/rules/color-contrast-matches.js
@@ -63,8 +63,8 @@ function colorContrastMatches(node, virtualNode) {
   }
   const nodeParentLabel = findUpVirtual(virtualNode, 'label');
   if (nodeName === 'label' || nodeParentLabel) {
-    let labelNode = nodeParentLabel || node;
-    let labelVirtual = nodeParentLabel
+    const labelNode = nodeParentLabel || node;
+    const labelVirtual = nodeParentLabel
       ? getNodeFromTree(nodeParentLabel)
       : virtualNode;
 
@@ -126,7 +126,7 @@ function colorContrastMatches(node, virtualNode) {
   const range = document.createRange();
   const childNodes = virtualNode.children;
   for (let index = 0; index < childNodes.length; index++) {
-    let child = childNodes[index];
+    const child = childNodes[index];
     if (
       child.actualNode.nodeType === 3 &&
       sanitize(child.actualNode.nodeValue) !== ''


### PR DESCRIPTION
As @stephenmathieson suggested, instead of listing out explicitly using [named functions](https://github.com/dequelabs/axe-core/pull/2697#discussion_r545362150) and [const and let](https://github.com/dequelabs/axe-core/pull/2697#discussion_r545362480) in our contributor guide, we can just let ESLint do that for us. 

Also enabled `no-eval` since we want to ensure we can run in CSP. 