### PR TITLE
fix(aria-roles): Mark as needs review if both none and presentation are used on element with no implicit role

### DIFF
--- a/lib/checks/aria/fallbackrole-evaluate.js
+++ b/lib/checks/aria/fallbackrole-evaluate.js
@@ -1,5 +1,21 @@
 import { tokenList } from '../../core/utils';
+import { getImplicitRole } from '../../commons/aria';
 
+/**
+ * @return {Boolean} True if the element has no implicit role and uses both none and presentation as explicit roles
+ */
+function nonePresentationOnElementWithNoImplicitRole(
+  virtualNode,
+  explicitRoles
+) {
+  const hasImplicitRole = getImplicitRole(virtualNode);
+  return (
+    !hasImplicitRole &&
+    explicitRoles.length === 2 &&
+    explicitRoles.includes('none') &&
+    explicitRoles.includes('presentation')
+  );
+}
 /**
  * Check that an element does not use more than one explicit role.
  *
@@ -7,7 +23,13 @@ import { tokenList } from '../../core/utils';
  * @return {Boolean} True if the element uses more than one explicit role. False otherwise.
  */
 function fallbackroleEvaluate(node, options, virtualNode) {
-  return tokenList(virtualNode.attr('role')).length > 1;
+  const explicitRoles = tokenList(virtualNode.attr('role'));
+  if (explicitRoles.length <= 1) {
+    return false;
+  }
+  return nonePresentationOnElementWithNoImplicitRole(virtualNode, explicitRoles)
+    ? undefined
+    : true;
 }
 
 export default fallbackroleEvaluate;

--- a/lib/checks/aria/fallbackrole.json
+++ b/lib/checks/aria/fallbackrole.json
@@ -5,7 +5,8 @@
     "impact": "serious",
     "messages": {
       "pass": "Only one role value used",
-      "fail": "Use only one role value, since fallback roles are not supported in older browsers"
+      "fail": "Use only one role value, since fallback roles are not supported in older browsers",
+      "incomplete": "Use only role 'presentation' or 'none' since they are synonymous."
     }
   }
 }

--- a/test/checks/aria/fallbackrole.js
+++ b/test/checks/aria/fallbackrole.js
@@ -13,28 +13,55 @@ describe('fallbackrole', function() {
       '<div id="target" role="button foobar">Foo</div>'
     );
     assert.isTrue(
-      checks.fallbackrole.evaluate(virtualNode.actualNode, 'radio', virtualNode)
+      checks.fallbackrole.evaluate(virtualNode.actualNode, null, virtualNode)
     );
   });
 
   it('should return false if fallback role is not used', function() {
     var virtualNode = queryFixture('<div id="target" role="button">Foo</div>');
     assert.isFalse(
-      checks.fallbackrole.evaluate(virtualNode.actualNode, 'radio', virtualNode)
+      checks.fallbackrole.evaluate(virtualNode.actualNode, null, virtualNode)
     );
   });
 
   it('should return false if applied to an invalid role', function() {
     var virtualNode = queryFixture('<div id="target" role="foobar">Foo</div>');
     assert.isFalse(
-      checks.fallbackrole.evaluate(virtualNode.actualNode, 'radio', virtualNode)
+      checks.fallbackrole.evaluate(virtualNode.actualNode, null, virtualNode)
     );
   });
 
   it('should return false if applied to an invalid role', function() {
     var virtualNode = queryFixture('<div id="target" role="foobar">Foo</div>');
     assert.isFalse(
-      checks.fallbackrole.evaluate(virtualNode.actualNode, 'radio', virtualNode)
+      checks.fallbackrole.evaluate(virtualNode.actualNode, null, virtualNode)
+    );
+  });
+
+  it('should return undefined/needs review if an element with no implicit role uses both none and presentation', function() {
+    var virtualNode = queryFixture(
+      '<div id="target" role="none presentation">Foo</div>'
+    );
+    assert.isUndefined(
+      checks.fallbackrole.evaluate(virtualNode.actualNode, null, virtualNode)
+    );
+  });
+
+  it('should return undefined/needs review if an element with no implicit role uses both presentation and none', function() {
+    var virtualNode = queryFixture(
+      '<div id="target" role="presentation none">Foo</div>'
+    );
+    assert.isUndefined(
+      checks.fallbackrole.evaluate(virtualNode.actualNode, null, virtualNode)
+    );
+  });
+
+  it('should return true if an element with an implicit role uses both presentation and none', function() {
+    var virtualNode = queryFixture(
+      '<input type="text" id="target" role="presentation none"/>'
+    );
+    assert.isTrue(
+      checks.fallbackrole.evaluate(virtualNode.actualNode, null, virtualNode)
     );
   });
 });


### PR DESCRIPTION
Closes issue #2909.
