### PR TITLE
fix(core): assign axe to global rather than window [WIP]

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -20,8 +20,8 @@ if (
     ')(typeof window === "object" ? window : this);';
   module.exports = axe;
 }
-if (typeof window.getComputedStyle === 'function') {
-  window.axe = axe;
+if (typeof global === 'object' && global !== null) {
+  global.axe = axe;
 }
 // local namespace for common functions
 var commons;

--- a/lib/intro.stub
+++ b/lib/intro.stub
@@ -9,7 +9,7 @@
  * distribute or in any file that contains substantial portions of this source
  * code.
  */
-(function axeFunction (window) {
-  // A window reference is required to access the axe object in a "global".
-  var global = window;
+(function axeFunction (global) {
+  // axe is assigned to global. Global may or may not be a window object
+  var window = global.window || global;
   var document = window.document;


### PR DESCRIPTION
This PR allows for axe to be assigned to a global object, and not have that be the actual window object.

Closes issue:
