### PR TITLE
chore: add parent frame context info

### DIFF
--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -235,6 +235,12 @@ function Context(spec) {
   this.frames = [];
   this.initiator =
     spec && typeof spec.initiator === 'boolean' ? spec.initiator : true;
+  this.focusable =
+    spec && typeof spec.focusable === 'boolean' ? spec.focusable : true;
+  this.boundingClientRect =
+    spec && typeof spec.boundingClientRect === 'object'
+      ? spec.boundingClientRect
+      : {};
   this.page = false;
 
   spec = normalizeContext(spec);

--- a/lib/core/utils/collect-results-from-frames.js
+++ b/lib/core/utils/collect-results-from-frames.js
@@ -6,14 +6,14 @@ import getSelector from './get-selector';
 /**
  * Sends a message to axe running in frames to start analysis and collate results (via `mergeResults`)
  * @private
- * @param  {Context}  context   The resolved Context object
+ * @param  {Context}  parentContent   The resolved Context object
  * @param  {Object}   options   Options object (as passed to `runRules`)
  * @param  {string}   command   Command sent to all frames
  * @param  {Array}    parameter Array of values to be passed along side the command
  * @param  {Function} callback  Function to call when results from all frames have returned
  */
 function collectResultsFromFrames(
-  context,
+  parentContent,
   options,
   command,
   parameter,
@@ -21,17 +21,30 @@ function collectResultsFromFrames(
   reject
 ) {
   var q = queue();
-  var frames = context.frames;
+  var frames = parentContent.frames;
 
   // Tell each axe running in each frame to collect results
   frames.forEach(frame => {
+    const tabindex = parseInt(frame.node.getAttribute('tabindex'), 10);
+    const focusable = isNaN(tabindex) || tabindex >= 0;
+    const rect = frame.node.getBoundingClientRect();
+
     var params = {
       options: options,
       command: command,
       parameter: parameter,
       context: {
         initiator: false,
-        page: context.page,
+
+        // if any parent iframe is not focusable then the entire
+        // iframe stack is not focusable (even if the descendant
+        // iframe has tabindex=0 on it)
+        focusable: parentContent.focusable === false ? false : focusable,
+        boundingClientRect: {
+          width: rect.width,
+          height: rect.height
+        },
+        page: parentContent.page,
         include: frame.include || [],
         exclude: frame.exclude || []
       }

--- a/test/checks/aria/aria-prohibited-attr.js
+++ b/test/checks/aria/aria-prohibited-attr.js
@@ -1,4 +1,4 @@
-describe.only('aria-prohibited-attr', function() {
+describe('aria-prohibited-attr', function() {
   'use strict';
 
   var checkContext = axe.testUtils.MockCheckContext();

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -405,7 +405,9 @@ describe('Context', function() {
         'flatTree',
         'initiator',
         'page',
-        'frames'
+        'frames',
+        'focusable',
+        'boundingClientRect'
       ]);
       assert.isArray(context.flatTree);
       assert.isAtLeast(context.flatTree.length, 1);
@@ -424,7 +426,9 @@ describe('Context', function() {
         'flatTree',
         'initiator',
         'page',
-        'frames'
+        'frames',
+        'focusable',
+        'boundingClientRect'
       ]);
       assert.lengthOf(context.include, 1);
       assert.equal(
@@ -511,6 +515,54 @@ describe('Context', function() {
       assert.isTrue(new Context(null).page);
       assert.isTrue(new Context().page);
       assert.isTrue(new Context(false).page);
+    });
+  });
+
+  describe('focusable', function() {
+    it('should default to true', function() {
+      var result = new Context();
+      assert.isTrue(result.focusable);
+    });
+
+    it('should use passed in value', function() {
+      var result = new Context({
+        focusable: false
+      });
+      assert.isFalse(result.focusable);
+    });
+
+    it('should reject bad values', function() {
+      var result = new Context({
+        focusable: 'hello'
+      });
+      assert.isTrue(result.focusable);
+    });
+  });
+
+  describe('boundingClientRect', function() {
+    it('should default to empty object', function() {
+      var result = new Context();
+      assert.deepEqual(result.boundingClientRect, {});
+    });
+
+    it('should use passed in value', function() {
+      var result = new Context({
+        boundingClientRect: {
+          width: 10,
+          height: 20
+        }
+      });
+      assert.deepEqual(result.boundingClientRect, {
+        width: 10,
+        height: 20
+      });
+    });
+
+    it('should reject bad values', function() {
+      var result = new Context({
+        boundingClientRect: 'hello'
+      });
+      assert.deepEqual(result.boundingClientRect, {});
     });
   });
 });


### PR DESCRIPTION
This is a small portion from #2762 that I'm hoping we can isolate to see if it's the thing causing ie11 to fail the frame-title stuff.