### PR TITLE
FIX: JS error in @axe-core/react caused by stale reference to heading

### DIFF
--- a/lib/checks/navigation/heading-order-after.js
+++ b/lib/checks/navigation/heading-order-after.js
@@ -114,11 +114,11 @@ function headingOrderAfter(results) {
     });
     const index = headingOrder.indexOf(heading);
     if (index > -1) {
-			headingOrder.splice(index, 1, {
-				level: headingOrder[index].level,
-				result
-			});
-		}
+      headingOrder.splice(index, 1, {
+        level: headingOrder[index].level,
+        result
+      });
+    }
   });
 
   // remove any iframes that aren't in context (level == -1)

--- a/lib/checks/navigation/heading-order-after.js
+++ b/lib/checks/navigation/heading-order-after.js
@@ -113,10 +113,12 @@ function headingOrderAfter(results) {
       return heading.ancestry === path;
     });
     const index = headingOrder.indexOf(heading);
-    headingOrder.splice(index, 1, {
-      level: headingOrder[index].level,
-      result
-    });
+    if (index > -1) {
+			headingOrder.splice(index, 1, {
+				level: headingOrder[index].level,
+				result
+			});
+		}
   });
 
   // remove any iframes that aren't in context (level == -1)


### PR DESCRIPTION
<< Describe the changes >>
Noticed a small bug when testing out a newer version of @axe-core/react (we were on a pretty old version of react-axe), we have a case where a heading gets removed during an animation and it seems that heading-order-after is called with a stale result such that when trying to find it's index in the heading order it can't be found and we see a error in the console like `TypeError: Cannot read property 'level' of undefined`. This is a simple naive fix to not use the index if it is -1, but I'm happy to try a different strategy if somebody with more context has a better one!

Closes issue:
`TypeError: Cannot read property 'level' of undefined` when @axe-core/react runs axe-core against a rapidly updating heading structure