### PR TITLE
fix(axe.d.ts): updates type definition for Rule to add reviewOnFail

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -233,6 +233,7 @@ declare namespace axe {
     none?: string[];
     tags?: string[];
     matches?: string;
+    reviewOnFail?: boolean;
   }
   interface AxePlugin {
     id: string;


### PR DESCRIPTION
…meter reviewOnFail

Updates the type definition file to add reviewOnFail to Rule type. ReviewOnFail is a valid configuration parameter that can be passed into the configure command in an array of rules.

Example:

`axe.configure({
  rules: [
    {
      id: 'new-rule',
      reviewOnFail: true
      // ...
    }
  ]
})`

Closes issue:

No issue attached.
