### PR TITLE
fix(aria-allowed-role): allow all roles on SVGs

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -822,7 +822,7 @@ const htmlElms = {
   },
   svg: {
     contentTypes: ['embedded', 'phrasing', 'flow'],
-    allowedRoles: ['application', 'document', 'img'],
+    allowedRoles: true,
     chromiumRole: 'SVGRoot',
     namingMethods: ['svgTitleText']
   },

--- a/test/commons/aria/is-aria-role-allowed-on-element.js
+++ b/test/commons/aria/is-aria-role-allowed-on-element.js
@@ -22,12 +22,12 @@ describe('aria.isAriaRoleAllowedOnElement', function() {
     assert.equal(actual, expected);
   });
 
-  it('returns false for SVG with role alertdialog', function() {
+  it('returns true for SVG with role alertdialog', function() {
     var node = document.createElement('svg');
     var role = 'alertdialog';
     node.setAttribute('role', role);
     flatTreeSetup(node);
-    assert.isFalse(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
+    assert.isTrue(axe.commons.aria.isAriaRoleAllowedOnElement(node, role));
   });
 
   it('returns true for OBJECT with role application', function() {


### PR DESCRIPTION
The current ARIA spec allows any role on an SVG element. 

Closes issue: #3082
