### PR TITLE
fix(focus-order-semantics): allow role=tooltip to pass

### DIFF
--- a/lib/checks/aria/valid-scrollable-semantics-evaluate.js
+++ b/lib/checks/aria/valid-scrollable-semantics-evaluate.js
@@ -1,3 +1,5 @@
+import { getExplicitRole } from '../../commons/aria';
+
 /**
  * A map from HTML tag names to a boolean which reflects whether it is
  * appropriate for scrollable elements found in the focus order.
@@ -42,12 +44,16 @@ function validScrollableTagName(node) {
  * @return {Boolean} Whether the node has a role appropriate for a scrollable
  *		 region.
  */
-function validScrollableRole(node) {
-  var role = node.getAttribute('role');
+function validScrollableRole(node, options) {
+  var role = getExplicitRole(node);
   if (!role) {
     return false;
   }
-  return VALID_ROLES_FOR_SCROLLABLE_REGIONS[role.toLowerCase()] || false;
+  return (
+    VALID_ROLES_FOR_SCROLLABLE_REGIONS[role] ||
+    options.roles.includes(role) ||
+    false
+  );
 }
 
 /**
@@ -57,8 +63,8 @@ function validScrollableRole(node) {
  * @param {HTMLElement} node
  * @return {Boolean} True if the elements role or tag name is a valid scrollable region. False otherwise.
  */
-function validScrollableSemanticsEvaluate(node) {
-  return validScrollableRole(node) || validScrollableTagName(node);
+function validScrollableSemanticsEvaluate(node, options) {
+  return validScrollableRole(node, options) || validScrollableTagName(node);
 }
 
 export default validScrollableSemanticsEvaluate;

--- a/lib/checks/aria/valid-scrollable-semantics.json
+++ b/lib/checks/aria/valid-scrollable-semantics.json
@@ -1,7 +1,9 @@
 {
   "id": "valid-scrollable-semantics",
   "evaluate": "valid-scrollable-semantics-evaluate",
-  "options": [],
+  "options": {
+    "roles": ["tooltip"]
+  },
   "metadata": {
     "impact": "minor",
     "messages": {

--- a/test/checks/aria/valid-scrollable-semantics.js
+++ b/test/checks/aria/valid-scrollable-semantics.js
@@ -2,6 +2,7 @@ describe('valid-scrollable-semantics', function() {
   'use strict';
 
   var fixture = document.getElementById('fixture');
+  var flatTreeSetup = axe.testUtils.flatTreeSetup;
   var checkContext = axe.testUtils.MockCheckContext();
 
   afterEach(function() {
@@ -13,6 +14,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', '"banner');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -24,6 +26,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'search');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -35,6 +38,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'form');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -46,6 +50,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'navigation');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -57,6 +62,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'complementary');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -68,6 +74,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'contentinfo');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -79,6 +86,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'main');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -90,6 +98,7 @@ describe('valid-scrollable-semantics', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'region');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -100,6 +109,7 @@ describe('valid-scrollable-semantics', function() {
   it('should return true for nav elements', function() {
     var node = document.createElement('nav');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -110,6 +120,7 @@ describe('valid-scrollable-semantics', function() {
   it('should return true for section elements', function() {
     var node = document.createElement('section');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -120,6 +131,7 @@ describe('valid-scrollable-semantics', function() {
   it('should return true for article elements', function() {
     var node = document.createElement('article');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
@@ -130,10 +142,37 @@ describe('valid-scrollable-semantics', function() {
   it('should return true for aside elements', function() {
     var node = document.createElement('aside');
     fixture.appendChild(node);
+    flatTreeSetup(fixture);
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('valid-scrollable-semantics')
         .call(checkContext, node)
     );
+  });
+
+  it('should return true for role=tooltip', function() {
+    var node = document.createElement('div');
+    node.setAttribute('role', 'tooltip');
+    fixture.appendChild(node);
+    flatTreeSetup(fixture);
+    assert.isTrue(
+      axe.testUtils
+        .getCheckEvaluate('valid-scrollable-semantics')
+        .call(checkContext, node)
+    );
+  });
+
+  describe('options', function() {
+    it('should allow options.roles to return true for role', function() {
+      var node = document.createElement('div');
+      node.setAttribute('role', 'banner');
+      fixture.appendChild(node);
+      flatTreeSetup(fixture);
+      assert.isTrue(
+        axe.testUtils
+          .getCheckEvaluate('valid-scrollable-semantics')
+          .call(checkContext, node, { roles: ['banner'] })
+      );
+    });
   });
 });

--- a/test/integration/rules/focus-order-semantics/focus-order-semantics.html
+++ b/test/integration/rules/focus-order-semantics/focus-order-semantics.html
@@ -29,6 +29,7 @@
       <div id="pass6" role="main" tabindex="0"></div>
       <div id="pass7" role="region" tabindex="0"></div>
       <div id="pass8" role="application" tabindex="0"></div>
+      <div id="pass9" role="tooltip" tabindex="0"></div>
     </div>
     <h4>
       Valid scrollable HTML tags for scrollable regions, not selected by this

--- a/test/integration/rules/focus-order-semantics/focus-order-semantics.json
+++ b/test/integration/rules/focus-order-semantics/focus-order-semantics.json
@@ -9,7 +9,8 @@
     ["#pass5"],
     ["#pass6"],
     ["#pass7"],
-    ["#pass8"]
+    ["#pass8"],
+    ["#pass9"]
   ],
   "violations": [
     ["#violation1"],


### PR DESCRIPTION
Added option to `valid-scrollable-semaantics` to accept a list of roles to pass.

Closes #2813 