### PR TITLE
fix(accessible name) Fix regression in accessible name computation

### DIFF
--- a/lib/commons/text/subtree-text.js
+++ b/lib/commons/text/subtree-text.js
@@ -54,7 +54,7 @@ function appendAccessibleText(contentText, virtualNode, context) {
     return contentText;
   }
 
-  if (nodeName === 'img' || !phrasingElements.includes(nodeName)) {
+  if (!phrasingElements.includes(nodeName)) {
     // Append space, if necessary
     if (contentTextAdd[0] !== ' ') {
       contentTextAdd += ' ';

--- a/lib/commons/text/subtree-text.js
+++ b/lib/commons/text/subtree-text.js
@@ -54,7 +54,7 @@ function appendAccessibleText(contentText, virtualNode, context) {
     return contentText;
   }
 
-  if (!phrasingElements.includes(nodeName)) {
+  if (nodeName === 'img' || !phrasingElements.includes(nodeName)) {
     // Append space, if necessary
     if (contentTextAdd[0] !== ' ') {
       contentTextAdd += ' ';

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -350,14 +350,17 @@ const htmlElms = {
       },
       usemap: {
         matches: '[usemap]',
-        contentTypes: ['interactive', 'embedded', 'phrasing', 'flow']
+        contentTypes: ['interactive', 'embedded', 'flow']
       },
       default: {
         // Note: allow role presentation and none on image with no
         // alt as a way to prevent axe from flagging the image as
         // needing an alt
         allowedRoles: ['presentation', 'none'],
-        contentTypes: ['embedded', 'phrasing', 'flow']
+        // Note: spec change (do not count as phrasing), because browsers
+        // insert a space between an img's accessible name and other
+        // elements' accessible names
+        contentTypes: ['embedded', 'flow']
       }
     },
     // 5.10 img Element

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -3208,6 +3208,17 @@ describe('text.accessibleTextVirtual', function() {
       assert.equal(accessibleText(target), 'Country of origin: United States');
     });
 
+    it('passes test 160', function() {
+      fixture.innerHTML =
+        '<a id="test" href="../images/index.html">Images tool test page<img id="img18" aria-label="aria-label text" alt="logo" src="../images/Accessibility.jpg" width="50" height="50"></a>';
+      axe.testUtils.flatTreeSetup(fixture);
+      var target = fixture.querySelector('#test');
+      assert.equal(
+        accessibleText(target),
+        'Images tool test page aria-label text'
+      );
+    });
+
     /**
 	// In case anyone even wants it, here's the script used to generate these test cases
 	function getTestCase(content, index = 0) {

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -1421,9 +1421,21 @@ describe('text.accessibleTextVirtual', function() {
         assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
       });
     });
+
+    it('inserts a space before img alt text', function() {
+      var accessibleText = axe.commons.text.accessibleText;
+      fixture.innerHTML =
+        '<a id="test" href="../images/index.html">Images tool test page<img id="img18" aria-label="aria-label text" alt="logo" src="../images/Accessibility.jpg" width="50" height="50"></a>';
+      axe.testUtils.flatTreeSetup(fixture);
+      var target = fixture.querySelector('#test');
+      assert.equal(
+        accessibleText(target),
+        'Images tool test page aria-label text'
+      );
+    });
   });
 
-  describe('text.accessibleText acceptence tests', function() {
+  describe('text.accessibleText acceptance tests', function() {
     'use strict';
     // Tests borrowed from the AccName 1.1 testing docs
     // https://www.w3.org/wiki/AccName_1.1_Testable_Statements#Name_test_case_539
@@ -3206,17 +3218,6 @@ describe('text.accessibleTextVirtual', function() {
       axe.testUtils.flatTreeSetup(fixture);
       var target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Country of origin: United States');
-    });
-
-    it('passes test 160', function() {
-      fixture.innerHTML =
-        '<a id="test" href="../images/index.html">Images tool test page<img id="img18" aria-label="aria-label text" alt="logo" src="../images/Accessibility.jpg" width="50" height="50"></a>';
-      axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
-      assert.equal(
-        accessibleText(target),
-        'Images tool test page aria-label text'
-      );
     });
 
     /**


### PR DESCRIPTION
This regression was introduced in [the commit to replace phrasing elements](https://github.com/dequelabs/axe-core/commit/6aab97f782304d3c43379d6f234673cbad6c0cdd), that replaced a hard-coded list of elements with a call to `getElementsByContentType('phrasing')`. 

In the hardcoded array, there are 44 elements that make up the `phrasingElements` array. In the new code using the function, there are 54 elements that are now considered phrasing elements. If the virtual node is a phrasing element as defined in that array, the new content does not get spaces added around it when appending to the virtual name. 

With this in mind, I think it's possible other regressions/behavior changes were caused by that commit but not caught by tests. I'm not sure what the correct behavior is - possibly to only include `img` elements in the things that get spaces appended around the accessible name, as I'm doing here, or maybe to do it for other elements that were added, too (going back to the hard-coded list). Or, possibly this was previously a bug when compared to the spec/actual AT behavior, and the change I made would be the wrong behavior?

Hopefully this PR helps expose the issue at least, even if there needs to be more discussion/investigation before it's merged. 

Closes issue: #2899 
