### PR TITLE
docs: reorganise the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Axe is an accessibility testing engine for websites and other HTML-based user in
 
 ## The Accessibility Rules
 
-Axe-core has different types of rules, for WCAG 2.0 and 2.1 on level A and AA, as well as a number of best practices that help you identify common accessibility practices like ensuring every page has an `h1` heading, and to help you avoid "gotchas" in ARIA like where an ARIA attribute you used will get ignored.
+Axe-core has different types of rules, for WCAG 2.0 and 2.1 on level A and AA, as well as a number of best practices that help you identify common accessibility practices like ensuring every page has an `h1` heading, and to help you avoid "gotchas" in ARIA like where an ARIA attribute you used will get ignored. With axe-core, you can find **up to 50% of WCAG issues automatically**. 
 
 The complete list of rules, grouped WCAG level and best practice, can found in [doc/rule-descriptions.md](./doc/rule-descriptions.md).
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Axe is an accessibility testing engine for websites and other HTML-based user in
 
 ## The Accessibility Rules
 
-Axe-core has different types of rules, for WCAG 2.0 and 2.1 on level A and AA, as well as a number of best practices that help you identify common accessibility practices like ensuring every page has an `h1` heading, and to help you avoid "gotchas" in ARIA like where an ARIA attribute you used will get ignored. With axe-core, you can find **up to 50% of WCAG issues automatically**. 
+Axe-core has different types of rules, for WCAG 2.0 and 2.1 on level A and AA, as well as a number of best practices that help you identify common accessibility practices like ensuring every page has an `h1` heading, and to help you avoid "gotchas" in ARIA like where an ARIA attribute you used will get ignored.
+
+With axe-core, you can find **up to 50% of WCAG issues automatically**. Additionally, axe-core will return elements as "incomplete" where axe-core could not be certain, and manual review is needed. To further improve test coverage we recommend the [intelligent guided tests](https://www.youtube.com/watch?v=AtsX0dPCG_4&feature=youtu.be&ab_channel=DequeSystems) in the [axe Extension](https://www.deque.com/axe/browser-extensions/).
 
 The complete list of rules, grouped WCAG level and best practice, can found in [doc/rule-descriptions.md](./doc/rule-descriptions.md).
-
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -11,24 +11,12 @@ Axe is an accessibility testing engine for websites and other HTML-based user in
 
 [Sign up for axe news](https://hubs.ly/H0fsN0b0) to get the latest on axe features, future releases, and events.
 
-## Philosophy
+## The Accessibility Rules
 
-The web can only become an accessible, inclusive space if developers are empowered to take responsibility for accessibility testing and accessible coding practices.
+Axe-core has different types of rules, for WCAG 2.0 and 2.1 on level A and AA, as well as a number of best practices that help you identify common accessibility practices like ensuring every page has an `h1` heading, and to help you avoid "gotchas" in ARIA like where an ARIA attribute you used will get ignored.
 
-Automated accessibility testing is a huge timesaver, it doesn't require special expertise, and it allows teams to focus expert resources on the accessibility issues that really need them. Unfortunately, most accessibility tools are meant to be run on sites and applications that have reached the end of the development process and often don't give clear or consistent results, causing frustration and delays just when you thought your product was ready to ship.
+The complete list of rules, grouped WCAG level and best practice, can found in [doc/rule-descriptions.md](./doc/rule-descriptions.md).
 
-Axe was built to reflect how web development actually works. It works with all modern browsers, tools, and testing environments a dev team might use. With axe, accessibility testing can be performed as part of your unit testing, integration testing, browser testing, and any other functional testing your team already performs on a day-to-day basis. Building accessibility testing into the early development process saves time, resources, and all kinds of frustration.
-
-## About axe - our Manifesto
-
-- Axe is open source.
-- It returns zero false positives (bugs notwithstanding).
-- It's designed to work on all modern browsers and with whatever tools, frameworks, libraries and environments you use today.
-- It's actively supported by [Deque Systems](https://www.deque.com), a major accessibility vendor.
-- It integrates with your existing functional/acceptance automated tests.
-- It automatically determines which rules to run based on the evaluation context.
-- Axe supports in-memory fixtures, static fixtures, integration tests and iframes of infinite depth.
-- Axe is highly configurable.
 
 ## Getting started
 
@@ -59,6 +47,25 @@ axe
   });
 ```
 
+## Philosophy
+
+The web can only become an accessible, inclusive space if developers are empowered to take responsibility for accessibility testing and accessible coding practices.
+
+Automated accessibility testing is a huge timesaver, it doesn't require special expertise, and it allows teams to focus expert resources on the accessibility issues that really need them. Unfortunately, most accessibility tools are meant to be run on sites and applications that have reached the end of the development process and often don't give clear or consistent results, causing frustration and delays just when you thought your product was ready to ship.
+
+Axe was built to reflect how web development actually works. It works with all modern browsers, tools, and testing environments a dev team might use. With axe, accessibility testing can be performed as part of your unit testing, integration testing, browser testing, and any other functional testing your team already performs on a day-to-day basis. Building accessibility testing into the early development process saves time, resources, and all kinds of frustration.
+
+## About axe - our Manifesto
+
+- Axe is open source.
+- It returns zero false positives (bugs notwithstanding).
+- It's designed to work on all modern browsers and with whatever tools, frameworks, libraries and environments you use today.
+- It's actively supported by [Deque Systems](https://www.deque.com), a major accessibility vendor.
+- It integrates with your existing functional/acceptance automated tests.
+- It automatically determines which rules to run based on the evaluation context.
+- Axe supports in-memory fixtures, static fixtures, integration tests and iframes of infinite depth.
+- Axe is highly configurable.
+
 ## Supported Browsers
 
 The [axe-core API](doc/API.md) fully supports the following browsers:
@@ -74,10 +81,6 @@ Support means that we will fix bugs and attempt to test each browser regularly. 
 There is limited support for JSDOM. We will attempt to make all rules compatible with JSDOM but where this is not possible, we recommend turning those rules off. Currently the `color-contrast` rule is known not to work with JSDOM.
 
 We can only support environments where features are either natively supported or polyfilled correctly. We do not support the deprecated v0 Shadow DOM implementation.
-
-## The Accessibility Rules
-
-The complete list of rules run by axe-core can be found in [doc/rule-descriptions.md](./doc/rule-descriptions.md).
 
 ## Contents of the API Package
 


### PR DESCRIPTION
One of the most common questions people have is what rules axe-core has, and how they map to WCAG. I hope that by being more explicit in the readme, and putting this section higher up we can limit how often this question is asked.