### PR TITLE
fix(utils): greatly improve the speed of our querySelectorAll code

### DIFF
--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -2,6 +2,7 @@ import AbstractVirtualNode from './abstract-virtual-node';
 import { isXHTML, validInputTypes } from '../../utils';
 import { isFocusable, getTabbableElements } from '../../../commons/dom';
 import cache from '../cache';
+import { cacheNodeSelectors } from '../../utils/selector-cache';
 
 let isXHTMLGlobal;
 let nodeIndex = 0;
@@ -50,6 +51,8 @@ class VirtualNode extends AbstractVirtualNode {
     if (cache.get('nodeMap')) {
       cache.get('nodeMap').set(node, this);
     }
+
+    cacheNodeSelectors(this);
   }
 
   // abstract Node properties so we can run axe in DOM-less environments.

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -46,6 +46,10 @@ import v2Reporter from './reporters/v2';
 
 import * as commons from '../commons';
 import * as utils from './utils';
+import {
+  cacheNodeSelectors,
+  getNodesMatchingExpression
+} from './utils/selector-cache';
 
 axe.constants = constants;
 axe.log = log;
@@ -70,6 +74,10 @@ axe._thisWillBeDeletedDoNotUse.base = {
 axe._thisWillBeDeletedDoNotUse.public = {
   reporters
 };
+axe._thisWillBeDeletedDoNotUse.utils =
+  axe._thisWillBeDeletedDoNotUse.utils || {};
+axe._thisWillBeDeletedDoNotUse.utils.cacheNodeSelectors = cacheNodeSelectors;
+axe._thisWillBeDeletedDoNotUse.utils.getNodesMatchingExpression = getNodesMatchingExpression;
 
 axe.imports = imports;
 

--- a/lib/core/utils/matches.js
+++ b/lib/core/utils/matches.js
@@ -224,6 +224,10 @@ export function convertSelector(selector) {
  * @returns {Boolean}
  */
 function optimizedMatchesExpression(vNode, expressions, index, matchAnyParent) {
+  if (!vNode) {
+    return false;
+  }
+
   const isArray = Array.isArray(expressions);
   const expression = isArray ? expressions[index] : expressions;
   let matches = matchExpression(vNode, expression);

--- a/lib/core/utils/matches.js
+++ b/lib/core/utils/matches.js
@@ -128,6 +128,7 @@ function convertAttributes(atts) {
     return {
       key: attributeKey,
       value: attributeValue,
+      type: typeof att.value === 'undefined' ? 'attrExist' : 'attrValue',
       test: test
     };
   });

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -1,4 +1,5 @@
 import { matchesExpression, convertSelector } from './matches';
+import { getNodesMatchingSelector } from './selector-cache';
 
 function createLocalVariables(
   vNodes,
@@ -123,6 +124,17 @@ function matchExpressions(domTree, expressions, filter) {
  */
 function querySelectorAllFilter(domTree, selector, filter) {
   domTree = Array.isArray(domTree) ? domTree : [domTree];
+
+  // see if the passed in node is the root node of the tree and can
+  // find nodes using the cache rather than looping through the
+  // the entire tree
+  const nodes = getNodesMatchingSelector(domTree, selector, filter);
+  if (nodes) {
+    return nodes;
+  }
+
+  // if the selector cache is not set up or if not passed the
+  // top level node we default back to parsing the whole tree
   const expressions = convertSelector(selector);
   return matchExpressions(domTree, expressions, filter);
 }

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -1,5 +1,5 @@
 import { matchesExpression, convertSelector } from './matches';
-import { getNodesMatchingSelector } from './selector-cache';
+import { getNodesMatchingExpression } from './selector-cache';
 
 function createLocalVariables(
   vNodes,
@@ -124,18 +124,18 @@ function matchExpressions(domTree, expressions, filter) {
  */
 function querySelectorAllFilter(domTree, selector, filter) {
   domTree = Array.isArray(domTree) ? domTree : [domTree];
+  const expressions = convertSelector(selector);
 
   // see if the passed in node is the root node of the tree and can
   // find nodes using the cache rather than looping through the
   // the entire tree
-  const nodes = getNodesMatchingSelector(domTree, selector, filter);
+  const nodes = getNodesMatchingExpression(domTree, expressions, filter);
   if (nodes) {
     return nodes;
   }
 
   // if the selector cache is not set up or if not passed the
   // top level node we default back to parsing the whole tree
-  const expressions = convertSelector(selector);
   return matchExpressions(domTree, expressions, filter);
 }
 

--- a/lib/core/utils/selector-cache.js
+++ b/lib/core/utils/selector-cache.js
@@ -1,10 +1,29 @@
 import { convertSelector, matchesExpression } from './matches';
+import tokenList from './token-list';
 
+// since attribute names can't contain whitespace, this will be
+// a reserved list for ids
+const idsKey = ' [idsMap]';
 let selectorMap = {};
 
-function cacheSelector(key, vNode) {
-  selectorMap[key] = selectorMap[key] || [];
-  selectorMap[key].push(vNode);
+function isGlobalSelector(exp) {
+  return exp.tag === '*' && !exp.attributes && !exp.id && !exp.classes;
+}
+
+function cacheSelector(key, vNode, map = selectorMap) {
+  map[key] = map[key] || [];
+  map[key].push(vNode);
+}
+
+/**
+ * Inner join two arrays.
+ */
+function innerJoin(a, b) {
+  if (!b.length) {
+    return a;
+  }
+
+  return a.filter(node => b.includes(node));
 }
 
 /**
@@ -26,6 +45,14 @@ export function cacheNodeSelectors(vNode) {
   cacheSelector('*', vNode);
 
   vNode.attrNames.forEach(attrName => {
+    // element ids are the only values we'll match
+    if (attrName === 'id') {
+      selectorMap[idsKey] = selectorMap[idsKey] || {};
+      tokenList(vNode.attr(attrName)).forEach(value => {
+        cacheSelector(value, vNode, selectorMap[idsKey]);
+      });
+    }
+
     cacheSelector(`[${attrName}]`, vNode);
   });
 }
@@ -47,6 +74,19 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
 
   const shadowId = domTree[0].shadowId;
   const expressions = convertSelector(selector);
+
+  // if the selector uses a global selector with a combinator
+  // (A *, A > *) it's actually faster to use our QSA code than
+  // getting all nodes and using matchesExpression
+  for (let i = 0; i < expressions.length; i++) {
+    if (
+      expressions[i].length > 1 &&
+      expressions[i].some(expression => isGlobalSelector(expression))
+    ) {
+      return;
+    }
+  }
+
   let matchedNodes = [];
 
   // find nodes that match just a part of the selector in order
@@ -55,44 +95,123 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
     // use the last part of the expression to find nodes as it's more
     // specific. e.g. for `body h1` use `h1` and not `body`
     const exp = expression[expression.length - 1];
-
-    // the expression `[id]` will use `*` as the tag name
-    const isGlobalSelector =
-      exp.tag === '*' && !exp.attributes && !exp.id && !exp.classes;
     let nodes = [];
 
-    if (isGlobalSelector && selectorMap['*']) {
+    // a complex selector is one that will require using
+    // matchesExpression to determine if it matches. these include
+    // pseudo selectors (:not), combinators (A > B), and any
+    // attribute value ([class=.foo]).
+    let isComplexSelector = expression.length > 1 || exp.pseudos || exp.classes;
+
+    if (isGlobalSelector(exp) && selectorMap['*']) {
       nodes = selectorMap['*'];
-    }
-    // for `h1[role]` we want to use the tag name as it is more
-    // specific than using all nodes with the role attribute
-    else if (exp.tag && exp.tag !== '*' && selectorMap[exp.tag]) {
-      nodes = selectorMap[exp.tag];
-    } else if (exp.id && selectorMap['[id]']) {
-      // when using id selector (#one) we should only select nodes
-      // that match the shadowId of the root
-      nodes = selectorMap['[id]'].filter(node => node.shadowId === shadowId);
-    } else if (exp.classes && selectorMap['[class]']) {
-      nodes = selectorMap['[class]'];
-    } else if (exp.attributes) {
-      // break once we find nodes that match any of the attributes
-      for (let i = 0; i < exp.attributes.length; i++) {
-        const attrName = exp.attributes[i].key;
-        if (selectorMap['['.concat(attrName, ']')]) {
-          nodes = selectorMap['['.concat(attrName, ']')];
-          break;
+    } else {
+      // a selector must match all parts, otherwise we can just exit
+      // early
+      if (exp.id) {
+        if (!selectorMap[idsKey] || !selectorMap[idsKey][exp.id]?.length) {
+          return;
+        }
+
+        // when using id selector (#one) we should only select nodes
+        // that match the shadowId of the root
+        nodes = selectorMap[idsKey][exp.id].filter(
+          node => node.shadowId === shadowId
+        );
+      }
+
+      if (exp.tag && exp.tag !== '*') {
+        if (!selectorMap[exp.tag]?.length) {
+          return;
+        }
+
+        nodes = innerJoin(selectorMap[exp.tag], nodes);
+      }
+
+      if (exp.classes) {
+        if (!selectorMap['[class]']?.length) {
+          return;
+        }
+
+        nodes = innerJoin(selectorMap[exp.classes], nodes);
+      }
+
+      if (exp.attributes) {
+        for (let i = 0; i < exp.attributes.length; i++) {
+          const attr = exp.attributes[i];
+
+          // to test if the attribute is looking for existence of
+          // the attribute or a specific value, we need to use
+          // the "test" function (since the expression doesn't
+          // differentiate between [href] and [href=""]).
+          // since specific values use string matching, passing
+          // the boolean true will only return true for existence
+          // tests.
+          // a specific value check is a complex selector
+          if (!attr.test(true)) {
+            isComplexSelector = true;
+          }
+
+          if (!selectorMap[`[${attr.key}]`]?.length) {
+            return;
+          }
+
+          nodes = innerJoin(selectorMap[`[${attr.key}]`], nodes);
         }
       }
     }
 
-    // now that we have a list of all nodes that match a part of
-    // the expression we need to check if the node actually matches
-    // the entire expression
     nodes.forEach(node => {
-      if (matchesExpression(node, expression) && !matchedNodes.includes(node)) {
+      if (isComplexSelector && !matchesExpression(node, expression)) {
+        return;
+      }
+
+      if (!matchedNodes.includes(node)) {
         matchedNodes.push(node);
       }
     });
+
+    // // use the last part of the expression to find nodes as it's more
+    // // specific. e.g. for `body h1` use `h1` and not `body`
+    // const exp = expression[expression.length - 1];
+
+    // // the expression `[id]` will use `*` as the tag name
+    // const isGlobalSelector =
+    //   exp.tag === '*' && !exp.attributes && !exp.id && !exp.classes;
+    // let nodes = [];
+
+    // if (isGlobalSelector && selectorMap['*']) {
+    //   nodes = selectorMap['*'];
+    // }
+    // // for `h1[role]` we want to use the tag name as it is more
+    // // specific than using all nodes with the role attribute
+    // else if (exp.tag && exp.tag !== '*' && selectorMap[exp.tag]) {
+    //   nodes = selectorMap[exp.tag];
+    // } else if (exp.id && selectorMap['[id]']) {
+    //   // when using id selector (#one) we should only select nodes
+    //   // that match the shadowId of the root
+    //   nodes = selectorMap['[id]'].filter(node => node.shadowId === shadowId);
+    // } else if (exp.classes && selectorMap['[class]']) {
+    //   nodes = selectorMap['[class]'];
+    // } else if (exp.attributes) {
+    //   // break once we find nodes that match any of the attributes
+    //   for (let i = 0; i < exp.attributes.length; i++) {
+    //     const attrName = exp.attributes[i].key;
+    //     if (selectorMap['['.concat(attrName, ']')]) {
+    //       nodes = selectorMap['['.concat(attrName, ']')];
+    //       break;
+    //     }
+    //   }
+    // }
+
+    // // now that we have a list of all nodes that match a part of
+    // // the expression we need to check if the node actually matches
+    // // the entire expression
+    // nodes.forEach(node => {
+    //   if (matchesExpression(node, expression) && !matchedNodes.includes(node)) {
+    //     matchedNodes.push(node);
+    //   }
+    // });
   });
 
   if (filter) {

--- a/lib/core/utils/selector-cache.js
+++ b/lib/core/utils/selector-cache.js
@@ -1,22 +1,36 @@
-import { convertSelector, matchesExpression } from './matches';
+import { matchesExpression } from './matches';
 import tokenList from './token-list';
 
 // since attribute names can't contain whitespace, this will be
-// a reserved list for ids
+// a reserved list for ids so we can perform virtual id lookups
 const idsKey = ' [idsMap]';
 let selectorMap = {};
 
+/**
+ * Non-tag selectors use `*` for the tag name so a global selector won't have any other properties of the expression.
+ * @param {Object} exp Selector Expression
+ * @returns {Boolean}
+ */
 function isGlobalSelector(exp) {
   return exp.tag === '*' && !exp.attributes && !exp.id && !exp.classes;
 }
 
+/**
+ * Save a selector and vNode to the selectorMap
+ * @param {String} key
+ * @param {VirtualNode} vNode
+ * @param {Object} map
+ */
 function cacheSelector(key, vNode, map = selectorMap) {
   map[key] = map[key] || [];
   map[key].push(vNode);
 }
 
 /**
- * Inner join two arrays.
+ * Inner join two arrays (find all nodes in a that are also in b).
+ * @param {*[]} a
+ * @param {*[]} b
+ * @returns {*[]}
  */
 function innerJoin(a, b) {
   if (!b.length) {
@@ -27,7 +41,7 @@ function innerJoin(a, b) {
 }
 
 /**
- * Cache selector information about a VirtalNode
+ * Cache selector information about a VirtalNode.
  * @param {VirtualNode} vNode
  */
 export function cacheNodeSelectors(vNode) {
@@ -58,13 +72,13 @@ export function cacheNodeSelectors(vNode) {
 }
 
 /**
- * Get nodes from the selector cache that match the selector
+ * Get nodes from the selector cache that match the selector.
  * @param {VirtualTree[]} domTree flattened tree collection to search
- * @param {String} selector
+ * @param {Object} expressions
  * @param {Function} filter function (optional)
  * @return {Mixed} Array of nodes that match the selector or undefined if the selector map is not setup
  */
-export function getNodesMatchingSelector(domTree, selector, filter) {
+export function getNodesMatchingExpression(domTree, expressions, filter) {
   // check to see if the domTree is the root and has the selector
   // map. if not we just return and let our QSA code do the finding
   const selectorMap = domTree[0]._selectorMap;
@@ -73,10 +87,9 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
   }
 
   const shadowId = domTree[0].shadowId;
-  const expressions = convertSelector(selector);
 
   // if the selector uses a global selector with a combinator
-  // (A *, A > *) it's actually faster to use our QSA code than
+  // (e.g. A *, A > *) it's actually faster to use our QSA code than
   // getting all nodes and using matchesExpression
   for (let i = 0; i < expressions.length; i++) {
     if (
@@ -100,21 +113,22 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
     // a complex selector is one that will require using
     // matchesExpression to determine if it matches. these include
     // pseudo selectors (:not), combinators (A > B), and any
-    // attribute value ([class=.foo]).
-    let isComplexSelector = expression.length > 1 || exp.pseudos || exp.classes;
+    // attribute value ([class=foo]).
+    let isComplexSelector =
+      expression.length > 1 || !!exp.pseudos || !!exp.classes;
 
-    if (isGlobalSelector(exp) && selectorMap['*']) {
+    if (isGlobalSelector(exp)) {
       nodes = selectorMap['*'];
     } else {
-      // a selector must match all parts, otherwise we can just exit
-      // early
       if (exp.id) {
+        // a selector must match all parts, otherwise we can just exit
+        // early
         if (!selectorMap[idsKey] || !selectorMap[idsKey][exp.id]?.length) {
           return;
         }
 
-        // when using id selector (#one) we should only select nodes
-        // that match the shadowId of the root
+        // when using id selector (#one) we only find nodes that
+        // match the shadowId of the root
         nodes = selectorMap[idsKey][exp.id].filter(
           node => node.shadowId === shadowId
         );
@@ -133,22 +147,16 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
           return;
         }
 
-        nodes = innerJoin(selectorMap[exp.classes], nodes);
+        nodes = innerJoin(selectorMap['[class]'], nodes);
       }
 
       if (exp.attributes) {
         for (let i = 0; i < exp.attributes.length; i++) {
           const attr = exp.attributes[i];
 
-          // to test if the attribute is looking for existence of
-          // the attribute or a specific value, we need to use
-          // the "test" function (since the expression doesn't
-          // differentiate between [href] and [href=""]).
-          // since specific values use string matching, passing
-          // the boolean true will only return true for existence
-          // tests.
-          // a specific value check is a complex selector
-          if (!attr.test(true)) {
+          // an attribute selector that looks for a specific value is
+          // a complex selector
+          if (attr.type === 'attrValue') {
             isComplexSelector = true;
           }
 
@@ -162,57 +170,15 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
     }
 
     nodes.forEach(node => {
+      // for complex selectors we need to verify that the node
+      // actually matches the entire selector since we only have
+      // nodes that partially match the last part of the selector
       if (isComplexSelector && !matchesExpression(node, expression)) {
         return;
       }
 
       matchedNodes.add(node);
-      // if (!matchedNodes.includes(node)) {
-      //   matchedNodes.push(node);
-      // }
     });
-
-    // // use the last part of the expression to find nodes as it's more
-    // // specific. e.g. for `body h1` use `h1` and not `body`
-    // const exp = expression[expression.length - 1];
-
-    // // the expression `[id]` will use `*` as the tag name
-    // const isGlobalSelector =
-    //   exp.tag === '*' && !exp.attributes && !exp.id && !exp.classes;
-    // let nodes = [];
-
-    // if (isGlobalSelector && selectorMap['*']) {
-    //   nodes = selectorMap['*'];
-    // }
-    // // for `h1[role]` we want to use the tag name as it is more
-    // // specific than using all nodes with the role attribute
-    // else if (exp.tag && exp.tag !== '*' && selectorMap[exp.tag]) {
-    //   nodes = selectorMap[exp.tag];
-    // } else if (exp.id && selectorMap['[id]']) {
-    //   // when using id selector (#one) we should only select nodes
-    //   // that match the shadowId of the root
-    //   nodes = selectorMap['[id]'].filter(node => node.shadowId === shadowId);
-    // } else if (exp.classes && selectorMap['[class]']) {
-    //   nodes = selectorMap['[class]'];
-    // } else if (exp.attributes) {
-    //   // break once we find nodes that match any of the attributes
-    //   for (let i = 0; i < exp.attributes.length; i++) {
-    //     const attrName = exp.attributes[i].key;
-    //     if (selectorMap['['.concat(attrName, ']')]) {
-    //       nodes = selectorMap['['.concat(attrName, ']')];
-    //       break;
-    //     }
-    //   }
-    // }
-
-    // // now that we have a list of all nodes that match a part of
-    // // the expression we need to check if the node actually matches
-    // // the entire expression
-    // nodes.forEach(node => {
-    //   if (matchesExpression(node, expression) && !matchedNodes.includes(node)) {
-    //     matchedNodes.push(node);
-    //   }
-    // });
   });
 
   matchedNodes = Array.from(matchedNodes);

--- a/lib/core/utils/selector-cache.js
+++ b/lib/core/utils/selector-cache.js
@@ -87,7 +87,7 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
     }
   }
 
-  let matchedNodes = [];
+  let matchedNodes = new Set();
 
   // find nodes that match just a part of the selector in order
   // to speed up traversing the entire tree
@@ -166,9 +166,10 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
         return;
       }
 
-      if (!matchedNodes.includes(node)) {
-        matchedNodes.push(node);
-      }
+      matchedNodes.add(node);
+      // if (!matchedNodes.includes(node)) {
+      //   matchedNodes.push(node);
+      // }
     });
 
     // // use the last part of the expression to find nodes as it's more
@@ -213,6 +214,8 @@ export function getNodesMatchingSelector(domTree, selector, filter) {
     //   }
     // });
   });
+
+  matchedNodes = Array.from(matchedNodes);
 
   if (filter) {
     matchedNodes = matchedNodes.filter(filter);

--- a/lib/core/utils/selector-cache.js
+++ b/lib/core/utils/selector-cache.js
@@ -1,0 +1,103 @@
+import { convertSelector, matchesExpression } from './matches';
+
+let selectorMap = {};
+
+function cacheSelector(key, vNode) {
+  selectorMap[key] = selectorMap[key] || [];
+  selectorMap[key].push(vNode);
+}
+
+/**
+ * Cache selector information about a VirtalNode
+ * @param {VirtualNode} vNode
+ */
+export function cacheNodeSelectors(vNode) {
+  if (vNode.props.nodeType !== 1) {
+    return;
+  }
+
+  // cache the selector map to the root node of the tree
+  if (vNode.nodeIndex === 0) {
+    selectorMap = {};
+    vNode._selectorMap = selectorMap;
+  }
+
+  cacheSelector(vNode.props.nodeName, vNode);
+  cacheSelector('*', vNode);
+
+  vNode.attrNames.forEach(attrName => {
+    cacheSelector(`[${attrName}]`, vNode);
+  });
+}
+
+/**
+ * Get nodes from the selector cache that match the selector
+ * @param {VirtualTree[]} domTree flattened tree collection to search
+ * @param {String} selector
+ * @param {Function} filter function (optional)
+ * @return {Mixed} Array of nodes that match the selector or undefined if the selector map is not setup
+ */
+export function getNodesMatchingSelector(domTree, selector, filter) {
+  // check to see if the domTree is the root and has the selector
+  // map. if not we just return and let our QSA code do the finding
+  const selectorMap = domTree[0]._selectorMap;
+  if (!selectorMap) {
+    return;
+  }
+
+  const shadowId = domTree[0].shadowId;
+  const expressions = convertSelector(selector);
+  let matchedNodes = [];
+
+  // find nodes that match just a part of the selector in order
+  // to speed up traversing the entire tree
+  expressions.forEach(expression => {
+    // use the last part of the expression to find nodes as it's more
+    // specific. e.g. for `body h1` use `h1` and not `body`
+    const exp = expression[expression.length - 1];
+
+    // the expression `[id]` will use `*` as the tag name
+    const isGlobalSelector =
+      exp.tag === '*' && !exp.attributes && !exp.id && !exp.classes;
+    let nodes = [];
+
+    if (isGlobalSelector && selectorMap['*']) {
+      nodes = selectorMap['*'];
+    }
+    // for `h1[role]` we want to use the tag name as it is more
+    // specific than using all nodes with the role attribute
+    else if (exp.tag && exp.tag !== '*' && selectorMap[exp.tag]) {
+      nodes = selectorMap[exp.tag];
+    } else if (exp.id && selectorMap['[id]']) {
+      // when using id selector (#one) we should only select nodes
+      // that match the shadowId of the root
+      nodes = selectorMap['[id]'].filter(node => node.shadowId === shadowId);
+    } else if (exp.classes && selectorMap['[class]']) {
+      nodes = selectorMap['[class]'];
+    } else if (exp.attributes) {
+      // break once we find nodes that match any of the attributes
+      for (let i = 0; i < exp.attributes.length; i++) {
+        const attrName = exp.attributes[i].key;
+        if (selectorMap['['.concat(attrName, ']')]) {
+          nodes = selectorMap['['.concat(attrName, ']')];
+          break;
+        }
+      }
+    }
+
+    // now that we have a list of all nodes that match a part of
+    // the expression we need to check if the node actually matches
+    // the entire expression
+    nodes.forEach(node => {
+      if (matchesExpression(node, expression) && !matchedNodes.includes(node)) {
+        matchedNodes.push(node);
+      }
+    });
+  });
+
+  if (filter) {
+    matchedNodes = matchedNodes.filter(filter);
+  }
+
+  return matchedNodes.sort((a, b) => a.nodeIndex - b.nodeIndex);
+}

--- a/test/core/base/virtual-node/virtual-node.js
+++ b/test/core/base/virtual-node/virtual-node.js
@@ -81,6 +81,20 @@ describe('VirtualNode', function() {
       assert.equal(vNode.props.nodeName, 'foobar');
     });
 
+    it('should add selectorMap to root element', function() {
+      node.setAttribute('data-foo', 'bar');
+      var vNode = new VirtualNode(node);
+
+      assert.exists(vNode._selectorMap);
+    });
+
+    it('should not add selectorMap to non-root element', function() {
+      node.setAttribute('data-foo', 'bar');
+      var vNode = new VirtualNode(node, new VirtualNode(node.cloneNode()));
+
+      assert.notExists(vNode._selectorMap);
+    });
+
     describe('attr', function() {
       it('should return the value of the given attribute', function() {
         node.setAttribute('data-foo', 'bar');

--- a/test/core/utils/qsa.js
+++ b/test/core/utils/qsa.js
@@ -57,190 +57,240 @@ describe('axe.utils.querySelectorAllFilter', function() {
   'use strict';
   var dom;
   afterEach(function() {});
-  beforeEach(function() {
-    dom = getTestDom();
-  });
-  it('should find nodes using just the tag', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'li');
-    assert.equal(result.length, 4);
-  });
-  it('should find nodes using parent selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'ul > li');
-    assert.equal(result.length, 4);
-  });
-  it('should NOT find nodes using parent selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'div > li');
-    assert.equal(result.length, 0);
-  });
-  it('should find nodes using nested parent selectors', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      'span > span > span > span'
-    );
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using hierarchical selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'div li');
-    assert.equal(result.length, 4);
-  });
-  it('should find nodes using class selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '.breaking');
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using hierarchical class selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '.first .breaking');
-    assert.equal(result.length, 2);
-  });
-  it('should NOT find nodes using hierarchical class selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '.second .breaking');
-    assert.equal(result.length, 0);
-  });
-  it('should find nodes using multiple class selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '.second.third');
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using id', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '#one');
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using id, but not in shadow DOM', function() {
-    var result = axe.utils.querySelectorAllFilter(dom[0].children[0], '#one');
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using id, within a shadow DOM', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom[0].children[0].children[2],
-      '#one'
-    );
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using attribute', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '[role]');
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using attribute with value', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '[role=tab]');
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using attribute with value', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '[role="button"]');
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using parent attribute with value', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      '[data-a11yhero="faulkner"] > ul'
-    );
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using hierarchical attribute with value', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      '[data-a11yhero="faulkner"] li'
-    );
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using :not selector with class', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'div:not(.first)');
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using :not selector with matching id', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'div:not(#one)');
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using :not selector with matching attribute selector', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      'div:not([data-a11yhero])'
-    );
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using :not selector with matching attribute selector with value', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      'div:not([data-a11yhero=faulkner])'
-    );
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes using :not selector with bogus attribute selector with value', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      'div:not([data-a11yhero=wilco])'
-    );
-    assert.equal(result.length, 3);
-  });
-  it('should find nodes using :not selector with bogus id', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'div:not(#thangy)');
-    assert.equal(result.length, 3);
-  });
-  it('should find nodes using :not selector with attribute', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'div:not([id])');
-    assert.equal(result.length, 2);
-  });
-  it('should find nodes hierarchically using :not selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'div:not(.first) li');
-    assert.equal(result.length, 2);
-  });
-  it('should find same nodes hierarchically using more :not selector', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      'div:not(.first) li:not(.breaking)'
-    );
-    assert.equal(result.length, 2);
-  });
-  it('should NOT find nodes hierarchically using :not selector', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      'div:not(.second) li:not(.breaking)'
-    );
-    assert.equal(result.length, 0);
-  });
-  it('should find nodes using ^= attribute selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '[class^="sec"]');
-    assert.equal(result.length, 1);
-  });
-  it('should find nodes using $= attribute selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '[id$="ne"]');
-    assert.equal(result.length, 3);
-  });
-  it('should find nodes using *= attribute selector', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, '[role*="t"]');
-    assert.equal(result.length, 2);
-  });
-  it('should put it all together', function() {
-    var result = axe.utils.querySelectorAllFilter(
-      dom,
-      '.first[data-a11yhero="faulkner"] > ul li.breaking'
-    );
-    assert.equal(result.length, 2);
-  });
-  it('should find an element only once', function() {
-    var divs = axe.utils.querySelectorAllFilter(dom, 'div');
-    var ones = axe.utils.querySelectorAllFilter(dom, '#one');
-    var divOnes = axe.utils.querySelectorAllFilter(dom, 'div, #one');
 
-    assert.isBelow(
-      divOnes.length,
-      divs.length + ones.length,
-      'Elements matching both parts of a selector should not be included twice'
-    );
-  });
-  it('should return nodes sorted by document position', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'ul, #one');
-    assert.equal(result[0].actualNode.nodeName, 'UL');
-    assert.equal(result[1].actualNode.nodeName, 'DIV');
-    assert.equal(result[2].actualNode.nodeName, 'UL');
-  });
-  it('should filter the returned nodes when passed a filter function', function() {
-    var result = axe.utils.querySelectorAllFilter(dom, 'ul, #one', function(
-      node
-    ) {
-      return node.actualNode.nodeName !== 'UL';
+  var tests = ['without cache', 'with cache'];
+  for (var i = 0; i < tests.length; i++) {
+    var describeName = tests[i];
+    describe(describeName, function() {
+      afterEach(function() {});
+
+      if (describeName === 'without cache') {
+        beforeEach(function() {
+          dom = getTestDom();
+
+          // prove we're using the DOM by deleting the cache
+          delete dom[0]._selectorCache;
+        });
+
+        it('should not have a primed cache', function() {
+          assert.isUndefined(dom[0]._selectorCache);
+        });
+      } else {
+        beforeEach(function() {
+          dom = getTestDom();
+
+          // prove we're using the cache by deleting all the children
+          dom[0].children = [];
+        });
+
+        it('should not use the cache if not using the top-level node', function() {
+          var nodes = axe.utils.querySelectorAllFilter(dom, 'ul');
+
+          // this would return 4 nodes if we were still using the
+          // top-level cache
+          var result = axe.utils.querySelectorAllFilter(nodes[0], 'li');
+          assert.equal(result.length, 2);
+        });
+      }
+
+      it('should find nodes using just the tag', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'li');
+        assert.equal(result.length, 4);
+      });
+      it('should find nodes using parent selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'ul > li');
+        assert.equal(result.length, 4);
+      });
+      it('should NOT find nodes using parent selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'div > li');
+        assert.equal(result.length, 0);
+      });
+      it('should find nodes using nested parent selectors', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          'span > span > span > span'
+        );
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using hierarchical selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'div li');
+        assert.equal(result.length, 4);
+      });
+      it('should find nodes using class selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '.breaking');
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using hierarchical class selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '.first .breaking');
+        assert.equal(result.length, 2);
+      });
+      it('should NOT find nodes using hierarchical class selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '.second .breaking');
+        assert.equal(result.length, 0);
+      });
+      it('should find nodes using multiple class selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '.second.third');
+        assert.equal(result.length, 1);
+      });
+      it('should find nodes using id', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '#one');
+        assert.equal(result.length, 1);
+      });
+
+      // can only select shadow dom nodes when we're not using the
+      // top-level node. but since the top-level node is the one
+      // with the cache, this only works when we are testing the full
+      // tree (i.e. without cache)
+      if (describeName === 'without cache') {
+        it('should find nodes using id, but not in shadow DOM', function() {
+          var result = axe.utils.querySelectorAllFilter(
+            dom[0].children[0],
+            '#one'
+          );
+          assert.equal(result.length, 1);
+        });
+        it('should find nodes using id, within a shadow DOM', function() {
+          var result = axe.utils.querySelectorAllFilter(
+            dom[0].children[0].children[2],
+            '#one'
+          );
+          assert.equal(result.length, 1);
+        });
+      }
+
+      it('should find nodes using attribute', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '[role]');
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using attribute with value', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '[role=tab]');
+        assert.equal(result.length, 1);
+      });
+      it('should find nodes using attribute with value', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '[role="button"]');
+        assert.equal(result.length, 1);
+      });
+      it('should find nodes using parent attribute with value', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          '[data-a11yhero="faulkner"] > ul'
+        );
+        assert.equal(result.length, 1);
+      });
+      it('should find nodes using hierarchical attribute with value', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          '[data-a11yhero="faulkner"] li'
+        );
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using :not selector with class', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'div:not(.first)');
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using :not selector with matching id', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'div:not(#one)');
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using :not selector with matching attribute selector', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          'div:not([data-a11yhero])'
+        );
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using :not selector with matching attribute selector with value', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          'div:not([data-a11yhero=faulkner])'
+        );
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes using :not selector with bogus attribute selector with value', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          'div:not([data-a11yhero=wilco])'
+        );
+        assert.equal(result.length, 3);
+      });
+      it('should find nodes using :not selector with bogus id', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'div:not(#thangy)');
+        assert.equal(result.length, 3);
+      });
+      it('should find nodes using :not selector with attribute', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'div:not([id])');
+        assert.equal(result.length, 2);
+      });
+      it('should find nodes hierarchically using :not selector', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          'div:not(.first) li'
+        );
+        assert.equal(result.length, 2);
+      });
+      it('should find same nodes hierarchically using more :not selector', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          'div:not(.first) li:not(.breaking)'
+        );
+        assert.equal(result.length, 2);
+      });
+      it('should NOT find nodes hierarchically using :not selector', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          'div:not(.second) li:not(.breaking)'
+        );
+        assert.equal(result.length, 0);
+      });
+      it('should find nodes using ^= attribute selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '[class^="sec"]');
+        assert.equal(result.length, 1);
+      });
+      it('should find nodes using $= attribute selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '[id$="ne"]');
+        assert.equal(result.length, 3);
+      });
+      it('should find nodes using *= attribute selector', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, '[role*="t"]');
+        assert.equal(result.length, 2);
+      });
+      it('should put it all together', function() {
+        var result = axe.utils.querySelectorAllFilter(
+          dom,
+          '.first[data-a11yhero="faulkner"] > ul li.breaking'
+        );
+        assert.equal(result.length, 2);
+      });
+      it('should find an element only once', function() {
+        var divs = axe.utils.querySelectorAllFilter(dom, 'div');
+        var ones = axe.utils.querySelectorAllFilter(dom, '#one');
+        var divOnes = axe.utils.querySelectorAllFilter(dom, 'div, #one');
+
+        assert.isBelow(
+          divOnes.length,
+          divs.length + ones.length,
+          'Elements matching both parts of a selector should not be included twice'
+        );
+      });
+      it('should return nodes sorted by document position', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'ul, #one');
+        assert.equal(result[0].actualNode.nodeName, 'UL');
+        assert.equal(result[1].actualNode.nodeName, 'DIV');
+        assert.equal(result[2].actualNode.nodeName, 'UL');
+      });
+      it('should filter the returned nodes when passed a filter function', function() {
+        var result = axe.utils.querySelectorAllFilter(dom, 'ul, #one', function(
+          node
+        ) {
+          return node.actualNode.nodeName !== 'UL';
+        });
+        assert.equal(result[0].actualNode.nodeName, 'DIV');
+        assert.equal(result.length, 1);
+      });
     });
