### PR TITLE
feat(options): accept a string for options.runOnly

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -78,7 +78,7 @@ declare namespace axe {
     };
   }
   interface RunOptions {
-    runOnly?: RunOnly | TagValue[] | string[];
+    runOnly?: RunOnly | TagValue[] | string[] | string;
     rules?: RuleObject;
     reporter?: ReporterVersion;
     resultTypes?: resultGroups[];

--- a/doc/API.md
+++ b/doc/API.md
@@ -484,11 +484,27 @@ axe.run(
 Alternatively, runOnly can be passed an array of tags:
 
 ```js
-axe.run({
-	runOnly: ['wcag2a', 'wcag2aa'];
-}, (err, results) => {
-  // ...
-})
+axe.run(
+  {
+    runOnly: ['wcag2a', 'wcag2aa']
+  },
+  (err, results) => {
+    // ...
+  }
+);
+```
+
+If you want to specify just one tag, you can pass in a string.
+
+```js
+axe.run(
+  {
+    runOnly: 'wcag2a'
+  },
+  (err, results) => {
+    // ...
+  }
+);
 ```
 
 2. Run only a specified list of Rules
@@ -519,6 +535,19 @@ axe.run({
 }, (err, results) => {
   // ...
 })
+```
+
+If you want to specify just one rule, you can pass in a string.
+
+```js
+axe.run(
+  {
+    runOnly: 'ruleId1'
+  },
+  (err, results) => {
+    // ...
+  }
+);
 ```
 
 3. Run all enabled Rules except for a list of rules

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -550,7 +550,10 @@ class Audit {
       });
     });
     // Validate runOnly
-    if (typeof options.runOnly === 'object') {
+    if (['object', 'string'].includes(typeof options.runOnly)) {
+      if (typeof options.runOnly === 'string') {
+        options.runOnly = [options.runOnly];
+      }
       if (Array.isArray(options.runOnly)) {
         const hasTag = options.runOnly.find(value => tags.includes(value));
         const hasRule = options.runOnly.find(value => ruleIds.includes(value));

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -1354,6 +1354,13 @@ describe('Audit', function() {
       assert.deepEqual(out.runOnly.values, ['positive1', 'negative1']);
     });
 
+    it('allows runOnly as a string as an alternative to an array', function() {
+      var opt = { runOnly: 'positive1' };
+      var out = a.normalizeOptions(opt);
+      assert(out.runOnly.type, 'rule');
+      assert.deepEqual(out.runOnly.values, ['positive1']);
+    });
+
     it('throws an error if runOnly contains both rules and tags', function() {
       assert.throws(function() {
         a.normalizeOptions({


### PR DESCRIPTION
Allows you to do `axe.run({runOnly: 'specialRule'})`

Closes issue: #3003
