### PR TITLE
fix(nested-interactive): update negative tabindex message to include asssistive technologies

### DIFF
--- a/lib/checks/keyboard/no-focusable-content.json
+++ b/lib/checks/keyboard/no-focusable-content.json
@@ -7,7 +7,7 @@
       "pass": "Element does not have focusable descendants",
       "fail": {
         "default": "Element has focusable descendants",
-        "notHidden": "Using a negative tabindex on an element inside an interactive control does not prevent a screen reader from focusing the element (even with 'aria-hidden=true')"
+        "notHidden": "Using a negative tabindex on an element inside an interactive control does not prevent assistive technologies from focusing the element (even with 'aria-hidden=true')"
       },
       "incomplete": "Could not determine if element has descendants"
     }


### PR DESCRIPTION
Should have caught this as #3194 but there was a lot going on in that pr I missed this wording.

Closes issue: #3232
