### PR TITLE
feat: Support multiple languages at once in builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -110,6 +110,9 @@ module.exports = function(grunt) {
       data: {
         entry: 'lib/commons/aria/index.js',
         destFile: 'doc/aria-supported.md',
+        options: {
+          langs: langs
+        },
         listType: 'unsupported' // Possible values for listType: 'supported', 'unsupported', 'all'
       }
     },

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ or equivalently:
 
 `npm run build -- --lang=nl`
 
-This will create a new build for axe, called `axe.<lang>.js` and `axe.<lang>.min.js`. If you want to build localized versions, simply pass in `--all-lang` instead.
+This will create a new build for axe, called `axe.<lang>.js` and `axe.<lang>.min.js`. If you want to build localized versions, simply pass in `--all-lang` instead. If you want to build multiple localized versions (but not all of them), you can pass in a comma-separated list of langages to the `--lang` flag, like `--lang=nl,ja`.
 
 To create a new translation for axe, start by running `grunt translate --lang=<langcode>`. This will create a json file fin the `./locales` directory, with the default English text in it for you to translate. We welcome any localization for axe-core. For details on how to contribute, see the Contributing section below. For details on the message syntax, see [Check Message Template](/docs/check-message-template.md).
 

--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -16,9 +16,8 @@ module.exports = function(grunt) {
        * as `axe` does not exist until grunt task `build:uglify` is complete,
        * hence cannot be required at the top of the file.
        */
-      const langOption = grunt.option('lang');
-      const fileNameSuffix =
-        langOption && langOption.length > 0 ? `.${langOption}` : '';
+      const { langs } = this.options();
+      const fileNameSuffix = langs && langs.length > 0 ? `${langs[0]}` : '';
       const axe = require(`../../axe${fileNameSuffix}`);
       const listType = this.data.listType.toLowerCase();
       const headings = {


### PR DESCRIPTION
Most of the code for this was already in place; only the aria-supported task was failing when you tried to enter multiple languages to build for. It doesn't seem like that task actually does anything different depending on the language, so this code uses the first language of the languages that were entered (if any) to find the right axe.**.js file to use to generate aria-supported.md. 

Closes issue #2714
