### PR TITLE
fix(utils): remove attributes from source string

### DIFF
--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -1,7 +1,6 @@
 import getSelector from './get-selector';
 import getAncestry from './get-ancestry';
 import getXpath from './get-xpath';
-import filterHtmlAttrs from './filter-html-attrs';
 
 function truncate(str, maxLength) {
   maxLength = maxLength || 300;
@@ -19,8 +18,7 @@ function getSource(element) {
   if (!source && typeof XMLSerializer === 'function') {
     source = new XMLSerializer().serializeToString(element);
   }
-  source = filterHtmlAttrs(source || '', axe._audit.denyList);
-  return truncate(source);
+  return truncate(source || '');
 }
 
 /**

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -1,6 +1,7 @@
 import getSelector from './get-selector';
 import getAncestry from './get-ancestry';
 import getXpath from './get-xpath';
+import filterHtmlAttrs from './filter-html-attrs';
 
 function truncate(str, maxLength) {
   maxLength = maxLength || 300;
@@ -18,7 +19,8 @@ function getSource(element) {
   if (!source && typeof XMLSerializer === 'function') {
     source = new XMLSerializer().serializeToString(element);
   }
-  return truncate(source || '');
+  source = filterHtmlAttrs(source || '', axe._audit.denyList);
+  return truncate(source);
 }
 
 /**

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -1,20 +1,137 @@
-function filterHtmlAttrs(htmlString, denylist = {}) {
-  const tagRegex = /<([^>]+?)>/g;
+// grab everything between an opening and closing bracket
+const tagStringRegex = /<([^>]+?)\/?>/g;
 
-  return htmlString.replace(tagRegex, (value, tagStr) => {
-    const [tagName, ...attributes] = tagStr.split(' ');
-    const name = tagName.toLowerCase();
+/* split a tag string by attributes:
+   (\S+)=       group 1: valued attribute name; look for non-whitespace characters followed by the "="" sign
+   ((["'])      start group 2: quoted attribute value; look for an opening quote (single or double)
+   (.*?)        start group 4: non-quoted attribute value; non-greedy match everything (.*?) (the 3rd group is ignored and only used for the back reference \3)
+   \3(?:\s|$)   end group 4: stop when we find a matching end quote and either a whitespace or the end of the string (allowing us to matching escaped quotes that match the opening quote)
+   |[^\s]+))    end of group 2; if no quote then match everything that is not a whitespace
+   |\b(\S+)\b   group 5: non-valued attribute name; look for any remaining non-matched strings and see if they are an attribute name without a value
 
-    if (!denylist[name]) {
-      return value;
+   tested with string: type="text" value="my value again" othervalue=foo ha='bar' ha='\"foo\"' again="\'thing\'" data-thing="foo" thing=bar bar=baz checked thing=bar thing="\"foo\"" thing='\'hello\''
+*/
+const attributeRegex = /(\S+)=((["'])(.*?)\3(?:\s|$)|[^\s]+)|\b(\S+)\b/g;
+
+const attrMap = {
+  for: 'htmlFor',
+  class: 'className'
+};
+
+/**
+ * Match an attribute to a matcher object.
+ * @param {String} nodeName - Name of the current node
+ * @param {Object[]} attributes - Array of node attributes and values
+ * @param {String} value - Value of the current attribute
+ * @param {any} matcher - How to match the value
+ */
+function matches(nodeName, attributes, value, matcher) {
+  switch (typeof matcher) {
+    case 'boolean':
+      return true;
+    case 'string':
+      return matcher === value;
+    case 'object':
+      if (Array.isArray(matcher)) {
+        return matcher.includes(value);
+      }
+
+      // matcher-like object, match all parts
+      let filter = true;
+
+      // match each property
+      if (matcher.nodeName) {
+        filter = filter && matcher.nodeName === nodeName;
+      }
+
+      if (matcher.attributes) {
+        Object.keys(matcher.attributes).forEach(attrName => {
+          const attr = attributes.find(attr => attr.name === attrName);
+          if (!attr) {
+            return false;
+          }
+
+          filter =
+            filter &&
+            matches(
+              nodeName,
+              attributes,
+              attr.value,
+              matcher.attributes[attrName]
+            );
+        });
+      }
+
+      return filter;
+  }
+}
+
+/**
+ * Filter attributes from an html string. This is not to prevent XSS attacks but instead is used to remove attributes which shouldn't appear in the output. As such, we can assume mostly normal attribute output and not attributes purposefully trying to break a parser
+ *
+ * Example:
+ * ```js
+ * // Remove attribute if present regardless of value
+ * axe.utils.filterHtmlAttrs('<div data-attr="foo">my div</div>', { 'data-attr': true });
+ *
+ * // Remove attribute if value matches
+ * axe.utils.filterHtmlAttrs('<div data-attr="foo">my div</div>', { 'data-attr': 'foo' });
+ *
+ * // Remove attribute if value matches list of values
+ * axe.utils.filterHtmlAttrs('<div data-attr="foo">my div</div>', { 'data-attr': ['foo', 'bar'] });
+ *
+ * // Remove attribute if tag matches matcher-like object
+ * axe.utils.filterHtmlAttrs('<div class="foo"><input type="text" class="foo"/></div>', { class: { nodeName: input } });
+ * ```
+ *
+ * @method getRootNode
+ * @memberof axe.utils
+ * @param {String} htmlString - HTML string to remove attributes from.
+ * @param {Object} filterAttrs - Attributes to remove and the qualifier of when to remove them.
+ * @returns {String}
+ */
+function filterHtmlAttrs(htmlString, filterAttrs) {
+  if (!filterAttrs) {
+    return htmlString;
+  }
+
+  return htmlString.replace(tagStringRegex, (match, tagStr) => {
+    // no need to filter end tags
+    if (tagStr.charAt(0) === '/') {
+      return match;
     }
 
-    const filteredAttrs = attributes.filter(attr => {
-      const attrName = attr.split('=')[0];
-      return !denylist[name].includes(attrName);
+    const nodeName = tagStr.substring(0, tagStr.indexOf(' ')).toLowerCase();
+    const attributeStr = tagStr.substring(tagStr.indexOf(' ') + 1).trim();
+
+    let groups;
+    const attributes = [];
+    while ((groups = attributeRegex.exec(attributeStr))) {
+      attributes.push({
+        // can be either a valued and non-valued attribute
+        name: (groups[1] || groups[5]).toLowerCase(),
+        // use the non-quoted attribute value
+        value: groups[4] || groups[2] || '',
+        // remove the whitespace caused by matching the end quote + whitespace
+        string: groups[0].trim()
+      });
+    }
+
+    const filteredAttrs = attributes.filter(attribute => {
+      const { name, value } = attribute;
+      const matcher = filterAttrs[attrMap[name] ? attrMap[name] : name];
+
+      if (!matcher) {
+        return true;
+      }
+
+      return !matches(nodeName, attributes, value, matcher);
     });
 
-    return value.replace(attributes.join(' '), filteredAttrs.join(' '));
+    return match.replace(
+      attributeStr,
+      filteredAttrs.map(attr => attr.string).join(' ')
+    );
   });
 }
 

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -3,17 +3,16 @@ const tagStringRegex = /<([^>]+?)\/?>/g;
 
 /*
   match attributes. html does not allow escaping quotes inside attributes so we don't have to worry about that (e.g. aria-label="\"label\"").
-
-  (?:(\S+)=      group 1: valued attribute name; look for non-whitespace characters followed by the "="" sign
-  (?:"([^"]+)"   group 2: double quoted attribute value; look for everything surrounded by double quotes
-  '([^']+)'      group 3: single quoted attribute value; look for everything surrounded by single quotes
-  ([^'"\s]+)))   group 4: non-quoted attribute value; look for any non-whitespace and quote characters
-  |\b(\S+)\b     group 5: non-valued attribute name; look for any remaining non-matched strings and see if they are an attribute name without a value
-
-  tested with string: type="text" value="my value again" othervalue=foo ha='bar' ha='\"foo\"' again="\'thing\'" data-thing="foo" thing=bar bar=baz checked thing=bar thing="'foo' asdf" hello='"foo"' goodbuy=' hello "doo" '
   @see https://regexr.com/5mbqb
 */
-const attributeRegex = /(?:(\S+)=(?:"([^"]+)"|'([^']+)'|([^'"\s]+)))|\b(\S+)\b/g;
+const attributeRegex = new RegExp(
+  `(?:([^\\s=]+)=` + // group 1: valued attribute name; look for non-whitespace, non-equal sign characters followed by the "=" sign
+  `(?:"([^"]*)"` + // group 2: double quoted attribute value; look for everything surrounded by double quotes
+  `|'([^']*)'` + // group 3: single quoted attribute value; look for everything surrounded by single quotes
+  `|([^'"\\s]*)))` + // group 4: non-quoted attribute value; look for any non-whitespace and quote characters
+    `|\\b(\\S+)(?:\\B|\\b)`, // group 5: non-valued attribute name; look for any remaining non-matched strings surrounded by word boundaries
+  'g'
+);
 
 const attrMap = {
   for: 'htmlFor',

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -1,17 +1,19 @@
 // grab everything between an opening and closing bracket
 const tagStringRegex = /<([^>]+?)\/?>/g;
 
-/* split a tag string by attributes:
-   (\S+)=       group 1: valued attribute name; look for non-whitespace characters followed by the "="" sign
-   ((["'])      start group 2: quoted attribute value; look for an opening quote (single or double)
-   (.*?)        start group 4: non-quoted attribute value; non-greedy match everything (.*?) (the 3rd group is ignored and only used for the back reference \3)
-   \3(?:\s|$)   end group 4: stop when we find a matching end quote and either a whitespace or the end of the string (allowing us to match escaped quotes that match the opening quote)
-   |[^\s]+))    end of group 2; if no quote then match everything that is not a whitespace
-   |\b(\S+)\b   group 5: non-valued attribute name; look for any remaining non-matched strings and see if they are an attribute name without a value
+/*
+  match attributes. html does not allow escaping quotes inside attributes so we don't have to worry about that (e.g. aria-label="\"label\"").
 
-   tested with string: type="text" value="my value again" othervalue=foo ha='bar' ha='\"foo\"' again="\'thing\'" data-thing="foo" thing=bar bar=baz checked thing=bar thing="\"foo\"" thing='\'hello\''
+  (?:(\S+)=      group 1: valued attribute name; look for non-whitespace characters followed by the "="" sign
+  (?:"([^"]+)"   group 2: double quoted attribute value; look for everything surrounded by double quotes
+  '([^']+)'      group 3: single quoted attribute value; look for everything surrounded by single quotes
+  ([^'"\s]+)))   group 4: non-quoted attribute value; look for any non-whitespace and quote characters
+  |\b(\S+)\b     group 5: non-valued attribute name; look for any remaining non-matched strings and see if they are an attribute name without a value
+
+  tested with string: type="text" value="my value again" othervalue=foo ha='bar' ha='\"foo\"' again="\'thing\'" data-thing="foo" thing=bar bar=baz checked thing=bar thing="'foo' asdf" hello='"foo"' goodbuy=' hello "doo" '
+  @see https://regexr.com/5mbqb
 */
-const attributeRegex = /(\S+)=((["'])(.*?)\3(?:\s|$)|[^\s]+)|\b(\S+)\b/g;
+const attributeRegex = /(?:(\S+)=(?:"([^"]+)"|'([^']+)'|([^'"\s]+)))|\b(\S+)\b/g;
 
 const attrMap = {
   for: 'htmlFor',
@@ -110,10 +112,9 @@ function filterHtmlAttrs(htmlString, filterAttrs) {
       attributes.push({
         // can be either a valued and non-valued attribute
         name: (groups[1] || groups[5]).toLowerCase(),
-        // use the non-quoted attribute value
-        value: groups[4] || groups[2] || '',
-        // remove the whitespace caused by matching the end quote + whitespace
-        string: groups[0].trim()
+        // double, single, or non-quoted value
+        value: groups[2] || groups[3] || groups[4] || '',
+        string: groups[0]
       });
     }
 

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -1,5 +1,6 @@
 import cache from '../base/cache';
 import getNodeAttributes from './get-node-attributes';
+import matchesSelector from './element-matches';
 
 /**
  * Test if node and attribute match one of the filtered attributes.
@@ -17,7 +18,7 @@ function attributeMatches(node, attrName, filterAttrs) {
     return true;
   }
 
-  return node.matches(filterAttrs[attrName]);
+  return matchesSelector(node, filterAttrs[attrName]);
 }
 
 /**

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -1,0 +1,21 @@
+function filterHtmlAttrs(htmlString, denylist = {}) {
+  const tagRegex = /<([^>]+?)>/g;
+
+  return htmlString.replace(tagRegex, (value, tagStr) => {
+    const [tagName, ...attributes] = tagStr.split(' ');
+    const name = tagName.toLowerCase();
+
+    if (!denylist[name]) {
+      return value;
+    }
+
+    const filteredAttrs = attributes.filter(attr => {
+      const attrName = attr.split('=')[0];
+      return !denylist[name].includes(attrName);
+    });
+
+    return value.replace(attributes.join(' '), filteredAttrs.join(' '));
+  });
+}
+
+export default filterHtmlAttrs;

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -5,7 +5,7 @@ const tagStringRegex = /<([^>]+?)\/?>/g;
    (\S+)=       group 1: valued attribute name; look for non-whitespace characters followed by the "="" sign
    ((["'])      start group 2: quoted attribute value; look for an opening quote (single or double)
    (.*?)        start group 4: non-quoted attribute value; non-greedy match everything (.*?) (the 3rd group is ignored and only used for the back reference \3)
-   \3(?:\s|$)   end group 4: stop when we find a matching end quote and either a whitespace or the end of the string (allowing us to matching escaped quotes that match the opening quote)
+   \3(?:\s|$)   end group 4: stop when we find a matching end quote and either a whitespace or the end of the string (allowing us to match escaped quotes that match the opening quote)
    |[^\s]+))    end of group 2; if no quote then match everything that is not a whitespace
    |\b(\S+)\b   group 5: non-valued attribute name; look for any remaining non-matched strings and see if they are an attribute name without a value
 

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -51,9 +51,13 @@ function filterHtmlAttrs(element, filterAttrs) {
   if (cache.get(outerHTML)) {
     node = cache.get(outerHTML);
   } else if (attributes) {
+    node = document.createElement(node.nodeName);
     Array.from(attributes).forEach(attr => {
-      if (attributeMatches(node, attr.name, filterAttrs)) {
-        node.removeAttribute(attr.name);
+      if (!attributeMatches(element, attr.name, filterAttrs)) {
+        // can't remove the value attribute from an input in IE11 so
+        // we'll have to reconstruct the node and set attribute
+        // manually
+        node.setAttribute(attr.name, attr.value);
       }
     });
 

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -1,178 +1,70 @@
-// grab everything between an opening and closing bracket
-const tagStringRegex = /<([^>]+?)\/?>/g;
-
-/*
-  match attributes. html does not allow escaping quotes inside attributes so we don't have to worry about that (e.g. aria-label="\"label\"").
-  @see https://regexr.com/5mbqb
-*/
-const attributeRegex = new RegExp(
-  `(?:([^\\s=]+)=` + // group 1: valued attribute name; look for non-whitespace, non-equal sign characters followed by the "=" sign
-  `(?:"([^"]*)"` + // group 2: double quoted attribute value; look for everything surrounded by double quotes
-  `|'([^']*)'` + // group 3: single quoted attribute value; look for everything surrounded by single quotes
-  `|([^'"\\s]*)))` + // group 4: non-quoted attribute value; look for any non-whitespace, non-quote characters
-    `|\\b(\\S+)(?:\\B|\\b)`, // group 5: non-valued attribute name; look for any remaining non-matched strings surrounded by word boundaries
-  'g'
-);
-
-const attrMap = {
-  for: 'htmlFor',
-  class: 'className'
-};
+import cache from '../base/cache';
+import getNodeAttributes from './get-node-attributes';
 
 /**
- * Match an attribute to a matcher object.
- * @param {String} nodeName - Name of the current node
- * @param {Object[]} attributes - Array of node attributes and values
- * @param {String} value - Value of the current attribute
- * @param {any} matcher - How to match the value
+ * Test if node and attribute match one of the filtered attributes.
+ * @param {HTMLElement} node - node to match
+ * @param {String} attrname - Name of the attribute to test
+ * @param {Object} filterAttrs - Attributes to remove and the qualifier of when to remove them.
  */
-function matches(nodeName, attributes, value, matcher) {
-  switch (typeof matcher) {
-    case 'boolean':
-      return true;
-    case 'string':
-      return matcher === value;
-    case 'object':
-      if (Array.isArray(matcher)) {
-        return matcher.includes(value);
-      }
-
-      // matcher-like object, match all parts
-      let filter = true;
-
-      // match each property
-      if (matcher.nodeName) {
-        filter = filter && matcher.nodeName === nodeName;
-      }
-
-      if (matcher.attributes) {
-        Object.keys(matcher.attributes).forEach(attrName => {
-          const attr = attributes.find(attr => attr.name === attrName);
-          if (!attr) {
-            return false;
-          }
-
-          filter =
-            filter &&
-            matches(
-              nodeName,
-              attributes,
-              attr.value,
-              matcher.attributes[attrName]
-            );
-        });
-      }
-
-      return filter;
-  }
-}
-
-/**
- * Parse an html string for each tag
- * @param {String} htmlString
- * @returns {Object[]} Parsed tags with nodeName, attributes, and raw properties
- */
-function parseElements(htmlString) {
-  const elements = [];
-  let match;
-  while ((match = tagStringRegex.exec(htmlString))) {
-    const tagStr = match[1];
-
-    // no need to filter end tags
-    if (tagStr.charAt(0) === '/') {
-      continue;
-    }
-
-    const index =
-      tagStr.indexOf(' ') !== -1 ? tagStr.indexOf(' ') : tagStr.length;
-    const nodeName = tagStr.substring(0, index).toLowerCase();
-    const attributeStr = tagStr.substring(index + 1).trim();
-
-    let groups;
-    const attributes = [];
-    while ((groups = attributeRegex.exec(attributeStr))) {
-      attributes.push({
-        // can be either a valued and non-valued attribute
-        name: (groups[1] || groups[5]).toLowerCase(),
-        // double, single, or non-quoted value
-        value: groups[2] || groups[3] || groups[4] || '',
-        raw: groups[0]
-      });
-    }
-
-    elements.push({
-      nodeName,
-      attributes,
-      raw: match[0]
-    });
+function attributeMatches(node, attrName, filterAttrs) {
+  if (typeof filterAttrs[attrName] === 'undefined') {
+    return false;
   }
 
-  return elements;
+  // filterAttrs can only be a boolean or a CSS selector
+  if (filterAttrs[attrName] === true) {
+    return true;
+  }
+
+  return node.matches(filterAttrs[attrName]);
 }
 
 /**
- * Filter out attributes from an an element.
- * @param {Object} element - element to filter
- * @param {Object} attrs - Attributes to filter
- * @returns {Object} element with filtered attributes removed
- */
-function filterAttributes({ nodeName, attributes, raw }, attrs) {
-  const filteredAttrs = attributes.filter(({ name, value }) => {
-    const matcher = attrs[attrMap[name] ? attrMap[name] : name];
-
-    if (!matcher) {
-      return true;
-    }
-
-    return !matches(nodeName, attributes, value, matcher);
-  });
-
-  return {
-    nodeName,
-    attributes: filteredAttrs,
-    raw: raw.replace(
-      attributes.map(attr => attr.raw).join(' '),
-      filteredAttrs.map(attr => attr.raw).join(' ')
-    )
-  };
-}
-
-/**
- * Filter attributes from an html string. This is not to prevent XSS attacks but instead is used to remove attributes which shouldn't appear in the output. As such, we can assume mostly normal attribute output and not attributes purposefully trying to break a parser
+ * Filter attributes from an html element and all of its children.
  *
  * Example:
  * ```js
- * // Remove attribute if present regardless of value
+ * // Remove attribute if present
  * axe.utils.filterHtmlAttrs('<div data-attr="foo">my div</div>', { 'data-attr': true });
  *
- * // Remove attribute if value matches
- * axe.utils.filterHtmlAttrs('<div data-attr="foo">my div</div>', { 'data-attr': 'foo' });
- *
- * // Remove attribute if value matches list of values
- * axe.utils.filterHtmlAttrs('<div data-attr="foo">my div</div>', { 'data-attr': ['foo', 'bar'] });
- *
- * // Remove attribute if tag matches matcher-like object
- * axe.utils.filterHtmlAttrs('<div class="foo"><input type="text" class="foo"/></div>', { class: { nodeName: input } });
+ * // Remove attribute if CSS selector matches
+ * axe.utils.filterHtmlAttrs('<div data-attr="foo">my div</div>', { 'data-attr': 'div' });
  * ```
  *
- * @method getRootNode
+ * @method filterHtmlAttrs
  * @memberof axe.utils
- * @param {String} htmlString - HTML string to remove attributes from.
- * @param {Object} filterAttrs - Attributes to remove and the qualifier of when to remove them.
- * @returns {String}
+ * @param {HTMLElement} element - HTML element to remove attributes from
+ * @param {Object} filterAttrs - Attributes to remove and the qualifier of when to remove them
+ * @returns {HTMLElement} Element with filtered attributes removed
  */
-function filterHtmlAttrs(htmlString, filterAttrs) {
+function filterHtmlAttrs(element, filterAttrs) {
   if (!filterAttrs) {
-    return htmlString;
+    return element;
   }
 
-  let filteredHtml = htmlString;
-  parseElements(htmlString).forEach(element => {
-    const filteredElement = filterAttributes(element, filterAttrs);
-    filteredHtml = filteredHtml.replace(element.raw, filteredElement.raw);
+  let node = element.cloneNode(false);
+  const outerHTML = node.outerHTML;
+  const attributes = getNodeAttributes(node);
+
+  if (cache.get(outerHTML)) {
+    node = cache.get(outerHTML);
+  } else if (attributes) {
+    Array.from(attributes).forEach(attr => {
+      if (attributeMatches(node, attr.name, filterAttrs)) {
+        node.removeAttribute(attr.name);
+      }
+    });
+
+    cache.set(outerHTML, node);
+  }
+
+  // be sure to append text nodes as well
+  Array.from(element.childNodes).forEach(child => {
+    node.appendChild(filterHtmlAttrs(child, filterAttrs));
   });
 
-  return filteredHtml;
+  return node;
 }
 
 export default filterHtmlAttrs;

--- a/lib/core/utils/filter-html-attrs.js
+++ b/lib/core/utils/filter-html-attrs.js
@@ -9,7 +9,7 @@ const attributeRegex = new RegExp(
   `(?:([^\\s=]+)=` + // group 1: valued attribute name; look for non-whitespace, non-equal sign characters followed by the "=" sign
   `(?:"([^"]*)"` + // group 2: double quoted attribute value; look for everything surrounded by double quotes
   `|'([^']*)'` + // group 3: single quoted attribute value; look for everything surrounded by single quotes
-  `|([^'"\\s]*)))` + // group 4: non-quoted attribute value; look for any non-whitespace and quote characters
+  `|([^'"\\s]*)))` + // group 4: non-quoted attribute value; look for any non-whitespace, non-quote characters
     `|\\b(\\S+)(?:\\B|\\b)`, // group 5: non-valued attribute name; look for any remaining non-matched strings surrounded by word boundaries
   'g'
 );
@@ -68,6 +68,76 @@ function matches(nodeName, attributes, value, matcher) {
 }
 
 /**
+ * Parse an html string for each tag
+ * @param {String} htmlString
+ * @returns {Object[]} Parsed tags with nodeName, attributes, and raw properties
+ */
+function parseElements(htmlString) {
+  const elements = [];
+  let match;
+  while ((match = tagStringRegex.exec(htmlString))) {
+    const tagStr = match[1];
+
+    // no need to filter end tags
+    if (tagStr.charAt(0) === '/') {
+      continue;
+    }
+
+    const index =
+      tagStr.indexOf(' ') !== -1 ? tagStr.indexOf(' ') : tagStr.length;
+    const nodeName = tagStr.substring(0, index).toLowerCase();
+    const attributeStr = tagStr.substring(index + 1).trim();
+
+    let groups;
+    const attributes = [];
+    while ((groups = attributeRegex.exec(attributeStr))) {
+      attributes.push({
+        // can be either a valued and non-valued attribute
+        name: (groups[1] || groups[5]).toLowerCase(),
+        // double, single, or non-quoted value
+        value: groups[2] || groups[3] || groups[4] || '',
+        raw: groups[0]
+      });
+    }
+
+    elements.push({
+      nodeName,
+      attributes,
+      raw: match[0]
+    });
+  }
+
+  return elements;
+}
+
+/**
+ * Filter out attributes from an an element.
+ * @param {Object} element - element to filter
+ * @param {Object} attrs - Attributes to filter
+ * @returns {Object} element with filtered attributes removed
+ */
+function filterAttributes({ nodeName, attributes, raw }, attrs) {
+  const filteredAttrs = attributes.filter(({ name, value }) => {
+    const matcher = attrs[attrMap[name] ? attrMap[name] : name];
+
+    if (!matcher) {
+      return true;
+    }
+
+    return !matches(nodeName, attributes, value, matcher);
+  });
+
+  return {
+    nodeName,
+    attributes: filteredAttrs,
+    raw: raw.replace(
+      attributes.map(attr => attr.raw).join(' '),
+      filteredAttrs.map(attr => attr.raw).join(' ')
+    )
+  };
+}
+
+/**
  * Filter attributes from an html string. This is not to prevent XSS attacks but instead is used to remove attributes which shouldn't appear in the output. As such, we can assume mostly normal attribute output and not attributes purposefully trying to break a parser
  *
  * Example:
@@ -96,43 +166,13 @@ function filterHtmlAttrs(htmlString, filterAttrs) {
     return htmlString;
   }
 
-  return htmlString.replace(tagStringRegex, (match, tagStr) => {
-    // no need to filter end tags
-    if (tagStr.charAt(0) === '/') {
-      return match;
-    }
-
-    const nodeName = tagStr.substring(0, tagStr.indexOf(' ')).toLowerCase();
-    const attributeStr = tagStr.substring(tagStr.indexOf(' ') + 1).trim();
-
-    let groups;
-    const attributes = [];
-    while ((groups = attributeRegex.exec(attributeStr))) {
-      attributes.push({
-        // can be either a valued and non-valued attribute
-        name: (groups[1] || groups[5]).toLowerCase(),
-        // double, single, or non-quoted value
-        value: groups[2] || groups[3] || groups[4] || '',
-        string: groups[0]
-      });
-    }
-
-    const filteredAttrs = attributes.filter(attribute => {
-      const { name, value } = attribute;
-      const matcher = filterAttrs[attrMap[name] ? attrMap[name] : name];
-
-      if (!matcher) {
-        return true;
-      }
-
-      return !matches(nodeName, attributes, value, matcher);
-    });
-
-    return match.replace(
-      attributeStr,
-      filteredAttrs.map(attr => attr.string).join(' ')
-    );
+  let filteredHtml = htmlString;
+  parseElements(htmlString).forEach(element => {
+    const filteredElement = filterAttributes(element, filterAttrs);
+    filteredHtml = filteredHtml.replace(element.raw, filteredElement.raw);
   });
+
+  return filteredHtml;
 }
 
 export default filterHtmlAttrs;

--- a/lib/core/utils/index.js
+++ b/lib/core/utils/index.js
@@ -68,6 +68,7 @@ export { default as querySelectorAll } from './query-selector-all';
 export { default as queue } from './queue';
 export { default as respondable } from './respondable';
 export { default as ruleShouldRun } from './rule-should-run';
+export { default as filterHtmlAttrs } from './filter-html-attrs';
 export { default as select } from './select';
 export { default as sendCommandToFrame } from './send-command-to-frame';
 export { default as setScrollState } from './set-scroll-state';

--- a/test/core/utils/filter-html-attrs.js
+++ b/test/core/utils/filter-html-attrs.js
@@ -215,5 +215,32 @@ describe('axe.utils.filterHtmlAttrs', function() {
         '<div class="foo"/>'
       );
     });
+
+    it('should handle complicated attributes', function() {
+      var html =
+        '<div type="text" value="my value again" othervalue=foo ha=\'bar\' haha=\'"foo"\' again="\'thing\'" data-thing="foo" thing=bar bar=baz checked thing2=bar thing3="\'foo\' asdf" hello=\'"foo"\' goodbye=\' hello "doo" \' hellomore="goodbye=hello" thing"hi"="good" thing"other" empty=""></div>';
+      var config = {
+        type: 'text',
+        value: 'my value again',
+        othervalue: 'foo',
+        ha: 'bar',
+        haha: '"foo"',
+        again: "'thing'",
+        'data-thing': 'foo',
+        thing: 'bar',
+        bar: 'baz',
+        checked: true,
+        thing2: 'bar',
+        thing3: "'foo' asdf",
+        hello: '"foo"',
+        goodbye: ' hello "doo" ',
+        hellomore: 'goodbye=hello',
+        'thing"hi"': 'good',
+        'thing"other"': true,
+        empty: true
+      };
+
+      assert.equal(filterHtmlAttrs(html, config), '<div ></div>');
+    });
   });
 });

--- a/test/core/utils/filter-html-attrs.js
+++ b/test/core/utils/filter-html-attrs.js
@@ -41,7 +41,7 @@ describe('axe.utils.filterHtmlAttrs', function() {
     assert.equal(
       filterHtmlAttrs(html, {
         type: true,
-        value: '[value="my value"]'
+        value: true
       }).outerHTML,
       '<label> My Label <input></label>'
     );

--- a/test/core/utils/filter-html-attrs.js
+++ b/test/core/utils/filter-html-attrs.js
@@ -1,246 +1,49 @@
 describe('axe.utils.filterHtmlAttrs', function() {
   'use strict';
+  var fixture = document.querySelector('#fixture');
+
   var filterHtmlAttrs = axe.utils.filterHtmlAttrs;
-  var html = '<label> My Label <input type="text" value="my value" /></label>';
-  var expected = '<label> My Label <input value="my value" /></label>';
+  var html, expected;
+
+  beforeEach(function() {
+    fixture.innerHTML =
+      '<label> My Label <input type="text" value="my value" /></label>';
+    html = fixture.firstChild;
+    expected = '<label> My Label <input value="my value"></label>';
+  });
 
   it('should return string if no attributes are passed', function() {
     assert.equal(filterHtmlAttrs(html), html);
   });
 
   it('should filter attribute if exists', function() {
-    assert.equal(filterHtmlAttrs(html, { type: true }), expected);
+    assert.equal(filterHtmlAttrs(html, { type: true }).outerHTML, expected);
   });
 
-  it('should filter attribute if matches value', function() {
-    assert.equal(filterHtmlAttrs(html, { type: 'text' }), expected);
+  it('should filter attribute if matches CSS selector', function() {
+    assert.equal(filterHtmlAttrs(html, { type: 'input' }).outerHTML, expected);
   });
 
   it('should not filter attribute if does not match value', function() {
-    assert.equal(filterHtmlAttrs(html, { type: 'submit' }), html);
-  });
-
-  it('should filter attribute if matches list of values', function() {
-    assert.equal(filterHtmlAttrs(html, { type: ['submit', 'text'] }), expected);
-  });
-
-  it('should not filter attribute if does not match list of values', function() {
-    assert.equal(filterHtmlAttrs(html, { type: ['submit', 'password'] }), html);
-  });
-
-  it('should filter attribute if node matches nodeName matcher', function() {
     assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          nodeName: 'input'
-        }
-      }),
-      expected
+      filterHtmlAttrs(html, { type: 'div' }).outerHTML,
+      html.outerHTML
     );
   });
 
-  it('should filter attribute if node matches attributes matcher (boolean)', function() {
-    assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          attributes: {
-            value: true
-          }
-        }
-      }),
-      expected
-    );
-  });
-
-  it('should filter attribute if node matches attributes matcher (string)', function() {
-    assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          attributes: {
-            value: 'my value'
-          }
-        }
-      }),
-      expected
-    );
-  });
-
-  it('should filter attribute if node matches attributes matcher (array)', function() {
-    assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          attributes: {
-            value: ['foo', 'my value']
-          }
-        }
-      }),
-      expected
-    );
-  });
-
-  it('should filter attribute if node matches all matcher', function() {
-    assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          attributes: {
-            nodeName: 'input',
-            value: 'my value'
-          }
-        }
-      }),
-      expected
-    );
-  });
-
-  it('should not filter attribute if node does not match nodeName  matcher', function() {
-    assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          nodeName: 'div'
-        }
-      }),
-      html
-    );
-  });
-
-  it('should not filter attribute if node does not match attribute  matcher (string)', function() {
-    assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          attributes: {
-            value: 'div'
-          }
-        }
-      }),
-      html
-    );
-  });
-
-  it('should not filter attribute if node does not match attribute  matcher (array)', function() {
-    assert.equal(
-      filterHtmlAttrs(html, {
-        type: {
-          attributes: {
-            value: ['div', 'bar']
-          }
-        }
-      }),
-      html
-    );
+  it('should not change the original element', function() {
+    var outerHTML = html.outerHTML;
+    assert.isTrue(filterHtmlAttrs(html, { type: true }) !== html);
+    assert.equal(html.outerHTML, outerHTML);
   });
 
   it('should filter multiple attributes', function() {
     assert.equal(
-      filterHtmlAttrs(html, { type: true, value: 'my value' }),
-      '<label> My Label <input  /></label>'
+      filterHtmlAttrs(html, {
+        type: true,
+        value: '[value="my value"]'
+      }).outerHTML,
+      '<label> My Label <input></label>'
     );
-  });
-
-  describe('attributes', function() {
-    it('should handle attribute with double quotes', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class="hello">', { className: 'hello' }),
-        '<div >'
-      );
-    });
-
-    it('should handle attribute with single quotes', function() {
-      assert.equal(
-        filterHtmlAttrs("<div class='hello'>", { className: 'hello' }),
-        '<div >'
-      );
-    });
-
-    it('should handle attribute with mixed quotes', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class="\'hello\'">', { className: "'hello'" }),
-        '<div >'
-      );
-    });
-
-    it('should handle attribute without quotes', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class=hello>', { className: 'hello' }),
-        '<div >'
-      );
-    });
-
-    it('should handle attributes with no values', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class>', { className: true }),
-        '<div >'
-      );
-    });
-
-    it('should handle whitespace in attribute', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class="foo bar baz">', {
-          className: 'foo bar baz'
-        }),
-        '<div >'
-      );
-    });
-
-    it('should handle dash-separated attribute names', function() {
-      assert.equal(
-        filterHtmlAttrs('<div aria-label="foo">', { 'aria-label': 'foo' }),
-        '<div >'
-      );
-    });
-
-    it('should handle end of tag terminator after unquoted value', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class=foo/>', { className: 'foo' }),
-        '<div />'
-      );
-    });
-
-    it('should handle end of tag terminator after quoted value', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class="foo"/>', { className: 'foo' }),
-        '<div />'
-      );
-    });
-
-    it('should be case insensitive for attribute name', function() {
-      assert.equal(
-        filterHtmlAttrs('<div CLASS="foo"/>', { className: 'foo' }),
-        '<div />'
-      );
-    });
-
-    it('should be case sensitive for attribute value', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class="foo"/>', { className: 'FOO' }),
-        '<div class="foo"/>'
-      );
-    });
-
-    it('should handle complicated attributes', function() {
-      var html =
-        '<div type="text" value="my value again" othervalue=foo ha=\'bar\' haha=\'"foo"\' again="\'thing\'" data-thing="foo" thing=bar bar=baz checked thing2=bar thing3="\'foo\' asdf" hello=\'"foo"\' goodbye=\' hello "doo" \' hellomore="goodbye=hello" thing"hi"="good" thing"other" empty=""></div>';
-      var config = {
-        type: 'text',
-        value: 'my value again',
-        othervalue: 'foo',
-        ha: 'bar',
-        haha: '"foo"',
-        again: "'thing'",
-        'data-thing': 'foo',
-        thing: 'bar',
-        bar: 'baz',
-        checked: true,
-        thing2: 'bar',
-        thing3: "'foo' asdf",
-        hello: '"foo"',
-        goodbye: ' hello "doo" ',
-        hellomore: 'goodbye=hello',
-        'thing"hi"': 'good',
-        'thing"other"': true,
-        empty: true
-      };
-
-      assert.equal(filterHtmlAttrs(html, config), '<div ></div>');
-    });
   });
 });

--- a/test/core/utils/filter-html-attrs.js
+++ b/test/core/utils/filter-html-attrs.js
@@ -1,0 +1,242 @@
+describe('axe.utils.filterHtmlAttrs', function() {
+  'use strict';
+  var filterHtmlAttrs = axe.utils.filterHtmlAttrs;
+  var html = '<label> My Label <input type="text" value="my value" /></label>';
+  var expected = '<label> My Label <input value="my value" /></label>';
+
+  it('should return string if no attributes are passed', function() {
+    assert.equal(filterHtmlAttrs(html), html);
+  });
+
+  it('should filter attribute if exists', function() {
+    assert.equal(filterHtmlAttrs(html, { type: true }), expected);
+  });
+
+  it('should filter attribute if matches value', function() {
+    assert.equal(filterHtmlAttrs(html, { type: 'text' }), expected);
+  });
+
+  it('should not filter attribute if does not match value', function() {
+    assert.equal(filterHtmlAttrs(html, { type: 'submit' }), html);
+  });
+
+  it('should filter attribute if matches list of values', function() {
+    assert.equal(filterHtmlAttrs(html, { type: ['submit', 'text'] }), expected);
+  });
+
+  it('should not filter attribute if does not match list of values', function() {
+    assert.equal(filterHtmlAttrs(html, { type: ['submit', 'password'] }), html);
+  });
+
+  it('should filter attribute if node matches nodeName matcher', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          nodeName: 'input'
+        }
+      }),
+      expected
+    );
+  });
+
+  it('should filter attribute if node matches attributes matcher (boolean)', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          attributes: {
+            value: true
+          }
+        }
+      }),
+      expected
+    );
+  });
+
+  it('should filter attribute if node matches attributes matcher (string)', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          attributes: {
+            value: 'my value'
+          }
+        }
+      }),
+      expected
+    );
+  });
+
+  it('should filter attribute if node matches attributes matcher (array)', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          attributes: {
+            value: ['foo', 'my value']
+          }
+        }
+      }),
+      expected
+    );
+  });
+
+  it('should filter attribute if node matches all matcher', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          attributes: {
+            nodeName: 'input',
+            value: 'my value'
+          }
+        }
+      }),
+      expected
+    );
+  });
+
+  it('should not filter attribute if node does not match nodeName  matcher', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          nodeName: 'div'
+        }
+      }),
+      html
+    );
+  });
+
+  it('should not filter attribute if node does not match attribute  matcher (string)', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          attributes: {
+            value: 'div'
+          }
+        }
+      }),
+      html
+    );
+  });
+
+  it('should not filter attribute if node does not match attribute  matcher (array)', function() {
+    assert.equal(
+      filterHtmlAttrs(html, {
+        type: {
+          attributes: {
+            value: ['div', 'bar']
+          }
+        }
+      }),
+      html
+    );
+  });
+
+  it('should filter multiple attributes', function() {
+    assert.equal(
+      filterHtmlAttrs(html, { type: true, value: 'my value' }),
+      '<label> My Label <input  /></label>'
+    );
+  });
+
+  describe('attributes', function() {
+    it('should handle attribute with double quotes', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class="hello">', { className: 'hello' }),
+        '<div >'
+      );
+    });
+
+    it('should handle attribute with single quotes', function() {
+      assert.equal(
+        filterHtmlAttrs("<div class='hello'>", { className: 'hello' }),
+        '<div >'
+      );
+    });
+
+    it('should handle attribute with double quotes and escaped double quotes', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class=""hello"">', { className: '"hello"' }),
+        '<div >'
+      );
+    });
+
+    it('should handle attribute with single quotes and escaped single quotes', function() {
+      assert.equal(
+        filterHtmlAttrs("<div class=''hello''>", { className: "'hello'" }),
+        '<div >'
+      );
+    });
+
+    it('should handle attribute with mixed quotes', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class="\'hello\'">', { className: "'hello'" }),
+        '<div >'
+      );
+    });
+
+    it('should handle attribute with escaped quotes in middle of string', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class=""hello"" id="foo">', {
+          className: '"hello"'
+        }),
+        '<div id="foo">'
+      );
+    });
+
+    it('should handle attribute without quotes', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class=hello>', { className: 'hello' }),
+        '<div >'
+      );
+    });
+
+    it('should handle attributes with no values', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class>', { className: true }),
+        '<div >'
+      );
+    });
+
+    it('should handle whitespace in attribute', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class="foo bar baz">', {
+          className: 'foo bar baz'
+        }),
+        '<div >'
+      );
+    });
+
+    it('should handle dash-separated attribute names', function() {
+      assert.equal(
+        filterHtmlAttrs('<div aria-label="foo">', { 'aria-label': 'foo' }),
+        '<div >'
+      );
+    });
+
+    it('should handle end of tag terminator after unquoted value', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class=foo/>', { className: 'foo' }),
+        '<div />'
+      );
+    });
+
+    it('should handle end of tag terminator after quoted value', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class="foo"/>', { className: 'foo' }),
+        '<div />'
+      );
+    });
+
+    it('should be case insensitive for attribute name', function() {
+      assert.equal(
+        filterHtmlAttrs('<div CLASS="foo"/>', { className: 'foo' }),
+        '<div />'
+      );
+    });
+
+    it('should be case sensitive for attribute value', function() {
+      assert.equal(
+        filterHtmlAttrs('<div class="foo"/>', { className: 'FOO' }),
+        '<div class="foo"/>'
+      );
+    });
+  });
+});

--- a/test/core/utils/filter-html-attrs.js
+++ b/test/core/utils/filter-html-attrs.js
@@ -41,7 +41,7 @@ describe('axe.utils.filterHtmlAttrs', function() {
     assert.equal(
       filterHtmlAttrs(html, {
         type: true,
-        value: true
+        value: '[value="my value"]'
       }).outerHTML,
       '<label> My Label <input></label>'
     );

--- a/test/core/utils/filter-html-attrs.js
+++ b/test/core/utils/filter-html-attrs.js
@@ -151,33 +151,10 @@ describe('axe.utils.filterHtmlAttrs', function() {
       );
     });
 
-    it('should handle attribute with double quotes and escaped double quotes', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class=""hello"">', { className: '"hello"' }),
-        '<div >'
-      );
-    });
-
-    it('should handle attribute with single quotes and escaped single quotes', function() {
-      assert.equal(
-        filterHtmlAttrs("<div class=''hello''>", { className: "'hello'" }),
-        '<div >'
-      );
-    });
-
     it('should handle attribute with mixed quotes', function() {
       assert.equal(
         filterHtmlAttrs('<div class="\'hello\'">', { className: "'hello'" }),
         '<div >'
-      );
-    });
-
-    it('should handle attribute with escaped quotes in middle of string', function() {
-      assert.equal(
-        filterHtmlAttrs('<div class=""hello"" id="foo">', {
-          className: '"hello"'
-        }),
-        '<div id="foo">'
       );
     });
 


### PR DESCRIPTION
Remove unwanted attributes from source string. Will add all the audit code around it in another pr so this one doesn't get too big.

For the record; this does add a small feature, but it is a feature necessary to address a security fix that will need to be applied to all supported minor versions of axe-core. We are therefor tagging this as a "fix" instead of a "feat".