### PR TITLE
fix(core): stop mutating Context's input

### DIFF
--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -236,12 +236,13 @@ export default function Context(spec, flatTree) {
   this.focusable = typeof spec?.focusable === 'boolean' ? spec.focusable : true;
   this.size = typeof spec?.size === 'object' ? spec.size : {};
 
-  spec = normalizeContext(spec);
-
+  const normalizedSpec = Object.assign({}, normalizeContext(spec));
   // cache the flattened tree
-  this.flatTree = flatTree ?? getFlattenedTree(getRootNode(spec));
-  this.exclude = spec.exclude;
-  this.include = spec.include;
+  this.flatTree = flatTree ?? getFlattenedTree(getRootNode(normalizedSpec));
+  this.exclude = normalizedSpec.exclude.map(x => x);
+  this.include = Array.isArray(normalizedSpec.include)
+    ? normalizedSpec.include.map(x => x)
+    : normalizedSpec.include;
 
   this.include = parseSelectorArray(this, 'include');
   this.exclude = parseSelectorArray(this, 'exclude');

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -88,12 +88,19 @@ function normalizeContext(context) {
       context.hasOwnProperty('include') ||
       context.hasOwnProperty('exclude')
     ) {
+      // const contextDupe = JSON.parse(JSON.stringify(context));
+      let exclude = context.exclude ? context.exclude : [];
+      if (exclude !== []) {
+        exclude = Array.isArray(context.exclude)
+          ? JSON.parse(JSON.stringify(context.exclude))
+          : exclude;
+      }
       return {
         include:
           context.include && +context.include.length
-            ? context.include
+            ? Array.from(context.include)
             : [document],
-        exclude: context.exclude || []
+        exclude: exclude
       };
     }
 
@@ -235,14 +242,11 @@ export default function Context(spec, flatTree) {
   this.initiator = typeof spec?.initiator === 'boolean' ? spec.initiator : true;
   this.focusable = typeof spec?.focusable === 'boolean' ? spec.focusable : true;
   this.size = typeof spec?.size === 'object' ? spec.size : {};
-
-  const normalizedSpec = Object.assign({}, normalizeContext(spec));
+  spec = normalizeContext(spec);
   // cache the flattened tree
-  this.flatTree = flatTree ?? getFlattenedTree(getRootNode(normalizedSpec));
-  this.exclude = normalizedSpec.exclude.map(x => x);
-  this.include = Array.isArray(normalizedSpec.include)
-    ? normalizedSpec.include.map(x => x)
-    : normalizedSpec.include;
+  this.flatTree = flatTree ?? getFlattenedTree(getRootNode(spec));
+  this.exclude = spec.exclude;
+  this.include = spec.include;
 
   this.include = parseSelectorArray(this, 'include');
   this.exclude = parseSelectorArray(this, 'exclude');

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -7,7 +7,8 @@ import {
   select,
   isNodeInContext,
   nodeSorter,
-  respondable
+  respondable,
+  clone
 } from '../utils';
 
 /**
@@ -88,12 +89,7 @@ function normalizeContext(context) {
       context.hasOwnProperty('include') ||
       context.hasOwnProperty('exclude')
     ) {
-      let exclude = context.exclude ? context.exclude : [];
-      if (exclude !== []) {
-        exclude = Array.isArray(context.exclude)
-          ? JSON.parse(JSON.stringify(context.exclude))
-          : exclude;
-      }
+      const exclude = context.exclude ? clone(context.exclude) : [];
       return {
         include:
           context.include && +context.include.length
@@ -241,7 +237,9 @@ export default function Context(spec, flatTree) {
   this.initiator = typeof spec?.initiator === 'boolean' ? spec.initiator : true;
   this.focusable = typeof spec?.focusable === 'boolean' ? spec.focusable : true;
   this.size = typeof spec?.size === 'object' ? spec.size : {};
+
   spec = normalizeContext(spec);
+
   // cache the flattened tree
   this.flatTree = flatTree ?? getFlattenedTree(getRootNode(spec));
   this.exclude = spec.exclude;

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -88,7 +88,6 @@ function normalizeContext(context) {
       context.hasOwnProperty('include') ||
       context.hasOwnProperty('exclude')
     ) {
-      // const contextDupe = JSON.parse(JSON.stringify(context));
       let exclude = context.exclude ? context.exclude : [];
       if (exclude !== []) {
         exclude = Array.isArray(context.exclude)

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -92,9 +92,9 @@ function normalizeContext(context) {
       return {
         include:
           context.include && +context.include.length
-            ? Array.from(context.include)
+            ? context.include
             : [document],
-        exclude: context.exclude ? clone(context.exclude) : []
+        exclude: context.exclude || []
       };
     }
 
@@ -231,6 +231,7 @@ function getRootNode({ include, exclude }) {
  * @param {Object} spec Configuration or "specification" object
  */
 export default function Context(spec, flatTree) {
+  spec = clone(spec);
   this.frames = [];
   this.page = typeof spec?.page === 'boolean' ? spec.page : undefined;
   this.initiator = typeof spec?.initiator === 'boolean' ? spec.initiator : true;

--- a/lib/core/base/context.js
+++ b/lib/core/base/context.js
@@ -89,13 +89,12 @@ function normalizeContext(context) {
       context.hasOwnProperty('include') ||
       context.hasOwnProperty('exclude')
     ) {
-      const exclude = context.exclude ? clone(context.exclude) : [];
       return {
         include:
           context.include && +context.include.length
             ? Array.from(context.include)
             : [document],
-        exclude: exclude
+        exclude: context.exclude ? clone(context.exclude) : []
       };
     }
 

--- a/lib/core/utils/clone.js
+++ b/lib/core/utils/clone.js
@@ -9,7 +9,7 @@ function clone(obj) {
     length,
     out = obj;
   // DOM nodes cannot be cloned.
-  if (obj instanceof window.Node) {
+  if (window?.Node && obj instanceof window.Node) {
     return obj;
   }
 

--- a/lib/core/utils/clone.js
+++ b/lib/core/utils/clone.js
@@ -9,7 +9,10 @@ function clone(obj) {
     length,
     out = obj;
   // DOM nodes cannot be cloned.
-  if (window?.Node && obj instanceof window.Node) {
+  if (
+    (window?.Node && obj instanceof window.Node) || 
+    (window?.HTMLCollection && obj instanceof window.HTMLCollection)
+  ) {
     return obj;
   }
 

--- a/lib/core/utils/clone.js
+++ b/lib/core/utils/clone.js
@@ -9,7 +9,7 @@ function clone(obj) {
     length,
     out = obj;
   if (obj instanceof window.Node) {
-    return obj.cloneNode(true);
+    return obj;
   }
 
   if (obj !== null && typeof obj === 'object') {

--- a/lib/core/utils/clone.js
+++ b/lib/core/utils/clone.js
@@ -8,6 +8,7 @@ function clone(obj) {
   var index,
     length,
     out = obj;
+  // DOM nodes cannot be cloned.
   if (obj instanceof window.Node) {
     return obj;
   }

--- a/lib/core/utils/clone.js
+++ b/lib/core/utils/clone.js
@@ -8,6 +8,9 @@ function clone(obj) {
   var index,
     length,
     out = obj;
+  if (obj instanceof window.Node) {
+    return obj.cloneNode(true);
+  }
 
   if (obj !== null && typeof obj === 'object') {
     if (Array.isArray(obj)) {

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -30,6 +30,32 @@ describe('Context', function() {
     assert.deepEqual(context, { include: [['#foo']] });
   });
 
+  it('should not share memory with complex object', function() {
+    fixture.innerHTML = '<div id="foo"><a href="">Click me</a></div>';
+    var spec = {
+      include: [['#foo'], ['a']],
+      exclude: [['iframe', '#foo2']],
+      size: { width: 100, height: 100 }
+    };
+    var context = new Context(spec);
+    assert.notStrictEqual(spec.include, context.include);
+    spec.include.forEach(function(_, index) {
+      assert.notStrictEqual(spec.include[index], context.include[index]);
+    });
+    assert.notStrictEqual(spec.exclude, context.exclude);
+    spec.exclude.forEach(function(_, index) {
+      assert.notStrictEqual(spec.exclude[index], context.exclude[index]);
+    });
+    assert.notStrictEqual(spec.size, context.size);
+  });
+
+  it('should not share memory with simple array', function() {
+    fixture.innerHTML = '<div id="foo"></div>';
+    var spec = ['#foo'];
+    var context = new Context(spec);
+    assert.notStrictEqual(spec, context.include);
+  });
+
   describe('include', function() {
     it('should accept a single selector', function() {
       fixture.innerHTML = '<div id="foo"></div>';

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -14,11 +14,20 @@ describe('Context', function() {
     fixture.innerHTML = '';
   });
 
-  it('should not mutate its input', function() {
-    var context = { exclude: [['iframe', 'foo']] };
+  it('should not mutate exclude in input', function() {
+    fixture.innerHTML = '<div id="foo"></div>';
+    var context = { exclude: [['iframe', '#foo']] };
     // eslint-disable-next-line no-new
     new Context(context);
-    assert.deepEqual(context, { exclude: [['iframe', 'foo']] });
+    assert.deepEqual(context, { exclude: [['iframe', '#foo']] });
+  });
+
+  it('should not mutate its include input', function() {
+    fixture.innerHTML = '<div id="foo"></div>';
+    var context = { include: [['#foo']] };
+    // eslint-disable-next-line no-new
+    new Context(context);
+    assert.deepEqual(context, { include: [['#foo']] });
   });
 
   describe('include', function() {

--- a/test/core/base/context.js
+++ b/test/core/base/context.js
@@ -14,6 +14,13 @@ describe('Context', function() {
     fixture.innerHTML = '';
   });
 
+  it('should not mutate its input', function() {
+    var context = { exclude: [['iframe', 'foo']] };
+    // eslint-disable-next-line no-new
+    new Context(context);
+    assert.deepEqual(context, { exclude: [['iframe', 'foo']] });
+  });
+
   describe('include', function() {
     it('should accept a single selector', function() {
       fixture.innerHTML = '<div id="foo"></div>';

--- a/test/core/utils/get-frame-contexts.js
+++ b/test/core/utils/get-frame-contexts.js
@@ -222,6 +222,7 @@ describe('utils.getFrameContexts', function() {
       assert.deepEqual(frameContexts[0].frameContext.exclude, []);
 
       frameContexts = getFrameContexts({ exclude: [f2] });
+      console.log(frameContexts);
       assert.lengthOf(frameContexts, 1);
       assert.include(frameContexts[0].frameSelector, 'iframe:nth-child(1)');
       assert.deepEqual(frameContexts[0].frameContext.include, []);

--- a/test/core/utils/get-frame-contexts.js
+++ b/test/core/utils/get-frame-contexts.js
@@ -222,7 +222,6 @@ describe('utils.getFrameContexts', function() {
       assert.deepEqual(frameContexts[0].frameContext.exclude, []);
 
       frameContexts = getFrameContexts({ exclude: [f2] });
-      console.log(frameContexts);
       assert.lengthOf(frameContexts, 1);
       assert.include(frameContexts[0].frameSelector, 'iframe:nth-child(1)');
       assert.deepEqual(frameContexts[0].frameContext.include, []);


### PR DESCRIPTION
getFrameContexts was mutating its input because Context mutates its input. This change makes it so Context no longer mutates its input. 

Closes issue: #3045
