### PR TITLE
fix(is-visible): do not error if window.Node does not exist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,16 @@ jobs:
       - run: npm run build
       - run: npm run test:locales
 
+  # Test virtual rules
+  test_virtual_rules:
+    <<: *defaults
+    <<: *unix_box
+    steps:
+      - checkout
+      - <<: *restore_dependency_cache_unix
+      - run: npm run build
+      - run: npm run test:virtual-rules
+
   # Run the test suite for nightly builds.
   test_nightly:
     <<: *defaults
@@ -262,6 +272,9 @@ workflows:
       - test_locales:
           requires:
             - test_unix
+      - test_virtual_rules:
+          requires:
+            - test_unix
       - build_api_docs:
           requires:
             - test_unix
@@ -279,6 +292,7 @@ workflows:
             - test_win
             - test_examples
             - test_locales
+            - test_virtual_rules
             - build_api_docs
             - test_rule_help_version
             - test_node
@@ -293,6 +307,7 @@ workflows:
             - test_unix
             - test_examples
             - test_locales
+            - test_virtual_rules
             - build_api_docs
           filters:
             branches:
@@ -304,6 +319,7 @@ workflows:
             - test_unix
             - test_examples
             - test_locales
+            - test_virtual_rules
             - build_api_docs
             - test_rule_help_version
             - test_node

--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -117,7 +117,7 @@ function isVisible(el, screenReader, recursed) {
   el = vNode ? vNode.actualNode : el;
 
   const cacheName = '_isVisible' + (screenReader ? 'ScreenReader' : '');
-  const { DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE } = window.Node;
+  const { DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE } = window.Node ?? {};
   const nodeType = vNode ? vNode.props.nodeType : el.nodeType;
   const nodeName = vNode ? vNode.props.nodeName : el.nodeName.toLowerCase();
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "test:act": "karma start test/act-mapping/karma.config.js",
     "test:act:debug": "npm run test:act -- --no-single-run --browsers=Chrome",
     "test:locales": "mocha test/test-locales.js",
+    "test:virtual-rules": "mocha test/test-virtual-rules.js",
     "test:rule-help-version": "mocha test/test-rule-help-version.js",
     "test:node": "mocha test/node/*.js",
     "version": "echo \"use 'npm run release' to bump axe-core version\" && exit 1",

--- a/test/test-virtual-rules.js
+++ b/test/test-virtual-rules.js
@@ -1,0 +1,23 @@
+var path = require('path');
+var assert = require('chai').assert;
+var glob = require('glob');
+var axe = require(path.join(__dirname, '../axe'));
+
+var files = glob.sync(path.join(__dirname, 'integration/virtual-rules/*.js'));
+
+before(function() {
+  global.axe = axe;
+  global.assert = assert;
+});
+
+after(function() {
+  delete global.axe;
+  delete global.assert;
+});
+
+describe('virtual-rule node tests', function() {
+  files.forEach(function(file) {
+    // load the test file and run with global axe and assert now defined
+    require(file);
+  });
+});

--- a/test/test-virtual-rules.js
+++ b/test/test-virtual-rules.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var assert = require('chai').assert;
 var glob = require('glob');
-var axe = require(path.join(__dirname, '../axe'));
+var axe = require('../axe');
 
 var files = glob.sync(path.join(__dirname, 'integration/virtual-rules/*.js'));
 


### PR DESCRIPTION
Allows `isVisible` to be run if `window.Node` is not defined.
