### PR TITLE
fix(docs): update readme to only include correct localization build flag command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,7 @@ The [axe-core API](doc/API.md) package consists of:
 
 Axe can be built using your local language. To do so, a localization file must be added to the `./locales` directory. This file must have be named in the following manner: `<langcode>.json`. To build axe using this locale, instead of the default, run axe with the `--lang` flag, like so:
 
-`grunt build --lang=nl`
-
-or equivalently:
-
-`npm run build -- --lang=nl`
+`grunt build -- --lang=nl`
 
 This will create a new build for axe, called `axe.<lang>.js` and `axe.<lang>.min.js`. If you want to build localized versions, simply pass in `--all-lang` instead.
 


### PR DESCRIPTION
Only one of these commands actually works; they are not equivalent. 

Closes #2649 
