### PR TITLE
fix(color-contrast): account for 0 width scroll regions with children

### DIFF
--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -186,12 +186,15 @@ function isVisible(el, screenReader, recursed) {
 
   // hidden from visual users
   const elHeight = parseInt(style.getPropertyValue('height'));
+  const elWidth = parseInt(style.getPropertyValue('width'));
 
   // ways to hide content visually
-  const scrollableWithZeroHeight = getScroll(el) && elHeight === 0;
+  const scroll = getScroll(el);
+  const scrollableWithZeroHeight = scroll && elHeight === 0;
+  const scrollableWithZeroWidth = scroll && elWidth === 0;
   const posAbsoluteOverflowHiddenAndSmall =
     style.getPropertyValue('position') === 'absolute' &&
-    elHeight < 2 &&
+    (elHeight < 2 || elWidth < 2) &&
     style.getPropertyValue('overflow') === 'hidden';
 
   if (
@@ -199,6 +202,7 @@ function isVisible(el, screenReader, recursed) {
     (isClipped(style) ||
       style.getPropertyValue('opacity') === '0' ||
       scrollableWithZeroHeight ||
+      scrollableWithZeroWidth ||
       posAbsoluteOverflowHiddenAndSmall)
   ) {
     return false;

--- a/test/commons/dom/is-visible.js
+++ b/test/commons/dom/is-visible.js
@@ -261,6 +261,14 @@ describe('dom.isVisible', function() {
       assert.isFalse(axe.commons.dom.isVisible(el));
     });
 
+    it('should return false for 0 width scrollable region', function() {
+      fixture.innerHTML =
+        '<div style="overflow: scroll; width: 0"><div id="target">Hello!</div></div>';
+      var el = document.getElementById('target');
+
+      assert.isFalse(axe.commons.dom.isVisible(el));
+    });
+
     it('returns false for `AREA` without closest `MAP` element', function() {
       var vNode = queryFixture(
         '<area id="target" role="link" shape="circle" coords="130,136,60" aria-label="MDN"/>'

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -248,3 +248,9 @@
     &#x20A0; &#x20A1; &#x20A2; &#x20A3;
   </div>
 </div>
+
+<div style="width: 0; height: 50px; overflow: scroll">
+  <div id="ignore7" style="width: 200px; height: 200px; background-color: blue">
+    Hello World
+  </div>
+</div>


### PR DESCRIPTION
Should fix the particular case brought up by the issue. I tested the other sites users said the problem occurred on and I couldn't get it to throw an error on any of them. Even the current page of the original issue has been updated and no longer throws the error, but luckily I left a note on what the issue was so could reproduce it.

Closes issue: #3171, #2674
