### PR TITLE
fix(heading-order): use aria-level on headings in addition to role=header elements

### DIFF
--- a/lib/checks/navigation/heading-order-evaluate.js
+++ b/lib/checks/navigation/heading-order-evaluate.js
@@ -4,17 +4,18 @@ import { isVisible } from '../../commons/dom';
 
 function getLevel(vNode) {
   const role = vNode.attr('role');
-  if (role && role.includes('heading')) {
-    const ariaHeadingLevel = vNode.attr('aria-level');
-    const level = parseInt(ariaHeadingLevel, 10);
+  const headingRole = role && role.includes('heading');
+  const ariaHeadingLevel = vNode.attr('aria-level');
+  const level = parseInt(ariaHeadingLevel, 10);
 
-    // default aria-level for a heading is 2 if it is
-    // not set or set to an incorrect value
-    // @see https://www.w3.org/TR/wai-aria-1.1/#heading
-    if (isNaN(level) || level < 1 || level > 6) {
-      return 2;
-    }
+  // default aria-level for a heading is 2 if it is
+  // not set or set to an incorrect value
+  // @see https://www.w3.org/TR/wai-aria-1.1/#heading
+  if ((headingRole && isNaN(level)) || level < 1 || level > 6) {
+    return 2;
+  }
 
+  if (level) {
     return level;
   }
 

--- a/lib/checks/navigation/heading-order-evaluate.js
+++ b/lib/checks/navigation/heading-order-evaluate.js
@@ -1,27 +1,33 @@
 import cache from '../../core/base/cache';
 import { querySelectorAllFilter, getAncestry } from '../../core/utils';
 import { isVisible } from '../../commons/dom';
+import { getRole } from '../../commons/aria';
 
 function getLevel(vNode) {
-  const role = vNode.attr('role');
+  const role = getRole(vNode);
   const headingRole = role && role.includes('heading');
   const ariaHeadingLevel = vNode.attr('aria-level');
-  const level = parseInt(ariaHeadingLevel, 10);
+  const ariaLevel = parseInt(ariaHeadingLevel, 10);
+
+  const [, headingLevel] = vNode.props.nodeName.match(/h(\d)/) || [];
+
+  if (!headingRole) {
+    return -1;
+  }
+
+  if (headingLevel && !ariaHeadingLevel) {
+    return parseInt(headingLevel, 10);
+  }
 
   // default aria-level for a heading is 2 if it is
   // not set or set to an incorrect value
   // @see https://www.w3.org/TR/wai-aria-1.1/#heading
-  if ((headingRole && isNaN(level)) || level < 1 || level > 6) {
+  if (isNaN(ariaLevel) || ariaLevel < 1 || ariaLevel > 6) {
     return 2;
   }
 
-  if (level) {
-    return level;
-  }
-
-  const headingLevel = vNode.props.nodeName.match(/h(\d)/);
-  if (headingLevel) {
-    return parseInt(headingLevel[1], 10);
+  if (ariaLevel) {
+    return ariaLevel;
   }
 
   return -1;
@@ -50,7 +56,7 @@ function headingOrderEvaluate() {
       level: getLevel(vNode)
     };
   });
-
+  console.log(headingOrder);
   this.data({ headingOrder });
   cache.set('headingOrder', vNodes);
   return true;

--- a/lib/checks/navigation/heading-order-evaluate.js
+++ b/lib/checks/navigation/heading-order-evaluate.js
@@ -22,8 +22,7 @@ function getLevel(vNode) {
   // default aria-level for a heading is 2 if it is
   // not set or set to an incorrect value
   // @see https://www.w3.org/TR/wai-aria-1.1/#heading
-  // note that NVDA and VO allow any positive level
-  if (isNaN(ariaLevel) || ariaLevel < 1 || ariaLevel > 6) {
+  if (isNaN(ariaLevel) || ariaLevel < 1) {
     if (headingLevel) {
       return parseInt(headingLevel, 10);
     }

--- a/lib/checks/navigation/heading-order-evaluate.js
+++ b/lib/checks/navigation/heading-order-evaluate.js
@@ -22,7 +22,11 @@ function getLevel(vNode) {
   // default aria-level for a heading is 2 if it is
   // not set or set to an incorrect value
   // @see https://www.w3.org/TR/wai-aria-1.1/#heading
+  // note that NVDA and VO allow any positive level
   if (isNaN(ariaLevel) || ariaLevel < 1 || ariaLevel > 6) {
+    if (headingLevel) {
+      return parseInt(headingLevel, 10);
+    }
     return 2;
   }
 

--- a/test/checks/navigation/heading-order.js
+++ b/test/checks/navigation/heading-order.js
@@ -79,6 +79,29 @@ describe('heading-order', function() {
     });
   });
 
+  it('should allow aria-level to override semantic level for hn tags and return true', function() {
+    var vNode = queryFixture(
+      '<h1 aria-level="2" id="target">Two</h1><h3 aria-level="4">Four</h3>'
+    );
+    assert.isTrue(
+      axe.testUtils
+        .getCheckEvaluate('heading-order')
+        .call(checkContext, null, {}, vNode, {})
+    );
+    assert.deepEqual(checkContext._data, {
+      headingOrder: [
+        {
+          ancestry: ['html > body > div:nth-child(1) > h1:nth-child(1)'],
+          level: 2
+        },
+        {
+          ancestry: ['html > body > div:nth-child(1) > h3:nth-child(2)'],
+          level: 4
+        }
+      ]
+    });
+  });
+
   it('should store the location of iframes', function() {
     var vNode = queryFixture(
       '<h1 id="target">One</h1><iframe></iframe><h3>Three</h3>'

--- a/test/checks/navigation/heading-order.js
+++ b/test/checks/navigation/heading-order.js
@@ -141,7 +141,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should return 2 when an hn tag has an invalid aria-level', function() {
+  it('should return the heading level when an hn tag has an invalid aria-level', function() {
     var vNode = queryFixture(
       '<h1 aria-level="-1" id="target">One</h1><h3 aria-level="12">Three</h3>'
     );
@@ -154,11 +154,11 @@ describe('heading-order', function() {
       headingOrder: [
         {
           ancestry: ['html > body > div:nth-child(1) > h1:nth-child(1)'],
-          level: 2
+          level: 1
         },
         {
           ancestry: ['html > body > div:nth-child(1) > h3:nth-child(2)'],
-          level: 2
+          level: 3
         }
       ]
     });

--- a/test/checks/navigation/heading-order.js
+++ b/test/checks/navigation/heading-order.js
@@ -33,7 +33,7 @@ describe('heading-order', function() {
 
   it('should handle incorrect aria-level values', function() {
     var vNode = queryFixture(
-      '<div role="heading" aria-level="-1" id="target">One</div><div role="heading" aria-level="12">Two</div><div role="heading">Three</div>'
+      '<div role="heading" aria-level="-1" id="target">One</div><div role="heading">Two</div>'
     );
     assert.isTrue(
       axe.testUtils
@@ -49,10 +49,25 @@ describe('heading-order', function() {
         {
           ancestry: ['html > body > div:nth-child(1) > div:nth-child(2)'],
           level: 2
-        },
+        }
+      ]
+    });
+  });
+
+  it('should allow high aria-level values', function() {
+    var vNode = queryFixture(
+      '<div role="heading" aria-level="12" id="target">One</div>'
+    );
+    assert.isTrue(
+      axe.testUtils
+        .getCheckEvaluate('heading-order')
+        .call(checkContext, null, {}, vNode, {})
+    );
+    assert.deepEqual(checkContext._data, {
+      headingOrder: [
         {
-          ancestry: ['html > body > div:nth-child(1) > div:nth-child(3)'],
-          level: 2
+          ancestry: ['html > body > div:nth-child(1) > div'],
+          level: 12
         }
       ]
     });
@@ -142,9 +157,7 @@ describe('heading-order', function() {
   });
 
   it('should return the heading level when an hn tag has an invalid aria-level', function() {
-    var vNode = queryFixture(
-      '<h1 aria-level="-1" id="target">One</h1><h3 aria-level="12">Three</h3>'
-    );
+    var vNode = queryFixture('<h1 aria-level="-1" id="target">One</h1>');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('heading-order')
@@ -153,12 +166,8 @@ describe('heading-order', function() {
     assert.deepEqual(checkContext._data, {
       headingOrder: [
         {
-          ancestry: ['html > body > div:nth-child(1) > h1:nth-child(1)'],
+          ancestry: ['html > body > div:nth-child(1) > h1'],
           level: 1
-        },
-        {
-          ancestry: ['html > body > div:nth-child(1) > h3:nth-child(2)'],
-          level: 3
         }
       ]
     });

--- a/test/checks/navigation/heading-order.js
+++ b/test/checks/navigation/heading-order.js
@@ -102,6 +102,68 @@ describe('heading-order', function() {
     });
   });
 
+  it('should ignore aria-level on iframe when not used with role=heading', function() {
+    var vNode = queryFixture('<iframe aria-level="2"></iframe>');
+    axe.testUtils
+      .getCheckEvaluate('heading-order')
+      .call(checkContext, null, {}, vNode, { initiator: true });
+    //assert.equal(checkContext._data.headingOrder[0].ancestry[0], 'html > body > div:nth-child(1) > iframe:nth-child(1)');
+    assert.deepEqual(checkContext._data, {
+      headingOrder: [
+        {
+          ancestry: ['html > body > div:nth-child(1) > iframe'],
+          level: -1
+        }
+      ]
+    });
+  });
+
+  it('should correctly give level on hn tag with role=heading', function() {
+    var vNode = queryFixture(
+      '<h1 role="heading" id="target">One</h1><h3 role="heading">Three</h3>'
+    );
+    assert.isTrue(
+      axe.testUtils
+        .getCheckEvaluate('heading-order')
+        .call(checkContext, null, {}, vNode, {})
+    );
+    assert.deepEqual(checkContext._data, {
+      headingOrder: [
+        {
+          ancestry: ['html > body > div:nth-child(1) > h1:nth-child(1)'],
+          level: 1
+        },
+        {
+          ancestry: ['html > body > div:nth-child(1) > h3:nth-child(2)'],
+          level: 3
+        }
+      ]
+    });
+  });
+
+  it('should return 2 when an hn tag has an invalid aria-level', function() {
+    var vNode = queryFixture(
+      '<h1 aria-level="-1" id="target">One</h1><h3 aria-level="12">Three</h3>'
+    );
+    assert.isTrue(
+      axe.testUtils
+        .getCheckEvaluate('heading-order')
+        .call(checkContext, null, {}, vNode, {})
+    );
+    assert.deepEqual(checkContext._data, {
+      headingOrder: [
+        {
+          ancestry: ['html > body > div:nth-child(1) > h1:nth-child(1)'],
+          level: 2
+        },
+        {
+          ancestry: ['html > body > div:nth-child(1) > h3:nth-child(2)'],
+          level: 2
+        }
+      ]
+    });
+  });
+
   it('should store the location of iframes', function() {
     var vNode = queryFixture(
       '<h1 id="target">One</h1><iframe></iframe><h3>Three</h3>'


### PR DESCRIPTION
Allow aria-level on hn elements to override the semantic level of the element. 

Closes issue: #2971 
