### PR TITLE
feat(matches): deprecate not-html-matches, use :not(html) instead

### DIFF
--- a/lib/rules/not-html-matches.js
+++ b/lib/rules/not-html-matches.js
@@ -1,3 +1,6 @@
+/**
+ * @deprecated; use :not(html) instead
+ */
 function notHtmlMatches(node, virtualNode) {
   return virtualNode.props.nodeName !== 'html';
 }


### PR DESCRIPTION
As of https://github.com/dequelabs/axe-core/pull/3523 we no longer need the not-html-matches check. This just marks the matches method as deprecated.
