### PR TITLE
fix(aria-required-attr): only require aria-controls if aria-expanded=true

### DIFF
--- a/lib/checks/aria/aria-required-attr-evaluate.js
+++ b/lib/checks/aria/aria-required-attr-evaluate.js
@@ -58,13 +58,14 @@ function ariaRequiredAttrEvaluate(node, options = {}, virtualNode) {
   // aria 1.2 combobox requires aria-controls, but aria-owns is acceptable instead in earlier versions of the guidelines. also either is only required if the element has aria-expanded=true
   // https://github.com/dequelabs/axe-core/issues/2505#issuecomment-788703942
   // https://github.com/dequelabs/axe-core/issues/2505#issuecomment-881947373
+  const comboboxMissingControls =
+    role === 'combobox' && missing.includes('aria-controls');
   if (
-    (missing.length === 1 &&
-      role === 'combobox' &&
-      virtualNode.attr('aria-expanded') !== 'true') ||
-    (missing[0] === 'aria-controls' && virtualNode.attr('aria-owns'))
+    comboboxMissingControls &&
+    (virtualNode.hasAttr('aria-owns') ||
+      virtualNode.attr('aria-expanded') !== 'true')
   ) {
-    return true;
+    missing.splice(missing.indexOf('aria-controls', 1));
   }
 
   if (missing.length) {

--- a/lib/checks/aria/aria-required-attr-evaluate.js
+++ b/lib/checks/aria/aria-required-attr-evaluate.js
@@ -55,13 +55,14 @@ function ariaRequiredAttrEvaluate(node, options = {}, virtualNode) {
     }
   }
 
-  // aria 1.2 combobox requires aria-controls, but aria-owns is acceptable instead in earlier versions of the guidelines
+  // aria 1.2 combobox requires aria-controls, but aria-owns is acceptable instead in earlier versions of the guidelines. also either is only required if the element has aria-expanded=true
   // https://github.com/dequelabs/axe-core/issues/2505#issuecomment-788703942
+  // https://github.com/dequelabs/axe-core/issues/2505#issuecomment-881947373
   if (
-    missing.length === 1 &&
-    role === 'combobox' &&
-    missing[0] === 'aria-controls' &&
-    virtualNode.attr('aria-owns')
+    (missing.length === 1 &&
+      role === 'combobox' &&
+      virtualNode.attr('aria-expanded') !== 'true') ||
+    (missing[0] === 'aria-controls' && virtualNode.attr('aria-owns'))
   ) {
     return true;
   }

--- a/test/checks/aria/aria-required-attr.js
+++ b/test/checks/aria/aria-required-attr.js
@@ -115,6 +115,28 @@ describe('aria-required-attr', function() {
           .call(checkContext, vNode.actualNode, options, vNode)
       );
     });
+
+    it('should report missing of multiple attributes correctly', function() {
+      axe.configure({
+        standards: {
+          ariaRoles: {
+            combobox: {
+              requiredAttrs: ['aria-expanded', 'aria-label', 'aria-controls']
+            }
+          }
+        }
+      });
+
+      var vNode = queryFixture(
+        '<div id="target" role="combobox" aria-expanded="false"></div>'
+      );
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('aria-required-attr')
+          .call(checkContext, vNode.actualNode, options, vNode)
+      );
+      assert.deepEqual(checkContext._data, ['aria-label']);
+    });
   });
 
   describe('options', function() {

--- a/test/checks/aria/aria-required-attr.js
+++ b/test/checks/aria/aria-required-attr.js
@@ -58,9 +58,31 @@ describe('aria-required-attr', function() {
   });
 
   describe('combobox special case', function() {
+    it('should fail comboboxes that have do not have aria-expanded', function() {
+      var vNode = queryFixture('<div id="target" role="combobox"></div>');
+
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('aria-required-attr')
+          .call(checkContext, vNode.actualNode, options, vNode)
+      );
+    });
+
+    it('should pass comboboxes that have aria-expanded="false"', function() {
+      var vNode = queryFixture(
+        '<div id="target" role="combobox" aria-expanded="false"></div>'
+      );
+
+      assert.isTrue(
+        axe.testUtils
+          .getCheckEvaluate('aria-required-attr')
+          .call(checkContext, vNode.actualNode, options, vNode)
+      );
+    });
+
     it('should pass comboboxes that have aria-owns and aria-expanded', function() {
       var vNode = queryFixture(
-        '<div id="target" role="combobox" aria-expanded="false" aria-owns="ownedchild"></div>'
+        '<div id="target" role="combobox" aria-expanded="true" aria-owns="ownedchild"></div>'
       );
 
       assert.isTrue(
@@ -72,7 +94,7 @@ describe('aria-required-attr', function() {
 
     it('should pass comboboxes that have aria-controls and aria-expanded', function() {
       var vNode = queryFixture(
-        '<div id="target" role="combobox" aria-expanded="false" aria-controls="test"></div>'
+        '<div id="target" role="combobox" aria-expanded="true" aria-controls="test"></div>'
       );
 
       assert.isTrue(
@@ -84,18 +106,8 @@ describe('aria-required-attr', function() {
 
     it('should fail comboboxes that have aria-expanded only', function() {
       var vNode = queryFixture(
-        '<div id="target" role="combobox" aria-expanded="false"></div>'
+        '<div id="target" role="combobox" aria-expanded="true"></div>'
       );
-
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
-      );
-    });
-
-    it('should fail comboboxes that have no required attributes', function() {
-      var vNode = queryFixture('<div id="target" role="combobox"></div>');
 
       assert.isFalse(
         axe.testUtils

--- a/test/checks/aria/aria-required-attr.js
+++ b/test/checks/aria/aria-required-attr.js
@@ -58,16 +58,6 @@ describe('aria-required-attr', function() {
   });
 
   describe('combobox special case', function() {
-    it('should fail comboboxes that have do not have aria-expanded', function() {
-      var vNode = queryFixture('<div id="target" role="combobox"></div>');
-
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
-      );
-    });
-
     it('should pass comboboxes that have aria-expanded="false"', function() {
       var vNode = queryFixture(
         '<div id="target" role="combobox" aria-expanded="false"></div>'
@@ -98,6 +88,16 @@ describe('aria-required-attr', function() {
       );
 
       assert.isTrue(
+        axe.testUtils
+          .getCheckEvaluate('aria-required-attr')
+          .call(checkContext, vNode.actualNode, options, vNode)
+      );
+    });
+
+    it('should fail comboboxes that have no required attributes', function() {
+      var vNode = queryFixture('<div id="target" role="combobox"></div>');
+
+      assert.isFalse(
         axe.testUtils
           .getCheckEvaluate('aria-required-attr')
           .call(checkContext, vNode.actualNode, options, vNode)


### PR DESCRIPTION
Closes issue #3090

The diff's a bit off as it thinks I changed contents of the first test instead of adding one above what was there.