### PR TITLE
fix(commons/dom): handle case where vNode is undefined in isVisible

### DIFF
--- a/lib/commons/dom/is-visible.js
+++ b/lib/commons/dom/is-visible.js
@@ -151,7 +151,7 @@ function isVisible(el, screenReader, recursed) {
 
   // detatched virtual node
   if (!el) {
-    const parent = vNode.parent;
+    const parent = vNode && vNode.parent;
     let visible = true;
     if (parent) {
       visible = isVisible(parent, screenReader, true);


### PR DESCRIPTION
Check to make sure `vNode` is defined before trying to access `vNode.parent`. This is inconsistent with what the code is already doing.

Closes issue: #3291
