### PR TITLE
chore: fix cherry-pick script

### DIFF
--- a/build/cherry-pick.js
+++ b/build/cherry-pick.js
@@ -93,7 +93,7 @@ function getCommits(branch) {
     // filter merge commits and any types that don't match the release type
     if (
       !merge &&
-      !subject.startsWith('merge branch') &&
+      subject && !subject.startsWith('merge branch') &&
       scope !== 'release' &&
       commitType[releaseType] &&
       !ignoreCommits.includes(hash)


### PR DESCRIPTION
Ran into a small problem with the [latest release](https://github.com/dequelabs/axe-core/pull/2946) when I tried to run the cherry-pick script. Seems that because one of the PRs was not squashed, we got a lot of commits without a `subject` which broke when the script tried to use `subject.startsWith`. 