-    assert.equal(result[0].actualNode.nodeName, 'DIV');
-    assert.equal(result.length, 1);
-  });
+  }
 });
+
 describe('axe.utils.querySelectorAll', function() {
   'use strict';
   var dom;

--- a/test/core/utils/selector-cache.js
+++ b/test/core/utils/selector-cache.js
@@ -1,0 +1,242 @@
+describe('utils.selector-cache', function() {
+  var fixture = document.querySelector('#fixture');
+  var cacheNodeSelectors =
+    axe._thisWillBeDeletedDoNotUse.utils.cacheNodeSelectors;
+  var getNodesMatchingExpression =
+    axe._thisWillBeDeletedDoNotUse.utils.getNodesMatchingExpression;
+  var convertSelector = axe.utils.convertSelector;
+
+  var vNode;
+  beforeEach(function() {
+    fixture.innerHTML = '<div id="target" class="foo" aria-label="bar"></div>';
+    vNode = new axe.VirtualNode(fixture.firstChild);
+  });
+
+  afterEach(function() {
+    fixture.innerHTML = '';
+  });
+
+  describe('cacheNodeSelectors', function() {
+    it('should add the node to the global selector', function() {
+      cacheNodeSelectors(vNode);
+      assert.deepEqual(vNode._selectorMap['*'], [vNode]);
+    });
+
+    it('should add the node to the nodeName', function() {
+      cacheNodeSelectors(vNode);
+      assert.deepEqual(vNode._selectorMap.div, [vNode]);
+    });
+
+    it('should add the node to all attribute selectors', function() {
+      cacheNodeSelectors(vNode);
+      assert.deepEqual(vNode._selectorMap['[id]'], [vNode]);
+      assert.deepEqual(vNode._selectorMap['[class]'], [vNode]);
+      assert.deepEqual(vNode._selectorMap['[aria-label]'], [vNode]);
+    });
+
+    it('should add the node to the id map', function() {
+      cacheNodeSelectors(vNode);
+      assert.deepEqual(vNode._selectorMap[' [idsMap]'].target, [vNode]);
+    });
+
+    it('should not add the node to selectors it does not match', function() {
+      cacheNodeSelectors(vNode);
+      assert.isUndefined(vNode._selectorMap['[for]']);
+      assert.isUndefined(vNode._selectorMap.h1);
+    });
+
+    it('should ignore non-element nodes', function() {
+      fixture.innerHTML = 'Hello';
+      vNode = new axe.VirtualNode(fixture.firstChild);
+      cacheNodeSelectors(vNode);
+
+      assert.isUndefined(vNode._selectorMap);
+    });
+  });
+
+  describe('getNodesMatchingExpression', function() {
+    var tree;
+    var spanVNode;
+
+    function createTree() {
+      var parent = document.createElement('section');
+      var parentVNode = new axe.VirtualNode(parent);
+      tree = [parentVNode];
+      var nodes = [];
+
+      for (var i = 0; i < fixture.children.length; i++) {
+        var child = fixture.children[i];
+        var isShadow = child.hasAttribute('data-shadow');
+        var childVNode = new axe.VirtualNode(
+          child,
+          parentVNode,
+          isShadow ? i : undefined
+        );
+        parentVNode.children.push(child);
+        nodes.push(childVNode);
+      }
+
+      return nodes;
+    }
+
+    beforeEach(function() {
+      var span = document.createElement('span');
+      span.setAttribute('class', 'bar');
+      span.setAttribute('id', 'notTarget');
+      span.setAttribute('aria-labelledby', 'target');
+      spanVNode = new axe.VirtualNode(span, vNode);
+      vNode.children.push(spanVNode);
+      tree = [vNode];
+    });
+
+    it('should return undefined if the cache is not primed', function() {
+      tree[0]._selectorMap = null;
+      var expression = convertSelector('div');
+      assert.isUndefined(getNodesMatchingExpression(tree, expression));
+    });
+
+    it('should return a list of matching nodes by global selector', function() {
+      var expression = convertSelector('*');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [
+        vNode,
+        spanVNode
+      ]);
+    });
+
+    it('should return a list of matching nodes by nodeName', function() {
+      var expression = convertSelector('div');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
+    });
+
+    it('should return a list of matching nodes by id', function() {
+      var expression = convertSelector('#target');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
+    });
+
+    it('should only return nodes matching shadowId when matching by id', function() {
+      fixture.innerHTML =
+        '<div id="target"></div><div id="target" data-shadow></div>';
+      var nodes = createTree();
+      var expression = convertSelector('#target');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [
+        nodes[0]
+      ]);
+    });
+
+    it('should return a list of matching nodes by class', function() {
+      var expression = convertSelector('.foo');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
+    });
+
+    it('should return a list of matching nodes by attribute', function() {
+      var expression = convertSelector('[aria-label]');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
+    });
+
+    it('should return an empty array if selector does not match', function() {
+      var expression = convertSelector('h1');
+      assert.lengthOf(getNodesMatchingExpression(tree, expression), 0);
+    });
+
+    it('should return nodes for each expression', function() {
+      fixture.innerHTML =
+        '<div role="button" aria-label="other"></div><span id="foo"></span>';
+      var nodes = createTree();
+      var expression = convertSelector('[role], [id]');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), nodes);
+    });
+
+    it('should return nodes for child combinator selector', function() {
+      var expression = convertSelector('div span');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [
+        spanVNode
+      ]);
+    });
+
+    it('should return nodes for direct child combinator selector', function() {
+      var expression = convertSelector('div > span');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [
+        spanVNode
+      ]);
+    });
+
+    it('should return nodes for attribute value selector', function() {
+      var expression = convertSelector('[id="target"]');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
+    });
+
+    it('should return undefined for combinator selector with global selector', function() {
+      var expression = convertSelector('body *');
+      assert.isUndefined(getNodesMatchingExpression(tree, expression));
+    });
+
+    it('should return nodes for multipart selectors', function() {
+      var expression = convertSelector('div.foo[id]');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
+    });
+
+    it('should remove duplicates', function() {
+      fixture.innerHTML = '<div role="button" aria-label="other"></div>';
+      var nodes = createTree();
+      var expression = convertSelector('div, [aria-label]');
+      assert.deepEqual(getNodesMatchingExpression(tree, expression), nodes);
+    });
+
+    it('should sort nodes by added order', function() {
+      fixture.innerHTML =
+        '<div id="id0"></div>' +
+        '<span id="id1"></span>' +
+        '<div id="id2"></div>' +
+        '<span id="id3"></span>' +
+        '<div id="id4"></div>' +
+        '<span id="id5"></span>' +
+        '<div id="id6"></div>' +
+        '<span id="id7"></span>' +
+        '<div id="id8"></div>' +
+        '<span id="id9"></span>';
+      createTree();
+
+      var expression = convertSelector('div, span');
+      var nodes = getNodesMatchingExpression(tree, expression);
+      var ids = [];
+      for (var i = 0; i < nodes.length; i++) {
+        ids.push(nodes[i].attr('id'));
+      }
+
+      assert.deepEqual(ids, [
+        'id0',
+        'id1',
+        'id2',
+        'id3',
+        'id4',
+        'id5',
+        'id6',
+        'id7',
+        'id8',
+        'id9'
+      ]);
+    });
+
+    it('should filter nodes', function() {
+      fixture.innerHTML =
+        '<div role="button" aria-label="other"></div><div></div>';
+      var nodes = createTree();
+
+      function filter(node) {
+        return node.hasAttr('role');
+      }
+
+      var nonFilteredNodes = getNodesMatchingExpression(
+        tree,
+        convertSelector('div, [aria-label]')
+      );
+      var filteredNodes = getNodesMatchingExpression(
+        tree,
+        convertSelector('div, [aria-label]'),
+        filter
+      );
+      assert.deepEqual(nonFilteredNodes, nodes);
+      assert.deepEqual(filteredNodes, [nodes[0]]);
+    });
+  });
+});


