### PR TITLE
 docs(examples/jest_react): fix typo referring to Jasmine 

### DIFF
--- a/doc/examples/jest_react/README.md
+++ b/doc/examples/jest_react/README.md
@@ -16,7 +16,7 @@ axe-core in Jest (using JSDOM and Enzyme).
 ## To run the example
 
 - Move to the `doc/examples/jest_react` directory
-- `npm test` to run Jasmine
+- `npm test` to run Jest
 
 You should see output indicating that the tests ran successfully, with zero
 failures.


### PR DESCRIPTION
According to `doc/examples/jest_react/package.json`, as well as terminal output, the `npm test` script runs **Jest**, not Jasmine within the scope of the `doc/examples/jest_react` directory. The `doc/examples/jest_react/README.md` has been updated to accurately describe this script event.