### PR TITLE
fix(axe.d.ts): allow Node for include/exclude object

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -50,8 +50,8 @@ declare namespace axe {
   type CrossFrameSelector = CrossTreeSelector[];
 
   type ContextObject = {
-    include?: BaseSelector | Array<BaseSelector | BaseSelector[]>;
-    exclude?: BaseSelector | Array<BaseSelector | BaseSelector[]>;
+    include?: Node | BaseSelector | Array<Node | BaseSelector | BaseSelector[]>;
+    exclude?: Node | BaseSelector | Array<Node | BaseSelector | BaseSelector[]>;
   };
 
   type RunCallback = (error: Error, results: AxeResults) => void;

--- a/doc/API.md
+++ b/doc/API.md
@@ -327,7 +327,7 @@ By default, `axe.run` will test the entire document. The context object is an op
 The include exclude object is a JSON object with two attributes: include and exclude. Either include or exclude is required. If only `exclude` is specified; include will default to the entire `document`.
 
 - A node, or
-- An array of arrays of Nodes or [CSS selectors](./developer-guide.md#supported-css-selectors)
+- An array of Nodes or an array of arrays of [CSS selectors](./developer-guide.md#supported-css-selectors)
   - If the nested array contains a single string, that string is the CSS selector
   - If the nested array contains multiple strings
     - The last string is the final CSS selector

--- a/doc/API.md
+++ b/doc/API.md
@@ -327,7 +327,7 @@ By default, `axe.run` will test the entire document. The context object is an op
 The include exclude object is a JSON object with two attributes: include and exclude. Either include or exclude is required. If only `exclude` is specified; include will default to the entire `document`.
 
 - A node, or
-- An array of arrays of [CSS selectors](./developer-guide.md#supported-css-selectors)
+- An array of arrays of Nodes or [CSS selectors](./developer-guide.md#supported-css-selectors)
   - If the nested array contains a single string, that string is the CSS selector
   - If the nested array contains multiple strings
     - The last string is the final CSS selector

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -1,7 +1,7 @@
 import * as axe from '../../axe';
 
 var context: any = document;
-var $fixture = document.querySelectorAll('div');
+var $fixture = [document];
 var options = { iframes: false, selectors: false, elementRef: false };
 
 axe.run(context, {}, (error: Error, results: axe.AxeResults) => {

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -1,7 +1,7 @@
 import * as axe from '../../axe';
 
 var context: any = document;
-var $fixture: any = {};
+var $fixture: NodeList = document.querySelectorAll('div');
 var options = { iframes: false, selectors: false, elementRef: false };
 
 axe.run(context, {}, (error: Error, results: axe.AxeResults) => {

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -1,7 +1,7 @@
 import * as axe from '../../axe';
 
 var context: any = document;
-var $fixture: NodeList = document.querySelectorAll('div');
+var $fixture = document.querySelectorAll('div');
 var options = { iframes: false, selectors: false, elementRef: false };
 
 axe.run(context, {}, (error: Error, results: axe.AxeResults) => {


### PR DESCRIPTION
These all work correctly:

```js
const div = document.querySelector('div');
await axe.run({ include: div });
await axe.run({ include: [div] });
await axe.run({ include: doument.querySelectorAll('div') });
```

Closes issue: #3334
