### PR TITLE
fix(run,finishRun): don't mutate options, set default reporter to v1

### DIFF
--- a/lib/core/public/finish-run.js
+++ b/lib/core/public/finish-run.js
@@ -9,6 +9,9 @@ import {
 
 export default function finishRun(partialResults, options = {}) {
   options = clone(options);
+
+  // normalize the runOnly option for the output of reporters toolOptions
+  axe._audit.normalizeOptions(options);
   options.reporter = options.reporter ?? axe._audit?.reporter ?? 'v1';
 
   setFrameSpec(partialResults);

--- a/lib/core/public/finish-run.js
+++ b/lib/core/public/finish-run.js
@@ -3,10 +3,14 @@ import {
   mergeResults,
   publishMetaData,
   finalizeRuleResult,
-  DqElement
+  DqElement,
+  clone
 } from '../utils';
 
 export default function finishRun(partialResults, options = {}) {
+  options = clone(options);
+  options.reporter = options.reporter ?? axe._audit?.reporter ?? 'v1';
+
   setFrameSpec(partialResults);
   let results = mergeResults(partialResults);
   results = axe._audit.after(results, options);

--- a/lib/core/public/run/normalize-run-params.js
+++ b/lib/core/public/run/normalize-run-params.js
@@ -1,3 +1,5 @@
+import { clone } from '../../utils';
+
 /**
  * Normalize the optional params of axe.run()
  * @param  {object}   context
@@ -36,6 +38,7 @@ export default function normalizeRunParams([context, options, callback]) {
     throw typeErr;
   }
 
+  options = clone(options);
   options.reporter = options.reporter ?? axe._audit?.reporter ?? 'v1';
   return { context, options, callback };
 }

--- a/test/core/public/finish-run.js
+++ b/test/core/public/finish-run.js
@@ -67,6 +67,22 @@ describe('axe.finishRun', function() {
       .catch(done);
   });
 
+  it('normalizes the runOnly option in the reporter', function(done) {
+    axe
+      .runPartial()
+      .then(function(partialResult) {
+        return axe.finishRun([partialResult], { runOnly: 'region' });
+      })
+      .then(function(results) {
+        assert.deepEqual(results.toolOptions.runOnly, {
+          type: 'rule',
+          values: ['region']
+        });
+        done();
+      })
+      .catch(done);
+  });
+
   it('can report violations results', function(done) {
     fixture.innerHTML = '<div aria-label="foo"></div>';
     axe
@@ -268,7 +284,7 @@ describe('axe.finishRun', function() {
         .then(function() {
           assert.lengthOf(axe._audit.after.args, 1);
           assert.deepEqual(axe._audit.after.args[0][1], {
-            runOnly: 'duplicate-id',
+            runOnly: { type: 'rule', values: ['duplicate-id'] },
             reporter: 'v1'
           });
           spy.restore();

--- a/test/core/public/finish-run.js
+++ b/test/core/public/finish-run.js
@@ -21,6 +21,20 @@ describe('axe.finishRun', function() {
       .catch(done);
   });
 
+  it('does not mutate the options object', function(done) {
+    var options = {};
+    axe
+      .runPartial(options)
+      .then(function(result) {
+        return axe.finishRun([result], options);
+      })
+      .then(function() {
+        assert.deepEqual(options, {});
+        done();
+      })
+      .catch(done);
+  });
+
   it('uses option.reporter to create the report', function(done) {
     axe
       .runPartial()
@@ -35,6 +49,19 @@ describe('axe.finishRun', function() {
           assert.property(rawResult, 'incomplete');
           assert.property(rawResult, 'inapplicable');
         });
+        done();
+      })
+      .catch(done);
+  });
+
+  it('defaults options.reporter to v1', function(done) {
+    axe
+      .runPartial()
+      .then(function(partialResult) {
+        return axe.finishRun([partialResult]);
+      })
+      .then(function(results) {
+        assert.equal(results.toolOptions.reporter, 'v1');
         done();
       })
       .catch(done);
@@ -241,7 +268,8 @@ describe('axe.finishRun', function() {
         .then(function() {
           assert.lengthOf(axe._audit.after.args, 1);
           assert.deepEqual(axe._audit.after.args[0][1], {
-            runOnly: 'duplicate-id'
+            runOnly: 'duplicate-id',
+            reporter: 'v1'
           });
           spy.restore();
           done();

--- a/test/core/public/run-partial.js
+++ b/test/core/public/run-partial.js
@@ -35,10 +35,21 @@ describe('axe.runPartial', function() {
 
   it('normalizes the options argument', function(done) {
     axe
-      .runPartial(/* no context */{ runOnly: 'image-alt' })
+      .runPartial(/* no context */ { runOnly: 'image-alt' })
       .then(function(partialResult) {
         assert.lengthOf(partialResult.results, 1);
         assert.equal(partialResult.results[0].id, 'image-alt');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('does not mutate the options object', function(done) {
+    var options = {};
+    axe
+      .runPartial(options)
+      .then(function() {
+        assert.deepEqual(options, {});
         done();
       })
       .catch(done);

--- a/test/core/public/run.js
+++ b/test/core/public/run.js
@@ -70,6 +70,14 @@ describe('axe.run', function() {
     axe.run(document, noop);
   });
 
+  it('does not mutate the options object', function(done) {
+    var options = {};
+    axe.run(options, function() {
+      assert.deepEqual(options, {});
+      done();
+    });
+  });
+
   it('works with performance logging enabled', function(done) {
     axe.run(document, { performanceTimer: true }, function(err, result) {
       assert.isObject(result);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -475,11 +475,7 @@ testUtils.runPartialRecursive = function runPartialRecursive(
   options = options || {};
   win = win || window;
   var axe = win.axe;
-
-  // axe.utils.getFrameContexts mutates
-  // https://github.com/dequelabs/axe-core/issues/3045
-  var contextCopy = axe.utils.clone(context);
-  var frameContexts = axe.utils.getFrameContexts(contextCopy);
+  var frameContexts = axe.utils.getFrameContexts(context);
   var promiseResults = [axe.runPartial(context, options)];
 
   frameContexts.forEach(function(c) {


### PR DESCRIPTION
This fixes an issue where not passing an `options` object to `axe.finishRun` would result in axe not using the `v1` reporter even though the [v1 reporter is the default for a axe.run](https://github.com/dequelabs/axe-core/blob/develop/lib/core/public/run/normalize-run-params.js#L39). This caused the results of the `axe.finishRun` to not include `failureSummary`.

```js
const results = await axe.runPartial()
await axe.finishRun([results])  // v1 reporter not used
```

The better question would be why we [set the v2 reporter as default](https://github.com/dequelabs/axe-core/blob/develop/lib/core/core.js#L95) when axe.run uses the v1 by default.