### PR TITLE
remove dpub role allowances for li element

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -547,9 +547,7 @@ const htmlElms = {
       'radio',
       'separator',
       'tab',
-      'treeitem',
-      'doc-biblioentry',
-      'doc-endnote'
+      'treeitem'
     ],
     implicitAttrs: {
       'aria-setsize': '1',


### PR DESCRIPTION
Updates `<li>` element to no longer allow the dpub roles [`doc-biblioentry`](https://w3c.github.io/dpub-aria/#doc-biblioentry) and [`doc-endnote`](https://w3c.github.io/dpub-aria/#doc-endnote) which are being deprecated in DPUB ARIA 1.1 due to better aligning with ARIA's clarified child element (role) allowances of a `list`.

Closes #3253
