### PR TITLE
fix(color-contrast): properly blend multiple alpha colors

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -73,7 +73,9 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
   } else if (fgColor && bgColor) {
     // Thin shadows can pass either by contrasting with the text color
     // or when contrasting with the background.
-    shadowColor = [...shadowColors, bgColor].reduce(flattenColors);
+    shadowColor = [bgColor, ...shadowColors].reduce((bgColor, fgColor) => {
+      return flattenColors(fgColor, bgColor);
+    });
     const bgContrast = getContrast(bgColor, shadowColor);
     const fgContrast = getContrast(shadowColor, fgColor);
     contrast = Math.max(bgContrast, fgContrast);

--- a/lib/commons/color/flatten-colors.js
+++ b/lib/commons/color/flatten-colors.js
@@ -1,5 +1,33 @@
 import Color from './color';
 
+// how to combine background and foreground colors together when using
+// the CSS property `mix-blend-mode`. Defaults to `normal`
+// @see https://www.w3.org/TR/compositing-1/#blendingseparable
+const blendFunctions = {
+  normal(Cb, Cs) {
+    return Cs;
+  }
+};
+
+// Simple Alpha Compositing written as non-premultiplied.
+// formula: Rrgb × Ra = Srgb × Sa + Drgb × Da × (1 − Sa)
+// Cs: the source color
+// αs: the source alpha
+// Cb: the backdrop color
+// αb: the backdrop alpha
+// @see https://www.w3.org/TR/compositing-1/#simplealphacompositing
+// @see https://www.w3.org/TR/compositing-1/#blending
+// @see https://ciechanow.ski/alpha-compositing/
+function simpleAlphaCompositing(Cs, αs, Cb, αb, blendMode) {
+  // RGB color space doesn't have decimal values so we will follow what browsers do and round
+  // e.g. rgb(255.2, 127.5, 127.8) === rgb(255, 128, 128)
+  return Math.round(
+    αs * (1 - αb) * Cs +
+      αs * αb * blendFunctions[blendMode](Cb, Cs) +
+      (1 - αs) * αb * Cb
+  );
+}
+
 /**
  * Combine the two given color according to alpha blending.
  * @method flattenColors
@@ -9,12 +37,36 @@ import Color from './color';
  * @param {Color} bgColor Background color
  * @return {Color} Blended color
  */
-function flattenColors(fgColor, bgColor) {
-  var alpha = fgColor.alpha;
-  var r = (1 - alpha) * bgColor.red + alpha * fgColor.red;
-  var g = (1 - alpha) * bgColor.green + alpha * fgColor.green;
-  var b = (1 - alpha) * bgColor.blue + alpha * fgColor.blue;
-  var a = fgColor.alpha + bgColor.alpha * (1 - fgColor.alpha);
+function flattenColors(fgColor, bgColor, blendMode = 'normal') {
+  // foreground is the "source" color and background is the "backdrop" color
+  const r = simpleAlphaCompositing(
+    fgColor.red,
+    fgColor.alpha,
+    bgColor.red,
+    bgColor.alpha,
+    blendMode
+  );
+  const g = simpleAlphaCompositing(
+    fgColor.green,
+    fgColor.alpha,
+    bgColor.green,
+    bgColor.alpha,
+    blendMode
+  );
+  const b = simpleAlphaCompositing(
+    fgColor.blue,
+    fgColor.alpha,
+    bgColor.blue,
+    bgColor.alpha,
+    blendMode
+  );
+
+  // formula: αo = αs + αb x (1 - αs)
+  // clamp alpha between 0 and 1
+  const a = Math.max(
+    0,
+    Math.min(fgColor.alpha + bgColor.alpha * (1 - fgColor.alpha), 1)
+  );
 
   return new Color(r, g, b, a);
 }

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -62,7 +62,7 @@ function getBackgroundColor(elm, bgElms = [], shadowOutlineEmMax = 0.1) {
     if (bgColor.alpha !== 0) {
       // store elements contributing to the br color.
       bgElms.push(bgElm);
-      bgColors.push(bgColor);
+      bgColors.unshift(bgColor);
 
       // Exit if the background is opaque
       return bgColor.alpha === 1;
@@ -75,9 +75,14 @@ function getBackgroundColor(elm, bgElms = [], shadowOutlineEmMax = 0.1) {
     return null;
   }
 
-  // Mix the colors together, on top of a default white
-  bgColors.push(new Color(255, 255, 255, 1));
-  var colors = bgColors.reduce(flattenColors);
+  // Mix the colors together, on top of a default white. Colors must be mixed
+  // in bottom up order (background to foreground order) to produce the correct
+  // result.
+  // @see https://github.com/dequelabs/axe-core/issues/2924
+  bgColors.unshift(new Color(255, 255, 255, 1));
+  var colors = bgColors.reduce((bgColor, fgColor) => {
+    return flattenColors(fgColor, bgColor);
+  });
   return colors;
 }
 

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -66,7 +66,11 @@ function getForegroundColor(node, _, bgColor) {
 
   if (fgColor.alpha < 1) {
     const textShadowColors = getTextShadowColors(node, { minRatio: 0 });
-    return [fgColor, ...textShadowColors, bgColor].reduce(flattenColors);
+    return [bgColor, ...textShadowColors, fgColor].reduce(
+      (bgColor, fgColor) => {
+        return flattenColors(fgColor, bgColor);
+      }
+    );
   }
 
   return flattenColors(fgColor, bgColor);

--- a/test/commons/color/flatten-colors.js
+++ b/test/commons/color/flatten-colors.js
@@ -6,7 +6,10 @@ describe('color.flattenColors', function() {
     var fullblack = new axe.commons.color.Color(0, 0, 0, 1);
     var transparent = new axe.commons.color.Color(0, 0, 0, 0);
     var white = new axe.commons.color.Color(255, 255, 255, 1);
-    var gray = new axe.commons.color.Color(127.5, 127.5, 127.5, 1);
+    var gray = new axe.commons.color.Color(128, 128, 128, 1);
+    var halfRed = new axe.commons.color.Color(255, 0, 0, 0.5);
+    var quarterLightGreen = new axe.commons.color.Color(0, 128, 0, 0.25);
+
     var flat = axe.commons.color.flattenColors(halfblack, white);
     assert.equal(flat.red, gray.red);
     assert.equal(flat.green, gray.green);
@@ -21,5 +24,23 @@ describe('color.flattenColors', function() {
     assert.equal(flat3.red, white.red);
     assert.equal(flat3.green, white.green);
     assert.equal(flat3.blue, white.blue);
+
+    var flat4 = axe.commons.color.flattenColors(halfRed, white);
+    assert.equal(flat4.red, 255);
+    assert.equal(flat4.green, 128);
+    assert.equal(flat4.blue, 128);
+    assert.equal(flat4.alpha, 1);
+
+    var flat5 = axe.commons.color.flattenColors(quarterLightGreen, white);
+    assert.equal(flat5.red, 191);
+    assert.equal(flat5.green, 223);
+    assert.equal(flat5.blue, 191);
+    assert.equal(flat5.alpha, 1);
+
+    var flat6 = axe.commons.color.flattenColors(quarterLightGreen, halfRed);
+    assert.equal(flat6.red, 96);
+    assert.equal(flat6.green, 32);
+    assert.equal(flat6.blue, 0);
+    assert.equal(flat6.alpha, 0.625);
   });
 });

--- a/test/integration/full/contrast/blending.html
+++ b/test/integration/full/contrast/blending.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Color Contrast Blending Verification Tests</title>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+    <style>
+      body {
+        margin: 4rem 2rem;
+      }
+
+      #fixture {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+
+      #fixture > div {
+        display: flex;
+        flex-direction: row;
+        border: 1px solid white;
+      }
+
+      #fixture * {
+        width: 100px;
+        height: 100px;
+        flex-shrink: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <p>
+      Use this page to verify that axe-core produces the correct colors for each
+      blended background. If using Chrome, please ensure it is using the sRGB
+      color profile by navigating to chrome://flags/, searching for "Force color
+      profile" and setting it to `sRGB` (otherwise it uses the OS color profile
+      which for Mac, which we believe is "Display P3 D65" and will produce the
+      incorrect result color when blending). As far as I know there's no way to
+      change the color profile for Safari.
+    </p>
+    <p>
+      For more information, see
+      <a href="https://github.com/dequelabs/axe-core/issues/2924"
+        >https://github.com/dequelabs/axe-core/issues/2924</a
+      >
+    </p>
+    <div id="fixture">
+      <div id="test1">
+        <div style="background-color: rgba(255, 255, 255, 1.0);">
+          <div style="background-color: rgba(0, 128, 0, 0.25);">
+            <div
+              id="test1-target"
+              style="background-color: rgba(255, 0, 0, 0.5);"
+            >
+              Test1
+            </div>
+          </div>
+        </div>
+        <div id="test1-result">Test1 result</div>
+      </div>
+
+      <div id="test2">
+        <div style="background-color: rgba(255, 255, 255, 1.0);">
+          <div
+            id="test2-target"
+            style="background-color: rgba(255, 0, 0, 0.5);"
+          >
+            Test2
+          </div>
+        </div>
+        <div id="test2-result">Test2 result</div>
+      </div>
+
+      <div id="test3">
+        <div style="background-color: rgba(255, 255, 255, 1.0);">
+          <div
+            id="test3-target"
+            style="background-color: rgba(0, 128, 0, 0.25);"
+          >
+            Test3
+          </div>
+        </div>
+        <div id="test3-result">Test3 result</div>
+      </div>
+
+      <div id="test4">
+        <div style="background-color: red;">
+          <div style="background-color: rgba(0, 0, 255, 0.3);">
+            <div
+              id="test4-target"
+              style="background-color: rgba(0, 128, 0, 0.3);"
+            >
+              Test4
+            </div>
+          </div>
+        </div>
+        <div id="test4-result">Test4 result</div>
+      </div>
+
+      <div id="test5">
+        <div style="background-color: red;">
+          <div
+            id="test5-target"
+            style="background-color: rgba(0, 128, 0, 0.3);"
+          >
+            Test5
+          </div>
+        </div>
+        <div id="test5-result">Test5 result</div>
+      </div>
+
+      <div id="test6">
+        <div style="background-color: red;">
+          <div
+            id="test6-target"
+            style="background-color: rgba(0, 0, 255, 0.3);"
+          >
+            Test6
+          </div>
+        </div>
+        <div id="test6-result">Test6 result</div>
+      </div>
+
+      <div id="test7">
+        <div style="background-color: rgba(255, 0, 0, 0.25);">
+          <div style="background-color: rgba(255, 0, 0, 0.25);">
+            <div style="background-color: rgba(0, 255, 0, 0.25);">
+              <div
+                id="test7-target"
+                style="background-color: rgba(0, 255, 0, 0.25);"
+              >
+                Test7
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="test7-result">Test7 result</div>
+      </div>
+
+      <div id="test8">
+        <div style="background-color: rgba(255, 0, 0, 0.25);">
+          <div style="background-color: rgba(255, 0, 0, 0.25);">
+            <div style="background-color: rgba(0, 255, 0, 0.25);">
+              <div style="background-color: rgba(0, 255, 0, 0.10);">
+                <div style="background-color: rgba(0, 0, 255, 0.10);">
+                  <div
+                    id="test8-target"
+                    style="background-color: rgba(0, 0, 255, 0.05);"
+                  >
+                    Test8
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="test8-result">Test8 result</div>
+      </div>
+    </div>
+
+    <div id="mocha"></div>
+    <script src="blending.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
+</html>

--- a/test/integration/full/contrast/blending.js
+++ b/test/integration/full/contrast/blending.js
@@ -1,0 +1,55 @@
+describe('color-contrast blending test', function() {
+  var include = [];
+  var resultElms = [];
+  var expected = [
+    'rgb(223, 112, 96)',
+    'rgb(255, 128, 128)',
+    'rgb(191, 223, 191)',
+    'rgb(125, 38, 54)',
+    'rgb(179, 38, 0)',
+    'rgb(179, 0, 77)',
+    'rgb(143, 192, 80)',
+    'rgb(147, 153, 119)'
+  ];
+  var testElms = document.querySelectorAll('#fixture > div');
+  testElms.forEach(function(testElm) {
+    var id = testElm.id;
+    var target = testElm.querySelector('#' + id + '-target');
+    var result = testElm.querySelector('#' + id + '-result');
+    include.push(target);
+    resultElms.push(result);
+  });
+
+  before(function(done) {
+    axe.run({ include: include }, { runOnly: ['color-contrast'] }, function(
+      err,
+      res
+    ) {
+      assert.isNull(err);
+
+      // don't care where the result goes as we just want to
+      // extract the background color for each one
+      var results = []
+        .concat(res.passes)
+        .concat(res.violations)
+        .concat(res.incomplete);
+      results.forEach(function(result) {
+        result.nodes.forEach(function(node) {
+          var bgColor = node.any[0].data.bgColor;
+          var id = node.target[0].split('-')[0];
+          var result = document.querySelector(id + '-result');
+          result.style.backgroundColor = bgColor;
+        });
+      });
+
+      done();
+    });
+  });
+
+  resultElms.forEach(function(elm, index) {
+    it('produces the correct blended color for ' + elm.id, function() {
+      var style = window.getComputedStyle(elm);
+      assert.equal(style.getPropertyValue('background-color'), expected[index]);
+    });
+  });
+});


### PR DESCRIPTION
I refactored the `flattenColors` function to use the exact algorithm found in the spec and left LOTS of comments so we wouldn't have to dig that up again and figure it out. I also have it set up to support blending modes from `mix-blend-mode` CSS property if we ever decide to support that. 

Lastly, I created an integration file that verifies the blending is correct fore more than 2 alpha layers. Our code correctly would blend 2 alpha layers (since order didn't matter), but would fail to blend correctly at 3 or more, as shown in the screenshot below.

<img width="1099" alt="Screen Shot 2021-10-06 at 2 06 12 PM" src="https://user-images.githubusercontent.com/2433219/136275680-f61c7ecf-61e3-4e91-9e25-13c5562e79e6.png">

With the changes to reverse the blending order we now produce the correct colors.

![image](https://user-images.githubusercontent.com/2433219/136275896-98a0e5da-0c54-4870-b15e-6a59fbeaad98.png)

I also had to reverse the blending for shadowText so background was blended first before foreground.

Closes issue: #2924
