### PR TITLE
perf(core): reduce memory allocations

### DIFF
--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -55,24 +55,28 @@ class VirtualNode extends AbstractVirtualNode {
   // abstract Node properties so we can run axe in DOM-less environments.
   // add to the prototype so memory is shared across all virtual nodes
   get props() {
-    const {
-      nodeType,
-      nodeName,
-      id,
-      multiple,
-      nodeValue,
-      value
-    } = this.actualNode;
+    if (!this._cache.hasOwnProperty('props')) {
+      const {
+        nodeType,
+        nodeName,
+        id,
+        multiple,
+        nodeValue,
+        value
+      } = this.actualNode;
 
-    return {
-      nodeType,
-      nodeName: this._isXHTML ? nodeName : nodeName.toLowerCase(),
-      id,
-      type: this._type,
-      multiple,
-      nodeValue,
-      value
-    };
+      this._cache.props = {
+        nodeType,
+        nodeName: this._isXHTML ? nodeName : nodeName.toLowerCase(),
+        id,
+        type: this._type,
+        multiple,
+        nodeValue,
+        value
+      };
+    }
+
+    return this._cache.props;
   }
 
   /**

--- a/lib/core/utils/matches.js
+++ b/lib/core/utils/matches.js
@@ -211,6 +211,50 @@ export function convertSelector(selector) {
 }
 
 /**
+ * Determine if a virtual node matches a Slick format CSS expression.
+ *
+ * Note: this function is in the hot path, avoid memory allocation.
+ *
+ * @private
+ * @method optimizedMatchesExpression
+ * @memberof axe.utils
+ * @param {VirtualNode} vNode VirtualNode to match
+ * @param {Object|Object[]} expressions CSS selector expression or array of expressions
+ * @param {Number|NaN} index index of expression to match on if expressions is array
+ * @returns {Boolean}
+ */
+function optimizedMatchesExpression(vNode, expressions, index, matchAnyParent) {
+  const isArray = Array.isArray(expressions);
+  const expression = isArray ? expressions[index] : expressions;
+  let matches = matchExpression(vNode, expression);
+
+  while (!matches && matchAnyParent && vNode.parent) {
+    vNode = vNode.parent;
+    matches = matchExpression(vNode, expression);
+  }
+
+  if (index > 0) {
+    if ([' ', '>'].includes(expression.combinator) === false) {
+      throw new Error(
+        'axe.utils.matchesExpression does not support the combinator: ' +
+          expression.combinator
+      );
+    }
+
+    matches =
+      matches &&
+      optimizedMatchesExpression(
+        vNode.parent,
+        expressions,
+        index - 1,
+        expression.combinator === ' '
+      );
+  }
+
+  return matches;
+}
+
+/**
  * Determine if a virtual node matches a Slick format CSS expression
  *
  * @private
@@ -221,29 +265,12 @@ export function convertSelector(selector) {
  * @returns {Boolean}
  */
 export function matchesExpression(vNode, expressions, matchAnyParent) {
-  const exps = [].concat(expressions);
-  const expression = exps.pop();
-  let matches = matchExpression(vNode, expression);
-
-  while (!matches && matchAnyParent && vNode.parent) {
-    vNode = vNode.parent;
-    matches = matchExpression(vNode, expression);
-  }
-
-  if (exps.length) {
-    if ([' ', '>'].includes(expression.combinator) === false) {
-      throw new Error(
-        'axe.utils.matchesExpression does not support the combinator: ' +
-          expression.combinator
-      );
-    }
-
-    matches =
-      matches &&
-      matchesExpression(vNode.parent, exps, expression.combinator === ' ');
-  }
-
-  return matches;
+  return optimizedMatchesExpression(
+    vNode,
+    expressions,
+    expressions.length - 1,
+    matchAnyParent
+  );
 }
 
 /**

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -1,15 +1,32 @@
 import { matchesExpression, convertSelector } from './matches';
 
-function createLocalVariables(vNodes, anyLevel, thisLevel, parentShadowId) {
-  const retVal = {
-    vNodes: vNodes,
-    vNodesIndex: 0,
-    anyLevel: anyLevel,
-    thisLevel: thisLevel,
-    parentShadowId: parentShadowId
-  };
+function createLocalVariables(
+  vNodes,
+  anyLevel,
+  thisLevel,
+  parentShadowId,
+  recycledLocalVariable
+) {
+  const retVal = recycledLocalVariable || {};
+
+  retVal.vNodes = vNodes;
+  retVal.vNodesIndex = 0;
+  retVal.anyLevel = anyLevel;
+  retVal.thisLevel = thisLevel;
+  retVal.parentShadowId = parentShadowId;
+
   return retVal;
 }
+
+/**
+ * Allocating new objects in createLocalVariables is quite expensive given
+ * that matchExpressions is in the hot path.
+ *
+ * Keep track of previously allocated objects to avoid useless allocations
+ * and garbage collection. This is intentionally shared between calls of
+ * matchExpressions.
+ */
+const recycledLocalVariables = [];
 
 function matchExpressions(domTree, expressions, filter) {
   const stack = [];
@@ -18,7 +35,8 @@ function matchExpressions(domTree, expressions, filter) {
     vNodes,
     expressions,
     [],
-    domTree[0].shadowId
+    domTree[0].shadowId,
+    recycledLocalVariables.pop()
   );
   const result = [];
 
@@ -75,7 +93,8 @@ function matchExpressions(domTree, expressions, filter) {
         vNode.children,
         childAny,
         childOnly,
-        vNode.shadowId
+        vNode.shadowId,
+        recycledLocalVariables.pop()
       );
     }
     // check for "return"
@@ -83,6 +102,7 @@ function matchExpressions(domTree, expressions, filter) {
       currentLevel.vNodesIndex === currentLevel.vNodes.length &&
       stack.length
     ) {
+      recycledLocalVariables.push(currentLevel);
       currentLevel = stack.pop();
     }
   }

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -34,7 +34,7 @@ function matchExpressions(domTree, expressions, filter) {
   let currentLevel = createLocalVariables(
     vNodes,
     expressions,
-    [],
+    null,
     domTree[0].shadowId,
     recycledLocalVariables.pop()
   );
@@ -42,17 +42,18 @@ function matchExpressions(domTree, expressions, filter) {
 
   while (currentLevel.vNodesIndex < currentLevel.vNodes.length) {
     const vNode = currentLevel.vNodes[currentLevel.vNodesIndex++];
-    const childOnly = []; // we will add hierarchical '>' selectors here
-    const childAny = [];
+    let childOnly = null; // we will add hierarchical '>' selectors here
+    let childAny = null;
     const combinedLength =
-      currentLevel.anyLevel.length + currentLevel.thisLevel.length;
+      (currentLevel.anyLevel?.length || 0) +
+      (currentLevel.thisLevel?.length || 0);
     let added = false;
     // see if node matches
     for (let i = 0; i < combinedLength; i++) {
       const exp =
-        i < currentLevel.anyLevel.length
+        i < (currentLevel.anyLevel?.length || 0)
           ? currentLevel.anyLevel[i]
-          : currentLevel.thisLevel[i - currentLevel.anyLevel.length];
+          : currentLevel.thisLevel[i - (currentLevel.anyLevel?.length || 0)];
       if (
         (!exp[0].id || vNode.shadowId === currentLevel.parentShadowId) &&
         matchesExpression(vNode, exp[0])
@@ -72,18 +73,18 @@ function matchExpressions(domTree, expressions, filter) {
           }
           if (rest[0].combinator === '>') {
             // add the rest to the childOnly array
-            childOnly.push(rest);
+            (childOnly = childOnly || []).push(rest);
           } else {
             // add the rest to the childAny array
-            childAny.push(rest);
+            (childAny = childAny || []).push(rest);
           }
         }
       }
       if (
         (!exp[0].id || vNode.shadowId === currentLevel.parentShadowId) &&
-        currentLevel.anyLevel.includes(exp)
+        currentLevel.anyLevel?.includes(exp)
       ) {
-        childAny.push(exp);
+        (childAny = childAny || []).push(exp);
       }
     }
 

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -26,13 +26,15 @@ function matchExpressions(domTree, expressions, filter) {
     const vNode = currentLevel.vNodes.pop();
     const childOnly = []; // we will add hierarchical '>' selectors here
     const childAny = [];
-    const combined = currentLevel.anyLevel
-      .slice()
-      .concat(currentLevel.thisLevel);
+    const combinedLength =
+      currentLevel.anyLevel.length + currentLevel.thisLevel.length;
     let added = false;
     // see if node matches
-    for (let i = 0; i < combined.length; i++) {
-      const exp = combined[i];
+    for (let i = 0; i < combinedLength; i++) {
+      const exp =
+        i < currentLevel.anyLevel.length
+          ? currentLevel.anyLevel[i]
+          : currentLevel.thisLevel[i - currentLevel.anyLevel.length];
       if (
         (!exp[0].id || vNode.shadowId === currentLevel.parentShadowId) &&
         matchesExpression(vNode, exp[0])

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -2,12 +2,12 @@ import { matchesExpression, convertSelector } from './matches';
 
 function createLocalVariables(vNodes, anyLevel, thisLevel, parentShadowId) {
   const retVal = {
-    vNodes: vNodes.slice(),
+    vNodes: vNodes,
+    vNodesIndex: 0,
     anyLevel: anyLevel,
     thisLevel: thisLevel,
     parentShadowId: parentShadowId
   };
-  retVal.vNodes.reverse();
   return retVal;
 }
 
@@ -22,8 +22,8 @@ function matchExpressions(domTree, expressions, filter) {
   );
   const result = [];
 
-  while (currentLevel.vNodes.length) {
-    const vNode = currentLevel.vNodes.pop();
+  while (currentLevel.vNodesIndex < currentLevel.vNodes.length) {
+    const vNode = currentLevel.vNodes[currentLevel.vNodesIndex++];
     const childOnly = []; // we will add hierarchical '>' selectors here
     const childAny = [];
     const combinedLength =
@@ -79,7 +79,10 @@ function matchExpressions(domTree, expressions, filter) {
       );
     }
     // check for "return"
-    while (!currentLevel.vNodes.length && stack.length) {
+    while (
+      currentLevel.vNodesIndex === currentLevel.vNodes.length &&
+      stack.length
+    ) {
       currentLevel = stack.pop();
     }
   }

--- a/test/commons/matches/node-name.js
+++ b/test/commons/matches/node-name.js
@@ -46,6 +46,7 @@ describe('matches.nodeName', function() {
   it('is case sensitive for XHTML', function() {
     var virtualNode = queryFixture('<H1 id="target">foo</H1>');
     virtualNode._isXHTML = true;
+    delete virtualNode._cache.props;
     assert.isFalse(matchNodeName(virtualNode, 'h1'));
   });
 

--- a/test/core/utils/matches.js
+++ b/test/core/utils/matches.js
@@ -20,12 +20,14 @@ describe('utils.matches', function() {
 
     it('is case sensitive for XHTML', function() {
       var virtualNode = queryFixture('<H1 id="target">foo</H1>');
+      delete virtualNode._cache.props;
       virtualNode._isXHTML = true;
       assert.isFalse(matches(virtualNode, 'h1'));
     });
 
     it('is case insensitive for HTML, but not for XHTML', function() {
       var virtualNode = queryFixture('<H1 id="target">foo</H1>');
+      delete virtualNode._cache.props;
       virtualNode._isXHTML = true;
       assert.isFalse(matches(virtualNode, 'h1'));
     });

--- a/test/core/utils/qsa.js
+++ b/test/core/utils/qsa.js
@@ -24,6 +24,14 @@ function getTestDom() {
     '<li role="button" id="one"></li>' +
     '</ul>' +
     '</div>' +
+    '<span class="fourth">' +
+    '<span>' +
+    '<span>' +
+    '<span></span>' +
+    '<span></span>' +
+    '</span>' +
+    '</span>' +
+    '</span>' +
     '</body>';
 
   // remove the head node
@@ -63,6 +71,13 @@ describe('axe.utils.querySelectorAllFilter', function() {
   it('should NOT find nodes using parent selector', function() {
     var result = axe.utils.querySelectorAllFilter(dom, 'div > li');
     assert.equal(result.length, 0);
+  });
+  it('should find nodes using nested parent selectors', function() {
+    var result = axe.utils.querySelectorAllFilter(
+      dom,
+      'span > span > span > span'
+    );
+    assert.equal(result.length, 2);
   });
   it('should find nodes using hierarchical selector', function() {
     var result = axe.utils.querySelectorAllFilter(dom, 'div li');


### PR DESCRIPTION
Profiling with [Firefox Profiler](https://profiler.firefox.com/) revealed some memory allocations in the hot path that can be avoided (see individual commits for more details). Removing these allocations results in lower memory usage (don't have hard numbers on this) and reduces the running time (by ~18% for certain use-cases):

```shell
# Before
hyperfine --warmup 1 'axe --browser firefox https://www.theguardian.com/international'                                   
Benchmark #1: axe --browser firefox https://www.theguardian.com/international
  Time (mean ± σ):     20.343 s ±  0.425 s    [User: 23.073 s, System: 3.503 s]
  Range (min … max):   19.959 s … 21.289 s    10 runs

# After
hyperfine --warmup 1 'axe --browser firefox https://www.theguardian.com/international'
Benchmark #1: axe --browser firefox https://www.theguardian.com/international
  Time (mean ± σ):     16.587 s ±  0.191 s    [User: 19.432 s, System: 3.307 s]
  Range (min … max):   16.365 s … 16.952 s    10 runs
```
