### PR TITLE
fix(respondable): avoid crashes if the data in `window.postMessage` is `null`

### DIFF
--- a/lib/core/utils/frame-messenger/message-handler.js
+++ b/lib/core/utils/frame-messenger/message-handler.js
@@ -23,29 +23,34 @@ export function messageHandler(
   { origin, data: dataString, source: win },
   topicHandler
 ) {
-  const data = parseMessage(dataString) || {};
-  const { channelId, message, messageId } = data;
-
-  if (!originIsAllowed(origin) || !isNewMessage(messageId)) {
-    return;
-  }
-
-  // An error should never come from a parent. Log it and exit.
-  if (message instanceof Error && win.parent !== window) {
-    axe.log(message);
-    return false;
-  }
-
   try {
-    if (data.topic) {
-      const responder = createResponder(win, channelId);
-      assertIsParentWindow(win);
-      topicHandler(data, responder);
-    } else {
-      callReplyHandler(win, data);
+    const data = parseMessage(dataString) || {};
+    const { channelId, message, messageId } = data;
+
+    if (!originIsAllowed(origin) || !isNewMessage(messageId)) {
+      return;
+    }
+
+    // An error should never come from a parent. Log it and exit.
+    if (message instanceof Error && win.parent !== window) {
+      axe.log(message);
+      return false;
+    }
+
+    try {
+      if (data.topic) {
+        const responder = createResponder(win, channelId);
+        assertIsParentWindow(win);
+        topicHandler(data, responder);
+      } else {
+        callReplyHandler(win, data);
+      }
+    } catch (error) {
+      processError(win, error, channelId);
     }
   } catch (error) {
-    processError(win, error, channelId);
+    axe.log(error);
+    return false;
   }
 }
 

--- a/lib/core/utils/frame-messenger/message-parser.js
+++ b/lib/core/utils/frame-messenger/message-parser.js
@@ -67,6 +67,7 @@ export function parseMessage(dataString) {
  */
 function isRespondableMessage(postedMessage) {
   return (
+    postedMessage !== null &&
     typeof postedMessage === 'object' &&
     typeof postedMessage.channelId === 'string' &&
     postedMessage.source === getSource()

--- a/test/core/utils/respondable.js
+++ b/test/core/utils/respondable.js
@@ -549,6 +549,21 @@ describe('axe.utils.respondable', function() {
       );
     });
 
+    it('is not called if data is null', function (done) {
+      axe.configure({
+        allowedOrigins: ['<unsafe_all_origins>']
+      });
+      var spy = sinon.spy();
+
+      frameSubscribe('greeting', spy);
+      frameWin.postMessage(null, '*');
+
+      setTimeout(function(){
+        assert.isFalse(spy.called);
+        done();
+      }, 500);
+    });
+
     it('is not called if origin does not match', function(done) {
       axe.configure({
         allowedOrigins: ['http://customOrigin.com']

--- a/test/core/utils/respondable.js
+++ b/test/core/utils/respondable.js
@@ -336,6 +336,27 @@ describe('axe.utils.respondable', function() {
     }, 'allowedOrigins value "foo.com" is not a valid origin');
   });
 
+  it('does not log error if message is null', function(done) {
+    axe.configure({
+      allowedOrigins: ['<unsafe_all_origins>']
+    });
+    var called = false;
+    frameWin.axe.log = function() {
+      called = true;
+    };
+
+    frameWin.postMessage(null, '*');
+
+    setTimeout(function() {
+      try {
+        assert.isFalse(called);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, 500);
+  });
+
   describe('subscribe', function() {
     it('is called with the same topic', function(done) {
       var called = false;
@@ -547,21 +568,6 @@ describe('axe.utils.respondable', function() {
         }, done),
         100
       );
-    });
-
-    it('is not called if data is null', function (done) {
-      axe.configure({
-        allowedOrigins: ['<unsafe_all_origins>']
-      });
-      var spy = sinon.spy();
-
-      frameSubscribe('greeting', spy);
-      frameWin.postMessage(null, '*');
-
-      setTimeout(function(){
-        assert.isFalse(spy.called);
-        done();
-      }, 500);
     });
 
     it('is not called if origin does not match', function(done) {


### PR DESCRIPTION
axe-core crashes if another process sends a `window.postMessage` with
data equals to `null`.

In the previous version, because `null` has a type of `'object'`, it
crashed when trying to access the `channelId`.

This change detects first if the data is not `null`.