### PR TITLE
fix(color-contrast-matches): do not pass empty string to getElementById

### DIFF
--- a/lib/rules/color-contrast-matches.js
+++ b/lib/rules/color-contrast-matches.js
@@ -69,14 +69,17 @@ function colorContrastMatches(node, virtualNode) {
       : virtualNode;
 
     // explicit label of disabled control
-    const doc = getRootNode(labelNode);
-    const explicitControl = doc.getElementById(labelNode.htmlFor || '');
-    const explicitControlVirtual =
-      explicitControl && getNodeFromTree(explicitControl);
+    if (labelNode.htmlFor) {
+      const doc = getRootNode(labelNode);
+      const explicitControl = doc.getElementById(labelNode.htmlFor);
+      const explicitControlVirtual =
+        explicitControl && getNodeFromTree(explicitControl);
 
-    if (explicitControlVirtual && isDisabled(explicitControlVirtual)) {
-      return false;
+      if (explicitControlVirtual && isDisabled(explicitControlVirtual)) {
+        return false;
+      }
     }
+
     // implicit label of disabled control
     const query =
       'input:not([type="hidden"]):not([type="image"])' +


### PR DESCRIPTION
In Firefox, a warning is logged when passing an empty string to `document.getElementById`. This changes the color-contrast-matches code so we don't do that anymore for implicit `labels`.

![image](https://user-images.githubusercontent.com/2433219/103945964-3e740d00-50f3-11eb-941b-5baa99410a08.png)

Closes issue: #2729
