### PR TITLE
feat(empty-table-headers): rule is now best-practice and fails instead of incompletes

### DIFF
--- a/lib/rules/empty-table-header.json
+++ b/lib/rules/empty-table-header.json
@@ -2,7 +2,6 @@
   "id": "empty-table-header",
   "selector": "th, [role=\"rowheader\"], [role=\"columnheader\"]",
   "tags": ["cat.name-role-value", "best-practice"],
-  "impact": "minor",
   "metadata": {
     "description": "Ensures table headers have discernible text",
     "help": "Table header text should not be empty"

--- a/lib/rules/empty-table-header.json
+++ b/lib/rules/empty-table-header.json
@@ -1,11 +1,11 @@
 {
   "id": "empty-table-header",
   "selector": "th, [role=\"rowheader\"], [role=\"columnheader\"]",
-  "tags": ["wcag131", "cat.aria"],
-  "reviewOnFail": true,
+  "tags": ["cat.name-role-value", "best-practice"],
+  "impact": "minor",
   "metadata": {
     "description": "Ensures table headers have discernible text",
-    "help": "Table header text must not be empty"
+    "help": "Table header text should not be empty"
   },
   "all": [],
   "any": ["has-visible-text"],

--- a/test/aria-practices/apg.spec.js
+++ b/test/aria-practices/apg.spec.js
@@ -53,8 +53,11 @@ describe('aria-practices', function() {
       'landmark-banner-is-top-level',
       'landmark-contentinfo-is-top-level'
     ],
-    //https://github.com/w3c/aria-practices/issues/2199
-    'button/button_idl.html': ['aria-allowed-attr']
+    // https://github.com/w3c/aria-practices/issues/2199
+    'button/button_idl.html': ['aria-allowed-attr'],
+    // https://github.com/w3c/aria-practices/issues/2285
+    'checkbox/checkbox.html': ['empty-table-header'],
+    'dialog-modal/datepicker-dialog.html': ['empty-table-header']
   };
 
   // Not an actual content file

--- a/test/integration/rules/empty-table-header/empty-table-header.html
+++ b/test/integration/rules/empty-table-header/empty-table-header.html
@@ -26,13 +26,13 @@
 
     <table>
       <tr>
-        <th id="incomplete1"></th>
+        <th id="fail1"></th>
       </tr>
     </table>
 
     <table>
       <tr>
-        <td id="incomplete2" role="rowheader">
+        <td id="fail2" role="rowheader">
           <div style="display: none">Not Ok</div>
         </td>
       </tr>
@@ -40,7 +40,7 @@
 
     <table>
       <tr>
-        <td id="incomplete3" role="columnheader">
+        <td id="fail3" role="columnheader">
           <div style="display: none">Not Ok</div>
         </td>
       </tr>

--- a/test/integration/rules/empty-table-header/empty-table-header.json
+++ b/test/integration/rules/empty-table-header/empty-table-header.json
@@ -1,6 +1,6 @@
 {
   "description": "empty-table-header tests",
   "rule": "empty-table-header",
-  "incomplete": [["#incomplete1"], ["#incomplete2"], ["#incomplete3"]],
+  "violations": [["#fail1"], ["#fail2"], ["#fail3"]],
   "passes": [["#pass1"], ["#pass2"], ["#pass3"]]
 }


### PR DESCRIPTION
References #3404

Updated empty table headers rule to be best practice rather than a WCAG failure.

Closes issue:
