### PR TITLE
ci: Fix sync branches workflow

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -7,7 +7,7 @@ jobs:
   create_sync_pull_request:
     runs-on: ubuntu-latest
     steps:
-      - uses: dequelabs/action-sync-branches@v1.0.0
+      - uses: dequelabs/action-sync-branches@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-title: "chore: merge master into develop"


### PR DESCRIPTION
Rather than explicitly using `v1.0.0`, we'll just use `v1`, which contains many bug fixes.
