### PR TITLE
docs(audit): add reject param for audit.run

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -413,7 +413,8 @@ class Audit {
    * @async
    * @param  {Context}   context The scope definition/context for analysis (include/exclude)
    * @param  {Object}    options Options object to pass into rules and/or disable rules or checks
-   * @param  {Function} fn       Callback function to fire when audit is complete
+   * @param  {Function}  resolve Callback function to fire when audit is complete
+   * @param  {Function}  reject  Callback function to fire when audit experiences an error
    */
   run(context, options, resolve, reject) {
     this.normalizeOptions(options);


### PR DESCRIPTION
Minor tweak to the jsdoc comment for `Audit`'s `run` method in /lib/core/base/audit.js

Closes: #2795
