### PR TITLE
fix(aria-hidden-focus): Update rule help & description

### DIFF
--- a/lib/rules/aria-hidden-focus.json
+++ b/lib/rules/aria-hidden-focus.json
@@ -7,7 +7,7 @@
   "actIds": ["6cfa84"],
   "metadata": {
     "description": "Ensures aria-hidden elements do not contain focusable elements",
-    "help": "ARIA hidden element must not contain focusable elements"
+    "help": "ARIA hidden element must not be focusable or contain focusable elements"
   },
   "all": [
     "focusable-modal-open",

--- a/lib/rules/aria-hidden-focus.json
+++ b/lib/rules/aria-hidden-focus.json
@@ -6,7 +6,7 @@
   "tags": ["cat.name-role-value", "wcag2a", "wcag412", "wcag131"],
   "actIds": ["6cfa84"],
   "metadata": {
-    "description": "Ensures aria-hidden elements do not contain focusable elements",
+    "description": "Ensures aria-hidden elements are not focusable nor contain focusable elements",
     "help": "ARIA hidden element must not be focusable or contain focusable elements"
   },
   "all": [


### PR DESCRIPTION
The current `help` value does not include the scenario in which `aria-hidden="true"` is on a focusable element. I updated it to include that scenario. Here's the PR, per @WilcoFiers suggestion. Slack thread: https://deque.slack.com/archives/C0LA5E545/p1646762357136919