### PR TITLE
adds role=radio to img alt=foo allowances

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -358,7 +358,7 @@ const htmlElms = {
           'menuitemradio',
           'option',
           'progressbar',
-	  'radio',
+          'radio',
           'scrollbar',
           'separator',
           'slider',

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -358,7 +358,7 @@ const htmlElms = {
           'menuitemradio',
           'option',
           'progressbar',
-					'radio',
+	  'radio',
           'scrollbar',
           'separator',
           'slider',

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -358,6 +358,7 @@ const htmlElms = {
           'menuitemradio',
           'option',
           'progressbar',
+					'radio',
           'scrollbar',
           'separator',
           'slider',

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -227,6 +227,11 @@
   aria-labelledby="image-baz"
   id="pass-img-valid-role-aria-labelledby"
 />
+<img
+	role="radio"
+	aria-label="test"
+	id="pass-img-valid-role-radio"
+>
 <img role="text" aria-label="foo" id="fail-img-invalid-role-aria-label" />
 <img role="spinbutton" title="bar" id="fail-img-invalid-role-title" />
 <img

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.json
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.json
@@ -78,6 +78,7 @@
     ["#pass-img-valid-role-aria-label"],
     ["#pass-img-valid-role-title"],
     ["#pass-img-valid-role-aria-labelledby"],
+    ["#pass-img-valid-role-radio"],
     ["#pass-imgmap-1"],
     ["#pass-imgmap-2"]
   ],


### PR DESCRIPTION
A `role=radio` was meant to be an allowance for an `img alt=foo`, but it had mistakenly been left out of the spec.
ARIA in HTML is fixing this oversight, https://github.com/w3c/html-aria/pull/381, so this PR is to match this added allowance.
