### PR TITLE
test(integration/full/configure-options): add `testutils.js` to configure-options.html 

### DIFF
--- a/test/integration/full/configure-options/configure-options.html
+++ b/test/integration/full/configure-options/configure-options.html
@@ -23,6 +23,7 @@
     <div id="target"></div>
 
     <div id="mocha"></div>
+    <script src="/test/testutils.js"></script>
     <script src="configure-options.js"></script>
     <script src="/test/integration/adapter.js"></script>
   </body>

--- a/test/integration/full/configure-options/configure-options.js
+++ b/test/integration/full/configure-options/configure-options.js
@@ -206,7 +206,6 @@ describe('Configure Options', function() {
       iframe.src = '/test/mock/frames/context.html';
       iframe.onload = function() {
         axe.configure(config);
-        iframe.contentWindow.axe.configure(config);
 
         axe.run(
           '#target',
@@ -247,7 +246,6 @@ describe('Configure Options', function() {
       iframe.src = '/test/mock/frames/noHtml-config.html';
       iframe.onload = function() {
         axe.configure(config);
-        iframe.contentWindow.axe.configure(config);
 
         axe.run('#target', {
           runOnly: {


### PR DESCRIPTION
Add `testutils.js` to configure-options.html.

Removed `iframe.contentWindow.axe.configure(config);` as we configure axe once the iframe has loaded. 


 
Closes issue: https://github.com/dequelabs/axe-core/issues/3219
