### PR TITLE
failing test for nested-interactive with role="presentation"

### DIFF
--- a/test/integration/rules/nested-interactive/nested-interactive.html
+++ b/test/integration/rules/nested-interactive/nested-interactive.html
@@ -3,6 +3,7 @@
 <div role="tab" id="pass3">pass</div>
 <div role="checkbox" id="pass4">pass</div>
 <div role="radio" id="pass5"><span>pass</span></div>
+<div role="button" id="pass6"><button role="presentation">pass</button></div>
 
 <button id="fail1"><span tabindex="0">fail</span></button>
 <div role="button" id="fail2"><input /></div>

--- a/test/integration/virtual-rules/nested-interactive.js
+++ b/test/integration/virtual-rules/nested-interactive.js
@@ -94,6 +94,29 @@ describe('nested-interactive virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
+  it('should pass for element with natively focusable content with role="presentation"', function() {
+    var node = new axe.SerialVirtualNode({
+      nodeName: 'div',
+      attributes: {
+        role: 'button'
+      }
+    });
+    var child = new axe.SerialVirtualNode({
+      nodeName: 'button',
+      attributes: {
+        role: 'presentation'
+      }
+    });
+    child.children = [];
+    node.children = [child];
+
+    var results = axe.runVirtualRule('nested-interactive', node);
+
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
   it('should return incomplete if element has undefined children', function() {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button'


### PR DESCRIPTION
Showcase failing situation for `nested-interactive` with role="presentation"

related issue: https://github.com/dequelabs/axe-core/issues/2906