### PR TITLE
chore(act): disable act rule until the test is fixed

### DIFF
--- a/test/act-mapping/scrollable-region-focus.json
+++ b/test/act-mapping/scrollable-region-focus.json
@@ -1,5 +1,0 @@
-{
-  "id": "0ssw9k",
-  "title": "Scrollable element is keyboard accessible",
-  "axeRules": ["scrollable-region-focusable"]
-}


### PR DESCRIPTION
Long story short; Chrome 96 came out and turned something that wasn't an issue into a legit accessibility issue. Axe-core caught it right away, and because we can't pin versions of Chrome, we're disabling this test until ACT has accepted and put out the change. This takes at least a weak and I don't want CI broken for a week.
