### PR TITLE
fix(types): make `evaluate` check optional

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -206,7 +206,7 @@ declare namespace axe {
   }
   interface Check {
     id: string;
-    evaluate: Function | string;
+    evaluate?: Function | string;
     after?: Function | string;
     options?: any;
     matches?: string;


### PR DESCRIPTION
See: #2901 
Closes issue:
