### PR TITLE
fix(typescript): allow passing a NodeList to ElementContext

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -56,7 +56,7 @@ declare namespace axe {
 
   type RunCallback = (error: Error, results: AxeResults) => void;
 
-  type ElementContext = Node | string | ContextObject;
+  type ElementContext = Node | NodeList | string | ContextObject;
 
   interface TestEngine {
     name: string;


### PR DESCRIPTION
As per the spec, the context parameter can be passed one of the following:

> A `NodeList` such as returned by `document.querySelectorAll`.

Source: https://www.deque.com/axe/core-documentation/api-documentation/#context-parameter