### PR TITLE
ci: use lts-browsers for nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,16 +170,20 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
-      # install Chrome Beta
-      - run: |
-          wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
-          sudo apt install ./google-chrome-beta_current_amd64.deb
-      # install Firefox Nightly
-      - run: |
-          wget -O firefox-nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
-          tar xf firefox-nightly.tar.bz2
-      - run: |
-          FIREFOX_NIGHTLY_BIN="$(pwd)/firefox/firefox-bin" npm run test -- --browsers Chrome,FirefoxNightly
+      - run:
+          name: Install Chrome Beta
+          command: |
+            wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+            sudo apt install ./google-chrome-beta_current_amd64.deb
+      - run:
+          name: Install Firefox Nightly
+          command: |
+            wget -O firefox-nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+            tar xf firefox-nightly.tar.bz2
+      - run:
+          name: Set Environment Variable
+          command: echo "export FIREFOX_NIGHTLY_BIN=$(pwd)/firefox/firefox-bin" >> $BASH_ENV
+      - run: npm run test -- --browsers Chrome,FirefoxNightly
 
   # Run the test suite for nightly builds.
   test_nightly_aria_practices:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,16 @@ jobs:
       - run: |
           wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
           sudo apt install ./google-chrome-beta_current_amd64.deb
+          echo "export CHROME_BIN=$(which google-chrome-beta)" >> ~/.bashrc
+      # install Firefox Nightly
       - run: |
-          CHROME_BIN="$(which google-chrome-beta)" && echo "CHROME_BIN: $CHROME_BIN"
+          wget -O firefox-nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+          tar xf firefox-nightly.tar.bz2
+          echo "export FIREFOX_NIGHTLY_BIN=$(pwd)/firefox/firefox-bin" >> ~/.bashrc
+      - run: |
+          source ~/.bashrc
+          echo "CHROME_BIN: $CHROME_BIN"
+          echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
           npm run test -- --browsers Chrome,FirefoxNightly
 
   # Run the test suite for nightly builds.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ win_box: &win_box
 orbs:
   win: circleci/windows@1.0.0
   puppeteer: threetreeslight/puppeteer@0.1.2
+  browser-tools: circleci/browser-tools@1.1.0
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
@@ -41,6 +42,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache_unix
@@ -67,6 +69,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run eslint
@@ -76,6 +79,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -105,6 +109,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -115,6 +120,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       # Always run on the latest master branch, regardless of cache
@@ -127,6 +133,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -137,6 +144,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -147,6 +155,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -157,6 +166,7 @@ jobs:
     <<: *defaults
     <<: *unix_nightly_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -173,6 +183,7 @@ jobs:
     <<: *defaults
     <<: *unix_nightly_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -185,6 +196,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run api-docs
@@ -195,6 +207,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run test:rule-help-version
@@ -204,6 +217,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -214,6 +228,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache_unix
@@ -227,6 +242,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache_unix
@@ -254,6 +270,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: .circleci/verify-release.sh post
@@ -263,6 +280,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run next-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,11 +179,7 @@ jobs:
           wget -O firefox-nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
           tar xf firefox-nightly.tar.bz2
       - run: |
-          CHROME_BIN="$(which google-chrome-beta)"
-          FIREFOX_NIGHTLY_BIN="$(pwd)/firefox/firefox-bin"
-          echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
-          echo "CHROME_BIN: $CHROME_BIN"
-          npm run test -- --browsers Chrome,FirefoxNightly
+          FIREFOX_NIGHTLY_BIN="$(pwd)/firefox/firefox-bin" npm run test -- --browsers Chrome,FirefoxNightly
 
   # Run the test suite for nightly builds.
   test_nightly_aria_practices:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ defaults: &defaults
 unix_box: &unix_box
   docker:
     - image: cimg/node:16.13-browsers
-  steps:
-    - browser-tools/install-browser-tools
 
 unix_nightly_box: &unix_nightly_box
   docker:
@@ -44,6 +42,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache_unix
@@ -80,6 +79,7 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,9 +306,9 @@ workflows:
             - dependencies_unix
       # Run tests on all commits, but after installing dependencies
       - test_unix:
-          requires:
-            - dependencies_unix
-            - lint
+          # requires:
+          #   - dependencies_unix
+          #   - lint
       # Run IE/ Windows test on all commits
       - test_win:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,9 +181,7 @@ jobs:
           tar xf firefox-nightly.tar.bz2
           echo "export FIREFOX_NIGHTLY_BIN=$(pwd)/firefox/firefox-bin" >> ~/.bashrc
       - run: |
-          source ~/.bashrc
-          echo "CHROME_BIN: $CHROME_BIN"
-          echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
+          source ~/.bashrc && echo "CHROME_BIN: $CHROME_BIN" && echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
           npm run test -- --browsers Chrome,FirefoxNightly
 
   # Run the test suite for nightly builds.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ unix_box: &unix_box
 
 unix_nightly_box: &unix_nightly_box
   docker:
-    - image: cimg/node:lts-browsers
+    - image: cimg/node:lts
 
 win_box: &win_box
   executor:
@@ -174,15 +174,16 @@ jobs:
       - run: |
           wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
           sudo apt install ./google-chrome-beta_current_amd64.deb
-          CHROME_BIN="$(which google-chrome-beta)"
-          echo "CHROME_BIN: $CHROME_BIN"
       # install Firefox Nightly
       - run: |
           wget -O firefox-nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
           tar xf firefox-nightly.tar.bz2
+      - run: |
+          CHROME_BIN="$(which google-chrome-beta)"
           FIREFOX_NIGHTLY_BIN="$(pwd)/firefox/firefox-bin"
           echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
