### PR TITLE
fix(utils): fix warning thrown by Webpack

### DIFF
--- a/lib/core/utils/uuid.js
+++ b/lib/core/utils/uuid.js
@@ -24,7 +24,7 @@ if (!_rng && _crypto && _crypto.getRandomValues) {
 }
 
 try {
-  if (!_rng && require) {
+  if (!_rng) {
     const nodeCrypto = require('crypto');
     _rng = () => nodeCrypto.randomBytes(16);
   }


### PR DESCRIPTION
https://github.com/dequelabs/axe-core/issues/2840#issuecomment-800588057

This PR updates [a line added in the recent 4.1.3 release](https://github.com/dequelabs/axe-core/pull/2826/files#diff-fb259cc117394538f4c068d26b0e2bc427ffc8b8d4d5f8eeb58f4783b7b35891R27). Webpack is throwing a warning when this library is included in a bundle, pointed at the given line.

I believe what's happening here is that Webpack sees the word "require", but doesn't understand that it's not being used to actually "require" something. Webpack doesn't know what to do with it, so it throws a warning.

The line is already wrapped in a try, so it should be fine to just drop the `&& require` in the condition. If `const nodeCrypto = require('crypto')` fails, the error will get caught and we can continue on.

Closes issue: #2840 