### PR TITLE
feat(getRules): return actIds when set

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -249,6 +249,7 @@ declare namespace axe {
     help: string;
     helpUrl: string;
     tags: string[];
+    actIds?: string[];
   }
   interface SerialDqElement {
     source: string;

--- a/doc/API.md
+++ b/doc/API.md
@@ -154,7 +154,7 @@ In this example, we pass in the WCAG 2 A and AA tags into `axe.getRules` to retr
       "section508",
       "section508.22.a"
     ],
-    actIds: ['abc123']
+    actIds: ['c487ae']
   },
   {
     description: "Ensures ARIA attributes are allowed for an element's role",

--- a/doc/API.md
+++ b/doc/API.md
@@ -153,7 +153,8 @@ In this example, we pass in the WCAG 2 A and AA tags into `axe.getRules` to retr
       "wcag412",
       "section508",
       "section508.22.a"
-    ]
+    ],
+    actIds: ['abc123']
   },
   {
     description: "Ensures ARIA attributes are allowed for an element's role",

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -97,6 +97,12 @@ function Rule(spec, parentAudit) {
    */
   this.preload = spec.preload ? true : false;
 
+  /**
+   * IDs of ACT rules the axe-core rule maps to
+   * @type {Array|undefined}
+   */
+  this.actIds = spec.actIds;
+
   if (spec.matches) {
     /**
      * Optional function to test if rule should be run against a node, overrides Rule#matches
@@ -593,6 +599,10 @@ Rule.prototype.configure = function configure(spec) {
 
   if (spec.hasOwnProperty('tags')) {
     this.tags = spec.tags;
+  }
+
+  if (spec.hasOwnProperty('actIds')) {
+    this.actIds = spec.actIds;
   }
 
   if (spec.hasOwnProperty('matches')) {

--- a/lib/core/public/get-rules.js
+++ b/lib/core/public/get-rules.js
@@ -21,7 +21,8 @@ function getRules(tags) {
       description: rd.description,
       help: rd.help,
       helpUrl: rd.helpUrl,
-      tags: matchingRule.tags
+      tags: matchingRule.tags,
+      actIds: matchingRule.actIds
     };
   });
 }

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -1875,6 +1875,7 @@ describe('Rule', function() {
         assert.equal(new Rule(spec).matches(), 'blah');
       });
     });
+
     describe('.tags', function() {
       it('should be set', function() {
         var spec = {
@@ -1886,6 +1887,20 @@ describe('Rule', function() {
       it('should default to empty array', function() {
         var spec = {};
         assert.deepEqual(new Rule(spec).tags, []);
+      });
+    });
+
+    describe('.actIds', function() {
+      it('should be set', function() {
+        var spec = {
+          actIds: ['abc123', 'xyz789']
+        };
+        assert.deepEqual(new Rule(spec).actIds, spec.actIds);
+      });
+
+      it('should default to undefined', function() {
+        var spec = {};
+        assert.isUndefined(new Rule(spec).actIds);
       });
     });
   });

--- a/test/core/public/get-rules.js
+++ b/test/core/public/get-rules.js
@@ -16,7 +16,8 @@ describe('axe.getRules', function() {
         {
           id: 'awesomeRule2',
           any: [],
-          tags: ['tag1', 'tag2']
+          tags: ['tag1', 'tag2'],
+          actIds: ['abc123', 'xyz789']
         }
       ],
       data: {
@@ -63,6 +64,7 @@ describe('axe.getRules', function() {
         '/awesomeRule2?application=axeAPI'
     );
     assert.deepEqual(retValue[1].tags, ['tag1', 'tag2']);
+    assert.deepEqual(retValue[1].actIds, ['abc123', 'xyz789']);
 
     retValue = axe.getRules(['tag2']);
     assert.isArray(retValue);
@@ -77,6 +79,7 @@ describe('axe.getRules', function() {
         '/awesomeRule2?application=axeAPI'
     );
     assert.deepEqual(retValue[0].tags, ['tag1', 'tag2']);
+    assert.deepEqual(retValue[0].actIds, ['abc123', 'xyz789']);
   });
 
   it('should not return nothing', function() {
@@ -108,6 +111,7 @@ describe('axe.getRules', function() {
         '/awesomeRule2?application=axeAPI'
     );
     assert.deepEqual(retValue[1].tags, ['tag1', 'tag2']);
+    assert.deepEqual(retValue[1].actIds, ['abc123', 'xyz789']);
   });
 
   it('should return all rules if given empty array', function() {
@@ -133,5 +137,6 @@ describe('axe.getRules', function() {
         '/awesomeRule2?application=axeAPI'
     );
     assert.deepEqual(retValue[1].tags, ['tag1', 'tag2']);
+    assert.deepEqual(retValue[1].actIds, ['abc123', 'xyz789']);
   });
 });


### PR DESCRIPTION
Return `actIds` from `axe.getRules()`.

Closes issue #3469