### PR TITLE
fix(standards): fix address typo in html-elms.js

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -43,7 +43,7 @@ const htmlElms = {
     contentTypes: ['phrasing', 'flow'],
     allowedRoles: true
   },
-  addres: {
+  address: {
     contentTypes: ['flow'],
     allowedRoles: true
   },


### PR DESCRIPTION
closes #3417

fix 'addres' to 'address'
