### PR TITLE
feat(utils/matches): support selectors level 4 :not and :is

### DIFF
--- a/lib/checks/keyboard/page-has-heading-one.json
+++ b/lib/checks/keyboard/page-has-heading-one.json
@@ -3,7 +3,7 @@
   "evaluate": "has-descendant-evaluate",
   "after": "has-descendant-after",
   "options": {
-    "selector": "h1:not([role]):not([aria-level]), h1:not([role])[aria-level=1], h2:not([role])[aria-level=1], h3:not([role])[aria-level=1], h4:not([role])[aria-level=1], h5:not([role])[aria-level=1], h6:not([role])[aria-level=1], [role=heading][aria-level=1]"
+    "selector": "h1:not([role], [aria-level]), :is(h1, h2, h3, h4, h5, h6):not([role])[aria-level=1]), [role=heading][aria-level=1]"
   },
   "metadata": {
     "impact": "moderate",

--- a/lib/checks/keyboard/page-has-heading-one.json
+++ b/lib/checks/keyboard/page-has-heading-one.json
@@ -3,7 +3,7 @@
   "evaluate": "has-descendant-evaluate",
   "after": "has-descendant-after",
   "options": {
-    "selector": "h1:not([role], [aria-level]), :is(h1, h2, h3, h4, h5, h6):not([role])[aria-level=1]), [role=heading][aria-level=1]"
+    "selector": "h1:not([role], [aria-level]), :is(h1, h2, h3, h4, h5, h6):not([role])[aria-level=1], [role=heading][aria-level=1]"
   },
   "metadata": {
     "impact": "moderate",

--- a/lib/checks/navigation/header-present.json
+++ b/lib/checks/navigation/header-present.json
@@ -3,7 +3,7 @@
   "evaluate": "has-descendant-evaluate",
   "after": "has-descendant-after",
   "options": {
-    "selector": "h1:not([role]), h2:not([role]), h3:not([role]), h4:not([role]), h5:not([role]), h6:not([role]), [role=heading]"
+    "selector": ":is(h1, h2, h3, h4, h5, h6):not([role]), [role=heading]"
   },
   "metadata": {
     "impact": "serious",

--- a/lib/core/utils/css-parser.js
+++ b/lib/core/utils/css-parser.js
@@ -2,6 +2,7 @@ import { CssSelectorParser } from 'css-selector-parser';
 
 const parser = new CssSelectorParser();
 parser.registerSelectorPseudos('not');
+parser.registerSelectorPseudos('is');
 parser.registerNestingOperators('>');
 parser.registerAttrEqualityMods('^', '$', '*', '~');
 

--- a/lib/core/utils/matches.js
+++ b/lib/core/utils/matches.js
@@ -30,7 +30,13 @@ function matchesPseudos(target, exp) {
     !exp.pseudos ||
     exp.pseudos.every(pseudo => {
       if (pseudo.name === 'not') {
-        return !matchesExpression(target, pseudo.expressions[0]);
+        return !pseudo.expressions.some(expression => {
+          return matchesExpression(target, expression);
+        });
+      } else if (pseudo.name === 'is') {
+        return pseudo.expressions.some(expression => {
+          return matchesExpression(target, expression);
+        });
       }
       throw new Error(
         'the pseudo selector ' + pseudo.name + ' has not yet been implemented'
@@ -148,7 +154,7 @@ function convertPseudos(pseudos) {
   return pseudos.map(p => {
     var expressions;
 
-    if (p.name === 'not') {
+    if (['is', 'not'].includes(p.name)) {
       expressions = p.value;
       expressions = expressions.selectors
         ? expressions.selectors

--- a/lib/rules/color-contrast-matches.js
+++ b/lib/rules/color-contrast-matches.js
@@ -79,8 +79,13 @@ function colorContrastMatches(node, virtualNode) {
     }
     // implicit label of disabled control
     const query =
-      'input:not([type="hidden"]):not([type="image"])' +
-      ':not([type="button"]):not([type="submit"]):not([type="reset"]), select, textarea';
+      'input:not(' +
+      '[type="hidden"],' +
+      '[type="image"],' +
+      '[type="button"],' +
+      '[type="submit"],' +
+      '[type="reset"]' +
+      '), select, textarea';
     const implicitControl = querySelectorAll(labelVirtual, query)[0];
 
     if (implicitControl && isDisabled(implicitControl)) {

--- a/lib/rules/role-img-alt.json
+++ b/lib/rules/role-img-alt.json
@@ -1,6 +1,6 @@
 {
   "id": "role-img-alt",
-  "selector": "[role='img']:not(img):not(area):not(input):not(object)",
+  "selector": "[role='img']:not(img, area, input, object)",
   "matches": "html-namespace-matches",
   "tags": [
     "cat.text-alternatives",

--- a/test/core/utils/matches.js
+++ b/test/core/utils/matches.js
@@ -214,6 +214,13 @@ describe('utils.matches', function() {
         var virtualNode = queryFixture('<h1 id="target">foo</h1>');
         assert.isFalse(matches(virtualNode, 'h1:is([class])'));
       });
+
+      it('returns false if :is matches none of the selectors', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isFalse(
+          matches(virtualNode, 'h1:is([class], span, #foo, .bar)')
+        );
+      });
     });
   });
 

--- a/test/core/utils/matches.js
+++ b/test/core/utils/matches.js
@@ -175,7 +175,7 @@ describe('utils.matches', function() {
 
       it('returns false if :not matches one of the selectors', function() {
         var virtualNode = queryFixture('<h1 id="target">foo</h1>');
-        assert.isFalse(matches(virtualNode, 'h1:not([role=heading], h1)'));
+        assert.isFalse(matches(virtualNode, 'h1:not([role=heading], [id])'));
       });
     });
 

--- a/test/core/utils/matches.js
+++ b/test/core/utils/matches.js
@@ -132,31 +132,6 @@ describe('utils.matches', function() {
   });
 
   describe('pseudos', function() {
-    it('returns true if :not matches using tag', function() {
-      var virtualNode = queryFixture('<h1 id="target">foo</h1>');
-      assert.isTrue(matches(virtualNode, 'h1:not(span)'));
-    });
-
-    it('returns true if :not matches using class', function() {
-      var virtualNode = queryFixture('<h1 id="target">foo</h1>');
-      assert.isTrue(matches(virtualNode, 'h1:not(.foo)'));
-    });
-
-    it('returns true if :not matches using attribute', function() {
-      var virtualNode = queryFixture('<h1 id="target">foo</h1>');
-      assert.isTrue(matches(virtualNode, 'h1:not([class])'));
-    });
-
-    it('returns true if :not matches using id', function() {
-      var virtualNode = queryFixture('<h1 id="target">foo</h1>');
-      assert.isTrue(matches(virtualNode, 'h1:not(#foo)'));
-    });
-
-    it('returns false if :not matches element', function() {
-      var virtualNode = queryFixture('<h1 id="target">foo</h1>');
-      assert.isFalse(matches(virtualNode, 'h1:not([id])'));
-    });
-
     it('throws error if pseudo is not implemented', function() {
       var virtualNode = queryFixture('<h1 id="target">foo</h1>');
       assert.throws(function() {
@@ -164,6 +139,80 @@ describe('utils.matches', function() {
       });
       assert.throws(function() {
         matches(virtualNode, 'h1::before');
+      });
+    });
+
+    describe(':not', function() {
+      it('returns true if :not matches using tag', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:not(span)'));
+      });
+
+      it('returns true if :not matches using class', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:not(.foo)'));
+      });
+
+      it('returns true if :not matches using attribute', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:not([class])'));
+      });
+
+      it('returns true if :not matches using id', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:not(#foo)'));
+      });
+
+      it('returns true if :not matches none of the selectors', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:not([role=heading], span)'));
+      });
+
+      it('returns false if :not matches element', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isFalse(matches(virtualNode, 'h1:not([id])'));
+      });
+
+      it('returns false if :not matches one of the selectors', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isFalse(matches(virtualNode, 'h1:not([role=heading], h1)'));
+      });
+    });
+
+    describe(':is', function() {
+      it('returns true if :is matches using tag', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, ':is(h1)'));
+      });
+
+      it('returns true if :is matches using class', function() {
+        var virtualNode = queryFixture('<h1 id="target" class="foo">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:is(.foo)'));
+      });
+
+      it('returns true if :is matches using attribute', function() {
+        var virtualNode = queryFixture('<h1 id="target" class="foo">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:is([class])'));
+      });
+
+      it('returns true if :is matches using id', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, 'h1:is(#target)'));
+      });
+
+      it('returns true if :is matches one of the selectors', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isTrue(matches(virtualNode, ':is([role=heading], h1)'));
+      });
+
+      it('returns true if :is matches complex selector', function() {
+        var virtualNode = queryFixture('<div><h1 id="target">foo</h1></div>');
+        assert.isTrue(matches(virtualNode, 'h1:is(div > #target)'));
+      });
+
+      it('returns false if :is does not match element', function() {
+        var virtualNode = queryFixture('<h1 id="target">foo</h1>');
+        assert.isFalse(matches(virtualNode, 'h1:is([class])'));
       });
     });
   });


### PR DESCRIPTION
Been wanting to do this for awhile now so decided to take some time to do it. We can now support the Selectors Level 4 [:is pseudo selector](https://drafts.csswg.org/selectors-4/#matches) (which allows us to simplify some heading selecting) and allows [:not to support more than one selector](https://drafts.csswg.org/selectors-4/#negation), which also helps us shorten and simplify selectors.

Since we use `utils/matches` for everything and we don't go through the DOM selector API, we don't have to worry about browser support since we match everything virtually.