### PR TITLE
ci: run tests against nightly browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,10 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
+      # Install Chrome Canary
+      - run: wget https://dl.google.com/chrome/mac/canary/googlechromecanary.dmg
+        open ~/Downloads/googlechromecanary.dmg
+        sudo cp -r /Volumes/Google\ Chrome\ Canary/Google\ Chrome\ Canary.app /Applications/
       - run: npm run test -- --browsers ChromeCanary,FirefoxNightly
 
   # Test api docs can be built

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,10 +129,11 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
-      # Install Chrome Canary
-      - run: wget https://dl.google.com/chrome/mac/canary/googlechromecanary.dmg
-        open ~/Downloads/googlechromecanary.dmg
-        sudo cp -r /Volumes/Google\ Chrome\ Canary/Google\ Chrome\ Canary.app /Applications/
+      # install Chrome Canary
+      - run: |
+          wget https://dl.google.com/chrome/mac/canary/googlechromecanary.dmg
+          open ~/Downloads/googlechromecanary.dmg
+          sudo cp -r /Volumes/Google\ Chrome\ Canary/Google\ Chrome\ Canary.app /Applications/
       - run: npm run test -- --browsers ChromeCanary,FirefoxNightly
 
   # Test api docs can be built

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,9 +131,8 @@ jobs:
       - run: npm run build
       # install Chrome Canary
       - run: |
-          wget https://dl.google.com/chrome/mac/canary/googlechromecanary.dmg
-          open ~/Downloads/googlechromecanary.dmg
-          sudo cp -r /Volumes/Google\ Chrome\ Canary/Google\ Chrome\ Canary.app /Applications/
+          wget https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
+          sudo apt-install ./google-chrome-unstable_current_amd64.deb
       - run: npm run test -- --browsers ChromeCanary,FirefoxNightly
 
   # Test api docs can be built

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,8 +317,8 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          # run at 22:15 UTC every day
-          cron: "15 22 * * *"
+          # run at 00:00 UTC every day
+          cron: "0 0 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,9 +239,6 @@ workflows:
           requires:
             - dependencies_unix
             - lint
-      - test_nightly:
-          requires:
-            - dependencies_unix
       # Run IE/ Windows test on all commits
       - test_win:
           requires:
@@ -317,3 +314,17 @@ workflows:
       - github_release:
           requires:
             - release
+  nightly:
+    triggers:
+      - schedule:
+          # run at 22:15 UTC every day
+          cron: "15 22 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - dependencies_unix
+      - test_nightly:
+          requires:
+            - dependencies_unix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,16 @@ jobs:
       - run: npm run build
       - run: npm run test:locales
 
+  # Run the test suite for nightly builds.
+  test_nightly:
+    <<: *defaults
+    <<: *unix_box
+    steps:
+      - checkout
+      - <<: *restore_dependency_cache_unix
+      - run: npm run build
+      - run: npm run test -- --browsers ChromeCanary,FirefoxNightly
+
   # Test api docs can be built
   build_api_docs:
     <<: *defaults
@@ -225,6 +235,9 @@ workflows:
           requires:
             - dependencies_unix
             - lint
+      - test_nightly:
+          requires:
+            - dependencies_unix
       # Run IE/ Windows test on all commits
       - test_win:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
       # install Chrome Canary
       - run: |
           wget https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
-          sudo apt-install ./google-chrome-unstable_current_amd64.deb
+          sudo apt install ./google-chrome-unstable_current_amd64.deb
       - run: npm run test -- --browsers ChromeCanary,FirefoxNightly
 
   # Test api docs can be built


### PR DESCRIPTION
Testing to see if circle ci even has nightly browsers set up.

Closes issue: https://github.com/dequelabs/axe-core/issues/980
 