### PR TITLE
ci: fix chrome nightly test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,9 @@ jobs:
       - run: |
           wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
           sudo apt install ./google-chrome-beta_current_amd64.deb
-      - run: CHROME_BIN="$(which google-chrome-beta)" npm run test -- --browsers Chrome,FirefoxNightly
+      - run: |
+          CHROME_BIN="$(which google-chrome-beta)" && echo $CHROME_BIN
+          npm run test -- --browsers Chrome,FirefoxNightly
 
   # Test api docs can be built
   build_api_docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
           wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
           sudo apt install ./google-chrome-beta_current_amd64.deb
       - run: |
-          CHROME_BIN="$(which google-chrome-beta)" && echo $CHROME_BIN
+          CHROME_BIN="$(which google-chrome-beta)" && echo "CHROME_BIN: $CHROME_BIN"
           npm run test -- --browsers Chrome,FirefoxNightly
 
   # Test api docs can be built
@@ -264,9 +264,6 @@ workflows:
           requires:
             - test_unix
       - test_rule_help_version:
-          requires:
-            - test_unix
-      - test_nightly:
           requires:
             - test_unix
       - test_node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,11 +135,11 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
-      # install Chrome Canary
+      # install Chrome Beta
       - run: |
-          wget https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
-          sudo apt install ./google-chrome-unstable_current_amd64.deb
-      - run: npm run test -- --browsers ChromeCanary,FirefoxNightly
+          wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+          sudo apt install ./google-chrome-beta_current_amd64.deb
+      - run: CHROME_BIN="$(which google-chrome-beta)" npm run test -- --browsers Chrome,FirefoxNightly
 
   # Test api docs can be built
   build_api_docs:
@@ -262,6 +262,9 @@ workflows:
           requires:
             - test_unix
       - test_rule_help_version:
+          requires:
+            - test_unix
+      - test_nightly:
           requires:
             - test_unix
       - test_node:


### PR DESCRIPTION
Use beta branch instead of canary branch as Chrome Canary doesn't really exist for linux. This still allow us to test what's coming in Chrome a 4-6 weeks ahead of it shipping to the stable branch. You can see this working here https://app.circleci.com/pipelines/github/dequelabs/axe-core/2285/workflows/99972573-a9a8-459c-9311-31bf54ac409b/jobs/31628 (I ran nighty as part of the build so we could see it work).

Closes issue: #2967 
