### PR TITLE
fix(aria-allowed-role): remove role allowances for embed, iframe and object

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -219,7 +219,7 @@ const htmlElms = {
   },
   embed: {
     contentTypes: ['interactive', 'embedded', 'phrasing', 'flow'],
-    allowedRoles: ['application', 'document', 'img', 'presentation', 'none'],
+    allowedRoles: false,
     chromiumRole: 'EmbeddedObject'
   },
   fieldset: {
@@ -324,7 +324,7 @@ const htmlElms = {
   },
   iframe: {
     contentTypes: ['interactive', 'embedded', 'phrasing', 'flow'],
-    allowedRoles: ['application', 'document', 'img', 'none', 'presentation'],
+    allowedRoles: false,
     chromiumRole: 'Iframe'
   },
   img: {
@@ -637,7 +637,7 @@ const htmlElms = {
         contentTypes: ['embedded', 'phrasing', 'flow']
       }
     },
-    allowedRoles: ['application', 'document', 'img'],
+    allowedRoles: false,
     chromiumRole: 'PluginObject'
   },
   ol: {


### PR DESCRIPTION
closes #3264

remove role allowances for `iframe`, `embed` and `object` per https://github.com/w3c/html-aria/pull/370
