### PR TITLE
test(integration/full/get-selector): fix get-selector test

### DIFF
--- a/test/integration/full/get-selector/get-selector.js
+++ b/test/integration/full/get-selector/get-selector.js
@@ -1,5 +1,8 @@
 describe('axe.utils.getSelector', function() {
   'use strict';
+  before(function() {
+    axe.setup();
+  });
   it('should work on namespaced elements', function() {
     var fixture = document.querySelector('#fixture');
     var node = fixture.firstElementChild;

--- a/test/integration/full/get-selector/get-selector.xhtml
+++ b/test/integration/full/get-selector/get-selector.xhtml
@@ -1,25 +1,29 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-	<title>axe.utils.getSelector test</title>
-	<meta charset="utf-8"/>
-	<link rel="stylesheet" type="text/css" href="/node_modules/mocha/mocha.css" />
-	<script src="/node_modules/mocha/mocha.js"></script>
-	<script src="/node_modules/chai/chai.js"></script>
-	<script src="/axe.js"></script>
-	<script>
-		mocha.setup({
-			timeout: 10000,
-			ui: 'bdd'
-		});
-		var assert = chai.assert;
-	</script>
-</head>
-<body>
-	<div id="fixture">
-		<m:math xmlns:m="http://www.w3.org/1998/Math/MathML"></m:math>
-	</div>
-<div id="mocha"></div>
-<script src="get-selector.js"></script>
-<script src="/test/integration/adapter.js"></script>
-</body>
+  <head>
+    <title>axe.utils.getSelector test</title>
+    <meta charset="utf-8" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+  </head>
+  <body>
+    <div id="fixture">
+      <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"></m:math>
+    </div>
+    <div id="mocha"></div>
+    <script src="get-selector.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
As per https://github.com/dequelabs/axe-core/issues/3220 `.xhtml` appear to be running (and passing), do we parse `.xhtml` files anywhere else? 

For the `get-selector.js` test, it was erroring with ` Error: Expect axe._selectorData to be set up`. Checking the console, axe exists but is not setup (is my thinking) as `._tree` is not defined.

```js
axe._selectorData
// output
undefined
```
Before the test is run calling `axe.setup()` generates the flattened DOM tree we need: 

```js
before(function() {
  axe.setup();
});
```
```js
axe._selectorData
//output
{classes: {…}, tags: {…}, attributes: {…}}
```