### PR DESCRIPTION
Following the QSA proposal, this greatly improves the speed of QSA as it no longer has to scan the entire DOM tree for top-level queries. For large sites the speed increase is substantial.

For https://js.tensorflow.org/api/latest/, the top slowest performanceTimer results were as follow:

Timer Name | Time (ms)
-- | --
rule_heading-order#gather | 136.40
rule_empty-heading#gather | 137.20
rule_empty-heading | 137.70
rule_list | 139.30
rule_aria-command-name#gather | 140.40
rule_aria-command-name | 140.70
rule_aria-allowed-attr#gather | 148.30
runchecks_heading-order | 151.10
runchecks_page-has-heading-one | 151.30
rule_page-has-heading-one | 151.40
rule_identical-links-same-purpose#gather | 172.60
runchecks_link-name | 197.30
rule_valid-lang#gather | 197.70
rule_valid-lang | 198.10
rule_landmark-unique#gather | 208.90
rule_landmark-unique | 210.80
rule_aria-allowed-attr | 216.40
rule_identical-links-same-purpose#matches | 273.50
rule_link-name | 278.60
rule_heading-order | 287.60
runchecks_bypass | 338.80
rule_bypass | 405.80
rule_identical-links-same-purpose | 575.70
runchecks_region | 871.80
rule_color-contrast#matches | 967.10
rule_region | 997.40
runchecks_color-contrast | 11,530.40
rule_color-contrast | 12,497.60
audit_start_to_end | 21,541.50

