### PR TITLE
fix(get-selector): do not URL encode or token escape attribute selectors

### DIFF
--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -27,6 +27,7 @@ const ignoredAttributes = [
 ];
 const MAXATTRIBUTELENGTH = 31;
 const attrCharsRegex = /([\\"])/g;
+const newlineChars = /(\r\n|\r|\n)/g;
 
 /**
  * Escape an attribute selector string.
@@ -34,7 +35,13 @@ const attrCharsRegex = /([\\"])/g;
  * @return {String}
  */
 function escapeAttribute(str) {
-  return str.replace(attrCharsRegex, '\\$1');
+  return (
+    str
+      // @see https://www.py4u.net/discuss/286669
+      .replace(attrCharsRegex, '\\$1')
+      // @see https://stackoverflow.com/a/20354013/2124254
+      .replace(newlineChars, '\\a ')
+  );
 }
 
 /**
@@ -55,7 +62,7 @@ function getAttributeNameValue(node, at) {
       atnv =
         escapeSelector(at.name) +
         '="' +
-        escapeSelector(node.getAttribute(name)) +
+        escapeAttribute(node.getAttribute(name)) +
         '"';
     }
   } else {

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -26,6 +26,16 @@ const ignoredAttributes = [
   'aria-valuenow'
 ];
 const MAXATTRIBUTELENGTH = 31;
+const attrCharsRegex = /([\\"])/g;
+
+/**
+ * Escape an attribute selector string.
+ * @param {String} str
+ * @return {String}
+ */
+function escapeAttribute(str) {
+  return str.replace(attrCharsRegex, '\\$1');
+}
 
 /**
  * get the attribute name and value as a string
@@ -40,7 +50,7 @@ function getAttributeNameValue(node, at) {
   if (name.indexOf('href') !== -1 || name.indexOf('src') !== -1) {
     const friendly = getFriendlyUriEnd(node.getAttribute(name));
     if (friendly) {
-      atnv = escapeSelector(at.name) + '$="' + friendly + '"';
+      atnv = escapeSelector(at.name) + '$="' + escapeAttribute(friendly) + '"';
     } else {
       atnv =
         escapeSelector(at.name) +
@@ -49,7 +59,7 @@ function getAttributeNameValue(node, at) {
         '"';
     }
   } else {
-    atnv = escapeSelector(name) + '="' + at.value + '"';
+    atnv = escapeSelector(name) + '="' + escapeAttribute(at.value) + '"';
   }
   return atnv;
 }

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -40,12 +40,7 @@ function getAttributeNameValue(node, at) {
   if (name.indexOf('href') !== -1 || name.indexOf('src') !== -1) {
     const friendly = getFriendlyUriEnd(node.getAttribute(name));
     if (friendly) {
-      const value = encodeURI(friendly);
-      if (value) {
-        atnv = escapeSelector(at.name) + '$="' + escapeSelector(value) + '"';
-      } else {
-        return;
-      }
+      atnv = escapeSelector(at.name) + '$="' + friendly + '"';
     } else {
       atnv =
         escapeSelector(at.name) +
@@ -54,7 +49,7 @@ function getAttributeNameValue(node, at) {
         '"';
     }
   } else {
-    atnv = escapeSelector(name) + '="' + escapeSelector(at.value) + '"';
+    atnv = escapeSelector(name) + '="' + at.value + '"';
   }
   return atnv;
 }

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -494,8 +494,8 @@ describe('axe.utils.getSelector', function() {
     img2.setAttribute('src', '//deque.com/logo.png');
 
     fixtureSetup([link1, link2, img1, img2]);
-    assert.equal(axe.utils.getSelector(link2), 'a[href$="about\\/"]');
-    assert.equal(axe.utils.getSelector(img2), 'img[src$="logo\\.png"]');
+    assert.equal(axe.utils.getSelector(link2), 'a[href$="about/"]');
+    assert.equal(axe.utils.getSelector(img2), 'img[src$="logo.png"]');
   });
 
   it('should escape href attributes', function() {
@@ -510,6 +510,17 @@ describe('axe.utils.getSelector', function() {
       axe.utils.getSelector(link2),
       'a[href="\\/\\/deque\\.com\\/child\\/\\ \\a \\a \\a "]'
     );
+  });
+
+  it('should not URL encode or token escape href attribute', function() {
+    var link1 = document.createElement('a');
+    link1.setAttribute('href', '3 Seater');
+
+    var link2 = document.createElement('a');
+    link2.setAttribute('href', '1 Seater');
+
+    fixtureSetup([link1, link2]);
+    assert.equal(axe.utils.getSelector(link2), 'a[href$="1 Seater"]');
   });
 
   it('should not generate universal selectors', function() {

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -519,8 +519,10 @@ describe('axe.utils.getSelector', function() {
     var link2 = document.createElement('a');
     link2.setAttribute('href', '1 Seater');
 
+    var expected = 'a[href$="1 Seater"]';
     fixtureSetup([link1, link2]);
-    assert.equal(axe.utils.getSelector(link2), 'a[href$="1 Seater"]');
+    assert.equal(axe.utils.getSelector(link2), expected);
+    assert.isTrue(axe.utils.matchesSelector(link2, expected));
   });
 
   it('should escape certain special characters in attribute', function() {
@@ -530,11 +532,10 @@ describe('axe.utils.getSelector', function() {
     var div2 = document.createElement('div');
     div2.setAttribute('data-thing', '!@#$%^&*()_+[]\\;\',./{}|:"<>?');
 
+    var expected = 'div[data-thing="!@#$%^&*()_+[]\\\\;\',./{}|:\\"<>?"]';
     fixtureSetup([div1, div2]);
-    assert.equal(
-      axe.utils.getSelector(div2),
-      'div[data-thing="!@#$%^&*()_+[]\\\\;\',./{}|:\\"<>?"]'
-    );
+    assert.equal(axe.utils.getSelector(div2), expected);
+    assert.isTrue(axe.utils.matchesSelector(div2, expected));
   });
 
   it('should escape newline characters in attribute', function() {
@@ -544,11 +545,10 @@ describe('axe.utils.getSelector', function() {
     var div2 = document.createElement('div');
     div2.setAttribute('data-thing', '  \n\n\n');
 
+    var expected = 'div[data-thing="  \\a \\a \\a "]';
     fixtureSetup([div1, div2]);
-    assert.equal(
-      axe.utils.getSelector(div2),
-      'div[data-thing="  \\a \\a \\a "]'
-    );
+    assert.equal(axe.utils.getSelector(div2), expected);
+    assert.isTrue(axe.utils.matchesSelector(div2, expected));
   });
 
   it('should not generate universal selectors', function() {

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -523,6 +523,20 @@ describe('axe.utils.getSelector', function() {
     assert.equal(axe.utils.getSelector(link2), 'a[href$="1 Seater"]');
   });
 
+  it('should work with special characters in attribute', function() {
+    var div1 = document.createElement('div');
+    div1.setAttribute('data-thing', 'foobar');
+
+    var div2 = document.createElement('div');
+    div2.setAttribute('data-thing', '!@#$%^&*()_+[]\\;\',./{}|:"<>?');
+
+    fixtureSetup([div1, div2]);
+    assert.equal(
+      axe.utils.getSelector(div2),
+      'div[data-thing="!@#$%^&*()_+[]\\\\;\',./{}|:\\"<>?"]'
+    );
+  });
+
   it('should not generate universal selectors', function() {
     var node = document.createElement('div');
     node.setAttribute('role', 'menuitem');

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -508,7 +508,7 @@ describe('axe.utils.getSelector', function() {
     fixtureSetup([link1, link2]);
     assert.equal(
       axe.utils.getSelector(link2),
-      'a[href="\\/\\/deque\\.com\\/child\\/\\ \\a \\a \\a "]'
+      'a[href="//deque.com/child/ \\a \\a \\a "]'
     );
   });
 
@@ -523,7 +523,7 @@ describe('axe.utils.getSelector', function() {
     assert.equal(axe.utils.getSelector(link2), 'a[href$="1 Seater"]');
   });
 
-  it('should work with special characters in attribute', function() {
+  it('should escape certain special characters in attribute', function() {
     var div1 = document.createElement('div');
     div1.setAttribute('data-thing', 'foobar');
 
@@ -534,6 +534,20 @@ describe('axe.utils.getSelector', function() {
     assert.equal(
       axe.utils.getSelector(div2),
       'div[data-thing="!@#$%^&*()_+[]\\\\;\',./{}|:\\"<>?"]'
+    );
+  });
+
+  it('should escape newline characters in attribute', function() {
+    var div1 = document.createElement('div');
+    div1.setAttribute('data-thing', 'foobar');
+
+    var div2 = document.createElement('div');
+    div2.setAttribute('data-thing', '  \n\n\n');
+
+    fixtureSetup([div1, div2]);
+    assert.equal(
+      axe.utils.getSelector(div2),
+      'div[data-thing="  \\a \\a \\a "]'
     );
   });
 
@@ -555,11 +569,8 @@ describe('axe.utils.getSelector', function() {
     node2.setAttribute('href', href2);
     fixtureSetup([node1, node2]);
 
-    assert.include(axe.utils.getSelector(node1), 'mars2\\.html\\?a\\=be_bold');
-    assert.include(
-      axe.utils.getSelector(node2),
-      'mars2\\.html\\?a\\=be_italic'
-    );
+    assert.include(axe.utils.getSelector(node1), 'mars2.html?a=be_bold');
+    assert.include(axe.utils.getSelector(node2), 'mars2.html?a=be_italic');
   });
 
   // shadow DOM v1 - note: v0 is compatible with this code, so no need


### PR DESCRIPTION
When trying to get the selector for the images on https://github.com/dequelabs/axe-core/issues/3109, the end result of the `getAttributeNameValue` would end up being URI encoded and token escaped. 

What that means is that instead of returning `[href$="1 Seater"]` (a valid CSS attribute selector) it would first URI encode it, which would turn into `[href$="1%20Seater"]`, and then token escape it which would try to prevent the first character from being a number (an invalid CSS token) and escape it, resulting in `[href$="\31 %20Seater"]`. This selector would not find anything in the document so [`:root` would be returned by default](https://github.com/dequelabs/axe-core/blob/develop/lib/core/utils/get-selector.js#L378-L384).

Since [attribute selectors can be strings](https://www.w3.org/TR/selectors/#attribute-selectors) and since we're wrapping the value in quotes, it wasn't necessary to do any escaping or encoding.

> Attribute values must be &lt;ident-token&gt;s or &lt;string-token&gt;s

Closes issue: #3109
