### PR TITLE
fix(custom-elms): Don't error on custom Element.children prop

### DIFF
--- a/lib/commons/aria/get-accessible-refs.js
+++ b/lib/commons/aria/get-accessible-refs.js
@@ -33,9 +33,9 @@ function cacheIdRefs(node, idRefs, refAttrs) {
     }
   }
 
-  for (const childNode of node.childNodes) {
-    if (childNode.nodeType === 1) {
-      cacheIdRefs(childNode, idRefs, refAttrs);
+  for (let i = 0; i < node.childNodes.length; i++) {
+    if (node.childNodes[i].nodeType === 1) {
+      cacheIdRefs(node.childNodes[i], idRefs, refAttrs);
     }
   }
 }

--- a/lib/commons/aria/get-accessible-refs.js
+++ b/lib/commons/aria/get-accessible-refs.js
@@ -33,8 +33,10 @@ function cacheIdRefs(node, idRefs, refAttrs) {
     }
   }
 
-  for (let i = 0; i < node.children.length; i++) {
-    cacheIdRefs(node.children[i], idRefs, refAttrs);
+  for (const childNode of node.childNodes) {
+    if (childNode.nodeType === 1) {
+      cacheIdRefs(childNode, idRefs, refAttrs);
+    }
   }
 }
 

--- a/test/commons/aria/get-accessible-refs.js
+++ b/test/commons/aria/get-accessible-refs.js
@@ -68,6 +68,18 @@ describe('aria.getAccessibleRefs', function() {
     assert.deepEqual(getAccessibleRefs(node), [ref1, ref2]);
   });
 
+  it('does not break on a custom .children property', function() {
+    setLookup({ 'aria-foo': { type: 'idref' } });
+    fixture.innerHTML = '<div id="ref" aria-foo="foo"></div><i id="foo"></i>';
+    var node = document.getElementById('foo');
+    var ref = document.getElementById('ref');
+    
+    Object.defineProperty(node, 'children', {
+      value: ['#ref']
+    });
+    assert.deepEqual(getAccessibleRefs(node), [ref]);
+  });
+
   (shadowSupport ? it : xit)('works inside shadow DOM', function() {
     setLookup({ 'aria-bar': { type: 'idref' } });
     fixture.innerHTML = '<div id="foo"></div>';


### PR DESCRIPTION
Encountered a site with custom elements which had its own `.children` property. Since this was an easy one to work around, and it completely choked up testing that site it seemed like something worth fixing.
