### PR TITLE
feat(configure): Deprecate branding: Object, use a string instead.

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -187,10 +187,7 @@ declare namespace axe {
     cssColors?: { [key: string]: number[] };
   }
   interface Spec {
-    branding?: {
-      brand?: string;
-      application?: string;
-    };
+    branding?: string | Branding;
     reporter?: ReporterVersion;
     checks?: Check[];
     rules?: Rule[];
@@ -202,6 +199,13 @@ declare namespace axe {
     allowedOrigins?: string[];
     // Deprecated - do not use.
     ver?: string;
+  }
+  /**
+   * @deprecated Use branding: string instead to set the application key in help URLs
+   */
+  interface Branding {
+    brand?: string;
+    application?: string;
   }
   interface Check {
     id: string;

--- a/doc/API.md
+++ b/doc/API.md
@@ -186,10 +186,7 @@ User specifies the format of the JSON structure passed to the callback of `axe.r
 
 ```js
 axe.configure({
-  branding: {
-    brand: String,
-    application: String
-  },
+  branding: String,
   reporter: 'option' | Function,
   checks: [Object],
   rules: [Object],
@@ -244,6 +241,8 @@ axe.configure({
   - `allowedOrigins` - Set which origins (URL domains) will communicate test data with. See [allowedOrigins](#allowedorigins).
 
 **Returns:** Nothing
+
+**Note**: The `branding` property accepts a `string`, which sets the application. Passing it an object is deprecated as of axe-core 4.4.0, as is the `branding.brand` property.
 
 ##### Page level rules
 

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -621,6 +621,9 @@ class Audit {
       brand: this.brand,
       application: this.application
     };
+    if (typeof branding === 'string') {
+      this.application = branding
+    }
     if (
       branding &&
       branding.hasOwnProperty('brand') &&

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -287,6 +287,14 @@ describe('Audit', function() {
       assert.equal(audit.brand, 'axe');
       assert.equal(audit.application, 'thing');
     });
+    it('should change the application when passed a string', function() {
+      var audit = new Audit();
+      assert.equal(audit.brand, 'axe');
+      assert.equal(audit.application, 'axeAPI');
+      audit.setBranding('thing');
+      assert.equal(audit.brand, 'axe');
+      assert.equal(audit.application, 'thing');
+    });
     it('should call _constructHelpUrls', function() {
       var audit = new Audit();
       audit.addRule({


### PR DESCRIPTION
Because the `brand` property is no longer in use, it is deprecated as of version 4.4. This makes it unnecessary to configure `branding` using an object, which now only has one property. So along with deprecating the `brand` property, the Branding object is also deprecated. Use a string instead:

```js
// previously
axe.configure({
  branding: { application: 'axe-playwright' }
})
// current
axe.configure({ branding: 'axe-playwright' })
```

Closes issue: #2891