### PR TITLE
perf(gather): Faster shadowDOM testing

### DIFF
--- a/lib/core/utils/contains.js
+++ b/lib/core/utils/contains.js
@@ -13,9 +13,10 @@ function contains(vNode, otherVNode) {
     if (vNode.shadowId === otherVNode.shadowId) {
       return true;
     }
-    return !!vNode.children.find(child => {
-      return containsShadowChild(child, otherVNode);
-    });
+    if (!otherVNode.parent) {
+      return false;
+    }
+    return containsShadowChild(vNode, otherVNode.parent);
   }
 
   if (vNode.shadowId || otherVNode.shadowId) {
@@ -31,7 +32,7 @@ function contains(vNode, otherVNode) {
       vNode.actualNode.compareDocumentPosition(otherVNode.actualNode) & 16
     );
   } else {
-    // fallback for virtualNode only contexts (e.g. linting)
+    // fallback for virtualNode only contexts
     // @see https://github.com/Financial-Times/polyfill-service/pull/183/files
     do {
       if (otherVNode === vNode) {

--- a/lib/core/utils/contains.js
+++ b/lib/core/utils/contains.js
@@ -6,42 +6,32 @@
  * @param  {VirtualNode} otherVNode The vNode to test is contained by `vNode`
  * @return {Boolean}           Whether `vNode` contains `otherVNode`
  */
-function contains(vNode, otherVNode) {
+export default function contains(vNode, otherVNode) {
   /*eslint no-bitwise: 0*/
-
-  function containsShadowChild(vNode, otherVNode) {
-    if (vNode.shadowId === otherVNode.shadowId) {
-      return true;
-    }
-    if (!otherVNode.parent) {
-      return false;
-    }
-    return containsShadowChild(vNode, otherVNode.parent);
-  }
-
   if (vNode.shadowId || otherVNode.shadowId) {
-    return containsShadowChild(vNode, otherVNode);
+    do {
+      if (vNode.shadowId === otherVNode.shadowId) {
+        return true;
+      }
+      otherVNode = otherVNode.parent;
+    } while (otherVNode)
+    return false;
   }
 
-  if (vNode.actualNode) {
-    if (typeof vNode.actualNode.contains === 'function') {
-      return vNode.actualNode.contains(otherVNode.actualNode);
-    }
-
-    return !!(
-      vNode.actualNode.compareDocumentPosition(otherVNode.actualNode) & 16
-    );
-  } else {
+  if (!vNode.actualNode) {
     // fallback for virtualNode only contexts
     // @see https://github.com/Financial-Times/polyfill-service/pull/183/files
     do {
       if (otherVNode === vNode) {
         return true;
       }
-    } while ((otherVNode = otherVNode && otherVNode.parent));
+      otherVNode = otherVNode.parent
+    } while (otherVNode);
   }
 
-  return false;
+  if (typeof vNode.actualNode.contains !== 'function') {
+    const position = vNode.actualNode.compareDocumentPosition(otherVNode.actualNode);
+    return !!(position & 16);
+  }
+  return vNode.actualNode.contains(otherVNode.actualNode);
 }
-
-export default contains;

--- a/lib/core/utils/select.js
+++ b/lib/core/utils/select.js
@@ -31,10 +31,11 @@ function pushNode(result, nodes) {
 
 /**
  * reduces the includes list to only the outermost includes
+ * @private
  * @param {Array} the array of include nodes
  * @return {Array} the modified array of nodes
  */
-function reduceIncludes(includes) {
+function getOuterIncludes(includes) {
   return includes.reduce((res, el) => {
     if (!res.length || !contains(res[res.length - 1], el)) {
       res.push(el);
@@ -62,18 +63,13 @@ function select(selector, context) {
       }
     }
   }
-  const curried = (context => {
-    return node => {
-      return isNodeInContext(node, context);
-    };
-  })(context);
-  const reducedIncludes = reduceIncludes(context.include);
-  for (let i = 0; i < reducedIncludes.length; i++) {
-    candidate = reducedIncludes[i];
-    result = pushNode(
-      result,
-      querySelectorAllFilter(candidate, selector, curried)
-    );
+
+  const outerIncludes = getOuterIncludes(context.include);
+  const isInContext = getContextFilter(context);
+  for (let i = 0; i < outerIncludes.length; i++) {
+    candidate = outerIncludes[i];
+    const nodes = querySelectorAllFilter(candidate, selector, isInContext);
+    result = pushNode(result, nodes);
   }
   if (axe._selectCache) {
     axe._selectCache.push({
@@ -85,3 +81,19 @@ function select(selector, context) {
 }
 
 export default select;
+
+/**
+ * Return a filter method to test if a node is in context; or
+ *  null if the node is always included.
+ * @private
+ * @param {Context}
+ * @return {Function|null}
+ */
+function getContextFilter(context) {
+  // Since we're starting from included nodes,
+  // if nothing is excluded, we can skip the filter step.
+  if (!context.exclude || context.exclude.length === 0) {
+    return null;
+  }
+  return node => isNodeInContext(node, context);
+}

--- a/test/integration/virtual-rules/nested-interactive.js
+++ b/test/integration/virtual-rules/nested-interactive.js
@@ -109,7 +109,7 @@ describe('nested-interactive virtual-rule', function() {
 
     var results = axe.runVirtualRule('nested-interactive', node);
 
-    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.passes, 1);
     assert.lengthOf(results.violations, 1);
     assert.lengthOf(results.incomplete, 0);
   });


### PR DESCRIPTION
Testing if deeply nested shadow DOM nodes are in context can be a very slow operation, especially on sites that make extreme use of shadow DOM (think 30+ layers of nested shadow trees). For a very large part, this is because calling  `containsShadowChild` thousands of times recursively is very slow.

This PR avoids calling `isNodeInContext` when it isn't necessary (when there are no excluded nodes), and makes `containsShadowChild` significantly faster by walking down to the root, rather than walking the entire tree.