### PR TITLE
test(integration/full/): add xhtml file extension to test file

### DIFF
--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -188,7 +188,10 @@ function start(options) {
     options.browser === 'edge' ? 'MicrosoftEdge' : options.browser;
 
   var testUrls = globby
-    .sync(['test/integration/full/**/*.html', '!**/frames/**/*.html'])
+    .sync([
+      'test/integration/full/**/*.{html,xhtml}',
+      '!**/frames/**/*.{html,xhtml}'
+    ])
     .map(function(url) {
       return 'http://localhost:9876/' + url;
     });


### PR DESCRIPTION
add `xhtml` extension to `globby.sync(...)`: 

example: 

```js
'somepath/*.{html,xhtml}',
```

Closes issue: https://github.com/dequelabs/axe-core/issues/3220
