### PR TITLE
feat(commons): deprecate shadowElementsFromPoint

### DIFF
--- a/lib/commons/dom/shadow-elements-from-point.js
+++ b/lib/commons/dom/shadow-elements-from-point.js
@@ -4,6 +4,7 @@ import { isShadowRoot } from '../../core/utils';
 
 /**
  * Get elements from point across shadow dom boundaries
+ * @deprecated As of axe-core 4.4. May be removed in axe-core 5.0
  * @method shadowElementsFromPoint
  * @memberof axe.commons.dom
  * @instance


### PR DESCRIPTION
`lib/commons/dom/shadow-elements-from-point.js`  should not longer be used.