### PR TITLE
feat(locale): Added Norwegian Bokmål locale

### DIFF
--- a/locales/nb-no.json
+++ b/locales/nb-no.json
@@ -1,0 +1,797 @@
+{
+  "lang": "nb-no",
+  "rules": {
+    "accesskeys": {
+      "description": "",
+      "help": "Verdien for attributten 'accesskey' skal være unik"
+    },
+    "area-alt": {
+      "description": "",
+      "help": "Aktive <area> elementer skal ha alternativ tekst"
+    },
+    "aria-allowed-attr": {
+      "description": "",
+      "help": "Elementer må kun bruke tillate ARIA-attributter"
+    },
+    "aria-allowed-role": {
+      "description": "",
+      "help": "ARIA-attributten 'role' skal være passende for elementet"
+    },
+    "aria-hidden-body": {
+      "description": "",
+      "help": "aria-hidden='true' skal ikke brukes på dokumentets <body> element"
+    },
+    "aria-hidden-focus": {
+      "description": "",
+      "help": "Elementer med ARIA-'hidden' skal ikke inneholde fokuserbare elementer"
+    },
+    "aria-input-field-name": {
+      "description": "",
+      "help": "ARIA-input-felter skal ha et tilgjengelig navn"
+    },
+    "aria-required-attr": {
+      "description": "",
+      "help": "Påkrevde ARIA-attributter skal være angivet"
+    },
+    "aria-required-children": {
+      "description": "",
+      "help": "Bestemte ARIA-roller skal inneholde spesifikke under-elementer"
+    },
+    "aria-required-parent": {
+      "description": "",
+      "help": "Bestemte ARIA-roller skal være under-element til spesifikke over-elementer"
+    },
+    "aria-roledescription": {
+      "description": "",
+      "help": "Bruk 'aria-roledescription' på elementer med en semantisk rolle"
+    },
+    "aria-roles": {
+      "description": "",
+      "help": "ARIA-roller skal ha en korrekt verdi"
+    },
+    "aria-toggle-field-name": {
+      "description": "",
+      "help": "ARIA avkrysningsfelter skal ha et tilgjengelig navn"
+    },
+    "aria-valid-attr-value": {
+      "description": "",
+      "help": "ARIA-attributter skal ha en korrekt verdi"
+    },
+    "aria-valid-attr": {
+      "description": "",
+      "help": "ARIA-attributter skal ha et korrekt navn"
+    },
+    "audio-caption": {
+      "description": "",
+      "help": "<audio> elementer skal ha en transkripsjon ('captions track')"
+    },
+    "autocomplete-valid": {
+      "description": "",
+      "help": "Attributten 'autocomplete' skal benyttes korrekt"
+    },
+    "avoid-inline-spacing": {
+      "description": "",
+      "help": "Inline tekst-avstand skal være justerbare med brukerdefinerte stylesheets"
+    },
+    "blink": {
+      "description": "",
+      "help": "Elementet <blink> er utfaset og skal ikke brukes"
+    },
+    "button-name": {
+      "description": "",
+      "help": "Knapper skal ha forståelig (dvs. detekterbar) tekst"
+    },
+    "bypass": {
+      "description": "",
+      "help": "Sider skal ha en metode for å hoppe over repetativt innhold"
+    },
+    "color-contrast": {
+      "description": "",
+      "help": "Elementer skal ha tilstrekkelig fargekontrast"
+    },
+    "color-contrast-enhanced": {
+      "description": "",
+      "help": "Elementer skal ha tilstrekkelig fargekontrast"
+    },
+    "css-orientation-lock": {
+      "description": "",
+      "help": "'CSS Media queries' bør ikke brukes til at låse skjermretningen ('orientation')"
+    },
+    "definition-list": {
+      "description": "",
+      "help": "<dl> elementer skal kun direkte inneholde velsorterede <dt> og <dd> grupper, <script> eller <template> elementer"
+    },
+    "dlitem": {
+      "description": "",
+      "help": "<dt> og <dd> elementer skal være under-element til et <dl> element"
+    },
+    "document-title": {
+      "description": "",
+      "help": "Dokumenter skal ha et <title> element for å bidra til enkel navigation"
+    },
+    "duplicate-id-active": {
+      "description": "",
+      "help": "'id'-attributten for aktive elementer skal være unik"
+    },
+    "duplicate-id-aria": {
+      "description": "",
+      "help": "'id'-attributten brukt på ARIA-elementer og -labels skal være unik"
+    },
+    "duplicate-id": {
+      "description": "",
+      "help": "Verdien for 'id'-attributten skal være unik"
+    },
+    "empty-heading": {
+      "description": "",
+      "help": "Overskrifter skal ikke være tomme"
+    },
+    "focus-order-semantics": {
+      "description": "",
+      "help": "Elementer i fokus-rekkefølgen bør ha en 'role'-attributt, som er passende for det interaktive innholdet"
+    },
+    "form-field-multiple-labels": {
+      "description": "",
+      "help": "Form-feltet bør ikke ha flere label-elementer"
+    },
+    "frame-tested": {
+      "description": "",
+      "help": "Frame-elementer skal være testet med axe-core"
+    },
+    "frame-title-unique": {
+      "description": "",
+      "help": "Frame-elementer skal ha en unik 'title'-attributt"
+    },
+    "frame-title": {
+      "description": "",
+      "help": "Frame-elementer skal ha 'title'-attributt"
+    },
+    "heading-order": {
+      "description": "",
+      "help": "Overksriftsnivåer bør kun endres sekventielt"
+    },
+    "hidden-content": {
+      "description": "",
+      "help": "Skjult innholdet på siden kan ikke analyseres"
+    },
+    "html-has-lang": {
+      "description": "",
+      "help": "<html> elementet skal ha en 'lang'-attributt"
+    },
+    "html-lang-valid": {
+      "description": "",
+      "help": "<html> elementet skal ha en korrekt verdi for 'lang'-attributten"
+    },
+    "html-xml-lang-mismatch": {
+      "description": "",
+      "help": "<html> elementer med 'lang' og 'xml:lang' skal ha det samme basespråk"
+    },
+    "image-alt": {
+      "description": "",
+      "help": "Bilder skal ha en alternativ tekst"
+    },
+    "image-redundant-alt": {
+      "description": "",
+      "help": "Alternativ tekst til bilder (alt-tekst) bør ikke gjentas som brødtekst"
+    },
+    "input-button-name": {
+      "description": "",
+      "help": "Input-knapper skal ha en forståelig tekst"
+    },
+    "input-image-alt": {
+      "description": "",
+      "help": "Bilde-knapper skal ha en alternativ tekst"
+    },
+    "label-content-name-mismatch": {
+      "description": "",
+      "help": "Elementer sin synlige tekst skal være del av deres tilgjengelige navn"
+    },
+    "label-title-only": {
+      "description": "",
+      "help": "Form-elementer bør ha en synlig label"
+    },
+    "label": {
+      "description": "",
+      "help": "Form-elementer skal ha labels"
+    },
+    "landmark-banner-is-top-level": {
+      "description": "",
+      "help": "Et 'banner'-landmark skal ikke være inne i et annet landmark"
+    },
+    "landmark-complementary-is-top-level": {
+      "description": "",
+      "help": "Et 'aside'- eller 'complimentary'-landmark skal ikke være inne i et annet landmark"
+    },
+    "landmark-contentinfo-is-top-level": {
+      "description": "",
+      "help": "Et 'contentinfo'-landmark skal ikke være inne i et annet landmark"
+    },
+    "landmark-main-is-top-level": {
+      "description": "",
+      "help": "Et 'main'-landmark skal ikke være inne i et annet landmark"
+    },
+    "landmark-no-duplicate-banner": {
+      "description": "",
+      "help": "Dokumentet skal ikke ha mer enn ett 'banner'-landmark"
+    },
+    "landmark-no-duplicate-contentinfo": {
+      "description": "",
+      "help": "Dokumentet skal ikke ha mer enn ett 'contentinfo'-landmark"
+    },
+    "landmark-one-main": {
+      "description": "",
+      "help": "Dokumentet skal ha ett 'main'-landmark"
+    },
+    "landmark-unique": {
+      "description": "",
+      "help": "Sikre at landmarks er unike"
+    },
+    "link-in-text-block": {
+      "description": "",
+      "help": "Lenker skal være fremtredende fra den omkringliggende teksten på en måte som ikke avhenger av farge"
+    },
+    "link-name": {
+      "description": "",
+      "help": "Lenker skal ha forståelig (detekterbar) tekst"
+    },
+    "list": {
+      "description": "",
+      "help": "<ul> og <ol> skal kun direkte inneholde <li>, <script> eller <template> elementer"
+    },
+    "listitem": {
+      "description": "",
+      "help": "<li> elementer skal være inne i et <ul> eller <ol> element"
+    },
+    "marquee": {
+      "description": "",
+      "help": "<marquee> elementer er utfaset og skal ikke brukes"
+    },
+    "meta-refresh": {
+      "description": "",
+      "help": "Tidsinnstilt 'refresh' skal ikke brukes"
+    },
+    "meta-viewport-large": {
+      "description": "",
+      "help": "Brukere bør kunne zoome og skalere tekst op til 500%"
+    },
+    "meta-viewport": {
+      "description": "",
+      "help": "Zoom og skalering skal ikke være slått av"
+    },
+    "object-alt": {
+      "description": "",
+      "help": "<object> elementer skal ha en alternativ tekst"
+    },
+    "p-as-heading": {
+      "description": "",
+      "help": "Fremhevelse med fet, kursiv og skriftstørrelse (font-size) skal ikke brukes til at style <p> elementer som en overskrift"
+    },
+    "page-has-heading-one": {
+      "description": "",
+      "help": "Siden skal inneholde en overskrift på øverste nivå"
+    },
+    "region": {
+      "description": "",
+      "help": "Alt innholdet på siden skal være inne i landmarks"
+    },
+    "role-img-alt": {
+      "description": "",
+      "help": "Elementer med 'role' attributtverdien 'img' skal ha en alternativ tekst"
+    },
+    "scope-attr-valid": {
+      "description": "",
+      "help": "'scope'-attributten skal brukes korrekt i tabeller"
+    },
+    "scrollable-region-focusable": {
+      "description": "",
+      "help": "Sørg for at en scrollbar region er tilgjengelig via tastatur"
+    },
+    "server-side-image-map": {
+      "description": "",
+      "help": "Såkalte 'server-side image-maps' skal ikke brukes"
+    },
+    "skip-link": {
+      "description": "",
+      "help": "En 'skip-link' skal peke på et eksisterende og fokuserbart element"
+    },
+    "tabindex": {
+      "description": "",
+      "help": "Elementer bør ikke ha et 'tabindex' høyere end 0"
+    },
+    "table-duplicate-name": {
+      "description": "",
+      "help": "Elementet <caption> bør ikke inneholde samme tekst som 'summary'-attributten"
+    },
+    "table-fake-caption": {
+      "description": "",
+      "help": "Data- eller overskrifts-celler bør ikke brukes til at beskrive innholdetet av en data-tabell"
+    },
+    "td-has-header": {
+      "description": "",
+      "help": "Alle ikke-tomme <td> elementer i en tabel større end 3x3 bør ha en tabelloverskrift (<th>)"
+    },
+    "td-headers-attr": {
+      "description": "",
+      "help": "Alle celler i en tabel, som  bruker 'header'-attributten skal kun referere til andre celler i samme tabel"
+    },
+    "th-has-data-cells": {
+      "description": "",
+      "help": "Alle <th> elementer og elementer med 'role=columnheader/rowheader' skal referere til de data-celler, som de beskriver"
+    },
+    "valid-lang": {
+      "description": "",
+      "help": "'lang'-attributten skal ha en korrekt verdi"
+    },
+    "video-caption": {
+      "description": "",
+      "help": "<video> elementer skal ha undertekster ('captions')"
+    }
+  },
+  "checks": {
+    "abstractrole": {
+      "pass": "Abstrakte roller er ikke brukt",
+      "fail": "Abstrakte roller bør ikke brukes"
+    },
+    "aria-allowed-attr": {
+      "pass": "ARIA-attribut er brukt korrekt for den angitte rolle",
+      "fail": {
+        "singular": "ARIA-attributterne er ikke tillatt: ${data.values}",
+        "plural": "ARIA-attribut er ikke tillatt: ${data.values}"
+      }
+    },
+    "aria-allowed-role": {
+      "pass": "ARIA-rollen er tillatt for det gitte element",
+      "fail": {
+        "singular": "ARIA-rollerne ${data.values} er ikke tillatt for det gitte element",
+        "plural": "ARIA-rollen ${data.values} er ikke tillatt for det gitte element"
+      },
+      "incomplete": {
+        "singular": "ARIA-rollerne ${data.values} skal være fjernet når elementet er synlig, da de ikke er tillatt for elementet",
+        "plural": "ARIA-rollen ${data.values} skal være fjernet når elementet er synlig, da det ikke er tillatt for elementet"
+      }
+    },
+    "aria-hidden-body": {
+      "pass": "Kunne ikke finne noen 'aria-hidden'-attributt i dokumentets <body> element",
+      "fail": "'aria-hidden=true' bør ikke brukes på dokumentets <body> element"
+    },
+    "aria-roledescription": {
+      "pass": "'aria-roledescription' brukes på en understøttet semantisk rolle",
+      "incomplete": "Sjekk at 'aria-roledescription' blir lest opp av understøttet skjermleser",
+      "fail": "Gi elementet en rolle som understøtter 'aria-roledescription'"
+    },
+    "aria-errormessage": {
+      "pass": "Bruker en understøttet 'aria-errormessage'-metode",
+      "fail": {
+        "singular": "'aria-errormessage'-verdier ${data.values}` bør bruke en metode for å annonsere beskeden (fx 'aria-live', 'aria-describedby', 'role=alert', osv.)",
+        "plural": "'aria-errormessage'-verdi ${data.values}` bør bruke en metode for å annonsere beskeden (fx 'aria-live', 'aria-describedby', 'role=alert', osv.)"
+      }
+    },
+    "has-widget-role": {
+      "pass": "Elementet har en 'widget'-rolle.",
+      "fail": "Elementet har ikke en 'widget'-rolle."
+    },
+    "invalidrole": {
+      "pass": "ARIA-rollen er korrekt",
+      "fail": "Rollen skal være en av de mulige ARIA-roller"
+    },
+    "no-implicit-explicit-label": {
+      "pass": "Der er uoverensstemmelse mellem <label> og det tilgjengelige navn",
+      "incomplete": "Sjekk at <label> elementet ikke behøver å være en del av ${data}-feltets navn"
+    },
+    "aria-required-attr": {
+      "pass": "Alle påkrevde ARIA-attributter er tilstede",
+      "fail": {
+        "singular": "Påkrevde ARIA-attributter er ikke til stede: ${data.values}",
+        "plural": "Påkrevde ARIA-attribut er ikke til stede: ${data.values}"
+      }
+    },
+    "aria-required-children": {
+      "pass": "Påkrevde ARIA-under-elementer er til stede",
+      "fail": {
+        "singular": "Påkrevde ARIA-under-elementers rolle er ikke til stede: ${data.values}",
+        "plural": "Påkrevde ARIA-under-elements rolle er ikke til stede: ${data.values}"
+      },
+      "incomplete": {
+        "singular": "Forventer at ARIA under-elementers rolle blir lagt til: ${data.values}",
+        "plural": "Forventer at ARIA under-elements rolle blir lagt til: ${data.values}"
+      }
+    },
+    "aria-required-parent": {
+      "pass": "Påkrevde ARIA-over-elements rolle er til stede",
+      "fail": {
+        "singular": "Påkrevde ARIA-over-elementers rolle er ikke til stede: ${data.values}",
+        "plural": "Påkrevde ARIA-over-elements rolle er ikke til stede: ${data.values}"
+      }
+    },
+    "aria-unsupported-attr": {
+      "pass": "ARIA-attribut er understøttet",
+      "fail": "ARIA-attribut er ikke bredt understøttet i skjermlesere og tilgjengelighetsteknologier:  ${data.values}"
+    },
+    "unsupportedrole": {
+      "pass": "ARIA rollen er understøttet",
+      "fail": "Den brukte rolle er ikke bredt understøttet i skjermlesere og tilgjengelighetsteknologier:  ${data.values}"
+    },
+    "aria-valid-attr-value": {
+      "pass": "ARIA-attributverdien er valid",
+      "fail": {
+        "singular": "Ikke-korrekt ARIA-attributverdier: ${data.values}",
+        "plural": "Ikke-korrekt ARIA-attributverdi: ${data.values}"
+      },
+      "incomplete": {
+        "singular": "Kunne ikke finne ARIA-attributternes element 'id' på siden: ${data.values}",
+        "plural": "Kunne ikke finne ARIA-attributtens element 'id' på siden: ${data.values}"
+      }
+    },
+    "aria-valid-attr": {
+      "pass": {
+        "singular": "ARIA-attributnavnene er korrekt",
+        "plural": "ARIA-attributnavnet er korrekt"
+      },
+      "fail": {
+        "singular": "Ikke-korrekt ARIA-attributnavne: ${data.values}",
+        "plural": "Ikke-korrekt ARIA-attributnavn: ${data.values}"
+      }
+    },
+    "valid-scrollable-semantics": {
+      "pass": "Elementet har korrekt semantikk for et element i fokus-rekkefølgen.",
+      "fail": "Elementet har ikke korrekt semantikk for et element i fokus-rekkefølgen."
+    },
+    "color-contrast": {
+      "pass": "Elementet har stor fargekontrast. Den er ${data.contrastRatio}",
+      "fail": "Elementet har ikke nok fargekontrast. Den er ${data.contrastRatio} (forgrunnsfarge: ${data.fgColor}, bakgrunnsfarge: ${data.bgColor}, tekststørrelse: ${data.fontSize}, teksttykkelse: ${data.fontWeight}). Forventet kontrastforhold er ${data.expectedContrastRatio}",
+      "incomplete": {
+        "bgImage": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av et bakgrunnsbildet",
+        "bgGradient": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av en bakgrunnsgradient",
+        "imgNode": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi elementet inneholder et Bildeelement",
+        "bgOverlap": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er overlappet av et annet element",
+        "fgAlpha": "Elementets forgrunnsfarge kunne ikke detekteres på grunn av dets gjennomsiktighet",
+        "elmPartiallyObscured": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er delvist dekket av et annet element",
+        "elmPartiallyObscuring": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det delvist dekker et annet element",
+        "outsideViewport": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er utenfor sidens 'viewport'",
+        "equalRatio": "Elementet har et 1:1-kontrastforhold med bakgrunnen",
+        "shortTextContent": "Elementets innholde er for kort til at kunne avgjøre om inneholdet faktisk ER tekst",
+        "default": "Kan ikke regne ut kontrastforhold"
+      }
+    },
+    "color-contrast-enhanced": {
+      "pass": "Elementet har stor fargekontrast, den er ${data.contrastRatio}",
+      "fail": "Elementet har ikke nok fargekontrast, den er ${data.contrastRatio} (forgrunnsfarge: ${data.fgColor}, bakgrunnsfarge: ${data.bgColor}, tekststørrelse: ${data.fontSize}, teksttykkelse: ${data.fontWeight}). Forventet kontrastforhold er ${data.expectedContrastRatio}",
+      "incomplete": {
+        "bgImage": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av et bakgrunnsbilde",
+        "bgGradient": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av en bakgrunnsgradient",
+        "imgNode": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi elementet inneholder et Bildeelement",
+        "bgOverlap": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er overlappet av et annet element",
+        "fgAlpha": "Elementets forgrunnsfarge kunne ikke detekteres på grunn av dets gjennomsiktighet",
+        "elmPartiallyObscured": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er delvist dekket av et annet element",
+        "elmPartiallyObscuring": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det delvist dekker et annet element",
+        "outsideViewport": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er utenfor sidens 'viewport'",
+        "equalRatio": "Elementet har et 1:1-kontrastforhold med bakgrunnen",
+        "shortTextContent": "Elementets innholdet er for kort til at kunne avgjøre om inneholdet faktisk ER tekst",
+        "default": "Kan ikke regne ut kontrastforhold"
+      }
+    },
+    "link-in-text-block": {
+      "pass": "Lenker kan adskilles fra den omkringliggende tekst på annen måte enn med farge",
+      "fail": "Lenker bør skille sig ud fra den omkringliggende tekst på annen måte enn med farge",
+      "incomplete": {
+        "bgContrast": "Elementets kontrastforhold kunne ikke detekteres. Sjekk for spesifikk 'hover'/'focus' styling",
+        "bgImage": "Elementets kontrastforhold kunne ikke detekteres på grunn av et bakgrunnsbilde",
+        "bgGradient": "Elementets kontrastforhold kunne ikke detekteres på grunn av en bakgrunnsgradient",
+        "imgNode": "Elementets kontrastforhold kunne ikke detekteres, fordi elementet inneholder et bildeelement",
+        "bgOverlap": "Elementets kontrastforhold kunne ikke detekteres på grunn av overlappende elementer",
+        "default": "Kan ikke regne ut kontrastforhold"
+      }
+    },
+    "autocomplete-appropriate": {
+      "pass": "'autocomplete'-verdien er brukt på et passende element",
+      "fail": "'autocomplete'-verdien er ikke passende for denne type input"
+    },
+    "autocomplete-valid": {
+      "pass": "'autocomplete'-attributten er korrekt formateret",
+      "fail": "'autocomplete'-attributten er forkert formateret"
+    },
+    "accesskeys": {
+      "pass": "'Accesskey' attributtverdien er unik",
+      "fail": "Dokumentet har flere elementer med den samme 'accesskey'-attributt"
+    },
+    "focusable-content": {
+      "pass": "Elementet inneholder fokuserbare elementer",
+      "fail": "Elementet bør ha fokuserbart innholdet"
+    },
+    "focusable-disabled": {
+      "pass": "Ingen fokuserbare elementer inne i elementet",
+      "fail": "Fokuserbart innholdet bør slås fra eller fjernes fra sidens DOM"
+    },
+    "focusable-element": {
+      "pass": "Elementet er fokuserbart",
+      "fail": "Elementet bør være fokuserbart"
+    },
+    "focusable-no-name": {
+      "pass": "Elementet er ikke i sidens tabulerings-rekkefølge ('tab order') eller har tilgjengelig tekst",
+      "fail": "Elementet er i sidens tabulerings-rekkefølge ('tab order') og har ikke tilgjengelig tekst"
+    },
+    "focusable-not-tabbable": {
+      "pass": "Ingen fokuserbare elementer inne i element",
+      "fail": "Fokuserbart innholdet bør ha tabindex='-1' eller fjernes fra sidens DOM"
+    },
+    "landmark-is-top-level": {
+      "pass": "${data.role} landmark er på det øverste nivå.",
+      "fail": "${data.role} landmark er innholdet i et annet landmark."
+    },
+    "page-has-heading-one": {
+      "pass": "Siden har minst én overskrift på nivå 1",
+      "fail": "Siden skal ha minst én overskrift på nivå 1"
+    },
+    "page-has-main": {
+      "pass": "Dokumentet har minst ét 'main'-landmark",
+      "fail": "Dokumentet har ikke et 'main'-landmark"
+    },
+    "page-no-duplicate-banner": {
+      "pass": "Dokumentet har ikke mer enn ett 'banner'-landmark",
+      "fail": "Dokumentet har mer enn ett 'banner-'landmark"
+    },
+    "page-no-duplicate-contentinfo": {
+      "pass": "Dokumentet har ikke mer enn ett 'contentinfo'-landmark",
+      "fail": "Dokumentet har mer enn ett 'contentinfo'-landmark"
+    },
+    "page-no-duplicate-main": {
+      "pass": "Dokumentet har ikke mer enn ett 'main'-landmark",
+      "fail": "Dokumentet har mer enn ett 'main'-landmark"
+    },
+    "tabindex": {
+      "pass": "Elementet har ikke et 'tabindex' større end 0",
+      "fail": "Elementet har et 'tabindex' større end 0"
+    },
+    "alt-space-value": {
+      "pass": "Elementet har en alt-attributt med gyldig verdi",
+      "fail": "Elementet har en alt-attributt som kun inneholder et mellomrom, som ikke ignoreres av alle skjermlesere"
+    },
+    "duplicate-img-label": {
+      "pass": "Elementet duplikerer ikke den eksisterende tekst fra <img> elementets alt-tekst",
+      "fail": "Elementet inneholder et <img> element med alt-tekst, som duplikerer den eksisterende tekst"
+    },
+    "explicit-label": {
+      "pass": "Form-elementet har en eksplisitt <label>",
+      "fail": "Form-elementet har ikke en eksplisitt <label>"
+    },
+    "help-same-as-label": {
+      "pass": "Hjelpeteksten ('title' eller 'aria-describedby') duplikerer ikke label-teksten",
+      "fail": "Hjelpeteksten ('title' eller 'aria-describedby') er den samme som label-teksten"
+    },
+    "hidden-explicit-label": {
+      "pass": "Form-elementet har en synlig og eksplisitt <label>",
+      "fail": "Form-elementet har en eksplisitt <label>, som er skjult"
+    },
+    "implicit-label": {
+      "pass": "Form-elementet har en implisitt (inne i en) <label>",
+      "fail": "Form-elementet har ikke en implisitt (inne i en) <label>"
+    },
+    "label-content-name-mismatch": {
+      "pass": "Elementet inneholder synlig tekst som del av dets tilgjengelige navn",
+      "fail": "Tekst i elementet er ikke inkluderet i det tilgjengelige navn"
+    },
+    "multiple-label": {
+      "pass": "Form-feltet har ikke flere label-elementer",
+      "incomplete": "Flere label-elementer er ikke bredt understøttet i tilgjengelighetsteknologier. Sørg for at det første label-element inneholder all nødvendige informasjon."
+    },
+    "title-only": {
+      "pass": "Form-elementet bruker ikke utelukkende 'title'-attributten som label",
+      "fail": "Kun 'title'-attributten er brukt som label for form-elementet"
+    },
+    "landmark-is-unique": {
+      "pass": "Landmarks skal ha en unik rolle eller 'role'/'label'/'title'-attribut-kombinasjon (som tilgjengelig navn)",
+      "fail": "Et landmark skal ha en unik 'aria-label', 'aria-labelledby', eller 'title' for at gjøre landmarks adskillelige"
+    },
+    "has-lang": {
+      "pass": "<html> elementet har en 'lang'-attributt",
+      "fail": "<html> elementet har ikke en 'lang'-attributt"
+    },
+    "valid-lang": {
+      "pass": "'lang'-attributtens verdi er inkluderet i listen over godkjente språk",
+      "fail": "'lang'-attributtens verdi er ikke inkluderet i listen over godkjente språk"
+    },
+    "xml-lang-mismatch": {
+      "pass": "Attributterne 'lang' og 'xml:lang' har samme basisspråk",
+      "fail": "Attributterne 'lang' og 'xml:lang' har ikke samme basisspråk"
+    },
+    "dlitem": {
+      "pass": "Beskrivelsesliste-elementet har et <dl>-over-element",
+      "fail": "Beskrivelsesliste-elementet har ikke et <dl>-over-element"
+    },
+    "listitem": {
+      "pass": "Elementet i listen har et <ul>, <ol> eller 'role=\"list\"'-over-element",
+      "fail": "Elementet i listen har ikke et <ul>, <ol> eller 'role=\"list\"'-over-element"
+    },
+    "only-dlitems": {
+      "pass": "Elementet i listen har kun direkte under-elementer, som er tilladt i <dt> eller <dd> elementer",
+      "fail": "Elementet i listen har direkte under-elementer, som ikke er tilladt inde i <dt> eller <dd> elementer"
+    },
+    "only-listitems": {
+      "pass": "Elementet i listen har kun direkte under-elementer, som er tilladt i <li> elementer",
+      "fail": "Elementet i listen har direkte under-elementer, som ikke er tilladt inde i <li> elementer"
+    },
+    "structured-dlitems": {
+      "pass": "Det ikke-tomme elementet har både <dt> og <dd> elementer",
+      "fail": "Det ikke-tomme elementet mangler minst ett <dt> element etterfulgt av minst ett <dd> element"
+    },
+    "caption": {
+      "pass": "Multimedia-elementet har et track med undertekster",
+      "incomplete": "Sjekk at undertekster er tilgjengelige for elementet"
+    },
+    "frame-tested": {
+      "pass": "Denne <iframe> ble testet av axe-core",
+      "fail": "Denne <iframe> kunne ikke testes av axe-core",
+      "incomplete": "Denne <iframe> er enda ikke bke testet av axe-core"
+    },
+    "css-orientation-lock": {
+      "pass": "Skjermen kan styres, og sidens skjermretning er ikke låst med med 'css-orientation-lock'",
+      "fail": "Skjermretningen ('css-orientation-lock') er låst, hvilket gjør sidevisning vanskelig at styre på skjermen",
+      "incomplete": "Det kan ikke detekteres om skjermretning er låst (med 'css-orientation-lock')"
+    },
+    "meta-viewport-large": {
+      "pass": "<meta>-tagget begrenser ikke høy zoom på mobile enheter",
+      "fail": "<meta>-tagget begrenser zoom på mobile enheter"
+    },
+    "meta-viewport": {
+      "pass": "<meta>-tagget slår ikke zoom av på mobile enheter",
+      "fail": "${data} på <meta>-tagget slår zoom av på mobile enheter"
+    },
+    "header-present": {
+      "pass": "Siden har en overskrift (header)",
+      "fail": "Siden har ikke en overskrift (header)"
+    },
+    "heading-order": {
+      "pass": "Rekkefølgen av overskiftsnivåer er korrekt",
+      "fail": "Rekkefølgen av overskiftsnivåer er ikke korrekt"
+    },
+    "internal-link-present": {
+      "pass": "Passende 'skip link' funnet",
+      "fail": "Ingen passende 'skip link' funnet"
+    },
+    "landmark": {
+      "pass": "Siden har en 'landmark' region",
+      "fail": "Siden har ikke en 'landmark' region"
+    },
+    "meta-refresh": {
+      "pass": "<meta>-tagget oppdaterer ikke siden med det samme",
+      "fail": "<meta>-tagget oppdaterer siden med det samme"
+    },
+    "p-as-heading": {
+      "pass": "<p> elementer er ikke stylet som en overskrift",
+      "fail": "Overskrifts-elementer (<h1>, <h2>, osv.) bør brukes i stedet for stylet <p> elementer"
+    },
+    "region": {
+      "pass": "Alt innholdet på siden er lagt inn under landmarks",
+      "fail": "Deler av sidens innholdet er ikke lagt inn under et landmark"
+    },
+    "skip-link": {
+      "pass": "Elementet som 'skip link' refererer til, eksisterer",
+      "incomplete": "Element som 'skip link' refererer til, bør bli synlig ved aktivering",
+      "fail": "Manglende 'skip link' 'target'-attributt"
+    },
+    "unique-frame-title": {
+      "pass": "Elementets 'title'-attributt er unik",
+      "fail": "Elementets 'title'-attributt er ikke unik"
+    },
+    "duplicate-id-active": {
+      "pass": "Dokumentet har ingen aktive elementer som deler den samme 'id'-attributt",
+      "fail": "Dokumentet har aktive elementer som deler den samme 'id'-attributten: ${data}"
+    },
+    "duplicate-id-aria": {
+      "pass": "Dokumentet har ingen elementer referert med ARIA eller labels, som deler den samme 'id'-attributten",
+      "fail": "Dokumentet har flere elementer referert med ARIA med den samme 'id'-attributten: ${data}"
+    },
+    "duplicate-id": {
+      "pass": "Dokumentet har ingen statiske elementer som deler den samme 'id'-attributten",
+      "fail": "Dokumentet har flere statiske elementer med den samme 'id'-attributten"
+    },
+    "aria-label": {
+      "pass": "'aria-label'-attribut er til stede og er ikke tom",
+      "fail": "'aria-label'-attribut eksisterer ikke eller er tom"
+    },
+    "aria-labelledby": {
+      "pass": "'aria-labelledby'-attribut eksisterer og refererer elementer som er synlige for skjermlesere",
+      "fail": "'aria-labelledby'-attribut eksisterer ikke, eller refererer elementer, som ikke eksisterer - eller refererer til elementer, som er tomme"
+    },
+    "avoid-inline-spacing": {
+      "pass": "Ingen inline styling med '!important', som påvirker tekst-mellomrom-avstand er spesifisert",
+      "fail": {
+        "singular": "Fjern '!important' fra inline stylings ${data.values}, da overskrivning av dette ikke er understøttet i de fleste nettlesere",
+        "plural": "Fjern '!important' fra inline styling ${data.values}, da overskrivning av dette ikke er understøttet i de fleste nettlesere"
+      }
+    },
+    "button-has-visible-text": {
+      "pass": "Elementet har indre tekst, som er synlig for skjermlesere",
+      "fail": "Elementet har ingen indre tekst, som er synlig for skjermlesere"
+    },
+    "doc-has-title": {
+      "pass": "Dokumentet har et <title> element som ikke er tomt",
+      "fail": "Dokumentet mangler et <title> element med innhold"
+    },
+    "exists": {
+      "pass": "Elementet eksisterer ikke",
+      "fail": "Elementet eksisterer"
+    },
+    "has-alt": {
+      "pass": "Elementet har en 'alt'-attributt",
+      "fail": "Elementet har ikke en 'alt'-attributt"
+    },
+    "has-visible-text": {
+      "pass": "Elementet har tekst som er synlig for skjermlesere",
+      "fail": "Elementet har ikke tekst som er synlig for skjermlesere"
+    },
+    "is-on-screen": {
+      "pass": "Elementet er ikke synlig",
+      "fail": "Elementet er synlig"
+    },
+    "non-empty-alt": {
+      "pass": "Elementet har 'alt'-attributt med innhold",
+      "fail": "Elementet har ingen 'alt'-attributt, eller 'alt'-attributten er tom"
+    },
+    "non-empty-if-present": {
+      "pass": {
+        "default": "Elementet har ikke en 'value'-attributt",
+        "has-label": "Elementet har en 'verdi'-attributt med innhold"
+      },
+      "fail": "Elementet har en 'value'-attributt, og 'verdi'-attributten er tom"
+    },
+    "non-empty-title": {
+      "pass": "Elementet har en 'title'-attributt",
+      "fail": "Elementet har ingen 'title'-attributt, eller 'title'-attributten er tom"
+    },
+    "non-empty-value": {
+      "pass": "Elementet har 'value'-attributt med innholdet",
+      "fail": "Elementet har ingen 'value'-attributt, eller 'value'-attributten er tom"
+    },
+    "role-none": {
+      "pass": "Elementets standard semantikk ble overskrevet med attributten 'role=\"none\"'",
+      "fail": "Elementets standard semantikk ble ikke overskrevet med attributten 'role=\"none\"'"
+    },
+    "role-presentation": {
+      "pass": "Elementets standard semantikk ble overskrevet med attributten 'role=\"presentation\"'",
+      "fail": "Elementets standard semantikk ble ikke overskrevet med attributten 'role=\"presentation\"'"
+    },
+    "caption-faked": {
+      "pass": "Den første række i tabellen er ikke brukt som en beskrivelse ('caption')",
+      "fail": "Det første element i tabellen bør være en beskrivelse (<caption>) i stedet for en celle"
+    },
+    "html5-scope": {
+      "pass": "'Scope'-attributten bør kun brukes på tabellens header-elementer (<th>)",
+      "fail": "'Scope'-attributten bør kun brukes på tabellens header-elementer (<th>)"
+    },
+    "same-caption-summary": {
+      "pass": "innholdetet av 'summary'-attributten og <caption> elementet er ikke identisk",
+      "fail": "innholdetet av 'summary'-attributten og <caption> elementet er identisk"
+    },
+    "scope-value": {
+      "pass": "'scope'-attributten brukes korrekt",
+      "fail": "Verdien av 'scope'-attributten skal kun være 'row' eller 'col'"
+    },
+    "td-has-header": {
+      "pass": "Alle data-celler med innhold har en tabell-header",
+      "fail": "Noen data-celler med innhold har ikke tabell-headers"
+    },
+    "td-headers-attr": {
+      "pass": "Header-attributten brukes kun til å referere til andre celler i den samme tabel",
+      "fail": "Header-attributten brukes ikke kun til å referere til andre celler i den samme tabel"
+    },
+    "th-has-data-cells": {
+      "pass": "Alle tabellens header-celler refererer til data-celler",
+      "fail": "Ikke alle tabellens header-celler refererer til data-celler",
+      "incomplete": "Noen av tabellens data-celler mangler eller er tomme"
+    },
+    "hidden-content": {
+      "pass": "Alt innholdet på siden er blitt analyseret.",
+      "fail": "Der var problemer med å analysere deler av innholdet på denne side.",
+      "incomplete": "Der er skjult innhold på siden som ikke ble analyseret. Du må gjøre dette innholdet synlig for å kunne analysere det."
+    }
+  },
+  "failureSummaries": {
+    "any": {
+      "failureMessage": "Rett en av følgende: {{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+    },
+    "none": {
+      "failureMessage": "Rett alle de følgende: {{~it:value}}\n  {{=value.split('\\n').join('\\n  ')}}{{~}}"
+    }
+  },
+  "incompleteFallbackMessage": "axe kunne ikke gi en årsak. Tid for å finne frem utviklingsverktøyet ditt!"
+}

--- a/locales/no_NB.json
+++ b/locales/no_NB.json
@@ -95,11 +95,11 @@
     },
     "css-orientation-lock": {
       "description": "",
-      "help": "'CSS Media queries' bør ikke brukes til at låse skjermretningen ('orientation')"
+      "help": "'CSS Media queries' skal ikke brukes til å låse skjermretningen ('orientation')"
     },
     "definition-list": {
       "description": "",
-      "help": "<dl> elementer skal kun direkte inneholde velsorterede <dt> og <dd> grupper, <script> eller <template> elementer"
+      "help": "<dl> elementer skal kun direkte inneholde velsorterte <dt> og <dd> grupper, <script> eller <template> elementer"
     },
     "dlitem": {
       "description": "",
@@ -115,7 +115,7 @@
     },
     "duplicate-id-aria": {
       "description": "",
-      "help": "'id'-attributtet brukt på ARIA-elementer og -labels skal være unik"
+      "help": "'id'-attributtet brukt på ARIA-elementer og -labels skal være unikt"
     },
     "duplicate-id": {
       "description": "",
@@ -127,11 +127,11 @@
     },
     "focus-order-semantics": {
       "description": "",
-      "help": "Elementer i fokus-rekkefølgen bør ha en 'role'-attributt, som er passende for det interaktive innholdet"
+      "help": "Elementer i fokus-rekkefølgen skal ha en 'role'-attributt, som er passende for det interaktive innholdet"
     },
     "form-field-multiple-labels": {
       "description": "",
-      "help": "Form-feltet bør ikke ha flere label-elementer"
+      "help": "Form-feltet skal ikke ha flere label-elementer"
     },
     "frame-tested": {
       "description": "",
@@ -151,7 +151,7 @@
     },
     "hidden-content": {
       "description": "",
-      "help": "Skjult innholdet på siden kan ikke analyseres"
+      "help": "Skjult innhold på siden kan ikke analyseres"
     },
     "html-has-lang": {
       "description": "",
@@ -171,7 +171,7 @@
     },
     "image-redundant-alt": {
       "description": "",
-      "help": "Alternativ tekst til bilder (alt-tekst) bør ikke gjentas som brødtekst"
+      "help": "Alternativ tekst til bilder (alt-tekst) skal ikke gjentas som brødtekst"
     },
     "input-button-name": {
       "description": "",
@@ -251,7 +251,7 @@
     },
     "meta-viewport-large": {
       "description": "",
-      "help": "Brukere bør kunne zoome og skalere tekst op til 500%"
+      "help": "Brukere skal kunne zoome og skalere tekst opp til 500%"
     },
     "meta-viewport": {
       "description": "",
@@ -295,19 +295,19 @@
     },
     "tabindex": {
       "description": "",
-      "help": "Elementer bør ikke ha et 'tabindex' høyere enn 0"
+      "help": "Elementer skal ikke ha et 'tabindex' høyere enn 0"
     },
     "table-duplicate-name": {
       "description": "",
-      "help": "Elementet <caption> bør ikke inneholde samme tekst som 'summary'-attributtet"
+      "help": "Elementet <caption> skal ikke inneholde samme tekst som 'summary'-attributtet"
     },
     "table-fake-caption": {
       "description": "",
-      "help": "Data- eller overskrifts-celler bør ikke brukes til å beskrive innholdet av en data-tabell"
+      "help": "Data- eller overskrifts-celler skal ikke brukes til å beskrive innholdet av en data-tabell"
     },
     "td-has-header": {
       "description": "",
-      "help": "Alle ikke-tomme <td> elementer i en tabel større enn 3x3 bør ha en tabelloverskrift (<th>)"
+      "help": "Alle ikke-tomme <td> elementer i en tabel større enn 3x3 skal ha en tabelloverskrift (<th>)"
     },
     "td-headers-attr": {
       "description": "",
@@ -329,7 +329,7 @@
   "checks": {
     "abstractrole": {
       "pass": "Abstrakte roller er ikke brukt",
-      "fail": "Abstrakte roller bør ikke brukes"
+      "fail": "Abstrakte roller skal ikke brukes"
     },
     "aria-allowed-attr": {
       "pass": "ARIA-attributt er brukt korrekt for den angitte rolle",
@@ -351,7 +351,7 @@
     },
     "aria-hidden-body": {
       "pass": "Kunne ikke finne noen 'aria-hidden'-attributt i dokumentets <body> element",
-      "fail": "'aria-hidden=true' bør ikke brukes på dokumentets <body> element"
+      "fail": "'aria-hidden=true' skal ikke brukes på dokumentets <body> element"
     },
     "aria-roledescription": {
       "pass": "'aria-roledescription' brukes på en understøttet semantisk rolle",
@@ -361,8 +361,8 @@
     "aria-errormessage": {
       "pass": "Bruker en understøttet 'aria-errormessage'-metode",
       "fail": {
-        "singular": "'aria-errormessage'-verdi ${data.values}` bør bruke en metode for å annonsere beskeden (f.eks. 'aria-live', 'aria-describedby', 'role=alert', osv.)",
-        "plural": "'aria-errormessage'-verdier ${data.values}` bør bruke en metode for å annonsere beskeden (f.eks. 'aria-live', 'aria-describedby', 'role=alert', osv.)"
+        "singular": "'aria-errormessage'-verdi ${data.values}` skal bruke en metode for å annonsere beskeden (f.eks. 'aria-live', 'aria-describedby', 'role=alert', osv.)",
+        "plural": "'aria-errormessage'-verdier ${data.values}` skal bruke en metode for å annonsere beskeden (f.eks. 'aria-live', 'aria-describedby', 'role=alert', osv.)"
       }
     },
     "has-widget-role": {
@@ -374,7 +374,7 @@
       "fail": "Rollen skal være en av de mulige ARIA-roller"
     },
     "no-implicit-explicit-label": {
-      "pass": "Der er uoverensstemmelse mellom <label> og det tilgjengelige navn",
+      "pass": "Det er uoverensstemmelse mellom <label> og det tilgjengelige navnet",
       "incomplete": "Sjekk at <label> elementet ikke behøver å være en del av ${data}-feltets navn"
     },
     "aria-required-attr": {
@@ -471,7 +471,7 @@
     },
     "link-in-text-block": {
       "pass": "Lenker kan adskilles fra den omkringliggende tekst på annen måte enn med farge",
-      "fail": "Lenker bør skille seg ut fra den omkringliggende tekst på annen måte enn med farge",
+      "fail": "Lenker må skille seg ut fra den omkringliggende tekst på annen måte enn med farge",
       "incomplete": {
         "bgContrast": "Elementets kontrastforhold kunne ikke detekteres. Sjekk for spesifikk 'hover'/'focus' styling",
         "bgImage": "Elementets kontrastforhold kunne ikke detekteres på grunn av et bakgrunnsbilde",
@@ -495,15 +495,15 @@
     },
     "focusable-content": {
       "pass": "Elementet inneholder fokuserbare elementer",
-      "fail": "Elementet bør ha fokuserbart innholdet"
+      "fail": "Elementet skal ha fokuserbart innhold"
     },
     "focusable-disabled": {
       "pass": "Ingen fokuserbare elementer inne i elementet",
-      "fail": "Fokuserbart innholdet bør slås fra eller fjernes fra sidens DOM"
+      "fail": "Fokuserbart innhold skal slås av eller fjernes fra sidens DOM"
     },
     "focusable-element": {
       "pass": "Elementet er fokuserbart",
-      "fail": "Elementet bør være fokuserbart"
+      "fail": "Elementet skal være fokuserbart"
     },
     "focusable-no-name": {
       "pass": "Elementet er ikke i sidens tabulerings-rekkefølge ('tab order') eller har tilgjengelig tekst",
@@ -511,7 +511,7 @@
     },
     "focusable-not-tabbable": {
       "pass": "Ingen fokuserbare elementer inne i element",
-      "fail": "Fokuserbart innholdet bør ha tabindex='-1' eller fjernes fra sidens DOM"
+      "fail": "Fokuserbart innholdet skal ha tabindex='-1' eller fjernes fra sidens DOM"
     },
     "landmark-is-top-level": {
       "pass": "${data.role} landemerke er på det øverste nivå.",
@@ -657,7 +657,7 @@
     },
     "p-as-heading": {
       "pass": "<p> elementer er ikke stylet som en overskrift",
-      "fail": "Overskrifts-elementer (<h1>, <h2>, osv.) bør brukes i stedet for stylet <p> elementer"
+      "fail": "Overskrifts-elementer (<h1>, <h2>, osv.) skal brukes i stedet for stylet <p> elementer"
     },
     "region": {
       "pass": "Alt innholdet på siden er lagt inn under landemerker",
@@ -665,7 +665,7 @@
     },
     "skip-link": {
       "pass": "Elementet som 'skip link' refererer til, eksisterer",
-      "incomplete": "Element som 'skip link' refererer til, bør bli synlig ved aktivering",
+      "incomplete": "Element som 'skip link' refererer til, skal bli synlig ved aktivering",
       "fail": "Manglende 'skip link' 'target'-attributt"
     },
     "unique-frame-title": {
@@ -752,11 +752,11 @@
     },
     "caption-faked": {
       "pass": "Den første raden i tabellen er ikke brukt som en beskrivelse ('caption')",
-      "fail": "Det første elementet i tabellen bør være en beskrivelse (<caption>) i stedet for en celle"
+      "fail": "Det første elementet i tabellen skal være en beskrivelse (<caption>) i stedet for en celle"
     },
     "html5-scope": {
-      "pass": "'Scope'-attributtet bør kun brukes på tabellens header-elementer (<th>)",
-      "fail": "'Scope'-attributtet bør kun brukes på tabellens header-elementer (<th>)"
+      "pass": "'Scope'-attributtet skal kun brukes på tabellens header-elementer (<th>)",
+      "fail": "'Scope'-attributtet skal kun brukes på tabellens header-elementer (<th>)"
     },
     "same-caption-summary": {
       "pass": "innholdet av 'summary'-attributtet og <caption> elementet er ikke identisk",

--- a/locales/no_NB.json
+++ b/locales/no_NB.json
@@ -151,7 +151,7 @@
     },
     "hidden-content": {
       "description": "",
-      "help": "Skjult innhold på siden kan ikke analyseres"
+      "help": "Skjult innhold på siden kunne ikke analyseres"
     },
     "html-has-lang": {
       "description": "",

--- a/locales/no_NB.json
+++ b/locales/no_NB.json
@@ -538,8 +538,8 @@
       "fail": "Dokumentet har mer enn ett 'main'-landemerke"
     },
     "tabindex": {
-      "pass": "Elementet har ikke et 'tabindex' større enn 0",
-      "fail": "Elementet har et 'tabindex' større enn 0"
+      "pass": "Elementet har ikke en 'tabindex' som er større enn 0",
+      "fail": "Elementet har en 'tabindex' som er større enn 0"
     },
     "alt-space-value": {
       "pass": "Elementet har en alt-attributt med gyldig verdi",
@@ -578,8 +578,8 @@
       "fail": "Kun 'title'-attributtet er brukt som label for form-elementet"
     },
     "landmark-is-unique": {
-      "pass": "Landemerker skal ha en unik rolle eller 'role'/'label'/'title'-attribut-kombinasjon (som tilgjengelig navn)",
-      "fail": "Et landemerke skal ha en unik 'aria-label', 'aria-labelledby', eller 'title' for at gjøre landemerker atskillelige"
+      "pass": "Landemerker skal ha en unik rolle eller 'role'/'label'/'title'-attributtkombinasjon (som tilgjengelig navn)",
+      "fail": "Et landemerke skal ha en unik 'aria-label', 'aria-labelledby', eller 'title' for å gjøre landemerker atskillelige"
     },
     "has-lang": {
       "pass": "<html> elementet har en 'lang'-attributt",

--- a/locales/no_NB.json
+++ b/locales/no_NB.json
@@ -3,7 +3,7 @@
   "rules": {
     "accesskeys": {
       "description": "",
-      "help": "Verdien for attributten 'accesskey' skal være unik"
+      "help": "Verdien for attributtet 'accesskey' skal være unik"
     },
     "area-alt": {
       "description": "",
@@ -15,7 +15,7 @@
     },
     "aria-allowed-role": {
       "description": "",
-      "help": "ARIA-attributten 'role' skal være passende for elementet"
+      "help": "ARIA-attributtet 'role' skal være passende for elementet"
     },
     "aria-hidden-body": {
       "description": "",
@@ -31,7 +31,7 @@
     },
     "aria-required-attr": {
       "description": "",
-      "help": "Påkrevde ARIA-attributter skal være angivet"
+      "help": "Påkrevde ARIA-attributter skal være angitt"
     },
     "aria-required-children": {
       "description": "",
@@ -51,7 +51,7 @@
     },
     "aria-toggle-field-name": {
       "description": "",
-      "help": "ARIA avkrysningsfelter skal ha et tilgjengelig navn"
+      "help": "ARIA avkrysningsboks skal ha et tilgjengelig navn"
     },
     "aria-valid-attr-value": {
       "description": "",
@@ -67,7 +67,7 @@
     },
     "autocomplete-valid": {
       "description": "",
-      "help": "Attributten 'autocomplete' skal benyttes korrekt"
+      "help": "Attributtet 'autocomplete' skal benyttes korrekt"
     },
     "avoid-inline-spacing": {
       "description": "",
@@ -83,7 +83,7 @@
     },
     "bypass": {
       "description": "",
-      "help": "Sider skal ha en metode for å hoppe over repetativt innhold"
+      "help": "Sider skal ha en metode for å hoppe over innhold som gjentas på flere websider"
     },
     "color-contrast": {
       "description": "",
@@ -111,15 +111,15 @@
     },
     "duplicate-id-active": {
       "description": "",
-      "help": "'id'-attributten for aktive elementer skal være unik"
+      "help": "'id'-attributtet for aktive elementer skal være unik"
     },
     "duplicate-id-aria": {
       "description": "",
-      "help": "'id'-attributten brukt på ARIA-elementer og -labels skal være unik"
+      "help": "'id'-attributtet brukt på ARIA-elementer og -labels skal være unik"
     },
     "duplicate-id": {
       "description": "",
-      "help": "Verdien for 'id'-attributten skal være unik"
+      "help": "Verdien for 'id'-attributtet skal være unik"
     },
     "empty-heading": {
       "description": "",
@@ -147,7 +147,7 @@
     },
     "heading-order": {
       "description": "",
-      "help": "Overksriftsnivåer bør kun endres sekventielt"
+      "help": "Rekkefølgen på overskriftsnivåene skal være korrekt"
     },
     "hidden-content": {
       "description": "",
@@ -159,11 +159,11 @@
     },
     "html-lang-valid": {
       "description": "",
-      "help": "<html> elementet skal ha en korrekt verdi for 'lang'-attributten"
+      "help": "<html> elementet skal ha en korrekt verdi for 'lang'-attributtet"
     },
     "html-xml-lang-mismatch": {
       "description": "",
-      "help": "<html> elementer med 'lang' og 'xml:lang' skal ha det samme basespråk"
+      "help": "<html> elementer med 'lang' og 'xml:lang' skal ha samme språk / dialekt"
     },
     "image-alt": {
       "description": "",
@@ -187,43 +187,43 @@
     },
     "label-title-only": {
       "description": "",
-      "help": "Form-elementer bør ha en synlig label"
+      "help": "Skjemaalement skal ha en synlig ledetekst"
     },
     "label": {
       "description": "",
-      "help": "Form-elementer skal ha labels"
+      "help": "Alle skjemaelement skal ha en tilknyttet ledetekst eller instruksjon"
     },
     "landmark-banner-is-top-level": {
       "description": "",
-      "help": "Et 'banner'-landmark skal ikke være inne i et annet landmark"
+      "help": "Et 'banner'-landemerke skal ikke være inne i et annet landemerke"
     },
     "landmark-complementary-is-top-level": {
       "description": "",
-      "help": "Et 'aside'- eller 'complimentary'-landmark skal ikke være inne i et annet landmark"
+      "help": "Et 'aside'- eller 'complimentary'-landemerke skal ikke være inne i et annet landemerke"
     },
     "landmark-contentinfo-is-top-level": {
       "description": "",
-      "help": "Et 'contentinfo'-landmark skal ikke være inne i et annet landmark"
+      "help": "Et 'contentinfo'-landemerke skal ikke være inne i et annet landemerke"
     },
     "landmark-main-is-top-level": {
       "description": "",
-      "help": "Et 'main'-landmark skal ikke være inne i et annet landmark"
+      "help": "Et 'main'-landemerke skal ikke være inne i et annet landemerke"
     },
     "landmark-no-duplicate-banner": {
       "description": "",
-      "help": "Dokumentet skal ikke ha mer enn ett 'banner'-landmark"
+      "help": "Dokumentet skal ikke ha mer enn ett 'banner'-landemerke"
     },
     "landmark-no-duplicate-contentinfo": {
       "description": "",
-      "help": "Dokumentet skal ikke ha mer enn ett 'contentinfo'-landmark"
+      "help": "Dokumentet skal ikke ha mer enn ett 'contentinfo'-landemerke"
     },
     "landmark-one-main": {
       "description": "",
-      "help": "Dokumentet skal ha ett 'main'-landmark"
+      "help": "Dokumentet skal ha ett 'main'-landemerke"
     },
     "landmark-unique": {
       "description": "",
-      "help": "Sikre at landmarks er unike"
+      "help": "Sikre at landemerker er unike"
     },
     "link-in-text-block": {
       "description": "",
@@ -263,7 +263,7 @@
     },
     "p-as-heading": {
       "description": "",
-      "help": "Fremhevelse med fet, kursiv og skriftstørrelse (font-size) skal ikke brukes til at style <p> elementer som en overskrift"
+      "help": "Fremhevelse med fet, kursiv og skriftstørrelse (font-size) skal ikke brukes til å 'style' <p> elementer som en overskrift"
     },
     "page-has-heading-one": {
       "description": "",
@@ -271,7 +271,7 @@
     },
     "region": {
       "description": "",
-      "help": "Alt innholdet på siden skal være inne i landmarks"
+      "help": "Alt innholdet på siden skal være inne i landemerker"
     },
     "role-img-alt": {
       "description": "",
@@ -279,7 +279,7 @@
     },
     "scope-attr-valid": {
       "description": "",
-      "help": "'scope'-attributten skal brukes korrekt i tabeller"
+      "help": "'scope'-attributtet skal brukes korrekt i tabeller"
     },
     "scrollable-region-focusable": {
       "description": "",
@@ -295,23 +295,23 @@
     },
     "tabindex": {
       "description": "",
-      "help": "Elementer bør ikke ha et 'tabindex' høyere end 0"
+      "help": "Elementer bør ikke ha et 'tabindex' høyere enn 0"
     },
     "table-duplicate-name": {
       "description": "",
-      "help": "Elementet <caption> bør ikke inneholde samme tekst som 'summary'-attributten"
+      "help": "Elementet <caption> bør ikke inneholde samme tekst som 'summary'-attributtet"
     },
     "table-fake-caption": {
       "description": "",
-      "help": "Data- eller overskrifts-celler bør ikke brukes til at beskrive innholdetet av en data-tabell"
+      "help": "Data- eller overskrifts-celler bør ikke brukes til å beskrive innholdet av en data-tabell"
     },
     "td-has-header": {
       "description": "",
-      "help": "Alle ikke-tomme <td> elementer i en tabel større end 3x3 bør ha en tabelloverskrift (<th>)"
+      "help": "Alle ikke-tomme <td> elementer i en tabel større enn 3x3 bør ha en tabelloverskrift (<th>)"
     },
     "td-headers-attr": {
       "description": "",
-      "help": "Alle celler i en tabel, som  bruker 'header'-attributten skal kun referere til andre celler i samme tabel"
+      "help": "Alle celler i en tabel, som  bruker 'header'-attributtet skal kun referere til andre celler i samme tabel"
     },
     "th-has-data-cells": {
       "description": "",
@@ -319,7 +319,7 @@
     },
     "valid-lang": {
       "description": "",
-      "help": "'lang'-attributten skal ha en korrekt verdi"
+      "help": "'lang'-attributtet skal ha en korrekt verdi"
     },
     "video-caption": {
       "description": "",
@@ -332,21 +332,21 @@
       "fail": "Abstrakte roller bør ikke brukes"
     },
     "aria-allowed-attr": {
-      "pass": "ARIA-attribut er brukt korrekt for den angitte rolle",
+      "pass": "ARIA-attributt er brukt korrekt for den angitte rolle",
       "fail": {
-        "singular": "ARIA-attributterne er ikke tillatt: ${data.values}",
-        "plural": "ARIA-attribut er ikke tillatt: ${data.values}"
+        "singular": "ARIA-attributtet er ikke tillatt: ${data.values}",
+        "plural": "ARIA-attributtene er ikke tillatt: ${data.values}"
       }
     },
     "aria-allowed-role": {
       "pass": "ARIA-rollen er tillatt for det gitte element",
       "fail": {
-        "singular": "ARIA-rollerne ${data.values} er ikke tillatt for det gitte element",
-        "plural": "ARIA-rollen ${data.values} er ikke tillatt for det gitte element"
+        "singular": "ARIA-rollen ${data.values} er ikke tillatt for det gitte element",
+        "plural": "ARIA-rollene ${data.values} er ikke tillatt for det gitte element"
       },
       "incomplete": {
-        "singular": "ARIA-rollerne ${data.values} skal være fjernet når elementet er synlig, da de ikke er tillatt for elementet",
-        "plural": "ARIA-rollen ${data.values} skal være fjernet når elementet er synlig, da det ikke er tillatt for elementet"
+        "singular": "ARIA-rollen ${data.values} skal være fjernet når elementet er synlig, da de ikke er tillatt for elementet",
+        "plural": "ARIA-rollene ${data.values} skal være fjernet når elementet er synlig, da det ikke er tillatt for elementet"
       }
     },
     "aria-hidden-body": {
@@ -361,8 +361,8 @@
     "aria-errormessage": {
       "pass": "Bruker en understøttet 'aria-errormessage'-metode",
       "fail": {
-        "singular": "'aria-errormessage'-verdier ${data.values}` bør bruke en metode for å annonsere beskeden (fx 'aria-live', 'aria-describedby', 'role=alert', osv.)",
-        "plural": "'aria-errormessage'-verdi ${data.values}` bør bruke en metode for å annonsere beskeden (fx 'aria-live', 'aria-describedby', 'role=alert', osv.)"
+        "singular": "'aria-errormessage'-verdi ${data.values}` bør bruke en metode for å annonsere beskeden (f.eks. 'aria-live', 'aria-describedby', 'role=alert', osv.)",
+        "plural": "'aria-errormessage'-verdier ${data.values}` bør bruke en metode for å annonsere beskeden (f.eks. 'aria-live', 'aria-describedby', 'role=alert', osv.)"
       }
     },
     "has-widget-role": {
@@ -374,61 +374,61 @@
       "fail": "Rollen skal være en av de mulige ARIA-roller"
     },
     "no-implicit-explicit-label": {
-      "pass": "Der er uoverensstemmelse mellem <label> og det tilgjengelige navn",
+      "pass": "Der er uoverensstemmelse mellom <label> og det tilgjengelige navn",
       "incomplete": "Sjekk at <label> elementet ikke behøver å være en del av ${data}-feltets navn"
     },
     "aria-required-attr": {
       "pass": "Alle påkrevde ARIA-attributter er tilstede",
       "fail": {
-        "singular": "Påkrevde ARIA-attributter er ikke til stede: ${data.values}",
-        "plural": "Påkrevde ARIA-attribut er ikke til stede: ${data.values}"
+        "singular": "Påkrevd ARIA-attributt er ikke til stede: ${data.values}",
+        "plural": "Påkrevde ARIA-attributter er ikke til stede: ${data.values}"
       }
     },
     "aria-required-children": {
       "pass": "Påkrevde ARIA-under-elementer er til stede",
       "fail": {
-        "singular": "Påkrevde ARIA-under-elementers rolle er ikke til stede: ${data.values}",
-        "plural": "Påkrevde ARIA-under-elements rolle er ikke til stede: ${data.values}"
+        "singular": "Påkrevd ARIA-under-element sin rolle er ikke til stede: ${data.values}",
+        "plural": "Påkrevde ARIA-under-elementer sine roller er ikke til stede: ${data.values}"
       },
       "incomplete": {
-        "singular": "Forventer at ARIA under-elementers rolle blir lagt til: ${data.values}",
-        "plural": "Forventer at ARIA under-elements rolle blir lagt til: ${data.values}"
+        "singular": "Forventer at ARIA under-element sin rolle blir lagt til: ${data.values}",
+        "plural": "Forventer at ARIA under-elementer sine roller blir lagt til: ${data.values}"
       }
     },
     "aria-required-parent": {
       "pass": "Påkrevde ARIA-over-elements rolle er til stede",
       "fail": {
-        "singular": "Påkrevde ARIA-over-elementers rolle er ikke til stede: ${data.values}",
-        "plural": "Påkrevde ARIA-over-elements rolle er ikke til stede: ${data.values}"
+        "singular": "Påkrevd ARIA-over-element sin rolle er ikke til stede: ${data.values}",
+        "plural": "Påkrevde ARIA-over-elementer sine roller er ikke til stede: ${data.values}"
       }
     },
     "aria-unsupported-attr": {
-      "pass": "ARIA-attribut er understøttet",
-      "fail": "ARIA-attribut er ikke bredt understøttet i skjermlesere og tilgjengelighetsteknologier:  ${data.values}"
+      "pass": "ARIA-attributt er understøttet",
+      "fail": "ARIA-attributt er ikke bredt understøttet i skjermlesere og tilgjengelighetsteknologier:  ${data.values}"
     },
     "unsupportedrole": {
       "pass": "ARIA rollen er understøttet",
       "fail": "Den brukte rolle er ikke bredt understøttet i skjermlesere og tilgjengelighetsteknologier:  ${data.values}"
     },
     "aria-valid-attr-value": {
-      "pass": "ARIA-attributverdien er valid",
+      "pass": "ARIA-attributverdien er gyldig",
       "fail": {
-        "singular": "Ikke-korrekt ARIA-attributverdier: ${data.values}",
-        "plural": "Ikke-korrekt ARIA-attributverdi: ${data.values}"
+        "singular": "Ugyldig ARIA-attributtverdi: ${data.values}",
+        "plural": "Ugyldige ARIA-attributtverdier: ${data.values}"
       },
       "incomplete": {
-        "singular": "Kunne ikke finne ARIA-attributternes element 'id' på siden: ${data.values}",
-        "plural": "Kunne ikke finne ARIA-attributtens element 'id' på siden: ${data.values}"
+        "singular": "Kunne ikke finne ARIA-attributtet sitt element 'id' på siden: ${data.values}",
+        "plural": "Kunne ikke finne ARIA-attributtene sine element 'id' på siden: ${data.values}"
       }
     },
     "aria-valid-attr": {
       "pass": {
-        "singular": "ARIA-attributnavnene er korrekt",
-        "plural": "ARIA-attributnavnet er korrekt"
+        "singular": "ARIA-attributnavnet er korrekt",
+        "plural": "ARIA-attributnavnene er korrekt"
       },
       "fail": {
-        "singular": "Ikke-korrekt ARIA-attributnavne: ${data.values}",
-        "plural": "Ikke-korrekt ARIA-attributnavn: ${data.values}"
+        "singular": "Ugyldig ARIA-attributtnavn: ${data.values}",
+        "plural": "Ugyldige ARIA-attributtnavn: ${data.values}"
       }
     },
     "valid-scrollable-semantics": {
@@ -441,14 +441,14 @@
       "incomplete": {
         "bgImage": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av et bakgrunnsbildet",
         "bgGradient": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av en bakgrunnsgradient",
-        "imgNode": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi elementet inneholder et Bildeelement",
+        "imgNode": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi elementet inneholder et bildeelement",
         "bgOverlap": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er overlappet av et annet element",
         "fgAlpha": "Elementets forgrunnsfarge kunne ikke detekteres på grunn av dets gjennomsiktighet",
         "elmPartiallyObscured": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er delvist dekket av et annet element",
         "elmPartiallyObscuring": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det delvist dekker et annet element",
         "outsideViewport": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er utenfor sidens 'viewport'",
         "equalRatio": "Elementet har et 1:1-kontrastforhold med bakgrunnen",
-        "shortTextContent": "Elementets innholde er for kort til at kunne avgjøre om inneholdet faktisk ER tekst",
+        "shortTextContent": "Elementets innhold er for kort til å kunne avgjøre om innholdet faktisk er tekst",
         "default": "Kan ikke regne ut kontrastforhold"
       }
     },
@@ -458,20 +458,20 @@
       "incomplete": {
         "bgImage": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av et bakgrunnsbilde",
         "bgGradient": "Elementets bakgrunnsfarge kunne ikke detekteres på grunn av en bakgrunnsgradient",
-        "imgNode": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi elementet inneholder et Bildeelement",
+        "imgNode": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi elementet inneholder et bildeelement",
         "bgOverlap": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er overlappet av et annet element",
         "fgAlpha": "Elementets forgrunnsfarge kunne ikke detekteres på grunn av dets gjennomsiktighet",
         "elmPartiallyObscured": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er delvist dekket av et annet element",
         "elmPartiallyObscuring": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det delvist dekker et annet element",
         "outsideViewport": "Elementets bakgrunnsfarge kunne ikke detekteres, fordi det er utenfor sidens 'viewport'",
         "equalRatio": "Elementet har et 1:1-kontrastforhold med bakgrunnen",
-        "shortTextContent": "Elementets innholdet er for kort til at kunne avgjøre om inneholdet faktisk ER tekst",
+        "shortTextContent": "Elementets innhold er for kort til å kunne avgjøre om innholdet faktisk er tekst",
         "default": "Kan ikke regne ut kontrastforhold"
       }
     },
     "link-in-text-block": {
       "pass": "Lenker kan adskilles fra den omkringliggende tekst på annen måte enn med farge",
-      "fail": "Lenker bør skille sig ud fra den omkringliggende tekst på annen måte enn med farge",
+      "fail": "Lenker bør skille seg ut fra den omkringliggende tekst på annen måte enn med farge",
       "incomplete": {
         "bgContrast": "Elementets kontrastforhold kunne ikke detekteres. Sjekk for spesifikk 'hover'/'focus' styling",
         "bgImage": "Elementets kontrastforhold kunne ikke detekteres på grunn av et bakgrunnsbilde",
@@ -486,12 +486,12 @@
       "fail": "'autocomplete'-verdien er ikke passende for denne type input"
     },
     "autocomplete-valid": {
-      "pass": "'autocomplete'-attributten er korrekt formateret",
-      "fail": "'autocomplete'-attributten er forkert formateret"
+      "pass": "'autocomplete'-attributtet er korrekt formatert",
+      "fail": "'autocomplete'-attributtet er ikke formatert korrekt"
     },
     "accesskeys": {
       "pass": "'Accesskey' attributtverdien er unik",
-      "fail": "Dokumentet har flere elementer med den samme 'accesskey'-attributt"
+      "fail": "Dokumentet har flere elementer med den samme 'accesskey'-attributtet"
     },
     "focusable-content": {
       "pass": "Elementet inneholder fokuserbare elementer",
@@ -514,47 +514,47 @@
       "fail": "Fokuserbart innholdet bør ha tabindex='-1' eller fjernes fra sidens DOM"
     },
     "landmark-is-top-level": {
-      "pass": "${data.role} landmark er på det øverste nivå.",
-      "fail": "${data.role} landmark er innholdet i et annet landmark."
+      "pass": "${data.role} landemerke er på det øverste nivå.",
+      "fail": "${data.role} landemerke er innholdet i et annet landemerke."
     },
     "page-has-heading-one": {
       "pass": "Siden har minst én overskrift på nivå 1",
       "fail": "Siden skal ha minst én overskrift på nivå 1"
     },
     "page-has-main": {
-      "pass": "Dokumentet har minst ét 'main'-landmark",
-      "fail": "Dokumentet har ikke et 'main'-landmark"
+      "pass": "Dokumentet har minst ét 'main'-landemerke",
+      "fail": "Dokumentet har ikke et 'main'-landemerke"
     },
     "page-no-duplicate-banner": {
-      "pass": "Dokumentet har ikke mer enn ett 'banner'-landmark",
-      "fail": "Dokumentet har mer enn ett 'banner-'landmark"
+      "pass": "Dokumentet har ikke mer enn ett 'banner'-landemerke",
+      "fail": "Dokumentet har mer enn ett 'banner-'landemerke"
     },
     "page-no-duplicate-contentinfo": {
-      "pass": "Dokumentet har ikke mer enn ett 'contentinfo'-landmark",
-      "fail": "Dokumentet har mer enn ett 'contentinfo'-landmark"
+      "pass": "Dokumentet har ikke mer enn ett 'contentinfo'-landemerke",
+      "fail": "Dokumentet har mer enn ett 'contentinfo'-landemerke"
     },
     "page-no-duplicate-main": {
-      "pass": "Dokumentet har ikke mer enn ett 'main'-landmark",
-      "fail": "Dokumentet har mer enn ett 'main'-landmark"
+      "pass": "Dokumentet har ikke mer enn ett 'main'-landemerke",
+      "fail": "Dokumentet har mer enn ett 'main'-landemerke"
     },
     "tabindex": {
-      "pass": "Elementet har ikke et 'tabindex' større end 0",
-      "fail": "Elementet har et 'tabindex' større end 0"
+      "pass": "Elementet har ikke et 'tabindex' større enn 0",
+      "fail": "Elementet har et 'tabindex' større enn 0"
     },
     "alt-space-value": {
       "pass": "Elementet har en alt-attributt med gyldig verdi",
       "fail": "Elementet har en alt-attributt som kun inneholder et mellomrom, som ikke ignoreres av alle skjermlesere"
     },
     "duplicate-img-label": {
-      "pass": "Elementet duplikerer ikke den eksisterende tekst fra <img> elementets alt-tekst",
-      "fail": "Elementet inneholder et <img> element med alt-tekst, som duplikerer den eksisterende tekst"
+      "pass": "Elementet duplisere ikke den eksisterende tekst fra <img> elementets alt-tekst",
+      "fail": "Elementet inneholder et <img> element med alt-tekst, som duplisere den eksisterende tekst"
     },
     "explicit-label": {
       "pass": "Form-elementet har en eksplisitt <label>",
       "fail": "Form-elementet har ikke en eksplisitt <label>"
     },
     "help-same-as-label": {
-      "pass": "Hjelpeteksten ('title' eller 'aria-describedby') duplikerer ikke label-teksten",
+      "pass": "Hjelpeteksten ('title' eller 'aria-describedby') duplisere ikke label-teksten",
       "fail": "Hjelpeteksten ('title' eller 'aria-describedby') er den samme som label-teksten"
     },
     "hidden-explicit-label": {
@@ -574,24 +574,24 @@
       "incomplete": "Flere label-elementer er ikke bredt understøttet i tilgjengelighetsteknologier. Sørg for at det første label-element inneholder all nødvendige informasjon."
     },
     "title-only": {
-      "pass": "Form-elementet bruker ikke utelukkende 'title'-attributten som label",
-      "fail": "Kun 'title'-attributten er brukt som label for form-elementet"
+      "pass": "Form-elementet bruker ikke utelukkende 'title'-attributtet som label",
+      "fail": "Kun 'title'-attributtet er brukt som label for form-elementet"
     },
     "landmark-is-unique": {
-      "pass": "Landmarks skal ha en unik rolle eller 'role'/'label'/'title'-attribut-kombinasjon (som tilgjengelig navn)",
-      "fail": "Et landmark skal ha en unik 'aria-label', 'aria-labelledby', eller 'title' for at gjøre landmarks adskillelige"
+      "pass": "Landemerker skal ha en unik rolle eller 'role'/'label'/'title'-attribut-kombinasjon (som tilgjengelig navn)",
+      "fail": "Et landemerke skal ha en unik 'aria-label', 'aria-labelledby', eller 'title' for at gjøre landemerker atskillelige"
     },
     "has-lang": {
       "pass": "<html> elementet har en 'lang'-attributt",
       "fail": "<html> elementet har ikke en 'lang'-attributt"
     },
     "valid-lang": {
-      "pass": "'lang'-attributtens verdi er inkluderet i listen over godkjente språk",
-      "fail": "'lang'-attributtens verdi er ikke inkluderet i listen over godkjente språk"
+      "pass": "'lang'-attributtet sin verdi er inkluderet i listen over godkjente språk",
+      "fail": "'lang'-attributtet sin verdi er ikke inkluderet i listen over godkjente språk"
     },
     "xml-lang-mismatch": {
-      "pass": "Attributterne 'lang' og 'xml:lang' har samme basisspråk",
-      "fail": "Attributterne 'lang' og 'xml:lang' har ikke samme basisspråk"
+      "pass": "Attributtene 'lang' og 'xml:lang' har samme språk / dialekt",
+      "fail": "Attributtene 'lang' og 'xml:lang' har ikke samme språk / dialekt"
     },
     "dlitem": {
       "pass": "Beskrivelsesliste-elementet har et <dl>-over-element",
@@ -602,12 +602,12 @@
       "fail": "Elementet i listen har ikke et <ul>, <ol> eller 'role=\"list\"'-over-element"
     },
     "only-dlitems": {
-      "pass": "Elementet i listen har kun direkte under-elementer, som er tilladt i <dt> eller <dd> elementer",
-      "fail": "Elementet i listen har direkte under-elementer, som ikke er tilladt inde i <dt> eller <dd> elementer"
+      "pass": "Elementet i listen har kun direkte under-elementer, som er tillatt i <dt> eller <dd> elementer",
+      "fail": "Elementet i listen har direkte under-elementer, som ikke er tillatt inde i <dt> eller <dd> elementer"
     },
     "only-listitems": {
-      "pass": "Elementet i listen har kun direkte under-elementer, som er tilladt i <li> elementer",
-      "fail": "Elementet i listen har direkte under-elementer, som ikke er tilladt inde i <li> elementer"
+      "pass": "Elementet i listen har kun direkte under-elementer, som er tillatt i <li> elementer",
+      "fail": "Elementet i listen har direkte under-elementer, som ikke er tillatt inne i <li> elementer"
     },
     "structured-dlitems": {
       "pass": "Det ikke-tomme elementet har både <dt> og <dd> elementer",
@@ -620,11 +620,11 @@
     "frame-tested": {
       "pass": "Denne <iframe> ble testet av axe-core",
       "fail": "Denne <iframe> kunne ikke testes av axe-core",
-      "incomplete": "Denne <iframe> er enda ikke bke testet av axe-core"
+      "incomplete": "Denne <iframe> er enda ikke testet av axe-core"
     },
     "css-orientation-lock": {
       "pass": "Skjermen kan styres, og sidens skjermretning er ikke låst med med 'css-orientation-lock'",
-      "fail": "Skjermretningen ('css-orientation-lock') er låst, hvilket gjør sidevisning vanskelig at styre på skjermen",
+      "fail": "Skjermretningen ('css-orientation-lock') er låst, hvilket gjør sidevisning vanskelig å styre på skjermen",
       "incomplete": "Det kan ikke detekteres om skjermretning er låst (med 'css-orientation-lock')"
     },
     "meta-viewport-large": {
@@ -648,8 +648,8 @@
       "fail": "Ingen passende 'skip link' funnet"
     },
     "landmark": {
-      "pass": "Siden har en 'landmark' region",
-      "fail": "Siden har ikke en 'landmark' region"
+      "pass": "Siden har en 'landemerke' region",
+      "fail": "Siden har ikke en 'landemerke' region"
     },
     "meta-refresh": {
       "pass": "<meta>-tagget oppdaterer ikke siden med det samme",
@@ -660,8 +660,8 @@
       "fail": "Overskrifts-elementer (<h1>, <h2>, osv.) bør brukes i stedet for stylet <p> elementer"
     },
     "region": {
-      "pass": "Alt innholdet på siden er lagt inn under landmarks",
-      "fail": "Deler av sidens innholdet er ikke lagt inn under et landmark"
+      "pass": "Alt innholdet på siden er lagt inn under landemerker",
+      "fail": "Deler av sidens innholdet er ikke lagt inn under et landemerke"
     },
     "skip-link": {
       "pass": "Elementet som 'skip link' refererer til, eksisterer",
@@ -681,16 +681,16 @@
       "fail": "Dokumentet har flere elementer referert med ARIA med den samme 'id'-attributten: ${data}"
     },
     "duplicate-id": {
-      "pass": "Dokumentet har ingen statiske elementer som deler den samme 'id'-attributten",
-      "fail": "Dokumentet har flere statiske elementer med den samme 'id'-attributten"
+      "pass": "Dokumentet har ingen statiske elementer som deler den samme 'id'-attributtet",
+      "fail": "Dokumentet har flere statiske elementer med den samme 'id'-attributtet"
     },
     "aria-label": {
-      "pass": "'aria-label'-attribut er til stede og er ikke tom",
-      "fail": "'aria-label'-attribut eksisterer ikke eller er tom"
+      "pass": "'aria-label'-attributt er til stede og er ikke tomt",
+      "fail": "'aria-label'-attributt eksisterer ikke eller er tomt"
     },
     "aria-labelledby": {
-      "pass": "'aria-labelledby'-attribut eksisterer og refererer elementer som er synlige for skjermlesere",
-      "fail": "'aria-labelledby'-attribut eksisterer ikke, eller refererer elementer, som ikke eksisterer - eller refererer til elementer, som er tomme"
+      "pass": "'aria-labelledby'-attributt eksisterer og refererer elementer som er synlige for skjermlesere",
+      "fail": "'aria-labelledby'-attributt eksisterer ikke, eller refererer elementer, som ikke eksisterer - eller refererer til elementer, som er tomme"
     },
     "avoid-inline-spacing": {
       "pass": "Ingen inline styling med '!important', som påvirker tekst-mellomrom-avstand er spesifisert",
@@ -725,54 +725,54 @@
     },
     "non-empty-alt": {
       "pass": "Elementet har 'alt'-attributt med innhold",
-      "fail": "Elementet har ingen 'alt'-attributt, eller 'alt'-attributten er tom"
+      "fail": "Elementet har ingen 'alt'-attributt, eller 'alt'-attributtet er tomt"
     },
     "non-empty-if-present": {
       "pass": {
         "default": "Elementet har ikke en 'value'-attributt",
         "has-label": "Elementet har en 'verdi'-attributt med innhold"
       },
-      "fail": "Elementet har en 'value'-attributt, og 'verdi'-attributten er tom"
+      "fail": "Elementet har en 'value'-attributt, og 'verdi'-attributtet er tomt"
     },
     "non-empty-title": {
       "pass": "Elementet har en 'title'-attributt",
-      "fail": "Elementet har ingen 'title'-attributt, eller 'title'-attributten er tom"
+      "fail": "Elementet har ingen 'title'-attributt, eller 'title'-attributtet er tomt"
     },
     "non-empty-value": {
       "pass": "Elementet har 'value'-attributt med innholdet",
-      "fail": "Elementet har ingen 'value'-attributt, eller 'value'-attributten er tom"
+      "fail": "Elementet har ingen 'value'-attributt, eller 'value'-attributtet er tomt"
     },
     "role-none": {
-      "pass": "Elementets standard semantikk ble overskrevet med attributten 'role=\"none\"'",
-      "fail": "Elementets standard semantikk ble ikke overskrevet med attributten 'role=\"none\"'"
+      "pass": "Elementets standard semantikk ble overskrevet med attributtet 'role=\"none\"'",
+      "fail": "Elementets standard semantikk ble ikke overskrevet med attributtet 'role=\"none\"'"
     },
     "role-presentation": {
-      "pass": "Elementets standard semantikk ble overskrevet med attributten 'role=\"presentation\"'",
-      "fail": "Elementets standard semantikk ble ikke overskrevet med attributten 'role=\"presentation\"'"
+      "pass": "Elementets standard semantikk ble overskrevet med attributtet 'role=\"presentation\"'",
+      "fail": "Elementets standard semantikk ble ikke overskrevet med attributtet 'role=\"presentation\"'"
     },
     "caption-faked": {
-      "pass": "Den første række i tabellen er ikke brukt som en beskrivelse ('caption')",
-      "fail": "Det første element i tabellen bør være en beskrivelse (<caption>) i stedet for en celle"
+      "pass": "Den første raden i tabellen er ikke brukt som en beskrivelse ('caption')",
+      "fail": "Det første elementet i tabellen bør være en beskrivelse (<caption>) i stedet for en celle"
     },
     "html5-scope": {
-      "pass": "'Scope'-attributten bør kun brukes på tabellens header-elementer (<th>)",
-      "fail": "'Scope'-attributten bør kun brukes på tabellens header-elementer (<th>)"
+      "pass": "'Scope'-attributtet bør kun brukes på tabellens header-elementer (<th>)",
+      "fail": "'Scope'-attributtet bør kun brukes på tabellens header-elementer (<th>)"
     },
     "same-caption-summary": {
-      "pass": "innholdetet av 'summary'-attributten og <caption> elementet er ikke identisk",
-      "fail": "innholdetet av 'summary'-attributten og <caption> elementet er identisk"
+      "pass": "innholdet av 'summary'-attributtet og <caption> elementet er ikke identisk",
+      "fail": "innholdet av 'summary'-attributtet og <caption> elementet er identisk"
     },
     "scope-value": {
-      "pass": "'scope'-attributten brukes korrekt",
-      "fail": "Verdien av 'scope'-attributten skal kun være 'row' eller 'col'"
+      "pass": "'scope'-attributtet brukes korrekt",
+      "fail": "Verdien av 'scope'-attributtet skal kun være 'row' eller 'col'"
     },
     "td-has-header": {
       "pass": "Alle data-celler med innhold har en tabell-header",
       "fail": "Noen data-celler med innhold har ikke tabell-headers"
     },
     "td-headers-attr": {
-      "pass": "Header-attributten brukes kun til å referere til andre celler i den samme tabel",
-      "fail": "Header-attributten brukes ikke kun til å referere til andre celler i den samme tabel"
+      "pass": "Header-attributtet brukes kun til å referere til andre celler i den samme tabel",
+      "fail": "Header-attributtet brukes ikke kun til å referere til andre celler i den samme tabel"
     },
     "th-has-data-cells": {
       "pass": "Alle tabellens header-celler refererer til data-celler",


### PR DESCRIPTION
I copied the danish locale (de.json) and translated to Norwegian (the languages are very similar). 

The added locale is the for the main dialect in Norway. The other one, Nynorsk, is often used on websites with high focus on accessibility, so it's a good idea to keep the file naming as proposed rather than just no.json. 