### PR TITLE
fix(core): Incomplete fallback message was missing

### DIFF
--- a/build/configure.js
+++ b/build/configure.js
@@ -148,16 +148,10 @@ function buildRules(grunt, options, commons, callback) {
     }
 
     function getIncompleteMsg(summaries) {
-      var result = {};
-      summaries.forEach(function(summary) {
-        if (
-          summary.incompleteFallbackMessage &&
-          doTRegex.test(summary.incompleteFallbackMessage)
-        ) {
-          result = doT.template(summary.incompleteFallbackMessage).toString();
-        }
+      var summary = summaries.find(function(summary) {
+        return typeof summary.incompleteFallbackMessage === 'string';
       });
-      return result;
+      return summary ? summary.incompleteFallbackMessage : '';
     }
 
     function replaceFunctions(string) {

--- a/lib/core/reporters/helpers/incomplete-fallback-msg.js
+++ b/lib/core/reporters/helpers/incomplete-fallback-msg.js
@@ -3,10 +3,13 @@
  * This mechanism allows the string to be localized.
  * @return {String}
  */
-function incompleteFallbackMessage() {
-  return typeof axe._audit.data.incompleteFallbackMessage === 'function'
-    ? axe._audit.data.incompleteFallbackMessage()
-    : axe._audit.data.incompleteFallbackMessage;
+ export default function incompleteFallbackMessage() {
+  let { incompleteFallbackMessage } = axe._audit.data;
+  if (typeof incompleteFallbackMessage === 'function') {
+    incompleteFallbackMessage = incompleteFallbackMessage();
+  }
+  if (typeof incompleteFallbackMessage !== 'string') {
+    return '';
+  }
+  return incompleteFallbackMessage;
 }
-
-export default incompleteFallbackMessage;

--- a/test/core/reporters/helpers/incomplete-fallback-msg.js
+++ b/test/core/reporters/helpers/incomplete-fallback-msg.js
@@ -1,6 +1,13 @@
 describe('helpers.incompleteFallbackMessage', function() {
   'use strict';
-  beforeEach(function() {
+
+  it('returns a non-empty string by default', function () {
+    var summary = helpers.incompleteFallbackMessage();
+    assert.typeOf(summary, 'string');
+    assert.notEqual(summary, '');
+  });
+
+  it('should return a string', function() {
     axe._load({
       messages: {},
       rules: [],
@@ -8,9 +15,6 @@ describe('helpers.incompleteFallbackMessage', function() {
         incompleteFallbackMessage: 'Dogs are the best'
       }
     });
-  });
-
-  it('should return a string', function() {
     var summary = helpers.incompleteFallbackMessage();
     assert.equal(summary, 'Dogs are the best');
   });
@@ -28,5 +32,40 @@ describe('helpers.incompleteFallbackMessage', function() {
 
     var summary = helpers.incompleteFallbackMessage();
     assert.equal(summary, 'Dogs are the best');
+  });
+
+  describe('when passed an invalid value', function () {
+    it('returns `` when set to an object', function () {
+      axe._load({
+        messages: {},
+        rules: [],
+        data: {
+          incompleteFallbackMessage: {}
+        }
+      });
+      assert.equal(helpers.incompleteFallbackMessage(), '');
+    });
+
+    it('returns `` when set to null', function () {
+      axe._load({
+        messages: {},
+        rules: [],
+        data: {
+          incompleteFallbackMessage: null
+        }
+      });
+      assert.equal(helpers.incompleteFallbackMessage(), '');
+    });
+
+    it('returns `` when set to undefined', function () {
+      axe._load({
+        messages: {},
+        rules: [],
+        data: {
+          incompleteFallbackMessage: undefined
+        }
+      });
+      assert.equal(helpers.incompleteFallbackMessage(), '');
+    });
   });
 });


### PR DESCRIPTION
A bug in the build step caused the incomplete fallback message to be an empty object, rather than a string. When an error occurred, rather than failing gracefully this caused infinite recursion. This change prevents that.

Closes issue: #3289