### PR TITLE
fix(aria-allowed-attr): allow aria-posinset and aria-setsize on row elements for treegrids

### DIFF
--- a/lib/commons/aria/lookup-table.js
+++ b/lib/commons/aria/lookup-table.js
@@ -1637,9 +1637,7 @@ lookupTable.role = {
         'aria-level',
         'aria-selected',
         'aria-rowindex',
-        'aria-errormessage',
-        'aria-setsize',
-        'aria-posinset'
+        'aria-errormessage'
       ]
     },
     owned: {

--- a/lib/commons/aria/lookup-table.js
+++ b/lib/commons/aria/lookup-table.js
@@ -1637,7 +1637,9 @@ lookupTable.role = {
         'aria-level',
         'aria-selected',
         'aria-rowindex',
-        'aria-errormessage'
+        'aria-errormessage',
+        'aria-setsize',
+        'aria-posinset'
       ]
     },
     owned: {

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -508,7 +508,9 @@ const ariaRoles = {
       'aria-rowindex',
       'aria-selected',
       'aria-activedescendant',
-      'aria-expanded'
+      'aria-expanded',
+      'aria-posinset',
+      'aria-setsize'
     ],
     superclassRole: ['group', 'widget'],
     nameFromContent: true

--- a/test/integration/rules/aria-allowed-attr/passes.html
+++ b/test/integration/rules/aria-allowed-attr/passes.html
@@ -1913,9 +1913,31 @@
 <iframe aria-label="value" id="pass82" src="/test/playground.html"></iframe>
 <canvas aria-label="value" id="pass83"></canvas>
 <dl aria-label="value" id="pass84"></dl>
-<input aria-label="value" id="pass85"/>
+<input aria-label="value" id="pass85" />
 <label aria-label="value" id="pass86"></label>
 <meter aria-label="value" id="pass87"></meter>
 <object aria-label="value" id="pass88"></object>
 <svg aria-label="value" id="pass89"></svg>
 <video aria-label="value" id="pass90" controls></video>
+
+<table role="treegrid">
+  <thead>
+    <tr>
+      <th>Col 1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr
+      id="treegrid"
+      role="row"
+      aria-level="1"
+      aria-posinset="1"
+      aria-setsize="1"
+      aria-expanded="true"
+    >
+      <td role="gridcell">
+        Treegrids are awesome
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/test/integration/rules/aria-allowed-attr/passes.json
+++ b/test/integration/rules/aria-allowed-attr/passes.json
@@ -92,6 +92,7 @@
     ["#pass87"],
     ["#pass88"],
     ["#pass89"],
-    ["#pass90"]
+    ["#pass90"],
+    ["#treegrid"]
   ]
 }


### PR DESCRIPTION
Adds aria-posinset and aria-setsize to the allowed aria attributes for row elements, in accordance with the [treegrid examples](https://www.w3.org/TR/wai-aria-practices-1.1/examples/treegrid/treegrid-1.html). 

See a live test case [on glitch](https://aria-treegrid-example.glitch.me/), which runs a local copy of axe that's been built with these changes. 

When I run this locally, the test I added isn't getting picked up and I'm not sure why - might need to pair on that. 

Closes #2720
