### PR TITLE
fix(dpub): deprecate doc-endnote rather than doc-endnotes (plural)

### DIFF
--- a/lib/standards/dpub-roles.js
+++ b/lib/standards/dpub-roles.js
@@ -91,13 +91,13 @@ const dpubRoles = {
       'aria-posinset',
       'aria-setsize'
     ],
-    superclassRole: ['listitem']
+    superclassRole: ['listitem'],
+    deprecated: true
   },
   'doc-endnotes': {
     type: 'landmark',
     allowedAttrs: ['aria-expanded'],
-    superclassRole: ['landmark'],
-    deprecated: true
+    superclassRole: ['landmark']
   },
   'doc-epigraph': {
     type: 'section',

--- a/test/integration/rules/aria-roles/aria-roles.html
+++ b/test/integration/rules/aria-roles/aria-roles.html
@@ -81,7 +81,7 @@
   <div role="doc-credit" id="pass82">ok</div>
   <div role="doc-credits" id="pass83">ok</div>
   <div role="doc-dedication" id="pass84">ok</div>
-  <div role="doc-endnote" id="pass85">ok</div>
+  <div role="doc-endnotes" id="pass85">ok</div>
   <div role="doc-epigraph" id="pass87">ok</div>
   <div role="doc-epilogue" id="pass88">ok</div>
   <div role="doc-errata" id="pass89">ok</div>
@@ -134,7 +134,7 @@
   <div role="button alert" id="fail14">fail</div>
   <!-- deprecated roles-->
   <div role="doc-biblioentry" id="fail15">fail</div>
-  <div role="doc-endnotes" id="fail16">fail</div>
+  <div role="doc-endnote" id="fail16">fail</div>
 </div>
 
 <!-- inapplicable  -->


### PR DESCRIPTION
Closes issue: #3372