### PR TITLE
tests: use new axe.setup method

### DIFF
--- a/lib/core/public/teardown.js
+++ b/lib/core/public/teardown.js
@@ -15,6 +15,7 @@ function teardown() {
   cache.clear();
   axe._tree = undefined;
   axe._selectorData = undefined;
+  axe._selectCache = undefined;
 }
 
 export default teardown;

--- a/test/commons/aria/arialabelledby-text.js
+++ b/test/commons/aria/arialabelledby-text.js
@@ -1,50 +1,48 @@
 describe('aria.arialabelledbyText', function() {
   'use strict';
   var aria = axe.commons.aria;
-  var fixtureSetup = axe.testUtils.fixtureSetup;
+  var queryFixture = axe.testUtils.queryFixture;
 
   it('returns the accessible name of the aria-labelledby references', function() {
-    var fixture = fixtureSetup(
-      '<div role="heading" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo">Foo text</div>'
     );
-    var accName = aria.arialabelledbyText(fixture.firstChild);
+    var accName = aria.arialabelledbyText(target);
     assert.equal(accName, 'Foo text');
   });
 
   it('works with virtual nodes', function() {
-    fixtureSetup(
-      '<div role="heading" id="hdr" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo">Foo text</div>'
     );
-    var target = axe.utils.querySelectorAll(axe._tree[0], '#hdr')[0];
     var accName = aria.arialabelledbyText(target);
     assert.equal(accName, 'Foo text');
   });
 
   it('returns references in order', function() {
-    var fixture = fixtureSetup(
-      '<div role="heading" aria-labelledby="bar baz foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="bar baz foo"></div>' +
         '<div id="foo">Foo</div>' +
         '<div id="bar">Bar</div>' +
         '<div id="baz">Baz</div>'
     );
-    var accName = aria.arialabelledbyText(fixture.firstChild);
+    var accName = aria.arialabelledbyText(target);
     assert.equal(accName, 'Bar Baz Foo');
   });
 
   it('returns "" if the node is not an element', function() {
-    var fixture = fixtureSetup('foo');
-    var accName = aria.arialabelledbyText(fixture.firstChild);
+    var target = queryFixture('<div id="target">foo</div>');
+    var accName = aria.arialabelledbyText(target.actualNode.firstChild);
     assert.equal(accName, '');
   });
 
   it('returns "" with context.inLabelledByContext: true', function() {
-    fixtureSetup(
-      '<div role="heading" id="hdr" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo">Foo text</div>'
     );
-    var target = axe.utils.querySelectorAll(axe._tree[0], '#hdr')[0];
     var accName = aria.arialabelledbyText(target, {
       inLabelledByContext: true
     });
@@ -52,11 +50,10 @@ describe('aria.arialabelledbyText', function() {
   });
 
   it('returns "" with context.inControlContext: true', function() {
-    fixtureSetup(
-      '<div role="heading" id="hdr" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo">Foo text</div>'
     );
-    var target = axe.utils.querySelectorAll(axe._tree[0], '#hdr')[0];
     var accName = aria.arialabelledbyText(target, {
       inControlContext: true
     });
@@ -64,42 +61,38 @@ describe('aria.arialabelledbyText', function() {
   });
 
   it('returns content of a aria-hidden reference', function() {
-    fixtureSetup(
-      '<div role="heading" id="hdr" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo" aria-hidden="true">Foo text</div>'
     );
-    var target = axe.utils.querySelectorAll(axe._tree[0], '#hdr')[0];
     var accName = aria.arialabelledbyText(target);
     assert.equal(accName, 'Foo text');
   });
 
   it('returns content of a `display:none` reference', function() {
-    fixtureSetup(
-      '<div role="heading" id="hdr" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo" style="display:none">Foo text</div>'
     );
-    var target = axe.utils.querySelectorAll(axe._tree[0], '#hdr')[0];
     var accName = aria.arialabelledbyText(target);
     assert.equal(accName, 'Foo text');
   });
 
   it('returns does not return hidden content of a visible reference', function() {
-    fixtureSetup(
-      '<div role="heading" id="hdr" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo"><div style="display:none">Foo text</div></div>'
     );
-    var target = axe.utils.querySelectorAll(axe._tree[0], '#hdr')[0];
     var accName = aria.arialabelledbyText(target);
     assert.equal(accName, '');
   });
 
   it('does not follow more than one aria-labelledy reference', function() {
-    fixtureSetup(
-      '<div role="heading" id="hdr" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo"><div aria-labelledby="bar" role="heading"></div></div>' +
         '<div id="bar">Foo text</div>'
     );
-    var target = axe.utils.querySelectorAll(axe._tree[0], '#hdr')[0];
     var accName = aria.arialabelledbyText(target, {
       inControlContext: true
     });
@@ -107,11 +100,11 @@ describe('aria.arialabelledbyText', function() {
   });
 
   it('preserves spacing', function() {
-    var fixture = fixtureSetup(
-      '<div role="heading" aria-labelledby="foo"></div>' +
+    var target = queryFixture(
+      '<div role="heading" id="target" aria-labelledby="foo"></div>' +
         '<div id="foo"> \t Foo \n text \t </div>'
     );
-    var accName = aria.arialabelledbyText(fixture.firstChild);
+    var accName = aria.arialabelledbyText(target);
     assert.equal(accName, ' \t Foo \n text \t ');
   });
 });

--- a/test/commons/dom/find-elms-in-context.js
+++ b/test/commons/dom/find-elms-in-context.js
@@ -5,12 +5,8 @@ describe('dom.findElmsInContext', function() {
   var fixtureSetup = axe.testUtils.fixtureSetup;
   var findElmsInContext = axe.commons.dom.findElmsInContext;
 
-  afterEach(function() {
-    fixtureSetup('');
-  });
-
   it('returns an array or elements in the same context', function() {
-    var fixture = fixtureSetup(
+    var rootNode = fixtureSetup(
       '<b name="foo">1</b>' +
         '<b name="foo">2</b>' +
         '<b name="bar">3</b>' +
@@ -22,7 +18,7 @@ describe('dom.findElmsInContext', function() {
         elm: 'b',
         attr: 'name',
         value: 'foo',
-        context: fixture
+        context: rootNode.actualNode
       }),
       Array.from(document.querySelectorAll('b[name=foo]'))
     );
@@ -35,13 +31,13 @@ describe('dom.findElmsInContext', function() {
       node.innerHTML = '<b name="foo">1</b>';
       var shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<b name="foo">2</b> <slot></slot>';
-      var fixture = fixtureSetup(node);
+      var rootNode = fixtureSetup(node);
 
       var result = findElmsInContext({
         elm: 'b',
         attr: 'name',
         value: 'foo',
-        context: fixture
+        context: rootNode.actualNode
       });
       assert.lengthOf(result, 1);
       assert.equal(result[0].innerText, '1');

--- a/test/commons/dom/get-tabbable-elements.js
+++ b/test/commons/dom/get-tabbable-elements.js
@@ -1,55 +1,44 @@
 describe('dom.getTabbableElements', function() {
   'use strict';
 
-  var fixtureSetup = axe.testUtils.fixtureSetup;
+  var queryFixture = axe.testUtils.queryFixture;
+  var injectIntoFixture = axe.testUtils.injectIntoFixture;
   var shadowSupported = axe.testUtils.shadowSupport.v1;
   var getTabbableElementsFn = axe.commons.dom.getTabbableElements;
 
-  afterEach(function() {
-    document.getElementById('fixture').innerHTML = '';
-  });
-
   it('returns tabbable elms when node contains tabbable element', function() {
-    var fixture = fixtureSetup(
+    var virtualNode = queryFixture(
       '<div id="target">' +
         '<label>Enter description:' +
         '<textarea></textarea>' +
         '</label>' +
         '</div>'
     );
-    var node = fixture.querySelector('#target');
-    var virtualNode = axe.utils.getNodeFromTree(node);
     var actual = getTabbableElementsFn(virtualNode);
     assert.lengthOf(actual, 1);
     assert.equal(actual[0].actualNode.nodeName.toUpperCase(), 'TEXTAREA');
   });
 
   it('returns empty [] when element does not contains tabbable element (using tabindex to take element out of tab-order)', function() {
-    var fixture = fixtureSetup(
+    var virtualNode = queryFixture(
       '<div id="target">' + '<input tabindex="-1">' + '</div>'
     );
-    var node = fixture.querySelector('#target');
-    var virtualNode = axe.utils.getNodeFromTree(node);
     var actual = getTabbableElementsFn(virtualNode);
     assert.lengthOf(actual, 0);
   });
 
   it('returns empty [] when element contains disabled (tabbable) element', function() {
-    var fixture = fixtureSetup(
+    var virtualNode = queryFixture(
       '<div id="target">' + '<button disabled>Submit Me</button>' + '</div>'
     );
-    var node = fixture.querySelector('#target');
-    var virtualNode = axe.utils.getNodeFromTree(node);
     var actual = getTabbableElementsFn(virtualNode);
     assert.lengthOf(actual, 0);
   });
 
   it('returns empty [] when element does not contain tabbable element', function() {
-    var fixture = fixtureSetup(
+    var virtualNode = queryFixture(
       '<div id="target">' + '<p>Some text</p>' + '</div>'
     );
-    var node = fixture.querySelector('#target');
-    var virtualNode = axe.utils.getNodeFromTree(node);
     var actual = getTabbableElementsFn(virtualNode);
     assert.lengthOf(actual, 0);
   });
@@ -57,13 +46,12 @@ describe('dom.getTabbableElements', function() {
   (shadowSupported ? it : xit)(
     'returns tabbable elms when element contains tabbable element inside shadowDOM',
     function() {
-      var fixture = fixtureSetup('<div id="target"></div>`');
+      var fixture = injectIntoFixture('<div id="target"></div>`');
       var node = fixture.querySelector('#target');
       var shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<button>btn</button>';
       // re build tree after shadowDOM is constructed
-      axe.testUtils.flatTreeSetup(fixture);
-      axe._selectorData = axe.utils.getSelectorData(axe._tree);
+      axe.setup(fixture);
       var virtualNode = axe.utils.getNodeFromTree(node);
       var actual = getTabbableElementsFn(virtualNode);
       assert.lengthOf(actual, 1);
@@ -74,13 +62,12 @@ describe('dom.getTabbableElements', function() {
   (shadowSupported ? it : xit)(
     'returns empty [] when element contains disabled (tabbable) element inside shadowDOM',
     function() {
-      var fixture = fixtureSetup('<div id="target"></div>`');
+      var fixture = injectIntoFixture('<div id="target"></div>`');
       var node = fixture.querySelector('#target');
       var shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<button disabled>btn</button>';
       // re build tree after shadowDOM is constructed
-      axe.testUtils.flatTreeSetup(fixture);
-      axe._selectorData = axe.utils.getSelectorData(axe._tree);
+      axe.setup(fixture);
       var virtualNode = axe.utils.getNodeFromTree(node);
       var actual = getTabbableElementsFn(virtualNode);
       assert.lengthOf(actual, 0);
@@ -90,13 +77,12 @@ describe('dom.getTabbableElements', function() {
   (shadowSupported ? it : xit)(
     'returns empty [] when element does not contain tabbable element inside shadowDOM',
     function() {
-      var fixture = fixtureSetup('<div id="target"></div>`');
+      var fixture = injectIntoFixture('<div id="target"></div>`');
       var node = fixture.querySelector('#target');
       var shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<p>I am not tabbable</p>';
       // re build tree after shadowDOM is constructed
-      axe.testUtils.flatTreeSetup(fixture);
-      axe._selectorData = axe.utils.getSelectorData(axe._tree);
+      axe.setup(fixture);
       var virtualNode = axe.utils.getNodeFromTree(node);
       var actual = getTabbableElementsFn(virtualNode);
       assert.lengthOf(actual, 0);

--- a/test/commons/dom/is-modal-open.js
+++ b/test/commons/dom/is-modal-open.js
@@ -6,10 +6,6 @@ describe('dom.isModalOpen', function() {
   var dialogElSupport =
     typeof document.createElement('dialog').open !== 'undefined';
 
-  afterEach(function() {
-    fixtureSetup('');
-  });
-
   it('returns true if there is a visible element with role=dialog', function() {
     fixtureSetup('<div role="dialog">Modal</div>');
     assert.isTrue(isModalOpen());

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -3,7 +3,6 @@ describe('dom.isVisible', function() {
 
   var fixture = document.getElementById('fixture');
   var queryFixture = axe.testUtils.queryFixture;
-  var fixtureSetup = axe.testUtils.fixtureSetup;
   var isIE11 = axe.testUtils.isIE11;
   var shadowSupported = axe.testUtils.shadowSupport.v1;
   var fakeNode = {
@@ -85,29 +84,26 @@ describe('dom.isVisible', function() {
     });
 
     it('should return false on STYLE tag', function() {
-      var fixture = fixtureSetup(
+      var vNode = queryFixture(
         '<style id="target"> @import "https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.css"; .green { background-color: green; } </style>'
       );
-      var node = fixture.querySelector('#target');
-      var actual = axe.commons.dom.isVisible(node);
+      var actual = axe.commons.dom.isVisible(vNode.actualNode);
       assert.isFalse(actual);
     });
 
     it('should return false on NOSCRIPT tag', function() {
-      var fixture = fixtureSetup(
+      var vNode = queryFixture(
         '<noscript id="target"><p class="invisible"><img src="/piwik/piwik.php?idsite=1" alt="" /></p></noscript>'
       );
-      var node = fixture.querySelector('#target');
-      var actual = axe.commons.dom.isVisible(node);
+      var actual = axe.commons.dom.isVisible(vNode.actualNode);
       assert.isFalse(actual);
     });
 
     it('should return false on TEMPLATE tag', function() {
-      var fixture = fixtureSetup(
+      var vNode = queryFixture(
         '<template id="target"><div>Name:</div></template>'
       );
-      var node = fixture.querySelector('#target');
-      var actual = axe.commons.dom.isVisible(node);
+      var actual = axe.commons.dom.isVisible(vNode.actualNode);
       assert.isFalse(actual);
     });
 

--- a/test/commons/text/is-icon-ligature.js
+++ b/test/commons/text/is-icon-ligature.js
@@ -170,9 +170,7 @@ describe('text.isIconLigature', function() {
       isIconLigature(target.children[0]);
 
       // change text to non-icon
-      var target = queryFixture(
-        '<div id="target" style="font-family: \'LigatureSymbols\'">__non-icon text__</div>'
-      );
+      target.children[0].actualNode.textContent = '__non-icon text__';
       assert.isTrue(isIconLigature(target.children[0]));
     }
   );
@@ -189,9 +187,7 @@ describe('text.isIconLigature', function() {
       isIconLigature(target.children[0]);
 
       // change text to icon
-      var target = queryFixture(
-        '<div id="target" style="font-family: \'Roboto\'">delete</div>'
-      );
+      target.children[0].actualNode.textContent = 'delete';
       assert.isFalse(isIconLigature(target.children[0]));
     }
   );
@@ -231,9 +227,7 @@ describe('text.isIconLigature', function() {
         isIconLigature(target.children[0]);
 
         // change text to non-icon
-        var target = queryFixture(
-          '<div id="target" style="font-family: \'LigatureSymbols\'">__non-icon text__</div>'
-        );
+        target.children[0].actualNode.textContent = '__non-icon text__';
         assert.isTrue(isIconLigature(target.children[0], 0.1, 1));
         assert.isFalse(isIconLigature(target.children[0]));
       }

--- a/test/core/public/teardown.js
+++ b/test/core/public/teardown.js
@@ -13,6 +13,12 @@ describe('axe.teardown', function() {
     assert.isUndefined(axe._selectorData);
   });
 
+  it('should reset selector data', function() {
+    axe._selectCache = 'foo';
+    axe.teardown();
+    assert.isUndefined(axe._selectCache);
+  });
+
   it('should reset memozied functions', function() {
     var orgFn = axe._memoizedFns[0];
     var called = false;

--- a/test/integration/full/contrast/code-highlighting.js
+++ b/test/integration/full/contrast/code-highlighting.js
@@ -1,64 +1,53 @@
 describe('color-contrast code highlighting test', function() {
   'use strict';
 
+  var results;
+  function run(done) {
+    axe.run(
+      '#fixture',
+      { runOnly: { type: 'rule', values: ['color-contrast'] } },
+      function(err, r) {
+        assert.isNull(err);
+        results = r;
+        done();
+      }
+    );
+  }
+
   before(function(done) {
     // wait for window load event (or if the window has already loaded) so the
     // prism styles have loaded before running the tests (in Chrome the load
     // even was already fired before Mocha starts the test suite)
     if (document.readyState === 'complete') {
-      done();
+      run(done);
     } else {
       window.addEventListener('load', function() {
-        done();
+        run(done);
       });
     }
   });
 
   describe('violations', function() {
-    it('should find issues', function(done) {
-      axe.run(
-        '#fixture',
-        { runOnly: { type: 'rule', values: ['color-contrast'] } },
-        function(err, results) {
-          assert.isNull(err);
-          assert.lengthOf(results.violations, 1);
-          assert.lengthOf(results.violations[0].nodes, 32);
-          done();
-        }
-      );
+    it('should find issues', function() {
+      assert.lengthOf(results.violations, 1);
+      assert.lengthOf(results.violations[0].nodes, 32);
     });
   });
 
   describe('passes', function() {
-    it('should find passes', function(done) {
-      axe.run(
-        '#fixture',
-        { runOnly: { type: 'rule', values: ['color-contrast'] } },
-        function(err, results) {
-          assert.isNull(err);
-          assert.lengthOf(results.passes, 1);
-          assert.lengthOf(results.passes[0].nodes, 27);
-          done();
-        }
-      );
+    it('should find passes', function() {
+      assert.lengthOf(results.passes, 1);
+      assert.lengthOf(results.passes[0].nodes, 27);
     });
   });
 
   describe('incomplete', function() {
-    it('should find just the code block', function(done) {
-      axe.run(
-        '#fixture',
-        { runOnly: { type: 'rule', values: ['color-contrast'] } },
-        function(err, results) {
-          assert.isNull(err);
-          assert.lengthOf(results.incomplete, 1);
-          assert.lengthOf(results.incomplete[0].nodes, 1);
-          assert.equal(
-            results.incomplete[0].nodes[0].html,
-            '<code class=" language-html">'
-          );
-          done();
-        }
+    it('should find just the code block', function() {
+      assert.lengthOf(results.incomplete, 1);
+      assert.lengthOf(results.incomplete[0].nodes, 1);
+      assert.equal(
+        results.incomplete[0].nodes[0].html,
+        '<code class=" language-html">'
       );
     });
   });

--- a/test/rule-matches/aria-hidden-focus-matches.js
+++ b/test/rule-matches/aria-hidden-focus-matches.js
@@ -2,15 +2,10 @@ describe('aria-hidden-focus-matches', function() {
   'use strict';
 
   var rule;
-  var fixtureSetup = axe.testUtils.fixtureSetup;
+  var queryFixture = axe.testUtils.queryFixture;
 
   beforeEach(function() {
     rule = axe.utils.getRule('aria-hidden-focus');
-  });
-
-  afterEach(function() {
-    var fixture = document.getElementById('fixture');
-    fixture.innerHTML = '';
   });
 
   it('is a function', function() {
@@ -18,26 +13,24 @@ describe('aria-hidden-focus-matches', function() {
   });
 
   it('return true when there is no parent with aria-hidden', function() {
-    var fixture = fixtureSetup('<div id="target">' + '</div>');
-    var node = fixture.querySelector('#target');
-    var actual = rule.matches(node);
+    var vNode = queryFixture('<div id="target">' + '</div>');
+    var actual = rule.matches(vNode.actualNode);
     assert.isTrue(actual);
   });
 
   it('return false when has a parent element with aria-hidden', function() {
-    var fixture = fixtureSetup(
+    var vNode = queryFixture(
       '<div aria-hidden="true">' +
         '<div id="target" aria-hidden="true">' +
         '</div>' +
         '</div>'
     );
-    var node = fixture.querySelector('#target');
-    var actual = rule.matches(node);
+    var actual = rule.matches(vNode.actualNode);
     assert.isFalse(actual);
   });
 
   it('return false when has any parent element with aria-hidden', function() {
-    var fixture = fixtureSetup(
+    var vNode = queryFixture(
       '<div aria-hidden="true">' +
         '<div>' +
         '<div id="target" aria-hidden="true">' +
@@ -45,21 +38,19 @@ describe('aria-hidden-focus-matches', function() {
         '</div>' +
         '</div>'
     );
-    var node = fixture.querySelector('#target');
-    var actual = rule.matches(node);
+    var actual = rule.matches(vNode.actualNode);
     assert.isFalse(actual);
   });
 
   it('return false when has any parent element with aria-hidden', function() {
-    var fixture = fixtureSetup(
+    var vNode = queryFixture(
       '<div aria-hidden="true">' +
         '<div aria-hidden="true">' +
         '<button id="target">btn</button>' +
         '</div>' +
         '</div>'
     );
-    var node = fixture.querySelector('#target');
-    var actual = rule.matches(node);
+    var actual = rule.matches(vNode.actualNode);
     assert.isFalse(actual);
   });
 });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -17,6 +17,14 @@ var originalAudit = axe._audit;
 var originalRules = axe._audit.rules;
 var originalCommons = (commons = axe.commons);
 
+// add fixture to the body if it's not already
+var fixture = document.getElementById('fixture');
+if (!fixture) {
+  fixture = document.createElement('div');
+  fixture.setAttribute('id', 'fixture');
+  document.body.insertBefore(fixture, document.body.firstChild);
+}
+
 /**
  * Create a check context for mocking/resetting data and relatedNodes in tests
  *
@@ -74,15 +82,21 @@ testUtils.shadowSupport = (function(document) {
 })(document);
 
 /**
- * Method for injecting content into a fixture and caching
- * the flattened DOM tree (light and Shadow DOM together)
- *
+ * Return the fixture element
+ * @return HTMLElement
+ */
+testUtils.getFixture = function() {
+  'use strict';
+  return fixture;
+};
+
+/**
+ * Method for injecting content into a fixture
  * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
  * @return HTMLElement
  */
-testUtils.fixtureSetup = function(content) {
+testUtils.injectIntoFixture = function(content) {
   'use strict';
-  var fixture = document.querySelector('#fixture');
   if (typeof content !== 'undefined') {
     fixture.innerHTML = '';
   }
@@ -96,10 +110,22 @@ testUtils.fixtureSetup = function(content) {
       fixture.appendChild(node);
     });
   }
-  axe._tree = axe.utils.getFlattenedTree(fixture);
-  axe._selectorData = axe.utils.getSelectorData(axe._tree);
 
   return fixture;
+};
+
+/**
+ * Method for injecting content into a fixture and caching
+ * the flattened DOM tree (light and Shadow DOM together)
+ *
+ * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
+ * @return HTMLElement
+ */
+testUtils.fixtureSetup = function(content) {
+  'use strict';
+  testUtils.injectIntoFixture(content);
+  axe.teardown();
+  return axe.setup(fixture);
 };
 
 /**
@@ -119,11 +145,11 @@ testUtils.checkSetup = function(content, options, target) {
   }
   // Normalize target, allow it to be the inserted node or '#target'
   target = target || (content instanceof Node ? content : '#target');
-  testUtils.fixtureSetup(content);
+  var rootNode = testUtils.fixtureSetup(content);
 
   var node;
   if (typeof target === 'string') {
-    node = axe.utils.querySelectorAll(axe._tree[0], target)[0];
+    node = axe.utils.querySelectorAll(rootNode, target)[0];
   } else if (target instanceof Node) {
     node = axe.utils.getNodeFromTree(target);
   } else {
@@ -160,7 +186,7 @@ testUtils.shadowCheckSetup = function(
     options = {};
   }
 
-  var fixture = testUtils.fixtureSetup(content);
+  var fixture = testUtils.injectIntoFixture(content);
   var targetCandidate = fixture.querySelector(targetSelector);
   var container = targetCandidate;
   if (!targetCandidate) {
@@ -186,7 +212,7 @@ testUtils.shadowCheckSetup = function(
   }
 
   // query the composed tree AFTER shadowDOM has been attached
-  axe._tree = axe.utils.getFlattenedTree(fixture);
+  axe.setup(fixture);
   var node = axe.utils.getNodeFromTree(targetCandidate);
   return [node.actualNode, options, node];
 };
@@ -373,8 +399,8 @@ testUtils.assertStylesheet = function assertStylesheet(
  * @return HTMLElement
  */
 testUtils.queryFixture = function queryFixture(html, query) {
-  testUtils.fixtureSetup(html);
-  return axe.utils.querySelectorAll(axe._tree, query || '#target')[0];
+  var rootNode = testUtils.fixtureSetup(html);
+  return axe.utils.querySelectorAll(rootNode, query || '#target')[0];
 };
 
 /**
@@ -402,16 +428,17 @@ testUtils.isIE11 = (function isIE11(navigator) {
 
 axe.testUtils = testUtils;
 
-// add fixture to the body if it's not already
-var fixture = document.getElementById('fixture');
-if (!fixture) {
-  fixture = document.createElement('div');
-  fixture.setAttribute('id', 'fixture');
-  document.body.insertBefore(fixture, document.body.firstChild);
-}
+beforeEach(function() {
+  // reset from axe._load overriding
+  checks = originalChecks;
+  axe._audit = originalAudit;
+  axe._audit.rules = originalRules;
+  commons = axe.commons = originalCommons;
+});
 
 afterEach(function() {
   axe.teardown();
+  fixture.innerHTML = '';
 
   // remove all attributes from fixture (otherwise a leftover
   // style attribute would cause avoid-inline-spacing integration
@@ -426,10 +453,4 @@ afterEach(function() {
 
   // reset body styles
   document.body.removeAttribute('style');
-
-  // reset from axe._load overriding
-  checks = originalChecks;
-  axe._audit = originalAudit;
-  axe._audit.rules = originalRules;
-  commons = axe.commons = originalCommons;
 });


### PR DESCRIPTION
Wanted to start updating the tests to stop using `axe._tree` everywhere and use the new `axe.setup` method, starting by updating the testUtils code. However this was a bit of a rabbit hole as to remove `axe._tree` I needed the root node returned by `axe._setup` which was done in `fixtureSetup`. 

However, updating `fixtureSetup` cause code that relied on it returning the fixture element to stop working, so had to update those tests to not use fixture from `fixtureSetup` (most of the time they just needed to use `queryFixture` instead).

I also found that code would use `fixtureSetup` multiple times when really what it wanted was to setup the fixture, do some shadow work, then setup the tree. To resolve these issues I created a new function to just inject code into the fixture without setting up the tree.

I also noticed in a test that `axe._selectCache` wasn't reset as part of the teardown method so did that in teardown to resolve that problem.

Lastly, I wanted to consolidate some repeated setup code for later by not having every test have to reset the `fixture.innerHTML` itself or call clean up functions every time. So now the beforeEach code will setup the audit to the default state and clean up the fixture element. I also wanted to remove every call of `var fixture = document.querySelector('#fixture')` in every test so that it's more flexible in the future and uses pure functions, so created a new function to just return the fixture element in the testUtils.

Also, as part of this I want to stop using `flatTreeSetup` as `axe.setup` does the exact same thing.