### PR TITLE
fix(publish-metadata): use fail message for rules with reviewOnFail:true

### DIFF
--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -22,7 +22,7 @@ function getIncompleteReason(checkData, messages) {
   }
   if (checkData && checkData.missingData) {
     try {
-      var msg = messages.incomplete[checkData.missingData[0].reason];
+      const msg = messages.incomplete[checkData.missingData[0].reason];
       if (!msg) {
         throw new Error();
       }
@@ -46,16 +46,17 @@ function getIncompleteReason(checkData, messages) {
  * Extend checksData with the correct result message
  * @param  {Object} checksData The check result data
  * @param  {Boolean} shouldBeTrue Result of pass/fail check run
+ * @param  {Object} rule The rule metadata
  * @return {Function}
  * @private
  */
-function extender(checksData, shouldBeTrue) {
+function extender(checksData, shouldBeTrue, rule) {
   return check => {
-    var sourceData = checksData[check.id] || {};
-    var messages = sourceData.messages || {};
-    var data = Object.assign({}, sourceData);
+    const sourceData = checksData[check.id] || {};
+    const messages = sourceData.messages || {};
+    const data = Object.assign({}, sourceData);
     delete data.messages;
-    if (check.result === undefined) {
+    if (!rule.reviewOnFail && check.result === undefined) {
       // handle old doT template
       if (
         typeof messages.incomplete === 'object' &&
@@ -89,14 +90,14 @@ function extender(checksData, shouldBeTrue) {
  */
 function publishMetaData(ruleResult) {
   // TODO: es-modules_audit
-  var checksData = axe._audit.data.checks || {};
-  var rulesData = axe._audit.data.rules || {};
-  var rule = findBy(axe._audit.rules, 'id', ruleResult.id) || {};
+  const checksData = axe._audit.data.checks || {};
+  const rulesData = axe._audit.data.rules || {};
+  const rule = findBy(axe._audit.rules, 'id', ruleResult.id) || {};
 
   ruleResult.tags = clone(rule.tags || []);
 
-  var shouldBeTrue = extender(checksData, true);
-  var shouldBeFalse = extender(checksData, false);
+  const shouldBeTrue = extender(checksData, true, rule);
+  const shouldBeFalse = extender(checksData, false, rule);
   ruleResult.nodes.forEach(detail => {
     detail.any.forEach(shouldBeTrue);
     detail.all.forEach(shouldBeTrue);

--- a/test/core/utils/publish-metadata.js
+++ b/test/core/utils/publish-metadata.js
@@ -1136,4 +1136,113 @@ describe('axe.utils.publishMetaData', function() {
       });
     });
   });
+
+  it('should use fail message for rules with "reviewOnFaill: true"', function() {
+    axe._load({
+      rules: [
+        {
+          id: 'cats',
+          reviewOnFail: true
+        }
+      ],
+      data: {
+        rules: {
+          cats: {
+            help: function() {
+              return 'cats-rule';
+            }
+          }
+        },
+        checks: {
+          'cats-NONE': {
+            messages: {
+              fail: function() {
+                return 'fail-NONE';
+              },
+              pass: function() {
+                return 'pass-NONE';
+              }
+            }
+          },
+          'cats-ANY': {
+            messages: {
+              fail: function() {
+                return 'fail-ANY';
+              },
+              pass: function() {
+                return 'pass-ANY';
+              }
+            }
+          },
+          'cats-ALL': {
+            messages: {
+              fail: function() {
+                return 'fail-ALL';
+              },
+              pass: function() {
+                return 'pass-ALL';
+              }
+            }
+          }
+        }
+      }
+    });
+
+    var result = {
+      id: 'cats',
+      nodes: [
+        {
+          any: [
+            {
+              result: undefined,
+              id: 'cats-ANY'
+            }
+          ],
+          none: [
+            {
+              result: undefined,
+              id: 'cats-NONE'
+            }
+          ],
+          all: [
+            {
+              result: undefined,
+              id: 'cats-ALL'
+            }
+          ]
+        }
+      ]
+    };
+    axe.utils.publishMetaData(result);
+    assert.deepEqual(result, {
+      id: 'cats',
+      help: 'cats-rule',
+      tags: [],
+      nodes: [
+        {
+          any: [
+            {
+              result: undefined,
+              id: 'cats-ANY',
+              message: 'fail-ANY'
+            }
+          ],
+          none: [
+            {
+              result: undefined,
+              id: 'cats-NONE',
+              message: 'fail-NONE'
+            }
+          ],
+          all: [
+            {
+              result: undefined,
+              id: 'cats-ALL',
+              message: 'fail-ALL'
+            }
+          ]
+        }
+      ]
+    });
+  });
 });

--- a/test/core/utils/publish-metadata.js
+++ b/test/core/utils/publish-metadata.js
@@ -1214,35 +1214,30 @@ describe('axe.utils.publishMetaData', function() {
       ]
     };
     axe.utils.publishMetaData(result);
-    assert.deepEqual(result, {
-      id: 'cats',
-      help: 'cats-rule',
-      tags: [],
-      nodes: [
-        {
-          any: [
-            {
-              result: undefined,
-              id: 'cats-ANY',
-              message: 'fail-ANY'
-            }
-          ],
-          none: [
-            {
-              result: undefined,
-              id: 'cats-NONE',
-              message: 'fail-NONE'
-            }
-          ],
-          all: [
-            {
-              result: undefined,
-              id: 'cats-ALL',
-              message: 'fail-ALL'
-            }
-          ]
-        }
-      ]
-    });
+    assert.deepEqual(result.nodes, [
+      {
+        any: [
+          {
+            result: undefined,
+            id: 'cats-ANY',
+            message: 'fail-ANY'
+          }
+        ],
+        none: [
+          {
+            result: undefined,
+            id: 'cats-NONE',
+            message: 'fail-NONE'
+          }
+        ],
+        all: [
+          {
+            result: undefined,
+            id: 'cats-ALL',
+            message: 'fail-ALL'
+          }
+        ]
+      }
+    ]);
   });
 });

--- a/test/playground.html
+++ b/test/playground.html
@@ -3,11 +3,27 @@
   <title>O hai</title>
 
   <div class="foo" id="foo">foo</div>
+  <nav>
+    <a href="foo">Nav 1</a>
+    <a href="foo">Nav 2</a>
+    <a href="foo">Nav 3</a>
+    <a href="foo">Nav 4</a>
+    <a href="foo">Nav 5</a>
+  </nav>
+
+  <table>
+    <tr>
+      <th></th>
+    </tr>
+  </table>
 
   <script src="/axe.js"></script>
   <script>
     window.addEventListener('load', function() {
-      axe.run(document, function(err, res) {
+      axe.run(document, { runOnly: ['empty-table-header'] }, function(
+        err,
+        res
+      ) {
         console.log(res.violations);
         res.incomplete.forEach(function(issue) {
           console.log(issue);

--- a/test/playground.html
+++ b/test/playground.html
@@ -3,27 +3,11 @@
   <title>O hai</title>
 
   <div class="foo" id="foo">foo</div>
-  <nav>
-    <a href="foo">Nav 1</a>
-    <a href="foo">Nav 2</a>
-    <a href="foo">Nav 3</a>
-    <a href="foo">Nav 4</a>
-    <a href="foo">Nav 5</a>
-  </nav>
-
-  <table>
-    <tr>
-      <th></th>
-    </tr>
-  </table>
 
   <script src="/axe.js"></script>
   <script>
     window.addEventListener('load', function() {
-      axe.run(document, { runOnly: ['empty-table-header'] }, function(
-        err,
-        res
-      ) {
+      axe.run(document, function(err, res) {
         console.log(res.violations);
         res.incomplete.forEach(function(issue) {
           console.log(issue);


### PR DESCRIPTION
Use the failure message from a check if a rule sets `reviewOnFail: true`.

Closes issue: #2956