We can see that the `#gather` step is what causes most rules to be slow (and not so much the `#runchecks` step), causing axe-core to take 20 seconds to just run through all the rules.

By caching node information ahead of time, the top slowest results are now as follows:

Timer Name | Time (ms)
-- | --
rule_page-has-heading-one | 31.90
runchecks_aria-hidden-body | 31.90
rule_aria-hidden-body | 32.00
rule_autocomplete-valid | 36.60
rule_aria-valid-attr-value | 36.70
rule_aria-valid-attr | 38.80
runchecks_list | 52.90
rule_list | 53.90
rule_scrollable-region-focusable#matches | 69.00
rule_nested-interactive#matches | 71.30
runchecks_bypass | 75.30
rule_bypass | 75.50
rule_aria-allowed-attr#gather_axe.utils.isHidden | 81.50
rule_nested-interactive | 91.80
rule_aria-allowed-attr#gather | 94.70
rule_scrollable-region-focusable | 99.20
rule_region#gather | 102.60
rule_aria-allowed-attr | 115.80
runchecks_identical-links-same-purpose | 121.90
rule_identical-links-same-purpose#matches | 181.30
runchecks_link-name | 186.10
rule_link-name | 193.50
rule_identical-links-same-purpose | 308.60
runchecks_region | 806.00
rule_region | 914.70
rule_color-contrast#matches | 1,054.00
runchecks_color-contrast | 11,780.90
rule_color-contrast | 12,835.00
audit_start_to_end | 15,093.50
axe | 16,805.50

