### PR TITLE
ci: fix nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,114 +297,104 @@ workflows:
   version: 2
   build:
     jobs:
+      # install deps
       - dependencies_unix
-      - test_nightly_browsers:
+      - dependencies_win
+      # Run linting
+      - lint:
           requires:
             - dependencies_unix
-      - test_nightly_act:
+      # Run tests on all commits, but after installing dependencies
+      - test_unix:
+          requires:
+            - lint
+      # Run IE/ Windows test on all commits
+      - test_win:
+          requires:
+            - dependencies_win
+      - test_examples:
+          requires:
+            - test_unix
+      - test_act:
+          requires:
+            - test_unix
+      - test_aria_practices:
+          requires:
+            - test_unix
+      - test_locales:
+          requires:
+            - test_unix
+      - test_virtual_rules:
+          requires:
+            - test_unix
+      - build_api_docs:
+          requires:
+            - test_unix
+      - test_rule_help_version:
+          requires:
+            - test_unix
+      - test_node:
+          requires:
+            - test_unix
+      # Hold for approval
+      - hold:
+          type: approval
+          requires:
+            - test_unix
+            - test_win
+            - test_examples
+            - test_locales
+            - test_virtual_rules
+            - build_api_docs
+            - test_rule_help_version
+            - test_node
+          filters:
+            branches:
+              only:
+                - master
+      # Run a next release on "develop" commits, but only after the tests pass and dependencies are installed
+      - next_release:
           requires:
             - dependencies_unix
-      - test_nightly_aria_practices:
+            - test_unix
+            - test_examples
+            - test_locales
+            - test_virtual_rules
+            - build_api_docs
+          filters:
+            branches:
+              only: develop
+      # Run a production release on "master" commits, but only after the tests pass and dependencies are installed
+      - release:
           requires:
             - dependencies_unix
-      # # install deps
-      # - dependencies_unix
-      # - dependencies_win
-      # # Run linting
-      # - lint:
-      #     requires:
-      #       - dependencies_unix
-      # # Run tests on all commits, but after installing dependencies
-      # - test_unix:
-      #     requires:
-      #       - lint
-      # # Run IE/ Windows test on all commits
-      # - test_win:
-      #     requires:
-      #       - dependencies_win
-      # - test_examples:
-      #     requires:
-      #       - test_unix
-      # - test_act:
-      #     requires:
-      #       - test_unix
-      # - test_aria_practices:
-      #     requires:
-      #       - test_unix
-      # - test_locales:
-      #     requires:
-      #       - test_unix
-      # - test_virtual_rules:
-      #     requires:
-      #       - test_unix
-      # - build_api_docs:
-      #     requires:
-      #       - test_unix
-      # - test_rule_help_version:
-      #     requires:
-      #       - test_unix
-      # - test_node:
-      #     requires:
-      #       - test_unix
-      # # Hold for approval
-      # - hold:
-      #     type: approval
-      #     requires:
-      #       - test_unix
-      #       - test_win
-      #       - test_examples
-      #       - test_locales
-      #       - test_virtual_rules
-      #       - build_api_docs
-      #       - test_rule_help_version
-      #       - test_node
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # # Run a next release on "develop" commits, but only after the tests pass and dependencies are installed
-      # - next_release:
-      #     requires:
-      #       - dependencies_unix
-      #       - test_unix
-      #       - test_examples
-      #       - test_locales
-      #       - test_virtual_rules
-      #       - build_api_docs
-      #     filters:
-      #       branches:
-      #         only: develop
-      # # Run a production release on "master" commits, but only after the tests pass and dependencies are installed
-      # - release:
-      #     requires:
-      #       - dependencies_unix
-      #       - test_unix
-      #       - test_examples
-      #       - test_locales
-      #       - test_virtual_rules
-      #       - build_api_docs
-      #       - test_rule_help_version
-      #       - test_node
-      #       - hold
-      #     filters:
-      #       branches:
-      #         only: master
-      # # Verify releases have all required files
-      # - verify_release:
-      #     requires:
-      #       - release
-      #     filters:
-      #       branches:
-      #         only: master
-      # - verify_next_release:
-      #     requires:
-      #       - next_release
-      #     filters:
-      #       branches:
-      #         only: develop
-      # - github_release:
-      #     requires:
-      #       - release
+            - test_unix
+            - test_examples
+            - test_locales
+            - test_virtual_rules
+            - build_api_docs
+            - test_rule_help_version
+            - test_node
+            - hold
+          filters:
+            branches:
+              only: master
+      # Verify releases have all required files
+      - verify_release:
+          requires:
+            - release
+          filters:
+            branches:
+              only: master
+      - verify_next_release:
+          requires:
+            - next_release
+          filters:
+            branches:
+              only: develop
+      - github_release:
+          requires:
+            - release
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,9 @@ jobs:
     <<: *defaults
     <<: *unix_nightly_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
