### PR TITLE
fix(meta-viewport): test that a user-scalable number does not prevent zoom

### DIFF
--- a/lib/checks/mobile/meta-viewport-scale-evaluate.js
+++ b/lib/checks/mobile/meta-viewport-scale-evaluate.js
@@ -45,6 +45,18 @@ function metaViewportScaleEvaluate(node, options, virtualNode) {
     return false;
   }
 
+  const userScalableAsFloat = parseFloat(result['user-scalable']);
+  if (
+    !lowerBound &&
+    result['user-scalable'] &&
+    (userScalableAsFloat || userScalableAsFloat === 0) &&
+    userScalableAsFloat > -1 &&
+    userScalableAsFloat < 1
+  ) {
+    this.data('user-scalable');
+    return false;
+  }
+
   if (
     result['maximum-scale'] &&
     parseFloat(result['maximum-scale']) < scaleMinimum

--- a/test/checks/mobile/meta-viewport-scale.js
+++ b/test/checks/mobile/meta-viewport-scale.js
@@ -34,6 +34,30 @@ describe('meta-viewport', function() {
       );
     });
 
+    it('should return false on user-scalable in the range <-1, 1>', function() {
+      var vNode = queryFixture(
+        '<meta id="target" name="viewport" content="foo=bar, cats=dogs, user-scalable=0, more-stuff=ok">'
+      );
+
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('meta-viewport')
+          .call(checkContext, null, null, vNode)
+      );
+    });
+
+    it('should return false on user-scalable in the range <-1, 1>', function() {
+      var vNode = queryFixture(
+        '<meta id="target" name="viewport" content="foo=bar, cats=dogs, user-scalable=-0.5, more-stuff=ok">'
+      );
+
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('meta-viewport')
+          .call(checkContext, null, null, vNode)
+      );
+    });
+
     it('should return true on user-scalable=yes', function() {
       var vNode = queryFixture(
         '<meta id="target" name="viewport" content="foo=bar, cats=dogs, user-scalable=yes, more-stuff=ok">'
@@ -169,6 +193,30 @@ describe('meta-viewport', function() {
           .call(checkContext, null, null, vNode)
       );
       assert.deepEqual(checkContext._data, 'user-scalable=no');
+    });
+
+    it('should return false on user-scalable in the range <-1, 1>', function() {
+      var vNode = queryFixture(
+        '<meta id="target" name="viewport" content="foo=bar, cats=dogs, user-scalable=0, more-stuff=ok">'
+      );
+
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('meta-viewport')
+          .call(checkContext, null, null, vNode)
+      );
+    });
+
+    it('should return false on user-scalable in the range <-1, 1>', function() {
+      var vNode = queryFixture(
+        '<meta id="target" name="viewport" content="foo=bar, cats=dogs, user-scalable=-0.5, more-stuff=ok">'
+      );
+
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('meta-viewport')
+          .call(checkContext, null, null, vNode)
+      );
     });
 
     it('should return true on user-scalable=yes', function() {

--- a/test/integration/virtual-rules/meta-viewport.js
+++ b/test/integration/virtual-rules/meta-viewport.js
@@ -69,6 +69,20 @@ describe('meta-viewport virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
+  it('should fail for user-scalable=0', function() {
+    var results = axe.runVirtualRule('meta-viewport', {
+      nodeName: 'meta',
+      attributes: {
+        name: 'viewport',
+        content: 'user-scalable=0'
+      }
+    });
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
   it('should fail for maximum-scale=yes', function() {
     var results = axe.runVirtualRule('meta-viewport', {
       nodeName: 'meta',


### PR DESCRIPTION
Check if the user-scalable attribute of the viewport meta is between -1 & 1 to be able to zoom.

In addition to check if the`user-scalable` attribute of the viewport meta is set to `no` we need to test if it's in between -1 & 1.
On iOS devices when `user-scalable` is set to `0` you can't zoom.

Related: 
-  [CCWG specs](https://drafts.csswg.org/css-device-adapt/#user-scalable)
- [This google lighthouse discussion](https://github.com/GoogleChrome/lighthouse/discussions/12448)


