### PR TITLE
refactor(checks/navigation): improve `internal-link-present-evaluate`

### DIFF
--- a/lib/checks/navigation/internal-link-present-evaluate.js
+++ b/lib/checks/navigation/internal-link-present-evaluate.js
@@ -3,7 +3,7 @@ import { querySelectorAll } from '../../core/utils';
 function internalLinkPresentEvaluate(node, options, virtualNode) {
   const links = querySelectorAll(virtualNode, 'a[href]');
   return links.some(vLink => {
-    return /^#[^/!]/.test(vLink.actualNode.getAttribute('href'));
+    return /^#[^/!]/.test(vLink.attr('href'));
   });
 }
 

--- a/test/checks/navigation/internal-link-present.js
+++ b/test/checks/navigation/internal-link-present.js
@@ -4,8 +4,8 @@ describe('internal-link-present', function() {
   var fixture = document.getElementById('fixture');
   var shadowSupported = axe.testUtils.shadowSupport.v1;
   var checkContext = axe.testUtils.MockCheckContext();
-  var checkSetup = axe.testUtils.checkSetup;
   var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
+  var queryFixture = axe.testUtils.queryFixture;
 
   afterEach(function() {
     fixture.innerHTML = '';
@@ -14,49 +14,49 @@ describe('internal-link-present', function() {
   });
 
   it('should return true when an internal link is found', function() {
-    var params = checkSetup('<div id="target"><a href="#haha">hi</a></div>');
+    var vNode = queryFixture('<div id="target"><a href="#haha">hi</a></div>');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('internal-link-present')
-        .apply(checkContext, params)
+        .call(checkContext, null, {}, vNode)
     );
   });
 
   it('should return false when a hashbang URL was used', function() {
-    var params = checkSetup('<div id="target"><a href="#!foo">hi</a></div>');
+    var vNode = queryFixture('<div id="target"><a href="#!foo">hi</a></div>');
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('internal-link-present')
-        .apply(checkContext, params)
+        .call(checkContext, null, {}, vNode)
     );
   });
 
   it('should return false when a hash route URL was used', function() {
-    var params = checkSetup('<div id="target"><a href="#/home">hi</a></div>');
+    var vNode = queryFixture('<div id="target"><a href="#/home">hi</a></div>');
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('internal-link-present')
-        .apply(checkContext, params)
+        .call(checkContext, null, {}, vNode)
     );
   });
 
   it('should return false when a hashbang + slash route URL was used', function() {
-    var params = checkSetup('<div id="target"><a href="#!/home">hi</a></div>');
+    var vNode = queryFixture('<div id="target"><a href="#!/home">hi</a></div>');
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('internal-link-present')
-        .apply(checkContext, params)
+        .call(checkContext, null, {}, vNode)
     );
   });
 
   it('should otherwise return false', function() {
-    var params = checkSetup(
+    var vNode = queryFixture(
       '<div id="target"><a href="http://www.deque.com/#haha">hi</a></div>'
     );
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('internal-link-present')
-        .apply(checkContext, params)
+        .call(checkContext, null, {}, vNode)
     );
   });
 
@@ -64,13 +64,14 @@ describe('internal-link-present', function() {
     'should return true when internal link is found in shadow dom',
     function() {
       var params = shadowCheckSetup(
-        '<div id="target"></div>',
+        '<div id="target"></div>', 
         '<a href="#haha">hi</a>'
       );
+	  var vNode = params[2];
       assert.isTrue(
         axe.testUtils
           .getCheckEvaluate('internal-link-present')
-          .apply(checkContext, params)
+          .call(checkContext, null, {}, vNode)
       );
     }
   );


### PR DESCRIPTION
Make `internal-link-present-evaluate` work with virtualNode rather than actualNode.

Closes issue #2466
