### PR TITLE
tests: remove act/aria-props-permitted

### DIFF
--- a/test/act-mapping/aria-props-permitted.json
+++ b/test/act-mapping/aria-props-permitted.json
@@ -1,5 +1,0 @@
-{
-  "id": "5c01ea",
-  "title": "ARIA state or property is permitted",
-  "axeRules": ["aria-allowed-attr"]
-}


### PR DESCRIPTION
This will start blocking any pr to develop as the [failed example 2](https://act-rules.github.io/rules/5c01ea#failed-example-2) does not fail in axe-core.

The reason is that the `audio` element [does not have an implicit role](https://w3c.github.io/html-aria/#el-audio) (see also https://www.w3.org/TR/html-aam-1.0/#details-id-8), and as such our aria-allowed-attr check [does not check allowed attrs for roleless elements](https://github.com/dequelabs/axe-core/blob/develop/lib/checks/aria/aria-allowed-attr-evaluate.js#L41). 

Once this is merged, I will create a tech debt ticket for it similar to https://github.com/dequelabs/axe-core/issues/2960 

