### PR TITLE
fix(aria-prohibited-attr): update metadata message

### DIFF
--- a/lib/checks/aria/aria-prohibited-attr.json
+++ b/lib/checks/aria/aria-prohibited-attr.json
@@ -8,8 +8,8 @@
     "impact": "serious",
     "messages": {
       "pass": "ARIA attribute is allowed",
-      "fail": "ARIA attribute: ${data.values} is not allowed. Use a different role attribute or a different element.",
-      "incomplete": "ARIA attribute is not well supported on the element and the text content will be used instead: ${data.values}"
+      "fail": "ARIA attribute: ${data.values} is not allowed. Use a different role attribute or element.",
+      "incomplete": "ARIA attribute: ${data.values} is not well supported. Use a different role attribute or element."
     }
   }
 }


### PR DESCRIPTION
update metadata message for prohibited attributes. 

Note: There are some [ARIA roles](https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited) whereby the name is prohibited, but the HTML element [(HTML role-mapping)](https://www.w3.org/TR/html-aam-1.0/) has no role to map to e.g. `code` and `sub` therefore, it falls under incomplete, I have updated the message to make it a bit more clear. Do we want to explicitly check for HTML elements that have a corresponding ARIA role in 1.2 and fail them?

Closes issue: https://github.com/dequelabs/axe-core/issues/3205
