### PR TITLE
tests: resolve isolated-env race condition

### DIFF
--- a/test/integration/full/isolated-env/isolated-env.js
+++ b/test/integration/full/isolated-env/isolated-env.js
@@ -40,7 +40,19 @@ describe('isolated-env test', function() {
       return this.skip();
     }
 
-    axe.testUtils.awaitNestedLoad(function() {
+    var nestedLoadPromise = new Promise(function(resolve) {
+      axe.testUtils.awaitNestedLoad(resolve);
+    });
+
+    var isloadedPromise = new Promise(function(resolve) {
+      window.addEventListener('message', function(msg) {
+        if (msg.data === 'axe-loaded') {
+          resolve();
+        }
+      });
+    });
+
+    Promise.all([nestedLoadPromise, isloadedPromise]).then(function() {
       win = fixture.querySelector('#isolated-frame').contentWindow;
       var focusableFrame = fixture.querySelector('#focusable-iframe');
 
@@ -53,8 +65,7 @@ describe('isolated-env test', function() {
         size: { width: 10, height: 10 }
       });
 
-      var promises = [axe.runPartial(), iframePromise];
-      Promise.all(promises)
+      Promise.all([axe.runPartial(), iframePromise])
         .then(function(r) {
           origPartialResults = r;
           done();


### PR DESCRIPTION
Turns out there was a race condition in the isolated-env tests between when the iframe `load` event was triggered and when the script contents to fetch axe and inject it into the page via `eval` would complete. Tests would fail if the script couldn't execute faster than the `load` event.

Fixed that by properly waiting for the post message the script sends in addition to waiting for the nested load function.

Closes issue: #3367  
