### PR TITLE
ci(act): Add nightly job to run latest ACT rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
-      # Always run on the latest master branch, regardless of cache
       - run: npm run build
       - run: npm run test:act
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       # Always run on the latest master branch, regardless of cache
-      - run: npm install act-rules/act-rules.github.io#master
       - run: npm run build
       - run: npm run test:act
 
@@ -174,6 +173,19 @@ jobs:
           name: Set Environment Variable
           command: echo "export FIREFOX_NIGHTLY_BIN=$(pwd)/firefox/firefox-bin" >> $BASH_ENV
       - run: npm run test -- --browsers Chrome,FirefoxNightly
+
+  # Run the test suite for nightly builds.
+  test_nightly_act:
+    <<: *defaults
+    <<: *unix_nightly_box
+    steps:
+      - browser-tools/install-browser-tools
+      - checkout
+      - <<: *restore_dependency_cache_unix
+      - run: npm run build
+      # install ACT rules
+      - run: npm install act-rules/act-rules.github.io#master
+      - run: npm run test:apg
 
   # Run the test suite for nightly builds.
   test_nightly_aria_practices:
@@ -390,6 +402,9 @@ workflows:
     jobs:
       - dependencies_unix
       - test_nightly_browsers:
+          requires:
+            - dependencies_unix
+      - test_nightly_act:
           requires:
             - dependencies_unix
       - test_nightly_aria_practices:

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.4",
     "@deque/dot": "^1.1.5",
-    "act-rules.github.io": "github:act-rules/act-rules.github.io#master",
+    "act-rules.github.io": "github:act-rules/act-rules.github.io#a5d7336e020fd04fd429f94c651102f8ab255f01",
     "aria-practices": "github:w3c/aria-practices#f7de7ec3a53534018237f24cb9e610f26c30c367",
     "aria-query": "^3.0.0",
     "browser-driver-manager": "1.0.3",


### PR DESCRIPTION
We had the ACT job fail because of an update to one of the rules. This PR makes it so we run tests against a pinned version of ACT. We'll have a nightly job run against the latest ACT rules so we can see if something in ACT broke our implementation.

I haven't looked at what was failing specifically. I'll do that in a separate PR.