+      - browser-tools/install-browser-tools
       - run: npm run build
       # install ACT rules
       - run: npm install act-rules/act-rules.github.io#master
@@ -191,9 +191,9 @@ jobs:
     <<: *defaults
     <<: *unix_nightly_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
       - <<: *restore_dependency_cache_unix
+      - browser-tools/install-browser-tools
       - run: npm run build
       # install ARIA practices
       - run: npm install w3c/aria-practices#main
@@ -291,104 +291,114 @@ workflows:
   version: 2
   build:
     jobs:
-      # install deps
       - dependencies_unix
-      - dependencies_win
-      # Run linting
-      - lint:
+      - test_nightly_browsers:
           requires:
             - dependencies_unix
-      # Run tests on all commits, but after installing dependencies
-      - test_unix:
-          requires:
-            - lint
-      # Run IE/ Windows test on all commits
-      - test_win:
-          requires:
-            - dependencies_win
-      - test_examples:
-          requires:
-            - test_unix
-      - test_act:
-          requires:
-            - test_unix
-      - test_aria_practices:
-          requires:
-            - test_unix
-      - test_locales:
-          requires:
-            - test_unix
-      - test_virtual_rules:
-          requires:
-            - test_unix
-      - build_api_docs:
-          requires:
-            - test_unix
-      - test_rule_help_version:
-          requires:
-            - test_unix
-      - test_node:
-          requires:
-            - test_unix
-      # Hold for approval
-      - hold:
-          type: approval
-          requires:
-            - test_unix
-            - test_win
-            - test_examples
-            - test_locales
-            - test_virtual_rules
-            - build_api_docs
-            - test_rule_help_version
-            - test_node
-          filters:
-            branches:
-              only:
-                - master
-      # Run a next release on "develop" commits, but only after the tests pass and dependencies are installed
-      - next_release:
+      - test_nightly_act:
           requires:
             - dependencies_unix
-            - test_unix
-            - test_examples
-            - test_locales
-            - test_virtual_rules
-            - build_api_docs
-          filters:
-            branches:
-              only: develop
-      # Run a production release on "master" commits, but only after the tests pass and dependencies are installed
-      - release:
+      - test_nightly_aria_practices:
           requires:
             - dependencies_unix
