### PR TITLE
update role allowances for aria-expanded [WIP]

### DIFF
--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -18,12 +18,11 @@
 const ariaRoles = {
   alert: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   alertdialog: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded', 'aria-modal'],
+    allowedAttrs: ['aria-modal'],
     superclassRole: ['alert', 'dialog'],
     accessibleNameRequired: true
   },
@@ -38,12 +37,11 @@ const ariaRoles = {
   },
   article: {
     type: 'structure',
-    allowedAttrs: ['aria-posinset', 'aria-setsize', 'aria-expanded'],
+    allowedAttrs: ['aria-posinset', 'aria-setsize'],
     superclassRole: ['document']
   },
   banner: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   blockquote: {
@@ -71,8 +69,7 @@ const ariaRoles = {
       'aria-colindex',
       'aria-colspan',
       'aria-rowindex',
-      'aria-rowspan',
-      'aria-expanded'
+      'aria-rowspan'
     ],
     superclassRole: ['section'],
     nameFromContent: true
@@ -85,7 +82,7 @@ const ariaRoles = {
     //
     // Note: aria-required is not in the 1.1 spec but is
     // consistently supported in ATs and was added in 1.2
-    allowedAttrs: ['aria-checked', 'aria-readonly', 'aria-required'],
+    allowedAttrs: ['aria-checked', 'aria-expanded', 'aria-readonly', 'aria-required'],
     superclassRole: ['input'],
     accessibleNameRequired: true,
     nameFromContent: true,
@@ -103,7 +100,6 @@ const ariaRoles = {
       'aria-sort',
       'aria-colindex',
       'aria-colspan',
-      'aria-expanded',
       'aria-readonly',
       'aria-required',
       'aria-rowindex',
@@ -135,7 +131,6 @@ const ariaRoles = {
   },
   complementary: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   composite: {
@@ -144,7 +139,6 @@ const ariaRoles = {
   },
   contentinfo: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   comment: {
@@ -154,7 +148,6 @@ const ariaRoles = {
   },
   definition: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   deletion: {
@@ -164,20 +157,18 @@ const ariaRoles = {
   },
   dialog: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded', 'aria-modal'],
+    allowedAttrs: ['aria-modal'],
     superclassRole: ['window'],
     accessibleNameRequired: true
   },
   directory: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['list'],
     // Note: spec difference
     nameFromContent: true
   },
   document: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['structure']
   },
   emphasis: {
@@ -188,19 +179,16 @@ const ariaRoles = {
   feed: {
     type: 'structure',
     requiredOwned: ['article'],
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['list']
   },
   figure: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
     nameFromContent: true
   },
   form: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   grid: {
@@ -212,7 +200,6 @@ const ariaRoles = {
       'aria-readonly',
       'aria-activedescendant',
       'aria-colcount',
-      'aria-expanded',
       'aria-rowcount'
     ],
     superclassRole: ['composite', 'table'],
@@ -237,13 +224,12 @@ const ariaRoles = {
   },
   group: {
     type: 'structure',
-    allowedAttrs: ['aria-activedescendant', 'aria-expanded'],
+    allowedAttrs: ['aria-activedescendant'],
     superclassRole: ['section']
   },
   heading: {
     type: 'structure',
     requiredAttrs: ['aria-level'],
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['sectionhead'],
     // Note: spec difference
     accessibleNameRequired: false,
@@ -251,7 +237,6 @@ const ariaRoles = {
   },
   img: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     accessibleNameRequired: true,
     childrenPresentational: true
@@ -279,7 +264,6 @@ const ariaRoles = {
   list: {
     type: 'structure',
     requiredOwned: ['group', 'listitem'],
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   listbox: {
@@ -311,22 +295,18 @@ const ariaRoles = {
   },
   log: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   main: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   marquee: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   math: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     childrenPresentational: true
   },
@@ -335,7 +315,6 @@ const ariaRoles = {
     requiredOwned: ['group', 'menuitemradio', 'menuitem', 'menuitemcheckbox'],
     allowedAttrs: [
       'aria-activedescendant',
-      'aria-expanded',
       'aria-orientation'
     ],
     superclassRole: ['select']
@@ -345,7 +324,6 @@ const ariaRoles = {
     requiredOwned: ['group', 'menuitemradio', 'menuitem', 'menuitemcheckbox'],
     allowedAttrs: [
       'aria-activedescendant',
-      'aria-expanded',
       'aria-orientation'
     ],
     superclassRole: ['menu']
@@ -365,6 +343,7 @@ const ariaRoles = {
     requiredContext: ['menu', 'menubar', 'group'],
     allowedAttrs: [
       'aria-checked',
+		'aria-expanded',
       'aria-posinset',
       'aria-readonly',
       'aria-setsize'
@@ -379,6 +358,7 @@ const ariaRoles = {
     requiredContext: ['menu', 'menubar', 'group'],
     allowedAttrs: [
       'aria-checked',
+		'aria-expanded',
       'aria-posinset',
       'aria-readonly',
       'aria-setsize'
@@ -403,7 +383,6 @@ const ariaRoles = {
   },
   navigation: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   none: {
@@ -413,7 +392,6 @@ const ariaRoles = {
   },
   note: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   option: {
@@ -446,7 +424,6 @@ const ariaRoles = {
   progressbar: {
     type: 'widget',
     allowedAttrs: [
-      'aria-expanded',
       'aria-valuemax',
       'aria-valuemin',
       'aria-valuenow',
@@ -482,7 +459,6 @@ const ariaRoles = {
       'aria-readonly',
       'aria-required',
       'aria-activedescendant',
-      'aria-expanded',
       'aria-orientation'
     ],
     superclassRole: ['select'],
@@ -495,7 +471,6 @@ const ariaRoles = {
   },
   region: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark'],
     // Note: spec difference
     accessibleNameRequired: false
@@ -535,7 +510,6 @@ const ariaRoles = {
       'aria-sort',
       'aria-colindex',
       'aria-colspan',
-      'aria-expanded',
       'aria-readonly',
       'aria-required',
       'aria-rowindex',
@@ -569,7 +543,6 @@ const ariaRoles = {
   },
   search: {
     type: 'landmark',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   searchbox: {
@@ -653,7 +626,6 @@ const ariaRoles = {
   },
   status: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   strong: {
@@ -678,7 +650,7 @@ const ariaRoles = {
   switch: {
     type: 'widget',
     requiredAttrs: ['aria-checked'],
-    allowedAttrs: ['aria-readonly'],
+    allowedAttrs: ['aria-expanded', 'aria-readonly'],
     superclassRole: ['checkbox'],
     accessibleNameRequired: true,
     nameFromContent: true,
@@ -706,7 +678,7 @@ const ariaRoles = {
   table: {
     type: 'structure',
     requiredOwned: ['rowgroup', 'row'],
-    allowedAttrs: ['aria-colcount', 'aria-rowcount', 'aria-expanded'],
+    allowedAttrs: ['aria-colcount', 'aria-rowcount'],
     // NOTE: although the spec says this is not named from contents,
     // the accessible text acceptance tests (#139 and #140) require
     // table be named from content (we even had to special case
@@ -725,21 +697,18 @@ const ariaRoles = {
       'aria-level',
       'aria-multiselectable',
       'aria-orientation',
-      'aria-activedescendant',
-      'aria-expanded'
+      'aria-activedescendant'
     ],
     superclassRole: ['composite']
   },
   tabpanel: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
     accessibleNameRequired: false
   },
   term: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
     nameFromContent: true
@@ -768,22 +737,19 @@ const ariaRoles = {
   },
   timer: {
     type: 'widget',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['status']
   },
   toolbar: {
     type: 'structure',
     allowedAttrs: [
       'aria-orientation',
-      'aria-activedescendant',
-      'aria-expanded'
+      'aria-activedescendant'
     ],
     superclassRole: ['group'],
     accessibleNameRequired: true
   },
   tooltip: {
     type: 'structure',
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     nameFromContent: true
   },
@@ -794,7 +760,6 @@ const ariaRoles = {
       'aria-multiselectable',
       'aria-required',
       'aria-activedescendant',
-      'aria-expanded',
       'aria-orientation'
     ],
     superclassRole: ['select'],
@@ -807,7 +772,6 @@ const ariaRoles = {
     allowedAttrs: [
       'aria-activedescendant',
       'aria-colcount',
-      'aria-expanded',
       'aria-level',
       'aria-multiselectable',
       'aria-orientation',


### PR DESCRIPTION
All roles reviewed to largely remove (but in a few cases add) `aria-expanded` as a supported attribute.  

This matches both work done in ARIA 1.2 to correct for roles that should not have allowed the attribute, while also incorporating some ARIA 1.2 updates where some roles had support for the attribute added.

closes #3339
