### PR TITLE
fix(html-elms): update role allowances for nav element

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -633,6 +633,8 @@ const htmlElms = {
       'doc-toc',
       'menu',
       'menubar',
+			'none',
+			'presentation',
       'tablist'
     ],
     shadowRoot: true

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -633,8 +633,8 @@ const htmlElms = {
       'doc-toc',
       'menu',
       'menubar',
-			'none',
-			'presentation',
+      'none',
+      'presentation',
       'tablist'
     ],
     shadowRoot: true

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -252,6 +252,8 @@
 <!-- landmarks -->
 <main><header role="banner" id="pass-header-banner">ok</header></main>
 <main><footer role="contentinfo" id="pass-footer-contentinfo">ok</footer></main>
+<nav role="none" id="pass-navnone-1">ok</nav>
+<nav role="presentation" id="pass-navnone-2">ok</nav>
 
 <img usemap="#my-map" />
 <map name="my-map">

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.json
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.json
@@ -80,7 +80,9 @@
     ["#pass-img-valid-role-aria-labelledby"],
     ["#pass-img-valid-role-radio"],
     ["#pass-imgmap-1"],
-    ["#pass-imgmap-2"]
+    ["#pass-imgmap-2"],
+    ["#pass-navnone-1"],
+    ["#pass-navnone-2"]
   ],
   "violations": [
     ["#fail-dd-no-role"],


### PR DESCRIPTION
closes #3401

allows `none` and `presentation` role on `<nav>` element.
