### PR TITLE
chore: use standards in aria-supported script

### DIFF
--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -39,14 +39,14 @@ module.exports = function(grunt) {
 
       const { diff: rolesTable, notes: rolesFootnotes } = getDiff(
         roles,
-        axe.commons.aria.lookupTable.role,
+        axe.utils.getStandards().ariaRoles,
         listType
       );
 
       const ariaQueryAriaAttributes = getAriaQueryAttributes();
       const { diff: attributesTable, notes: attributesFootnotes } = getDiff(
         ariaQueryAriaAttributes,
-        axe.commons.aria.lookupTable.attributes,
+        axe.utils.getStandards().ariaAttrs,
         listType
       );
       const attributesTableMarkdown = mdTable([

--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -37,16 +37,17 @@ module.exports = function(grunt) {
         attributesMdTableHeader: ['aria-attribute', 'axe-core support']
       };
 
+      const { ariaRoles, ariaAttrs } = axe.utils.getStandards();
       const { diff: rolesTable, notes: rolesFootnotes } = getDiff(
         roles,
-        axe.utils.getStandards().ariaRoles,
+        ariaRoles,
         listType
       );
 
       const ariaQueryAriaAttributes = getAriaQueryAttributes();
       const { diff: attributesTable, notes: attributesFootnotes } = getDiff(
         ariaQueryAriaAttributes,
-        axe.utils.getStandards().ariaAttrs,
+        ariaAttrs,
         listType
       );
       const attributesTableMarkdown = mdTable([


### PR DESCRIPTION
Currently nothing is unsupported in our standards object though, but I tested it with `aria-busy` and it worked.

Closes issue: #3081
