### PR TITLE
tests: teardown after every test

### DIFF
--- a/test/commons/text/subtree-text.js
+++ b/test/commons/text/subtree-text.js
@@ -1,8 +1,6 @@
 describe('text.subtreeText', function() {
   var fixtureSetup = axe.testUtils.fixtureSetup;
   var subtreeText = axe.commons.text.subtreeText;
-  var flatTreeSetup = axe.testUtils.flatTreeSetup;
-  var fixture = document.querySelector('#fixture');
 
   it('concatinated the accessible name for child elements', function() {
     fixtureSetup('<span>foo</span> <span>bar</span> <span>baz</span>');
@@ -37,12 +35,14 @@ describe('text.subtreeText', function() {
   });
 
   describe('context.processed', function() {
-    it('appends the element to context.processed to prevent duplication', function() {
+    beforeEach(function() {
       fixtureSetup('<h1>foo</h1>');
+    });
+
+    it('appends the element to context.processed to prevent duplication', function() {
       var h1 = axe.utils.querySelectorAll(axe._tree[0], 'h1')[0];
       var text = h1.children[0];
       var context = { processed: [] };
-      flatTreeSetup(fixture);
       subtreeText(h1, context);
       assert.deepEqual(context.processed, [h1, text]);
     });
@@ -51,14 +51,12 @@ describe('text.subtreeText', function() {
       var h1 = axe.utils.querySelectorAll(axe._tree[0], 'h1')[0];
       var text = h1.children[0];
       var emptyContext = {};
-      flatTreeSetup(fixture);
       subtreeText(h1, emptyContext);
       assert.deepEqual(emptyContext.processed, [h1, text]);
     });
 
     it('returns `` when the element is in the `processed` array', function() {
       var h1 = axe.utils.querySelectorAll(axe._tree[0], 'h1')[0];
-      flatTreeSetup(fixture);
       var context = {
         processed: [h1]
       };

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -1166,6 +1166,10 @@ describe('Audit', function() {
           throw new Error('Launch the super sheep!');
         }
       });
+
+      // check error node requires _selectorCache to be setup
+      axe.setup();
+
       a.run(
         { include: [axe.utils.getFlattenedTree(fixture)[0]] },
         {

--- a/test/core/utils/preload.js
+++ b/test/core/utils/preload.js
@@ -3,8 +3,8 @@ describe('axe.utils.preload', function() {
 
   var fixture = document.getElementById('fixture');
 
-  before(function() {
-    axe._tree = axe.utils.getFlattenedTree(fixture);
+  beforeEach(function() {
+    axe.setup(fixture);
   });
 
   it('returns `undefined` when `preload` option is set to false.', function(done) {
@@ -29,15 +29,17 @@ describe('axe.utils.preload', function() {
       }
     };
     var actual = axe.utils.preload(options);
-    actual.then(function(results) {
-      assert.isDefined(results);
-      assert.property(results, 'cssom');
+    actual
+      .then(function(results) {
+        assert.isDefined(results);
+        assert.property(results, 'cssom');
 
-      axe.utils.preloadCssom(options).then(function(resultFromPreloadCssom) {
-        assert.deepEqual(results.cssom, resultFromPreloadCssom);
-        done();
-      });
-    });
+        axe.utils.preloadCssom(options).then(function(resultFromPreloadCssom) {
+          assert.deepEqual(results.cssom, resultFromPreloadCssom);
+          done();
+        });
+      })
+      .catch(done);
   });
 
   describe('axe.utils.shouldPreload', function() {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -411,7 +411,7 @@ if (!fixture) {
 }
 
 afterEach(function() {
-  axe._cache.clear();
+  axe.teardown();
 
   // remove all attributes from fixture (otherwise a leftover
   // style attribute would cause avoid-inline-spacing integration


### PR DESCRIPTION
Use the new `axe.teardown` method after every test. I'm sure there's plenty of places in our test that we can replace `axe._tree` with the new setup function. Will open a separate PR for that.