### PR TITLE
docs: consistent dot notation in rule-development docs

### DIFF
--- a/doc/rule-development.md
+++ b/doc/rule-development.md
@@ -43,7 +43,7 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | evaluate                     | Evaluating function, returning a boolean value |
 | options                      | Configurable value for the check               |
 | after                        | Cleanup function, run after check is done      |
-| metadata impact              | "minor", "serious", "critical"                 |
+| metadata.impact              | "minor", "serious", "critical"                 |
 | metadata.messages.pass       | Describes why the check passed                 |
 | metadata.messages.fail       | Describes why the check failed                 |
 | metadata.messages.incomplete | Describes why the check didn’t complete        |


### PR DESCRIPTION
I was just reading the docs for writing custom rules & noticed an inconsistency in the check properties table
