### PR TITLE
tests: add virtual-rules test for tabindex

### DIFF
--- a/test/integration/virtual-rules/tabindex.js
+++ b/test/integration/virtual-rules/tabindex.js
@@ -1,0 +1,46 @@
+describe('tabindex virtual-rule', function() {
+  it('should pass for tabindex = 0', function() {
+    var node = {
+      nodeName: 'div',
+      attributes: {
+        tabindex: 0
+      }
+    };
+
+    var results = axe.runVirtualRule('tabindex', node);
+
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should pass for tabindex = -1', function() {
+    var node = {
+      nodeName: 'div',
+      attributes: {
+        tabindex: -1
+      }
+    };
+
+    var results = axe.runVirtualRule('tabindex', node);
+
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should fail for tabindex > 0', function() {
+    var node = {
+      nodeName: 'div',
+      attributes: {
+        tabindex: 1
+      }
+    };
+
+    var results = axe.runVirtualRule('tabindex', node);
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+});


### PR DESCRIPTION
Tabindex rule can already run virtual, just adding tests.

Part of issue: #2734
