### PR TITLE
chore: don't tag releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
   "standard-version": {
     "scripts": {
       "postbump": "npm ci && npm run sri-update"
+    },
+    "skip": {
+      "tag": true
     }
   },
   "scripts": {
@@ -87,7 +90,7 @@
     "test:rule-help-version": "mocha test/test-rule-help-version.js",
     "test:node": "mocha test/node/*.js",
     "version": "echo \"use 'npm run release' to bump axe-core version\" && exit 1",
-    "release": "standard-version -a",
+    "release": "git fetch origin --tags --force && standard-version -a",
     "rule-gen": "node build/rule-generator",
     "next-release": "standard-version --scripts.prebump=./build/next-version.js --skip.commit=true --skip.tag=true",
     "sri-update": "grunt build && node build/sri-update && git add sri-history.json",


### PR DESCRIPTION
I believe this was causing our changelogs to always be incorrect and require manual editing. When we run `standard-version`, it automatically creates a tag for the next version. However that tag is never pushed to the remote and we instead have our CI script create a tag for us after the PR has been merged. This causes the tag on the local machine to be out-of-sync with the tag in the remote.

By skipping the tagging step of standard-version and forcing the release script to fetch all tags before creating a release, this should allow standard-version to find the correct tagged commit and create the changelog properly.