### PR TITLE
fix(aria-allowed-role): updates the allowed roles for the wbr element to none and presentation

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -936,7 +936,7 @@ const htmlElms = {
   },
   wbr: {
     contentTypes: ['phrasing', 'flow'],
-    allowedRoles: true
+    allowedRoles: ['presentation', 'none']
   }
 };
 


### PR DESCRIPTION
Changes the allowed roles of the `wbr` element from "all roles", to `none` and `presentation` only.

related to issue #3177 (but does not entirely close it)
