### PR TITLE
Use more specific failure messages for color contrast failures

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -136,6 +136,8 @@ function colorContrastEvaluate(node, options, virtualNode) {
   let missing;
   if (bgColor === null) {
     missing = incompleteData.get('bgColor');
+  } else {
+    missing = contrastContributor;
   }
 
   const equalRatio = truncatedResult === 1;
@@ -145,8 +147,6 @@ function colorContrastEvaluate(node, options, virtualNode) {
   } else if (shortTextContent && !ignoreLength) {
     // Check that the text content is a single character long
     missing = 'shortTextContent';
-  } else {
-    missing = contrastContributor;
   }
 
   // need both independently in case both are missing

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -81,7 +81,6 @@ function colorContrastEvaluate(node, options, virtualNode) {
   let contrastContributor = null;
   if (shadowColors.length === 0) {
     contrast = getContrast(bgColor, fgColor);
-    contrastContributor = 'fgOnBgColor';
   } else if (fgColor && bgColor) {
     // Thin shadows can pass either by contrasting with the text color
     // or when contrasting with the background.

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -77,8 +77,10 @@ function colorContrastEvaluate(node, options, virtualNode) {
   const bold = parseFloat(fontWeight) >= boldValue || fontWeight === 'bold';
 
   let contrast = null;
+  let contrastContributor = null;
   if (shadowColors.length === 0) {
     contrast = getContrast(bgColor, fgColor);
+    contrastContributor = 'fgOnBgColor';
   } else if (fgColor && bgColor) {
     // Thin shadows can pass either by contrasting with the text color
     // or when contrasting with the background.
@@ -86,6 +88,8 @@ function colorContrastEvaluate(node, options, virtualNode) {
     const bgContrast = getContrast(bgColor, shadowColor);
     const fgContrast = getContrast(shadowColor, fgColor);
     contrast = Math.max(bgContrast, fgContrast);
+    contrastContributor =
+      bgContrast > fgContrast ? 'shadowOnBgColor' : 'fgOnShadowColor';
   }
 
   const ptSize = Math.ceil(fontSize * 72) / 96;
@@ -140,6 +144,8 @@ function colorContrastEvaluate(node, options, virtualNode) {
   } else if (shortTextContent && !ignoreLength) {
     // Check that the text content is a single character long
     missing = 'shortTextContent';
+  } else {
+    missing = contrastContributor;
   }
 
   // need both independently in case both are missing
@@ -150,7 +156,8 @@ function colorContrastEvaluate(node, options, virtualNode) {
     fontSize: `${((fontSize * 72) / 96).toFixed(1)}pt (${fontSize}px)`,
     fontWeight: bold ? 'bold' : 'normal',
     messageKey: missing,
-    expectedContrastRatio: expected + ':1'
+    expectedContrastRatio: expected + ':1',
+    shadowColor: shadowColors.map(c => c.toHexString()).join(', ')
   };
 
   this.data(data);

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -23,8 +23,8 @@
       "pass": "Element has sufficient color contrast of ${data.contrastRatio}",
       "fail": {
         "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
+        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
       },
       "incomplete": {
         "default": "Unable to determine contrast ratio",

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -21,7 +21,11 @@
     "impact": "serious",
     "messages": {
       "pass": "Element has sufficient color contrast of ${data.contrastRatio}",
-      "fail": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+      "fail": {
+        "fgOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
+      },
       "incomplete": {
         "default": "Unable to determine contrast ratio",
         "bgImage": "Element's background color could not be determined due to a background image",

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -22,7 +22,7 @@
     "messages": {
       "pass": "Element has sufficient color contrast of ${data.contrastRatio}",
       "fail": {
-        "fgOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
         "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
         "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
       },

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -172,7 +172,7 @@ describe('color-contrast', function() {
 
     assert.isFalse(contrastEvaluate.apply(checkContext, params));
     assert.deepEqual(checkContext._relatedNodes, [params[0]]);
-    assert.deepEqual(checkContext._data.messageKey, 'fgOnBgColor');
+    assert.deepEqual(checkContext._data.messageKey, null);
   });
 
   it('should ignore position:fixed elements above the target', function() {
@@ -733,7 +733,7 @@ describe('color-contrast', function() {
       checkOptions
     );
     assert.isFalse(contrastEvaluate.apply(checkContext, params));
-    assert.equal(checkContext._data.messageKey, 'fgOnBgColor');
+    assert.equal(checkContext._data.messageKey, null);
   });
 
   it('fails if text shadows do not have sufficient contrast with the foreground', function() {

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -164,7 +164,7 @@ describe('color-contrast', function() {
     assert.deepEqual(checkContext._relatedNodes, []);
   });
 
-  it('should return false when there is not sufficient contrast', function() {
+  it('should return false when there is not sufficient contrast between foreground and background', function() {
     var params = checkSetup(
       '<div style="color: yellow; background-color: white;" id="target">' +
         'My text</div>'
@@ -172,6 +172,7 @@ describe('color-contrast', function() {
 
     assert.isFalse(contrastEvaluate.apply(checkContext, params));
     assert.deepEqual(checkContext._relatedNodes, [params[0]]);
+    assert.deepEqual(checkContext._data.messageKey, 'fgOnBgColor');
   });
 
   it('should ignore position:fixed elements above the target', function() {
@@ -722,7 +723,7 @@ describe('color-contrast', function() {
     assert.isTrue(contrastEvaluate.apply(checkContext, params));
   });
 
-  it('fails if text shadows have sufficient contrast with the background if its with is thicker than `shadowOutlineEmMax`', function() {
+  it('fails if text shadows have sufficient contrast with the background if its width is thicker than `shadowOutlineEmMax`', function() {
     var checkOptions = { shadowOutlineEmMax: 0.05 };
     var params = checkSetup(
       '<div id="target" style="background-color: #aaa; color:#666; ' +
@@ -732,5 +733,28 @@ describe('color-contrast', function() {
       checkOptions
     );
     assert.isFalse(contrastEvaluate.apply(checkContext, params));
+    assert.equal(checkContext._data.messageKey, 'fgOnBgColor');
+  });
+
+  it('fails if text shadows do not have sufficient contrast with the foreground', function() {
+    var params = checkSetup(
+      '<div id="target" style="background-color: #aaa; color:#666; ' +
+        'text-shadow: 1px 1px 0.01em #000">' +
+        '  Hello world' +
+        '</div>'
+    );
+    assert.isFalse(contrastEvaluate.apply(checkContext, params));
+    assert.equal(checkContext._data.messageKey, 'fgOnShadowColor');
+  });
+
+  it('fails if text shadows do not have sufficient contrast with the background', function() {
+    var params = checkSetup(
+      '<div id="target" style="background-color: #aaa; color:#666; ' +
+        'text-shadow: 0 0 0.01em #000">' +
+        '  Hello world' +
+        '</div>'
+    );
+    assert.isFalse(contrastEvaluate.apply(checkContext, params));
+    assert.equal(checkContext._data.messageKey, 'shadowOnBgColor');
   });
 });


### PR DESCRIPTION
Builds off the other color contrast work that's been happening, so base of the PR is not `develop`
Closes issue: #2925
