### PR TITLE
fix(meta-refresh): Add WCAG's 20-hour exception

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -25,6 +25,7 @@
   - [css-orientation-lock](#css-orientation-lock)
   - [meta-viewport-large](#meta-viewport-large)
   - [meta-viewport](#meta-viewport)
+  - [meta-refresh](#meta-refresh)
   - [header-present](#header-present)
   - [landmark](#landmark)
   - [p-as-heading](#p-as-heading)
@@ -384,6 +385,13 @@ th</code></pre>
 | Option         | Default | Description                                                                                  |
 | -------------- | :------ | :------------------------------------------------------------------------------------------- |
 | `scaleMinimum` | `2`     | The `scale-maximum` CSS value the check applies to. Values above this number will be ignored |
+
+### meta-refresh
+
+| Option     | Default | Description                                                                         |
+| ---------- | :------ | :---------------------------------------------------------------------------------- |
+| `minDelay` | `0`     | Passes if the redirect is equal or less than this. Can be set to `false` to disable |
+| `maxDelay` | `7200`  | Passes if the redirect is greater than this. Can be set to `false` to disable       |
 
 ### header-present
 

--- a/lib/checks/navigation/meta-refresh-evaluate.js
+++ b/lib/checks/navigation/meta-refresh-evaluate.js
@@ -1,8 +1,24 @@
-function metaRefreshEvaluate(node, options, virtualNode) {
-  var content = virtualNode.attr('content') || '',
-    parsedParams = content.split(/[;,]/);
+const separatorRegex = /[;,\s]/
+const validRedirectNumRegex = /^[0-9.]+$/
 
-  return content === '' || parsedParams[0] === '0';
+function metaRefreshEvaluate(node, options, virtualNode) {
+  const content = (virtualNode.attr('content') || '').trim();
+  if (!content) {
+    return true;
+  }  
+  const [redirectStr] = content.split(separatorRegex);
+  if (!redirectStr.match(validRedirectNumRegex)) {
+    return true;
+  }
+  // Prepend "0" to deal with the ".5" case:
+  const redirectNum = parseInt('0' + redirectStr);
+  if (typeof options?.minDelay === 'number' && redirectNum <= options.minDelay) {
+    return true;
+  }
+  if (typeof options?.maxDelay === 'number' && redirectNum > options.maxDelay) {
+    return true;
+  }
+  return false;
 }
 
 export default metaRefreshEvaluate;

--- a/lib/checks/navigation/meta-refresh-evaluate.js
+++ b/lib/checks/navigation/meta-refresh-evaluate.js
@@ -11,11 +11,12 @@ function metaRefreshEvaluate(node, options, virtualNode) {
     return true;
   }
   // Prepend "0" to deal with the ".5" case:
-  const redirectNum = parseInt('0' + redirectStr);
-  if (typeof options?.minDelay === 'number' && redirectNum <= options.minDelay) {
+  const redirectDelay = parseInt('0' + redirectStr);
+  this.data({ redirectDelay });
+  if (typeof options?.minDelay === 'number' && redirectDelay <= options.minDelay) {
     return true;
   }
-  if (typeof options?.maxDelay === 'number' && redirectNum > options.maxDelay) {
+  if (typeof options?.maxDelay === 'number' && redirectDelay > options.maxDelay) {
     return true;
   }
   return false;

--- a/lib/checks/navigation/meta-refresh-evaluate.js
+++ b/lib/checks/navigation/meta-refresh-evaluate.js
@@ -2,26 +2,19 @@ const separatorRegex = /[;,\s]/;
 const validRedirectNumRegex = /^[0-9.]+$/;
 
 export default function metaRefreshEvaluate(node, options, virtualNode) {
+  const { minDelay, maxDelay } = options || {};
   const content = (virtualNode.attr('content') || '').trim();
-  if (!content) {
-    return true;
-  }
   const [redirectStr] = content.split(separatorRegex);
   if (!redirectStr.match(validRedirectNumRegex)) {
     return true;
   }
-  const redirectDelay = praseFloat(redirectStr);
+
+  const redirectDelay = parseFloat(redirectStr);
   this.data({ redirectDelay });
-  if (
-    typeof options?.minDelay === 'number' &&
-    redirectDelay <= options.minDelay
-  ) {
+  if (typeof minDelay === 'number' && redirectDelay <= options.minDelay) {
     return true;
   }
-  if (
-    typeof options?.maxDelay === 'number' &&
-    redirectDelay > options.maxDelay
-  ) {
+  if (typeof maxDelay === 'number' && redirectDelay > options.maxDelay) {
     return true;
   }
   return false;

--- a/lib/checks/navigation/meta-refresh-evaluate.js
+++ b/lib/checks/navigation/meta-refresh-evaluate.js
@@ -1,25 +1,28 @@
-const separatorRegex = /[;,\s]/
-const validRedirectNumRegex = /^[0-9.]+$/
+const separatorRegex = /[;,\s]/;
+const validRedirectNumRegex = /^[0-9.]+$/;
 
-function metaRefreshEvaluate(node, options, virtualNode) {
+export default function metaRefreshEvaluate(node, options, virtualNode) {
   const content = (virtualNode.attr('content') || '').trim();
   if (!content) {
     return true;
-  }  
+  }
   const [redirectStr] = content.split(separatorRegex);
   if (!redirectStr.match(validRedirectNumRegex)) {
     return true;
   }
-  // Prepend "0" to deal with the ".5" case:
-  const redirectDelay = parseInt('0' + redirectStr);
+  const redirectDelay = praseFloat(redirectStr);
   this.data({ redirectDelay });
-  if (typeof options?.minDelay === 'number' && redirectDelay <= options.minDelay) {
+  if (
+    typeof options?.minDelay === 'number' &&
+    redirectDelay <= options.minDelay
+  ) {
     return true;
   }
-  if (typeof options?.maxDelay === 'number' && redirectDelay > options.maxDelay) {
+  if (
+    typeof options?.maxDelay === 'number' &&
+    redirectDelay > options.maxDelay
+  ) {
     return true;
   }
   return false;
 }
-
-export default metaRefreshEvaluate;

--- a/lib/checks/navigation/meta-refresh.json
+++ b/lib/checks/navigation/meta-refresh.json
@@ -1,6 +1,10 @@
 {
   "id": "meta-refresh",
   "evaluate": "meta-refresh-evaluate",
+  "options": {
+    "minDelay": 0,
+    "maxDelay": 72000
+  },
   "metadata": {
     "impact": "critical",
     "messages": {

--- a/lib/rules/meta-refresh.json
+++ b/lib/rules/meta-refresh.json
@@ -1,6 +1,6 @@
 {
   "id": "meta-refresh",
-  "selector": "meta[http-equiv=\"refresh\"]",
+  "selector": "meta[http-equiv=\"refresh\"][content]",
   "excludeHidden": false,
   "tags": [
     "cat.time-and-media",

--- a/test/checks/navigation/meta-refresh.js
+++ b/test/checks/navigation/meta-refresh.js
@@ -3,132 +3,186 @@ describe('meta-refresh', function() {
 
   var checkContext = axe.testUtils.MockCheckContext();
   var checkSetup = axe.testUtils.checkSetup;
-  var metaRefreshCheck = axe.testUtils.getCheckEvaluate('meta-refresh')
+  var metaRefreshCheck = axe.testUtils.getCheckEvaluate('meta-refresh');
 
   afterEach(function() {
     checkContext.reset();
   });
 
-  it('returns false if there is a number', function () {
+  it('returns false if there is a number', function() {
     var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">');
     assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
   });
 
-  describe('returns false when valid', function () {
-    it('there is  a decimal', function () {
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3.1">');
+  describe('returns false when valid', function() {
+    it('there is a decimal', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3.1">'
+      );
       assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('there is a number followed by a dot', function () {
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3.">');
-      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
-    });
-  
-    it('there is whitespace before the number', function () {
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="  \n\t3">');
+    it('there is a number followed by a dot', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3.">'
+      );
       assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    describe('with a valid separator', function () {
-      it('the number is followed by a semicolon', function () {
-        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3;">');
-        assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
-      });
-  
-      it('the number is followed by a comma', function () {
-        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3;">');
+    it('there is a dot followed by a number', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content=".5">'
+      );
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+
+    it('there is whitespace before the number', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="  \n\t3">'
+      );
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+
+    describe('with a valid separator', function() {
+      it('the number is followed by a semicolon', function() {
+        var checkArgs = checkSetup(
+          '<meta id="target" name="refresh" content="3;">'
+        );
         assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
       });
 
-      it('the number is followed spaces, and then a separator', function () {
-        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3 \t\n;">');
+      it('the number is followed by a comma', function() {
+        var checkArgs = checkSetup(
+          '<meta id="target" name="refresh" content="3,">'
+        );
         assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
       });
 
-      it('the separator is followed by non-separator characters', function () {
-        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3; https://deque.com/">');
+      it('the number is followed spaces, and then a separator', function() {
+        var checkArgs = checkSetup(
+          '<meta id="target" name="refresh" content="3 \t\n;">'
+        );
         assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
       });
 
-      it('the separator is a space', function () {
-        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3 https://deque.com/">');
+      it('the separator is followed by non-separator characters', function() {
+        var checkArgs = checkSetup(
+          '<meta id="target" name="refresh" content="3; https://deque.com/">'
+        );
+        assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+      });
+
+      it('the separator is a space', function() {
+        var checkArgs = checkSetup(
+          '<meta id="target" name="refresh" content="3 https://deque.com/">'
+        );
         assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
       });
     });
-  })
+  });
 
-  describe('returns true when invalid', function () {
-    it('the number is prefaced with a plus', function () {
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="+3">');
+  describe('returns true when invalid', function() {
+    it('the number is prefaced with a plus', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="+3">'
+      );
       assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
     });
-  
-    it('the number is prefaced with a minus', function () {
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="a3">');
-      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
-    });
-  
-    it('the number is prefaced with a letter', function () {
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="-3">');
+
+    it('the number is prefaced with a minus', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="-3">'
+      );
       assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('the number is followed by an invalid separator character', function () {
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3: https://deque.com/">');
+    it('the number is prefaced with a letter', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="a3">'
+      );
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+
+    it('the number is followed by an invalid separator character', function() {
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3: https://deque.com/">'
+      );
       assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
     });
   });
 
-
-  describe('options.minDelay', function () {
-    it('returns false when the redirect number is greater than minDelay', function () {
-      var options = { minDelay: 2 }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+  describe('options.minDelay', function() {
+    it('returns false when the redirect number is greater than minDelay', function() {
+      var options = { minDelay: 2 };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3">',
+        options
+      );
       assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('returns true when the redirect number equals minDelay', function () {
-      var options = { minDelay: 3 }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+    it('returns true when the redirect number equals minDelay', function() {
+      var options = { minDelay: 3 };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3">',
+        options
+      );
       assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('returns true when the redirect number is less than minDelay', function () {
-      var options = { minDelay: 4 }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+    it('returns true when the redirect number is less than minDelay', function() {
+      var options = { minDelay: 4 };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3">',
+        options
+      );
       assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('ignores minDelay when set to false', function () {
-      var options = { minDelay: false }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="0">', options);
+    it('ignores minDelay when set to false', function() {
+      var options = { minDelay: false };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="0">',
+        options
+      );
       assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
   });
 
-  describe('options.maxDelay', function () {
-    it('returns true when the redirect number is greater than maxDelay', function () {
-      var options = { maxDelay: 2 }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+  describe('options.maxDelay', function() {
+    it('returns true when the redirect number is greater than maxDelay', function() {
+      var options = { maxDelay: 2 };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3">',
+        options
+      );
       assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('returns false when the redirect number equals maxDelay', function () {
-      var options = { maxDelay: 3 }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+    it('returns false when the redirect number equals maxDelay', function() {
+      var options = { maxDelay: 3 };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3">',
+        options
+      );
       assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('returns false when the redirect number is less than maxDelay', function () {
-      var options = { maxDelay: 4 }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+    it('returns false when the redirect number is less than maxDelay', function() {
+      var options = { maxDelay: 4 };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="3">',
+        options
+      );
       assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('ignores maxDelay when set to false', function () {
-      var options = { maxDelay: false }
-      var checkArgs = checkSetup('<meta id="target" name="refresh" content="9999">', options);
+    it('ignores maxDelay when set to false', function() {
+      var options = { maxDelay: false };
+      var checkArgs = checkSetup(
+        '<meta id="target" name="refresh" content="9999">',
+        options
+      );
       assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
   });

--- a/test/checks/navigation/meta-refresh.js
+++ b/test/checks/navigation/meta-refresh.js
@@ -3,68 +3,133 @@ describe('meta-refresh', function() {
 
   var checkContext = axe.testUtils.MockCheckContext();
   var checkSetup = axe.testUtils.checkSetup;
+  var metaRefreshCheck = axe.testUtils.getCheckEvaluate('meta-refresh')
 
   afterEach(function() {
     checkContext.reset();
   });
 
-  describe('; separator', function() {
-    it('should return false if content value is not 0', function() {
-      var checkArgs = checkSetup(
-        '<meta id="target" name="refresh" content="300">'
-      );
+  it('returns false if there is a number', function () {
+    var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">');
+    assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+  });
 
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('meta-refresh')
-          .apply(checkContext, checkArgs)
-      );
+  describe('returns false when valid', function () {
+    it('there is  a decimal', function () {
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3.1">');
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('should return false if content value does not start with 0', function() {
-      var checkArgs = checkSetup(
-        '<meta id="target" name="refresh" content="300;URL=something.html">'
-      );
-
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('meta-refresh')
-          .apply(checkContext, checkArgs)
-      );
+    it('there is a number followed by a dot', function () {
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3.">');
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+  
+    it('there is whitespace before the number', function () {
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="  \n\t3">');
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('should return true if content value starts with 0', function() {
-      var checkArgs = checkSetup(
-        '<meta id="target" name="refresh" content="0;URL=something.html">'
-      );
+    describe('with a valid separator', function () {
+      it('the number is followed by a semicolon', function () {
+        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3;">');
+        assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+      });
+  
+      it('the number is followed by a comma', function () {
+        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3;">');
+        assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+      });
 
-      assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('meta-refresh')
-          .apply(checkContext, checkArgs)
-      );
+      it('the number is followed spaces, and then a separator', function () {
+        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3 \t\n;">');
+        assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+      });
+
+      it('the separator is followed by non-separator characters', function () {
+        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3; https://deque.com/">');
+        assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+      });
+
+      it('the separator is a space', function () {
+        var checkArgs = checkSetup('<meta id="target" name="refresh" content="3 https://deque.com/">');
+        assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+      });
+    });
+  })
+
+  describe('returns true when invalid', function () {
+    it('the number is prefaced with a plus', function () {
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="+3">');
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+  
+    it('the number is prefaced with a minus', function () {
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="a3">');
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+  
+    it('the number is prefaced with a letter', function () {
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="-3">');
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('should return true if content value is 0', function() {
-      var checkArgs = checkSetup(
-        '<meta id="target" name="refresh" content="0">'
-      );
+    it('the number is followed by an invalid separator character', function () {
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3: https://deque.com/">');
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+  });
 
-      assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('meta-refresh')
-          .apply(checkContext, checkArgs)
-      );
+
+  describe('options.minDelay', function () {
+    it('returns false when the redirect number is greater than minDelay', function () {
+      var options = { minDelay: 2 }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
 
-    it('should return true if there is no content value', function() {
-      var checkArgs = checkSetup('<meta id="target" name="refresh">');
+    it('returns true when the redirect number equals minDelay', function () {
+      var options = { minDelay: 3 }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
 
-      assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('meta-refresh')
-          .apply(checkContext, checkArgs)
-      );
+    it('returns true when the redirect number is less than minDelay', function () {
+      var options = { minDelay: 4 }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+
+    it('ignores minDelay when set to false', function () {
+      var options = { minDelay: false }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="0">', options);
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+  });
+
+  describe('options.maxDelay', function () {
+    it('returns true when the redirect number is greater than maxDelay', function () {
+      var options = { maxDelay: 2 }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+      assert.isTrue(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+
+    it('returns false when the redirect number equals maxDelay', function () {
+      var options = { maxDelay: 3 }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+
+    it('returns false when the redirect number is less than maxDelay', function () {
+      var options = { maxDelay: 4 }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="3">', options);
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
+    });
+
+    it('ignores maxDelay when set to false', function () {
+      var options = { maxDelay: false }
+      var checkArgs = checkSetup('<meta id="target" name="refresh" content="9999">', options);
+      assert.isFalse(metaRefreshCheck.apply(checkContext, checkArgs));
     });
   });
 });

--- a/test/integration/full/meta-refresh/meta-refresh-fail.js
+++ b/test/integration/full/meta-refresh/meta-refresh-fail.js
@@ -1,0 +1,21 @@
+describe('meta-refresh fail', function() {
+  'use strict';
+
+  it('should find no matches', function(done) {
+    axe.run(
+      { runOnly: 'meta-refresh' },
+      function(err, results) {
+        try {
+          assert.isNull(err);
+          assert.lengthOf(results.violations, 1, 'violations');
+          assert.lengthOf(results.passes, 0, 'passes');
+          assert.lengthOf(results.incomplete, 0, 'passes');
+          assert.lengthOf(results.inapplicable, 0, 'inapplicable');
+          done();
+        } catch (e){
+          done(e);
+        }
+      }
+    );
+  });
+});

--- a/test/integration/full/meta-refresh/meta-refresh-fail.js
+++ b/test/integration/full/meta-refresh/meta-refresh-fail.js
@@ -1,21 +1,18 @@
 describe('meta-refresh fail', function() {
   'use strict';
 
-  it('should find no matches', function(done) {
-    axe.run(
-      { runOnly: 'meta-refresh' },
-      function(err, results) {
-        try {
-          assert.isNull(err);
-          assert.lengthOf(results.violations, 1, 'violations');
-          assert.lengthOf(results.passes, 0, 'passes');
-          assert.lengthOf(results.incomplete, 0, 'passes');
-          assert.lengthOf(results.inapplicable, 0, 'inapplicable');
-          done();
-        } catch (e){
-          done(e);
-        }
+  it('should be a violation', function(done) {
+    axe.run({ runOnly: 'meta-refresh' }, function(err, results) {
+      try {
+        assert.isNull(err);
+        assert.lengthOf(results.violations, 1, 'violations');
+        assert.lengthOf(results.passes, 0, 'passes');
+        assert.lengthOf(results.incomplete, 0, 'passes');
+        assert.lengthOf(results.inapplicable, 0, 'inapplicable');
+        done();
+      } catch (e) {
+        done(e);
       }
-    );
+    });
   });
 });

--- a/test/integration/full/meta-refresh/meta-refresh-fail1.html
+++ b/test/integration/full/meta-refresh/meta-refresh-fail1.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8" />
+    <title>Meta-refresh fail 1</title>
+    <meta http-equiv="refresh" content="10 https://deque.com/">
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="meta-refresh-fail.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
+</html>

--- a/test/integration/full/meta-refresh/meta-refresh-inapplicable.js
+++ b/test/integration/full/meta-refresh/meta-refresh-inapplicable.js
@@ -1,0 +1,21 @@
+describe('meta-refresh inapplicable', function() {
+  'use strict';
+
+  it('should find no matches', function(done) {
+    axe.run(
+      { runOnly: 'meta-refresh' },
+      function(err, results) {
+        try {
+          assert.isNull(err);
+          assert.lengthOf(results.violations, 0, 'violations');
+          assert.lengthOf(results.passes, 0, 'passes');
+          assert.lengthOf(results.incomplete, 0, 'passes');
+          assert.lengthOf(results.inapplicable, 1, 'inapplicable');
+          done();
+        } catch (e){
+          done(e);
+        }
+      }
+    );
+  });
+});

--- a/test/integration/full/meta-refresh/meta-refresh-inapplicable.js
+++ b/test/integration/full/meta-refresh/meta-refresh-inapplicable.js
@@ -1,21 +1,18 @@
 describe('meta-refresh inapplicable', function() {
   'use strict';
 
-  it('should find no matches', function(done) {
-    axe.run(
-      { runOnly: 'meta-refresh' },
-      function(err, results) {
-        try {
-          assert.isNull(err);
-          assert.lengthOf(results.violations, 0, 'violations');
-          assert.lengthOf(results.passes, 0, 'passes');
-          assert.lengthOf(results.incomplete, 0, 'passes');
-          assert.lengthOf(results.inapplicable, 1, 'inapplicable');
-          done();
-        } catch (e){
-          done(e);
-        }
+  it('should be inapplicable', function(done) {
+    axe.run({ runOnly: 'meta-refresh' }, function(err, results) {
+      try {
+        assert.isNull(err);
+        assert.lengthOf(results.violations, 0, 'violations');
+        assert.lengthOf(results.passes, 0, 'passes');
+        assert.lengthOf(results.incomplete, 0, 'passes');
+        assert.lengthOf(results.inapplicable, 1, 'inapplicable');
+        done();
+      } catch (e) {
+        done(e);
       }
-    );
+    });
   });
 });

--- a/test/integration/full/meta-refresh/meta-refresh-inapplicable1.html
+++ b/test/integration/full/meta-refresh/meta-refresh-inapplicable1.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8" />
+    <title>Meta-refresh inapplicable 1</title>
+    <!-- no content attribute -->
+    <meta http-equiv="refresh">
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="meta-refresh-inapplicable.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
+</html>

--- a/test/integration/full/meta-refresh/meta-refresh-inapplicable2.html
+++ b/test/integration/full/meta-refresh/meta-refresh-inapplicable2.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8" />
+    <title>Meta-refresh inapplicable 2</title>
+    <!-- no http-equiv="refresh" attribute -->
+    <meta http-equiv="something-else" content="5">
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="meta-refresh-inapplicable.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
+</html>

--- a/test/integration/full/meta-refresh/meta-refresh-pass.js
+++ b/test/integration/full/meta-refresh/meta-refresh-pass.js
@@ -1,20 +1,17 @@
 describe('meta-refresh pass', function() {
   'use strict';
 
-  it('should find no matches', function(done) {
-    axe.run(
-      { runOnly: 'meta-refresh' },
-      function(err, results) {
-        try {
-          assert.isNull(err);
-          assert.lengthOf(results.violations, 0, 'violations');
-          assert.lengthOf(results.passes, 1, 'passes');
-          assert.lengthOf(results.incomplete, 0, 'passes');
-          done();
-        } catch (e){
-          done(e);
-        }
+  it('should pass', function(done) {
+    axe.run({ runOnly: 'meta-refresh' }, function(err, results) {
+      try {
+        assert.isNull(err);
+        assert.lengthOf(results.violations, 0, 'violations');
+        assert.lengthOf(results.passes, 1, 'passes');
+        assert.lengthOf(results.incomplete, 0, 'passes');
+        done();
+      } catch (e) {
+        done(e);
       }
-    );
+    });
   });
 });

--- a/test/integration/full/meta-refresh/meta-refresh-pass.js
+++ b/test/integration/full/meta-refresh/meta-refresh-pass.js
@@ -1,0 +1,20 @@
+describe('meta-refresh pass', function() {
+  'use strict';
+
+  it('should find no matches', function(done) {
+    axe.run(
+      { runOnly: 'meta-refresh' },
+      function(err, results) {
+        try {
+          assert.isNull(err);
+          assert.lengthOf(results.violations, 0, 'violations');
+          assert.lengthOf(results.passes, 1, 'passes');
+          assert.lengthOf(results.incomplete, 0, 'passes');
+          done();
+        } catch (e){
+          done(e);
+        }
+      }
+    );
+  });
+});

--- a/test/integration/full/meta-refresh/meta-refresh-pass1.html
+++ b/test/integration/full/meta-refresh/meta-refresh-pass1.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8" />
+    <title>Meta-refresh pass 1</title>
+    <!-- "-10" is not valid, this will be ignored -->
+    <meta http-equiv="refresh" content="-10 https://deque.com/">
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="meta-refresh-pass.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
+</html>

--- a/test/integration/full/meta-refresh/meta-refresh-pass2.html
+++ b/test/integration/full/meta-refresh/meta-refresh-pass2.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8" />
+    <title>Meta-refresh pass 1</title>
+    <!-- "9000" is greater than the minimum 20 hours (7200 seconds) -->
+    <meta http-equiv="refresh" content="9000; https://deque.com/">
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="meta-refresh-pass.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
+</html>

--- a/test/integration/full/meta-refresh/meta-refresh-pass2.html
+++ b/test/integration/full/meta-refresh/meta-refresh-pass2.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf8" />
     <title>Meta-refresh pass 1</title>
-    <!-- "9000" is greater than the minimum 20 hours (7200 seconds) -->
-    <meta http-equiv="refresh" content="9000; https://deque.com/">
+    <!-- "90000" is greater than the minimum 20 hours (72000 seconds) -->
+    <meta http-equiv="refresh" content="90000; https://deque.com/">
     <link
       rel="stylesheet"
       type="text/css"

--- a/test/integration/virtual-rules/meta-refresh.js
+++ b/test/integration/virtual-rules/meta-refresh.js
@@ -3,7 +3,7 @@ describe('meta-refresh virtual-rule', function() {
     var results = axe.runVirtualRule('meta-refresh', {
       nodeName: 'meta',
       attributes: {
-        'http-equiv': 'refresh',
+        'http-equiv': 'refresh'
       }
     });
 

--- a/test/integration/virtual-rules/meta-refresh.js
+++ b/test/integration/virtual-rules/meta-refresh.js
@@ -1,15 +1,16 @@
 describe('meta-refresh virtual-rule', function() {
-  it('should pass missing content', function() {
+  it('should be inapplicable for missing content', function() {
     var results = axe.runVirtualRule('meta-refresh', {
       nodeName: 'meta',
       attributes: {
-        'http-equiv': 'refresh'
+        'http-equiv': 'refresh',
       }
     });
 
-    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.passes, 0);
     assert.lengthOf(results.violations, 0);
     assert.lengthOf(results.incomplete, 0);
+    assert.lengthOf(results.inapplicable, 1);
   });
 
   it('should pass for content=0', function() {


### PR DESCRIPTION
1. Ensure that redirects after 20 hours are passed
2. Improve the accuracy of the redirect number parsing
3. Add options for minDelay and maxDelay, to make the check configurable
4. Make the rule inapplicable when there's no content attribute
5. Add more integration tests

Closes issue: #3496
