### PR TITLE
fix(color-contrast-matches): only absolutely positioned elements using clip should be not visible

### DIFF
--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -25,10 +25,14 @@ function isClipped(style) {
     .getPropertyValue('clip-path')
     .match(clipPathRegex);
   if (matchesClip && matchesClip.length === 5) {
-    return (
-      matchesClip[3] - matchesClip[1] <= 0 &&
-      matchesClip[2] - matchesClip[4] <= 0
-    );
+    const position = style.getPropertyValue('position');
+    // clip is only applied to absolutely positioned elements
+    if (['fixed', 'absolute'].includes(position)) {
+      return (
+        matchesClip[3] - matchesClip[1] <= 0 &&
+        matchesClip[2] - matchesClip[4] <= 0
+      );
+    }
   }
   if (matchesClipPath) {
     const type = matchesClipPath[1];

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -158,6 +158,20 @@ describe('dom.isVisible', function() {
       assert.isFalse(axe.commons.dom.isVisible(el));
     });
 
+    it('should detect when clip is not applied because of positioning', function() {
+      var el,
+        clip =
+          'clip: rect(1px 1px 1px 1px);' +
+          'clip: rect(1px, 1px, 1px, 1px);' +
+          'position: relative;' +
+          'overflow: hidden;';
+
+      fixture.innerHTML = '<div id="target" style="' + clip + '">Hi</div>';
+
+      el = document.getElementById('target');
+      assert.isTrue(axe.commons.dom.isVisible(el));
+    });
+
     it('should detect clip rect hidden text technique on parent', function() {
       var el,
         clip =
@@ -172,6 +186,21 @@ describe('dom.isVisible', function() {
 
       el = document.getElementById('target');
       assert.isFalse(axe.commons.dom.isVisible(el));
+    });
+
+    it('should detect when clip is not applied because of positioning on parent', function() {
+      var el,
+        clip =
+          'clip: rect(1px 1px 1px 1px);' +
+          'clip: rect(1px, 1px, 1px, 1px);' +
+          'position: relative;' +
+          'overflow: hidden;';
+
+      fixture.innerHTML =
+        '<div style="' + clip + '">' + '<div id="target">Hi</div>' + '</div>';
+
+      el = document.getElementById('target');
+      assert.isTrue(axe.commons.dom.isVisible(el));
     });
 
     it('should detect poorly hidden clip rects', function() {
@@ -513,6 +542,20 @@ describe('dom.isVisible', function() {
       assert.isTrue(axe.commons.dom.isVisible(el, true));
     });
 
+    it('should detect even when clip is not applied because of positioning', function() {
+      var el,
+        clip =
+          'clip: rect(1px 1px 1px 1px);' +
+          'clip: rect(1px, 1px, 1px, 1px);' +
+          'position: relative;' +
+          'overflow: hidden;';
+
+      fixture.innerHTML = '<div id="target" style="' + clip + '">Hi</div>';
+
+      el = document.getElementById('target');
+      assert.isTrue(axe.commons.dom.isVisible(el, true));
+    });
+
     it('should detect clip rect hidden text technique on parent', function() {
       var el,
         clip =
@@ -524,6 +567,20 @@ describe('dom.isVisible', function() {
 
       fixture.innerHTML =
         '<div style="' + clip + '">' + '<div id="target">Hi</div>' + '</div>';
+
+      el = document.getElementById('target');
+      assert.isTrue(axe.commons.dom.isVisible(el, true));
+    });
+
+    it('should detect even when clip is not applied because of positioning', function() {
+      var el,
+        clip =
+          'clip: rect(1px 1px 1px 1px);' +
+          'clip: rect(1px, 1px, 1px, 1px);' +
+          'position: relative;' +
+          'overflow: hidden;';
+
+      fixture.innerHTML = '<div id="target" style="' + clip + '">Hi</div>';
 
       el = document.getElementById('target');
       assert.isTrue(axe.commons.dom.isVisible(el, true));

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -158,6 +158,21 @@ describe('dom.isVisible', function() {
       assert.isFalse(axe.commons.dom.isVisible(el));
     });
 
+    it('should detect clip rect hidden text technique using position: fixed', function() {
+      var el,
+        clip =
+          'clip: rect(1px 1px 1px 1px);' +
+          'clip: rect(1px, 1px, 1px, 1px);' +
+          'width: 1px; height: 1px;' +
+          'position: fixed;' +
+          'overflow: hidden;';
+
+      fixture.innerHTML = '<div id="target" style="' + clip + '">Hi</div>';
+
+      el = document.getElementById('target');
+      assert.isFalse(axe.commons.dom.isVisible(el));
+    });
+
     it('should detect when clip is not applied because of positioning', function() {
       var el,
         clip =
@@ -572,7 +587,7 @@ describe('dom.isVisible', function() {
       assert.isTrue(axe.commons.dom.isVisible(el, true));
     });
 
-    it('should detect even when clip is not applied because of positioning', function() {
+    it('should detect even when clip is not applied because of positioning on parent', function() {
       var el,
         clip =
           'clip: rect(1px 1px 1px 1px);' +
@@ -580,7 +595,8 @@ describe('dom.isVisible', function() {
           'position: relative;' +
           'overflow: hidden;';
 
-      fixture.innerHTML = '<div id="target" style="' + clip + '">Hi</div>';
+      fixture.innerHTML =
+        '<div style="' + clip + '">' + '<div id="target">Hi</div>' + '</div>';
 
       el = document.getElementById('target');
       assert.isTrue(axe.commons.dom.isVisible(el, true));


### PR DESCRIPTION
Clip is only applied on absolutely positioned elements (`position: fixed` or `position: absolute`), so if an element is using `clip` but doesn't have that positioning, it will still be visible.

Closes issue: #3037
