### PR TITLE
docs: Update rule-proposal to add link to tag assignment

### DIFF
--- a/doc/rule-proposal.md
+++ b/doc/rule-proposal.md
@@ -28,7 +28,7 @@ Example: "Elements must only use allowed ARIA attributes"
 
 #### Tags
 
-Indicate which tags the rule should use. See the documentation on [how we assign tags](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#axe-core-tags).
+Indicate which tags the rule should use. More information available in the [how we assign tags documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#axe-core-tags).
 
 Example: wcag2a, wcag211, cat.keyboard
 


### PR DESCRIPTION
Link to clarification of how tags are assigned.

