### PR TITLE
feat(virtual-node): add attrNames property which returns list of attribute names

### DIFF
--- a/lib/core/base/virtual-node/abstract-virtual-node.js
+++ b/lib/core/base/virtual-node/abstract-virtual-node.js
@@ -13,11 +13,15 @@ class AbstractVirtualNode {
   }
 
   attr() {
-    throw new Error('VirtualNode class must have a "attr" function');
+    throw new Error('VirtualNode class must have an "attr" function');
   }
 
   hasAttr() {
     throw new Error('VirtualNode class must have a "hasAttr" function');
+  }
+
+  attrNames() {
+    throw new Error('VirtualNode class must have an "attrNames" function');
   }
 
   hasClass(className) {

--- a/lib/core/base/virtual-node/abstract-virtual-node.js
+++ b/lib/core/base/virtual-node/abstract-virtual-node.js
@@ -12,16 +12,16 @@ class AbstractVirtualNode {
     );
   }
 
+  get attrNames() {
+    throw new Error('VirtualNode class must have an "attrNames" property');
+  }
+
   attr() {
     throw new Error('VirtualNode class must have an "attr" function');
   }
 
   hasAttr() {
     throw new Error('VirtualNode class must have a "hasAttr" function');
-  }
-
-  attrNames() {
-    throw new Error('VirtualNode class must have an "attrNames" function');
   }
 
   hasClass(className) {

--- a/lib/core/base/virtual-node/serial-virtual-node.js
+++ b/lib/core/base/virtual-node/serial-virtual-node.js
@@ -35,6 +35,10 @@ class SerialVirtualNode extends AbstractVirtualNode {
     return this._attrs[attrName] !== undefined;
   }
 
+  /**
+   * Return a list of attribute names for the element.
+   * @return {String[]}
+   */
   get attrNames() {
     return Object.keys(this._attrs);
   }

--- a/lib/core/base/virtual-node/serial-virtual-node.js
+++ b/lib/core/base/virtual-node/serial-virtual-node.js
@@ -34,6 +34,10 @@ class SerialVirtualNode extends AbstractVirtualNode {
   hasAttr(attrName) {
     return this._attrs[attrName] !== undefined;
   }
+
+  get attrNames() {
+    return Object.keys(this._attrs);
+  }
 }
 
 /**

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -96,7 +96,7 @@ class VirtualNode extends AbstractVirtualNode {
   }
 
   /**
-   * Return a list of attributes names for the element.
+   * Return a list of attribute names for the element.
    * @return {String[]}
    */
   get attrNames() {

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -96,6 +96,32 @@ class VirtualNode extends AbstractVirtualNode {
   }
 
   /**
+   * Return a list of attributes names for the element.
+   * @return {String[]}
+   */
+  get attrNames() {
+    if (!this._cache.hasOwnProperty('attrNames')) {
+      let attrs;
+
+      // eslint-disable-next-line no-restricted-syntax
+      if (this.actualNode.attributes instanceof window.NamedNodeMap) {
+        // eslint-disable-next-line no-restricted-syntax
+        attrs = this.actualNode.attributes;
+      }
+      // if the attributes property is not of type NamedNodeMap
+      // then the DOM has been clobbered. E.g. <form><input name="attributes"></form>.
+      // We can clone the node to isolate it and then return
+      // the attributes
+      else {
+        attrs = this.actualNode.cloneNode(false).attributes;
+      }
+
+      this._cache.attrNames = Array.from(attrs).map(attr => attr.name);
+    }
+    return this._cache.attrNames;
+  }
+
+  /**
    * Return a property of the computed style for this element and cache the result. This is much faster than called `getPropteryValue` every time.
    * @see https://jsperf.com/get-property-value
    * @return {String}

--- a/lib/core/utils/get-node-attributes.js
+++ b/lib/core/utils/get-node-attributes.js
@@ -3,6 +3,7 @@
  * @method getNodeAttributes
  * @memberof axe.utils
  * @param {Element} node
+ * @deprecated
  * @returns {NamedNodeMap}
  */
 function getNodeAttributes(node) {

--- a/test/core/base/virtual-node/abstract-virtual-node.js
+++ b/test/core/base/virtual-node/abstract-virtual-node.js
@@ -14,6 +14,17 @@ describe('AbstractVirtualNode', function() {
     assert.throws(fn);
   });
 
+  it('should throw an error when accessing attrNames', function() {
+    function fn() {
+      var abstractNode = new axe.AbstractVirtualNode();
+      if (abstractNode.attrNames.length) {
+        return;
+      }
+    }
+
+    assert.throws(fn);
+  });
+
   it('should throw an error when accessing hasClass', function() {
     function fn() {
       var abstractNode = new axe.AbstractVirtualNode();
@@ -29,17 +40,6 @@ describe('AbstractVirtualNode', function() {
     function fn() {
       var abstractNode = new axe.AbstractVirtualNode();
       if (abstractNode.attr('foo') === 'bar') {
-        return;
-      }
-    }
-
-    assert.throws(fn);
-  });
-
-  it('should throw an error when accessing attrNames', function() {
-    function fn() {
-      var abstractNode = new axe.AbstractVirtualNode();
-      if (abstractNode.attrNames()) {
         return;
       }
     }

--- a/test/core/base/virtual-node/abstract-virtual-node.js
+++ b/test/core/base/virtual-node/abstract-virtual-node.js
@@ -36,6 +36,17 @@ describe('AbstractVirtualNode', function() {
     assert.throws(fn);
   });
 
+  it('should throw an error when accessing attrNames', function() {
+    function fn() {
+      var abstractNode = new axe.AbstractVirtualNode();
+      if (abstractNode.attrNames()) {
+        return;
+      }
+    }
+
+    assert.throws(fn);
+  });
+
   it('should throw an error when accessing hasAttr', function() {
     function fn() {
       var abstractNode = new axe.AbstractVirtualNode();

--- a/test/core/base/virtual-node/abstract-virtual-node.js
+++ b/test/core/base/virtual-node/abstract-virtual-node.js
@@ -17,12 +17,10 @@ describe('AbstractVirtualNode', function() {
   it('should throw an error when accessing attrNames', function() {
     function fn() {
       var abstractNode = new axe.AbstractVirtualNode();
-      if (abstractNode.attrNames.length) {
-        return;
-      }
+      return abstractNode.attrNames;
     }
 
-    assert.throws(fn);
+    assert.throws(fn, 'VirtualNode class must have an "attrNames" property');
   });
 
   it('should throw an error when accessing hasClass', function() {

--- a/test/core/base/virtual-node/serial-virtual-node.js
+++ b/test/core/base/virtual-node/serial-virtual-node.js
@@ -274,4 +274,22 @@ describe('SerialVirtualNode', function() {
       assert.isTrue(nodeWithClass.hasAttr('class'));
     });
   });
+
+  describe('attrNames', function() {
+    it('should return a list of attribute names', function() {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: { foo: 'bar' }
+      });
+
+      assert.deepEqual(vNode.attrNames, ['foo']);
+    });
+
+    it('should return an empty array if there are no attributes', function() {
+      var vNode = new SerialVirtualNode({
+        nodeName: 'div'
+      });
+      assert.deepEqual(vNode.attrNames, []);
+    });
+  });
 });

--- a/test/core/base/virtual-node/virtual-node.js
+++ b/test/core/base/virtual-node/virtual-node.js
@@ -129,6 +129,29 @@ describe('VirtualNode', function() {
       });
     });
 
+    describe('attrNames', function() {
+      it('should return a list of attribute names', function() {
+        node.setAttribute('foo', 'bar');
+        var vNode = new VirtualNode(node);
+
+        assert.deepEqual(vNode.attrNames, ['foo']);
+      });
+
+      it('should work with clobbered attributes', function() {
+        var node = document.createElement('form');
+        node.setAttribute('id', '123');
+        node.innerHTML = '<select name="attributes"></select>';
+        var vNode = new VirtualNode(node);
+
+        assert.deepEqual(vNode.attrNames, ['id']);
+      });
+
+      it('should return an empty array if there are no attributes', function() {
+        var vNode = new VirtualNode(node);
+        assert.deepEqual(vNode.attrNames, []);
+      });
+    });
+
     describe.skip('isFocusable', function() {
       var commons;
 


### PR DESCRIPTION
The `getNodeAttributes` function does not support virtual nodes. Deprecating `getNodeAttributes` in favor of a property on the virtual node that returns an array of attribute names. From the list of names we can call `vNode.attr(name)` to get the value.

Part of issue #2734
