### PR TITLE
fix(color-contrast) Zero size text shadow should not be included as background color

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -68,6 +68,7 @@ function colorContrastEvaluate(node, options, virtualNode) {
   const fgColor = getForegroundColor(node, false, bgColor);
   // Thin shadows only. Thicker shadows are included in the background instead
   const shadowColors = getTextShadowColors(node, {
+    minRatio: 0.001,
     maxRatio: shadowOutlineEmMax
   });
 

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -696,6 +696,22 @@ describe('color-contrast', function() {
     assert.isTrue(contrastEvaluate.apply(checkContext, params));
   });
 
+  it('does not count text shadows of offset 0, blur 0 as part of the background color', function() {
+    var params = checkSetup(
+      '<div id="target" style="background-color: #fff; color:#0f833e; ' +
+        'text-shadow: 0 0 0 #000">' +
+        '  Hello world' +
+        '</div>'
+    );
+
+    var white = new axe.commons.color.Color(255, 255, 255, 1);
+
+    assert.isTrue(contrastEvaluate.apply(checkContext, params));
+    assert.equal(checkContext._data.bgColor, white.toHexString());
+    assert.equal(checkContext._data.fgColor, '#0f833e');
+    assert.equal(checkContext._data.contrastRatio, '4.84');
+  });
+
   it('passes if thin text shadows have sufficient contrast with the background', function() {
     var params = checkSetup(
       '<div id="target" style="background-color: #aaa; color:#666; ' +


### PR DESCRIPTION
Makes it so thin shadows must have a nonzero ratio in order to be counted as something the background or foreground will get compared against. Builds off the work in PR #3001, which includes text shadows as part of the foreground color if blur is 0 and offset is 0.

Closes issue: #2930
