### PR TITLE
chore: hidden and aria-hidden for nested-interactive

### DIFF
--- a/test/integration/rules/nested-interactive/nested-interactive.html
+++ b/test/integration/rules/nested-interactive/nested-interactive.html
@@ -3,7 +3,7 @@
 <div role="tab" id="pass3">pass</div>
 <div role="checkbox" id="pass4">pass</div>
 <div role="radio" id="pass5"><span>pass</span></div>
-<div role="button" id="pass6"><button aria-hidden="true" tabindex="-1">pass</button></div>
+<div role="button" id="pass7"><button aria-hidden="true" tabindex="-1">pass</button></div>
 
 <button id="fail1"><span tabindex="0">fail</span></button>
 <div role="button" id="fail2"><input /></div>

--- a/test/integration/rules/nested-interactive/nested-interactive.html
+++ b/test/integration/rules/nested-interactive/nested-interactive.html
@@ -3,12 +3,15 @@
 <div role="tab" id="pass3">pass</div>
 <div role="checkbox" id="pass4">pass</div>
 <div role="radio" id="pass5"><span>pass</span></div>
+<div role="button" id="pass6"><button aria-hidden="true" tabindex="-1">pass</button></div>
 
 <button id="fail1"><span tabindex="0">fail</span></button>
 <div role="button" id="fail2"><input /></div>
 <div role="tab" id="fail3"><button id="pass6">fail</button></div>
 <div role="checkbox" id="fail4"><a href="foo.html">fail</a></div>
 <div role="radio" id="fail5"><span tabindex="0">fail</span></div>
+<div role="button" id="fail6"><button aria-hidden="true">fail</button></div>
+<div role="button" id="fail7"><button tabindex="-1">fail</button></div>
 
 <a id="ignored1" href="foo.html">ignored</a>
 <span id="ignored2">ignored</span>

--- a/test/integration/virtual-rules/nested-interactive.js
+++ b/test/integration/virtual-rules/nested-interactive.js
@@ -94,6 +94,30 @@ describe('nested-interactive virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
+  it('should pass for element with interactive control with aria-hidden="true"', function() {
+    var node = new axe.SerialVirtualNode({
+      nodeName: 'div',
+      attributes: {
+        role: 'button'
+      }
+    });
+    var child = new axe.SerialVirtualNode({
+      nodeName: 'button',
+      attributes: {
+        'aria-hidden': true,
+        tabindex: -1
+      }
+    });
+    child.children = [];
+    node.children = [child];
+
+    var results = axe.runVirtualRule('nested-interactive', node);
+
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
   it('should return incomplete if element has undefined children', function() {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button'


### PR DESCRIPTION
The standard technique for hiding content for all users has been the use CSS display:none. Now, both ARIA and HTML5 also provide a semantic indication of content state that indicates content is hidden or should not be available to users

- [HTML5 Accessibility Chops: hidden and aria-hidden - Steve Faulkner](https://www.tpgi.com/html5-accessibility-chops-hidden-and-aria-hidden/)
- [The state of hidden content support in 2016 - Steve Faulkner](https://www.tpgi.com/the-state-of-hidden-content-support-in-2016/)

In nested interactive controls they would have the same behavior if hidden pass the test; aria-hidden=true test would behave in the same way