This change shaves off about 7-10 seconds from the time needed to run all of axe rules on the site (`audit_start_to_end`).

As the page size increases, so too does the savings. Testing an extremely large site (152,000 nodes), this is the final time difference:

Timer Name | Normal Run Time (ms) | Cache Run Time (ms)
-- | -- | --
audit_start_to_end | 62,128.60 | 45,251.90
axe | 75,526.50 | 60,693.90

This is about a 20 second savings. On medium size pages, the savings is minimal (almost no difference).

To ensure the results are the same, I ran axe-core against the tensorflow site, recorded the results, then ran the caching verison of axe core and compared the two results for equality. Here's the code I used. 

```js
const { AxePuppeteer } = require('@axe-core/puppeteer');
const puppeteer = require('puppeteer');
const fs = require('fs');
const chai = require('chai');
const processArgs = require('./process-args');

const { assert } = chai;
const args = processArgs(process.argv.slice(2));

if (!args.url) {
  throw new Error('Must include a url to test');
}
if (!args.numTests) {
  args.numTests = 1;
}

function assertShallowEqual(obj1, obj2, parentKey = '') {
  let keys;
  if (Array.isArray(obj1)) {
    keys = obj1.map((value, index) => index);

  }
  else {
    keys = Object.keys(obj1);
  }

  keys.forEach(key => {
    const valueObj1 = obj1[key];
    const valueObj2 = obj2[key];

    // don't compare html output, just selector
    if (key === 'html') return;

    // don't compare url props (can contain date-time...)
    if (key === 'urlProps') return;

    // don't compare axe testEngine since they are named differently
    // to ensure correct tests
    if (key === 'testEngine') return;

    // don't look for null
    if (valueObj1) {
      assert.exists(valueObj2, `${key} does not exist on ${parentKey}`);
    }

    if (valueObj1 && (Array.isArray(valueObj1) || typeof valueObj1 === 'object')) {
      assertShallowEqual(valueObj1, valueObj2, `${parentKey}.${key}`);
    }
    else {
      assert.equal(valueObj1, valueObj2, `${parentKey}.${key} not equal`);
    }
  });
}

(async () => {
  const browser = await puppeteer.launch();
  const page = await browser.newPage();
  await page.setBypassCSP(true);

  const axe = new AxePuppeteer(page);
  const results = [];

  const axeCorePath = require.resolve('axe-core');
  const origAxeCore = fs.readFileSync(axeCorePath, 'utf8');
  const devAxeCore = fs.readFileSync('./axe-develop.js', 'utf8');
  const perfAxeCore = fs.readFileSync('./axe-perf.js', 'utf8');

  fs.rmSync('./control', { recursive: true, force: true });
  fs.rmSync('./test', { recursive: true, force: true });

  fs.mkdirSync('./control');
  fs.mkdirSync('./test');

  async function runAxe(dir) {
    for (let i = 0; i < args.numTests; i++) {
      page.goto(args.url);

      // wait for content to settle
      await new Promise((resolve) => {
        setTimeout(resolve, 5000)
      });

      const result = await axe.analyze();
      delete result.timestamp;
      fs.writeFileSync(`./${dir}/result-${i}.json`, JSON.stringify(result, null, 2), 'utf8');
      results.push(result);
    }
  }

  fs.writeFileSync(axeCorePath, devAxeCore, 'utf8');
  await runAxe('control');
  fs.writeFileSync(axeCorePath, perfAxeCore, 'utf8');
  await runAxe('test');
  fs.writeFileSync(axeCorePath, origAxeCore, 'utf8');

  try {
    for (let i = 0; i < args.numTests; i++) {
      assertShallowEqual(results[i], results[i+1]);
    }
  } finally {
    await page.close();
    await browser.close();
  }
})();
```