### PR TITLE
fix(roledescription): add gridcell as supported role

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -191,7 +191,8 @@ All checks allow these global options:
   'radio',
   'combobox',
   'menuitemcheckbox',
-  'menuitemradio'
+  'menuitemradio',
+  'gridcell'
 ]</code></pre>
         </td>
       <td align="left">List of ARIA roles that support the <code>aria-roledescription</code> attribute</td>
@@ -265,13 +266,13 @@ All checks allow these global options:
         <code>selector</code>
       </td>
       <td align="left">
-        <pre lang=css><code>h1:not([role]):not([aria-level]), 
-h1:not([role])[aria-level=1], 
-h2:not([role])[aria-level=1], 
-h3:not([role])[aria-level=1], 
-h4:not([role])[aria-level=1], 
-h5:not([role])[aria-level=1], 
-h6:not([role])[aria-level=1], 
+        <pre lang=css><code>h1:not([role]):not([aria-level]),
+h1:not([role])[aria-level=1],
+h2:not([role])[aria-level=1],
+h3:not([role])[aria-level=1],
+h4:not([role])[aria-level=1],
+h5:not([role])[aria-level=1],
+h6:not([role])[aria-level=1],
 [role=heading][aria-level=1]</code></pre>
         </td>
       <td align="left">Selector used to determine if a page has a level one heading</td>
@@ -401,12 +402,12 @@ th</code></pre>
         <code>selector</code>
       </td>
       <td align="left">
-        <pre lang=css><code>h1:not([role]), 
-h2:not([role]), 
-h3:not([role]), 
-h4:not([role]), 
-h5:not([role]), 
-h6:not([role]), 
+        <pre lang=css><code>h1:not([role]),
+h2:not([role]),
+h3:not([role]),
+h4:not([role]),
+h5:not([role]),
+h6:not([role]),
 [role=heading]</code></pre>
         </td>
       <td align="left">Selector used to determine if a page has a heading</td>
@@ -437,9 +438,9 @@ h6:not([role]),
       </td>
       <td align="left">
         <pre lang=js><code>[
-  { "weight": 150, "italic": true }, 
-  { "weight": 150, "size": 1.15 }, 
-  { "italic": true, "size": 1.15 }, 
+  { "weight": 150, "italic": true },
+  { "weight": 150, "size": 1.15 },
+  { "italic": true, "size": 1.15 },
   { "size": 1.4 }
 ]</code></pre>
         </td>

--- a/lib/checks/aria/aria-roledescription.json
+++ b/lib/checks/aria/aria-roledescription.json
@@ -9,7 +9,8 @@
       "radio",
       "combobox",
       "menuitemcheckbox",
-      "menuitemradio"
+      "menuitemradio",
+      "gridcell"
     ]
   },
   "metadata": {

--- a/test/integration/rules/aria-roledescription/aria-roledescription.html
+++ b/test/integration/rules/aria-roledescription/aria-roledescription.html
@@ -15,6 +15,11 @@
 ></div>
 <input type="checkbox" aria-roledescription="my checkbox" id="pass8" />
 <input type="radio" aria-roledescription="my radio" id="pass9" />
+<div role="grid">
+  <div role="gridrow">
+    <div role="gridcell" aria-roledescription="my radio" id="pass10" />
+  </div>
+</div>
 
 <h1 aria-roledescription="my heading" id="incomplete1">heading</h1>
 <div role="rowgroup" aria-roledescription="my row" id="incomplete2"></div>

--- a/test/integration/rules/aria-roledescription/aria-roledescription.json
+++ b/test/integration/rules/aria-roledescription/aria-roledescription.json
@@ -11,7 +11,8 @@
     ["#pass6"],
     ["#pass7"],
     ["#pass8"],
-    ["#pass9"]
+    ["#pass9"],
+    ["#pass10"]
   ],
   "incomplete": [["#incomplete1"], ["#incomplete2"]]
 }


### PR DESCRIPTION
Adds 'gridcell' as a supported role for aria-roledescription.

Closes issue: #3381 