-            - test_unix
-            - test_examples
-            - test_locales
-            - test_virtual_rules
-            - build_api_docs
-            - test_rule_help_version
-            - test_node
-            - hold
-          filters:
-            branches:
-              only: master
-      # Verify releases have all required files
-      - verify_release:
-          requires:
-            - release
-          filters:
-            branches:
-              only: master
-      - verify_next_release:
-          requires:
-            - next_release
-          filters:
-            branches:
-              only: develop
-      - github_release:
-          requires:
-            - release
+      # # install deps
+      # - dependencies_unix
+      # - dependencies_win
+      # # Run linting
+      # - lint:
+      #     requires:
+      #       - dependencies_unix
+      # # Run tests on all commits, but after installing dependencies
+      # - test_unix:
+      #     requires:
+      #       - lint
+      # # Run IE/ Windows test on all commits
+      # - test_win:
+      #     requires:
+      #       - dependencies_win
+      # - test_examples:
+      #     requires:
+      #       - test_unix
+      # - test_act:
+      #     requires:
+      #       - test_unix
+      # - test_aria_practices:
+      #     requires:
+      #       - test_unix
+      # - test_locales:
+      #     requires:
+      #       - test_unix
+      # - test_virtual_rules:
+      #     requires:
+      #       - test_unix
+      # - build_api_docs:
+      #     requires:
+      #       - test_unix
+      # - test_rule_help_version:
+      #     requires:
+      #       - test_unix
+      # - test_node:
+      #     requires:
+      #       - test_unix
+      # # Hold for approval
+      # - hold:
+      #     type: approval
+      #     requires:
+      #       - test_unix
+      #       - test_win
+      #       - test_examples
+      #       - test_locales
+      #       - test_virtual_rules
+      #       - build_api_docs
+      #       - test_rule_help_version
+      #       - test_node
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # # Run a next release on "develop" commits, but only after the tests pass and dependencies are installed
+      # - next_release:
+      #     requires:
+      #       - dependencies_unix
+      #       - test_unix
+      #       - test_examples
+      #       - test_locales
+      #       - test_virtual_rules
+      #       - build_api_docs
+      #     filters:
+      #       branches:
+      #         only: develop
+      # # Run a production release on "master" commits, but only after the tests pass and dependencies are installed
+      # - release:
+      #     requires:
+      #       - dependencies_unix
+      #       - test_unix
+      #       - test_examples
+      #       - test_locales
+      #       - test_virtual_rules
+      #       - build_api_docs
+      #       - test_rule_help_version
+      #       - test_node
+      #       - hold
+      #     filters:
+      #       branches:
+      #         only: master
+      # # Verify releases have all required files
+      # - verify_release:
+      #     requires:
+      #       - release
+      #     filters:
+      #       branches:
+      #         only: master
+      # - verify_next_release:
+      #     requires:
+      #       - next_release
+      #     filters:
+      #       branches:
+      #         only: develop
+      # - github_release:
+      #     requires:
+      #       - release
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,7 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - browser-tools/install-browser-tools
+      - npx browser-driver-manager install chromedriver --verbose
       - run: npm run build
       # install ACT rules
       - run: npm install act-rules/act-rules.github.io#master
@@ -194,6 +195,7 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - browser-tools/install-browser-tools
+      - npx browser-driver-manager install chromedriver --verbose
       - run: npm run build
       # install ARIA practices
       - run: npm install w3c/aria-practices#main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,11 +181,13 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - browser-tools/install-browser-tools
+      # install ACT rules
+      # install first as for some reason installing a single package
+      # also re-installs all repo dependencies as well
+      - run: npm install act-rules/act-rules.github.io#master
       - run: npx browser-driver-manager install chromedriver --verbose
       - run: npm run build
-      # install ACT rules
-      - run: npm install act-rules/act-rules.github.io#master
-      - run: npm run test:apg
+      - run: npm run test:act
 
   # Run the test suite for nightly builds.
   test_nightly_aria_practices:
@@ -195,10 +197,12 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - browser-tools/install-browser-tools
+      # install ARIA practices
+      # install first as for some reason installing a single package
+      # also re-installs all repo dependencies as well
+      - run: npm install w3c/aria-practices#main
       - run: npx browser-driver-manager install chromedriver --verbose
       - run: npm run build
-      # install ARIA practices
-      - run: npm install w3c/aria-practices#main
       - run: npm run test:apg
 
   # Test api docs can be built

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - browser-tools/install-browser-tools
-      - npx browser-driver-manager install chromedriver --verbose
+      - run: npx browser-driver-manager install chromedriver --verbose
       - run: npm run build
       # install ACT rules
       - run: npm install act-rules/act-rules.github.io#master
@@ -195,7 +195,7 @@ jobs:
       - checkout
       - <<: *restore_dependency_cache_unix
       - browser-tools/install-browser-tools
-      - npx browser-driver-manager install chromedriver --verbose
+      - run: npx browser-driver-manager install chromedriver --verbose
       - run: npm run build
       # install ARIA practices
       - run: npm install w3c/aria-practices#main


### PR DESCRIPTION
Apparently what was going on was that after `npx browser-driver-manager install chromedriver` installed chromedriver 99/100, doing `npm install w3c/aria-practices#main` would __override__ the previously installed chromedriver with the version listed in `package-lock.json`. So the fix was to change the order of installs so that chromedriver was installed as the last thing.

Also fixed the nightly act running apg instead.

Here's the build showing nightly works now https://app.circleci.com/pipelines/github/dequelabs/axe-core/3537/workflows/1685f851-de20-40d5-b955-bf36ab194c51