-      - run: npm run test -- --browsers Chrome,FirefoxNightly
+          echo "CHROME_BIN: $CHROME_BIN"
+          npm run test -- --browsers Chrome,FirefoxNightly
 
   # Run the test suite for nightly builds.
   test_nightly_aria_practices:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - run: npm run eslint
 
   # Run the test suite.
-  test_unix:
+  test_nightly_chrome:
     <<: *defaults
     <<: *unix_box
     steps:
@@ -162,7 +162,7 @@ jobs:
       - run: npm run test:virtual-rules
 
   # Run the test suite for nightly builds.
-  test_nightly_chrome:
+  test_unix:
     <<: *defaults
     <<: *unix_nightly_box
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,14 +175,16 @@ jobs:
           wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
           sudo apt install ./google-chrome-beta_current_amd64.deb
           echo "export CHROME_BIN=$(which google-chrome-beta)" >> ~/.bashrc
+          cat ~/.bashrc
       # install Firefox Nightly
       - run: |
           wget -O firefox-nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
           tar xf firefox-nightly.tar.bz2
           echo "export FIREFOX_NIGHTLY_BIN=$(pwd)/firefox/firefox-bin" >> ~/.bashrc
+          cat ~/.bashrc
       - run: |
-          source ~/.bashrc && echo "CHROME_BIN: $CHROME_BIN" && echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
-          npm run test -- --browsers Chrome,FirefoxNightly
+          cat ~/.bashrc && source ~/.bashrc && echo "CHROME_BIN: $CHROME_BIN" && echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
+      - run: npm run test -- --browsers Chrome,FirefoxNightly
 
   # Run the test suite for nightly builds.
   test_nightly_aria_practices:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ defaults: &defaults
 unix_box: &unix_box
   docker:
     - image: cimg/node:16.13-browsers
+  steps:
+    - browser-tools/install-browser-tools
 
 unix_nightly_box: &unix_nightly_box
   docker:
@@ -42,7 +44,6 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache_unix
@@ -79,7 +80,6 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ workflows:
           requires:
             - dependencies_unix
       # Run tests on all commits, but after installing dependencies
-      - test_unix:
+      - test_unix
           # requires:
           #   - dependencies_unix
           #   - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
     <<: *defaults
     <<: *unix_nightly_box
     steps:
-      - browser-tools/install-browser-tools
+      # - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -174,16 +174,14 @@ jobs:
       - run: |
           wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
           sudo apt install ./google-chrome-beta_current_amd64.deb
-          echo "export CHROME_BIN=$(which google-chrome-beta)" >> ~/.bashrc
-          cat ~/.bashrc
+          CHROME_BIN="$(which google-chrome-beta)"
+          echo "CHROME_BIN: $CHROME_BIN"
       # install Firefox Nightly
       - run: |
           wget -O firefox-nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
           tar xf firefox-nightly.tar.bz2
-          echo "export FIREFOX_NIGHTLY_BIN=$(pwd)/firefox/firefox-bin" >> ~/.bashrc
-          cat ~/.bashrc
-      - run: |
-          cat ~/.bashrc && source ~/.bashrc && echo "CHROME_BIN: $CHROME_BIN" && echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
+          FIREFOX_NIGHTLY_BIN="$(pwd)/firefox/firefox-bin"
+          echo "FIREFOX_NIGHTLY_BIN: $FIREFOX_NIGHTLY_BIN"
       - run: npm run test -- --browsers Chrome,FirefoxNightly
 
   # Run the test suite for nightly builds.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,11 @@ defaults: &defaults
 
 unix_box: &unix_box
   docker:
-    - image: circleci/node:16-browsers
+    - image: cimg/node:16.13-browsers
+
+unix_nightly_box: &unix_nightly_box
+  docker:
+    - image: cimg/node:lts-browsers
 
 win_box: &win_box
   executor:
@@ -15,7 +19,6 @@ win_box: &win_box
 orbs:
   win: circleci/windows@1.0.0
   puppeteer: threetreeslight/puppeteer@0.1.2
-
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
@@ -152,7 +155,7 @@ jobs:
   # Run the test suite for nightly builds.
   test_nightly_chrome:
     <<: *defaults
-    <<: *unix_box
+    <<: *unix_nightly_box
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
@@ -168,7 +171,7 @@ jobs:
   # Run the test suite for nightly builds.
   test_nightly_aria_practices:
     <<: *defaults
-    <<: *unix_box
+    <<: *unix_nightly_box
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ unix_box: &unix_box
 
 unix_nightly_box: &unix_nightly_box
   docker:
-    - image: cimg/node:lts
+    - image: cimg/node:lts-browsers
 
 win_box: &win_box
   executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - run: npm run eslint
 
   # Run the test suite.
-  test_nightly_chrome:
+  test_unix:
     <<: *defaults
     <<: *unix_box
     steps:
@@ -162,11 +162,10 @@ jobs:
       - run: npm run test:virtual-rules
 
   # Run the test suite for nightly builds.
-  test_unix:
+  test_nightly_browsers:
     <<: *defaults
     <<: *unix_nightly_box
     steps:
-      # - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
       - run: npm run build
@@ -305,10 +304,9 @@ workflows:
           requires:
             - dependencies_unix
       # Run tests on all commits, but after installing dependencies
-      - test_unix
-          # requires:
-          #   - dependencies_unix
-          #   - lint
+      - test_unix:
+          requires:
+            - lint
       # Run IE/ Windows test on all commits
       - test_win:
           requires:
@@ -407,7 +405,7 @@ workflows:
                 - develop
     jobs:
       - dependencies_unix
-      - test_nightly_chrome:
+      - test_nightly_browsers:
           requires:
             - dependencies_unix
       - test_nightly_aria_practices:


### PR DESCRIPTION
Also updated the image syntax for our normal runs.

See https://circleci.com/developer/images/image/cimg/node