### PR TITLE
docs: change `/docs/projects.md` to include Parcel

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -55,3 +55,4 @@ Add your project/integration to this file and submit a pull request.
 1. [Selenium.Axe for .NET](https://github.com/TroyWalshProf/SeleniumAxeDotnet)
 1. [vue-axe](https://github.com/vue-a11y/vue-axe-next)
 1. [a11y-sitechecker](https://github.com/forsti0506/a11y-sitechecker)
+1. [Parcel](https://parcel.io)


### PR DESCRIPTION
docs: change `/docs/projects.md` to include Parcel

Parcel.io (https://parcel.io) now integrates axe-core. Change `/docs/projects.md` to include Parcel

Closes issue: n/a
