### PR TITLE
fix(aria-allowed-roles): update role allowances for section element

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -738,7 +738,7 @@ const htmlElms = {
       'dialog',
       'document',
       'feed',
-			'group',
+      'group',
       'log',
       'main',
       'marquee',


### PR DESCRIPTION
closes #3237
related to https://github.com/w3c/html-aria/pull/367

updates section element to allow `role=group`
