### PR TITLE
fix(meta-viewport) Don't check zooming/scaling ability in iframe-embedded pages

### DIFF
--- a/lib/checks/mobile/meta-viewport.json
+++ b/lib/checks/mobile/meta-viewport.json
@@ -1,7 +1,6 @@
 {
   "id": "meta-viewport",
   "evaluate": "meta-viewport-scale-evaluate",
-  "matches": "is-initiator-matches",
   "options": {
     "scaleMinimum": 2
   },

--- a/lib/checks/mobile/meta-viewport.json
+++ b/lib/checks/mobile/meta-viewport.json
@@ -1,6 +1,7 @@
 {
   "id": "meta-viewport",
   "evaluate": "meta-viewport-scale-evaluate",
+  "matches": "is-initiator-matches",
   "options": {
     "scaleMinimum": 2
   },

--- a/lib/rules/meta-viewport-large.json
+++ b/lib/rules/meta-viewport-large.json
@@ -1,6 +1,7 @@
 {
   "id": "meta-viewport-large",
   "selector": "meta[name=\"viewport\"]",
+  "matches": "is-initiator-matches",
   "excludeHidden": false,
   "tags": ["cat.sensory-and-visual-cues", "best-practice"],
   "metadata": {

--- a/lib/rules/meta-viewport.json
+++ b/lib/rules/meta-viewport.json
@@ -1,6 +1,7 @@
 {
   "id": "meta-viewport",
   "selector": "meta[name=\"viewport\"]",
+  "matches": "is-initiator-matches",
   "excludeHidden": false,
   "tags": ["cat.sensory-and-visual-cues", "best-practice", "ACT"],
   "actIds": ["b4f0c3"],

--- a/test/integration/rules/meta-viewport/frames/iframe-with-zooming-disabled.html
+++ b/test/integration/rules/meta-viewport/frames/iframe-with-zooming-disabled.html
@@ -1,0 +1,12 @@
+<html lang="en">
+  <head>
+    <script src="/axe.js"></script>
+    <meta name="viewport" content="maximum-scale=yes" />
+    <title>Test Page</title>
+  </head>
+  <body>
+    <main>
+      <h1>hello world</h1>
+    </main>
+  </body>
+</html>

--- a/test/integration/rules/meta-viewport/meta-viewport-pass3.html
+++ b/test/integration/rules/meta-viewport/meta-viewport-pass3.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta id="mvp" name="viewport" content="maximum-scale=2;" />
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <!-- iframe with zooming disabled should not fail the rule-->
+    <iframe
+      srcdoc="<html lang='en'><head>
+        <meta name='viewport' content='maximum-scale=yes' />
+        <title>Test Page</title>
+    </head>
+    <body>
+        <main>
+        <h1>hello world</h1>
+    </main></body></html>"
+    ></iframe>
+  </body>
+</html>

--- a/test/integration/rules/meta-viewport/meta-viewport-pass3.html
+++ b/test/integration/rules/meta-viewport/meta-viewport-pass3.html
@@ -7,15 +7,6 @@
   <body>
     <div id="mocha"></div>
     <!-- iframe with zooming disabled should not fail the rule-->
-    <iframe
-      srcdoc="<html lang='en'><head>
-        <meta name='viewport' content='maximum-scale=yes' />
-        <title>Test Page</title>
-    </head>
-    <body>
-        <main>
-        <h1>hello world</h1>
-    </main></body></html>"
-    ></iframe>
+    <iframe src="frames/iframe-with-zooming-disabled"></iframe>
   </body>
 </html>

--- a/test/integration/rules/meta-viewport/meta-viewport-pass3.json
+++ b/test/integration/rules/meta-viewport/meta-viewport-pass3.json
@@ -1,0 +1,5 @@
+{
+  "description": "meta-viewport passes when zooming is disabled on an iframe on the page",
+  "rule": "meta-viewport",
+  "passes": [["#mvp"]]
+}


### PR DESCRIPTION
Adds a matcher to the meta-viewport rules so that only the top-level/initiator page is checked to see if zooming and scaling is available appropriately.

Closes #2210
