### PR TITLE
fix(color-contrast): add special case for new sr-only technique

### DIFF
--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -163,7 +163,7 @@ function isVisible(el, screenReader, recursed) {
       style.getPropertyValue('opacity') === '0' ||
       (getScroll(el) && elHeight === 0) ||
       (style.getPropertyValue('position') === 'absolute' &&
-        elHeight <= 1 &&
+        elHeight < 2 &&
         style.getPropertyValue('overflow') === 'hidden'))
   ) {
     return false;

--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -157,14 +157,20 @@ function isVisible(el, screenReader, recursed) {
 
   // hidden from visual users
   const elHeight = parseInt(style.getPropertyValue('height'));
+
+  // ways to hide content visually
+  const scrollableWithZeroHeight = getScroll(el) && elHeight === 0;
+  const posAbsoluteOverflowHiddenAndSmall =
+    style.getPropertyValue('position') === 'absolute' &&
+    elHeight < 2 &&
+    style.getPropertyValue('overflow') === 'hidden';
+
   if (
     !screenReader &&
     (isClipped(style) ||
       style.getPropertyValue('opacity') === '0' ||
-      (getScroll(el) && elHeight === 0) ||
-      (style.getPropertyValue('position') === 'absolute' &&
-        elHeight < 2 &&
-        style.getPropertyValue('overflow') === 'hidden'))
+      scrollableWithZeroHeight ||
+      posAbsoluteOverflowHiddenAndSmall)
   ) {
     return false;
   }

--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -156,11 +156,15 @@ function isVisible(el, screenReader, recursed) {
   }
 
   // hidden from visual users
+  const elHeight = parseInt(style.getPropertyValue('height'));
   if (
     !screenReader &&
     (isClipped(style) ||
       style.getPropertyValue('opacity') === '0' ||
-      (getScroll(el) && parseInt(style.getPropertyValue('height')) <= 1))
+      (getScroll(el) && elHeight === 0) ||
+      (style.getPropertyValue('position') === 'absolute' &&
+        elHeight <= 1 &&
+        style.getPropertyValue('overflow') === 'hidden'))
   ) {
     return false;
   }

--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -160,7 +160,7 @@ function isVisible(el, screenReader, recursed) {
     !screenReader &&
     (isClipped(style) ||
       style.getPropertyValue('opacity') === '0' ||
-      (getScroll(el) && parseInt(style.getPropertyValue('height')) === 0))
+      (getScroll(el) && parseInt(style.getPropertyValue('height')) <= 1))
   ) {
     return false;
   }

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -356,6 +356,13 @@ describe('dom.isVisible', function() {
         assert.isFalse(axe.commons.dom.isVisible(el.actualNode));
       }
     );
+    it('should return false if element is visually hidden using position absolute, overflow hidden, and a very small height', function() {
+      fixture.innerHTML =
+        '<div id="target" style="position:absolute; height: 1px; overflow: hidden;">StickySticky</div>';
+      var el = document.getElementById('target');
+
+      assert.isFalse(axe.commons.dom.isVisible(el));
+    });
   });
 
   describe('screen readers', function() {


### PR DESCRIPTION
The minimum CSS that makes the element from the example visually hidden is a combination of: 
```css
overflow: hidden;
position: absolute;
height: 1px;
```

So if the user is doing that, they are probably trying to hide the element visually and axe-core should recognize that.

Note that the repro case will not fail in Firefox even without this code. 
 
Closes #2962
