### PR TITLE
fix: avoid 'undefined' showing in check messages

### DIFF
--- a/lib/core/utils/process-message.js
+++ b/lib/core/utils/process-message.js
@@ -17,7 +17,9 @@ function substitute(str, data) {
   for (const prop in data) {
     if (data.hasOwnProperty(prop)) {
       const regex = new RegExp('\\${\\s?data\\.' + prop + '\\s?}', 'g');
-      str = str.replace(regex, data[prop]);
+      const replace =
+        typeof data[prop] === 'undefined' ? '' : String(data[prop]);
+      str = str.replace(regex, replace);
     }
   }
 

--- a/test/core/utils/process-message.js
+++ b/test/core/utils/process-message.js
@@ -33,6 +33,12 @@ describe('axe.utils.processMessage', function() {
     assert.equal(output, 'Hello World!');
   });
 
+  it('should replace ${data.prop}', function() {
+    var message = 'Hello ${data.world}';
+    var output = axe.utils.processMessage(message, { world: undefined });
+    assert.equal(output, 'Hello ');
+  });
+
   it('should replace ${ data.prop } (with whitespace)', function() {
     var message = 'Hello ${ data.world }';
     var output = axe.utils.processMessage(message, { world: 'World!' });


### PR DESCRIPTION
Sometimes "undefined" can get into the data object. Especially "messageKey" can be undefined at times. This PR does two things:
1. It prevents "undefined" from ever showing in the message.
2. It ensures that buggy implementations of string.replace() always get a string passed as its second argument. The later one caused issues on a customer website.
