### PR TITLE
fix(getStandards): Read standards from utils

### DIFF
--- a/lib/core/utils/get-standards.js
+++ b/lib/core/utils/get-standards.js
@@ -1,0 +1,6 @@
+import standards from '../../standards/index'
+import clone from './clone'
+
+export default function getStandards() {
+  return clone(standards);
+}

--- a/lib/core/utils/get-standards.js
+++ b/lib/core/utils/get-standards.js
@@ -1,4 +1,4 @@
-import standards from '../../standards/index'
+import standards from '../../standards'
 import clone from './clone'
 
 export default function getStandards() {

--- a/lib/core/utils/index.js
+++ b/lib/core/utils/index.js
@@ -38,6 +38,7 @@ export { default as getScrollState } from './get-scroll-state';
 export { default as getScroll } from './get-scroll';
 export { default as getShadowSelector } from './get-shadow-selector';
 export { default as getSelector, getSelectorData } from './get-selector';
+export { default as getStandards } from './get-standards';
 export { default as getStyleSheetFactory } from './get-stylesheet-factory';
 export { default as getXpath } from './get-xpath';
 export { default as getAncestry } from './get-ancestry';

--- a/test/core/utils/get-standards.js
+++ b/test/core/utils/get-standards.js
@@ -1,0 +1,11 @@
+describe('axe.utils.getStandards', function () {
+  it('returns the standards object', function () {
+    var standards = axe.utils.getStandards();
+    assert.hasAnyKeys(standards, [
+      'ariaAttrs',
+      'ariaRoles',
+      'htmlElms',
+      'cssColors'
+    ]);
+  });
+});


### PR DESCRIPTION
Should have made this info available before. Not sure why we overlooked that.

Closes issue #2889