### PR TITLE
ci(sync-branches): Do not include PR template

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -12,4 +12,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-title: "chore: merge master into develop"
           pr-reviewers: straker,WilcoFiers,stephenmathieson
-          pr-template: .github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
This PR template is no longer relevant here.
