### PR TITLE
chore: add target assert to queryFixture

### DIFF
--- a/test/checks/navigation/heading-order.js
+++ b/test/checks/navigation/heading-order.js
@@ -1,14 +1,15 @@
-describe('heading-order', function() {
+describe('heading-order', function () {
   'use strict';
 
   var checkContext = axe.testUtils.MockCheckContext();
   var queryFixture = axe.testUtils.queryFixture;
+  var fixtureSetup = axe.testUtils.fixtureSetup;
 
-  afterEach(function() {
+  afterEach(function () {
     checkContext.reset();
   });
 
-  it('should store the heading order path and level for [role=heading] elements and return true', function() {
+  it('should store the heading order path and level for [role=heading] elements and return true', function () {
     var vNode = queryFixture(
       '<div role="heading" aria-level="1" id="target">One</div><div role="heading" aria-level="3">Three</div>'
     );
@@ -31,7 +32,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should handle incorrect aria-level values', function() {
+  it('should handle incorrect aria-level values', function () {
     var vNode = queryFixture(
       '<div role="heading" aria-level="-1" id="target">One</div><div role="heading">Two</div>'
     );
@@ -54,7 +55,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should allow high aria-level values', function() {
+  it('should allow high aria-level values', function () {
     var vNode = queryFixture(
       '<div role="heading" aria-level="12" id="target">One</div>'
     );
@@ -73,7 +74,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should store the correct header level for hn tags and return true', function() {
+  it('should store the correct header level for hn tags and return true', function () {
     var vNode = queryFixture('<h1 id="target">One</h1><h3>Three</h3>');
     assert.isTrue(
       axe.testUtils
@@ -94,7 +95,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should allow aria-level to override semantic level for hn tags and return true', function() {
+  it('should allow aria-level to override semantic level for hn tags and return true', function () {
     var vNode = queryFixture(
       '<h1 aria-level="2" id="target">Two</h1><h3 aria-level="4">Four</h3>'
     );
@@ -117,8 +118,8 @@ describe('heading-order', function() {
     });
   });
 
-  it('should ignore aria-level on iframe when not used with role=heading', function() {
-    var vNode = queryFixture('<iframe aria-level="2"></iframe>');
+  it('should ignore aria-level on iframe when not used with role=heading', function () {
+    var vNode = fixtureSetup('<iframe aria-level="2"></iframe>');
     axe.testUtils
       .getCheckEvaluate('heading-order')
       .call(checkContext, null, {}, vNode, { initiator: true });
@@ -132,7 +133,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should correctly give level on hn tag with role=heading', function() {
+  it('should correctly give level on hn tag with role=heading', function () {
     var vNode = queryFixture(
       '<h1 role="heading" id="target">One</h1><h3 role="heading">Three</h3>'
     );
@@ -155,7 +156,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should return the heading level when an hn tag has an invalid aria-level', function() {
+  it('should return the heading level when an hn tag has an invalid aria-level', function () {
     var vNode = queryFixture('<h1 aria-level="-1" id="target">One</h1>');
     assert.isTrue(
       axe.testUtils
@@ -172,7 +173,7 @@ describe('heading-order', function() {
     });
   });
 
-  it('should store the location of iframes', function() {
+  it('should store the location of iframes', function () {
     var vNode = queryFixture(
       '<h1 id="target">One</h1><iframe></iframe><h3>Three</h3>'
     );
@@ -197,8 +198,8 @@ describe('heading-order', function() {
     });
   });
 
-  describe('after', function() {
-    it('should return false when header level increases by 2', function() {
+  describe('after', function () {
+    it('should return false when header level increases by 2', function () {
       var results = [
         {
           data: {
@@ -224,7 +225,7 @@ describe('heading-order', function() {
       assert.isFalse(checks['heading-order'].after(results)[1].result);
     });
 
-    it('should return true when header level decreases by 1', function() {
+    it('should return true when header level decreases by 1', function () {
       var results = [
         {
           data: {
@@ -250,7 +251,7 @@ describe('heading-order', function() {
       assert.isTrue(checks['heading-order'].after(results)[1].result);
     });
 
-    it('should return true when header level decreases by 2', function() {
+    it('should return true when header level decreases by 2', function () {
       var results = [
         {
           data: {
@@ -276,7 +277,7 @@ describe('heading-order', function() {
       assert.isTrue(checks['heading-order'].after(results)[1].result);
     });
 
-    it('should return true when there is only one header', function() {
+    it('should return true when there is only one header', function () {
       var results = [
         {
           data: {
@@ -294,7 +295,7 @@ describe('heading-order', function() {
       assert.isTrue(checks['heading-order'].after(results)[0].result);
     });
 
-    it('should return true when header level increases by 1', function() {
+    it('should return true when header level increases by 1', function () {
       var results = [
         {
           data: {
@@ -324,7 +325,7 @@ describe('heading-order', function() {
       assert.isTrue(checks['heading-order'].after(results)[1].result);
     });
 
-    it('should return true if heading levels are correct across iframes', function() {
+    it('should return true if heading levels are correct across iframes', function () {
       var results = [
         {
           data: {
@@ -374,7 +375,7 @@ describe('heading-order', function() {
       assert.isTrue(afterResults[2].result);
     });
 
-    it('should return false if heading levels are incorrect across iframes', function() {
+    it('should return false if heading levels are incorrect across iframes', function () {
       var results = [
         {
           data: {
@@ -424,7 +425,7 @@ describe('heading-order', function() {
       assert.isTrue(afterResults[2].result);
     });
 
-    it('should handle nested iframes', function() {
+    it('should handle nested iframes', function () {
       var results = [
         {
           data: {
@@ -493,7 +494,7 @@ describe('heading-order', function() {
       assert.isTrue(afterResults[3].result);
     });
 
-    it('sets the result to undefined when the heading is not in the map', function() {
+    it('sets the result to undefined when the heading is not in the map', function () {
       var results = [
         {
           data: {
@@ -522,7 +523,7 @@ describe('heading-order', function() {
       assert.isUndefined(afterResults[1].result);
     });
 
-    it('ignores frames for which there are no results', function() {
+    it('ignores frames for which there are no results', function () {
       var results = [
         {
           data: {
@@ -574,7 +575,7 @@ describe('heading-order', function() {
       assert.isFalse(afterResults[2].result);
     });
 
-    it('should not error if iframe is first result', function() {
+    it('should not error if iframe is first result', function () {
       var results = [
         {
           data: {
@@ -624,7 +625,7 @@ describe('heading-order', function() {
       assert.isTrue(afterResults[2].result);
     });
 
-    it('runs when the top frame has no heading', function() {
+    it('runs when the top frame has no heading', function () {
       var results = [
         {
           data: {
@@ -657,7 +658,7 @@ describe('heading-order', function() {
       assert.isFalse(afterResults[1].result);
     });
 
-    it('understand shadow DOM in ancestries', function() {
+    it('understand shadow DOM in ancestries', function () {
       var results = [
         {
           data: {
@@ -720,7 +721,7 @@ describe('heading-order', function() {
       assert.isTrue(afterResults[3].result);
     });
 
-    it('run when an in-between frame has no heading', function() {
+    it('run when an in-between frame has no heading', function () {
       var results = [
         {
           data: {
@@ -779,7 +780,7 @@ describe('heading-order', function() {
       assert.isTrue(afterResults[3].result);
     });
 
-    it('can fail the second heading, if the first is excluded', function() {
+    it('can fail the second heading, if the first is excluded', function () {
       var results = [
         {
           data: {

--- a/test/checks/navigation/heading-order.js
+++ b/test/checks/navigation/heading-order.js
@@ -3,7 +3,6 @@ describe('heading-order', function () {
 
   var checkContext = axe.testUtils.MockCheckContext();
   var queryFixture = axe.testUtils.queryFixture;
-  var fixtureSetup = axe.testUtils.fixtureSetup;
 
   afterEach(function () {
     checkContext.reset();
@@ -119,7 +118,7 @@ describe('heading-order', function () {
   });
 
   it('should ignore aria-level on iframe when not used with role=heading', function () {
-    var vNode = fixtureSetup('<iframe aria-level="2"></iframe>');
+    var vNode = queryFixture('<iframe aria-level="2" id="target"></iframe>');
     axe.testUtils
       .getCheckEvaluate('heading-order')
       .call(checkContext, null, {}, vNode, { initiator: true });

--- a/test/commons/text/form-control-value.js
+++ b/test/commons/text/form-control-value.js
@@ -1,4 +1,4 @@
-describe('text.formControlValue', function() {
+describe('text.formControlValue', function () {
   var formControlValue = axe.commons.text.formControlValue;
   var queryFixture = axe.testUtils.queryFixture;
   var fixtureSetup = axe.testUtils.fixtureSetup;
@@ -16,7 +16,7 @@ describe('text.formControlValue', function() {
     return nodeType;
   }
 
-  it('returns the first truthy result from text.formControlValueMethods', function() {
+  it('returns the first truthy result from text.formControlValueMethods', function () {
     var target = queryFixture(
       '<div id="target" role="textbox" value="foo">bar</div>'
     );
@@ -24,28 +24,28 @@ describe('text.formControlValue', function() {
     assert.equal(formControlValue(target, { startNode: fixture }), 'bar');
   });
 
-  it('returns `` when the node equals context.startNode', function() {
+  it('returns `` when the node equals context.startNode', function () {
     var target = queryFixture('<input id="target" value="foo" />');
     assert.equal(formControlValue(target, { startNode: target }), '');
   });
 
-  it('returns `` when accessibleNameFromFieldValue says the role is unsupported', function() {
+  it('returns `` when accessibleNameFromFieldValue says the role is unsupported', function () {
     var target = queryFixture(
       '<input id="target" value="foo" role="combobox"/>'
     );
     assert.equal(formControlValue(target), '');
   });
 
-  describe('nativeTextboxValue', function() {
+  describe('nativeTextboxValue', function () {
     var nativeTextboxValue =
       axe.commons.text.formControlValueMethods.nativeTextboxValue;
 
-    it('returns the value of textarea elements', function() {
+    it('returns the value of textarea elements', function () {
       var target = queryFixture('<textarea>foo</textarea>', 'textarea');
       assert.equal(nativeTextboxValue(target), 'foo');
     });
 
-    it('returns the value of text field input elements', function() {
+    it('returns the value of text field input elements', function () {
       var formData = {
         text: 'foo',
         date: '2018-12-12',
@@ -60,7 +60,7 @@ describe('text.formControlValue', function() {
         week: '2018-W46'
       };
       fixtureSetup(
-        Object.keys(formData).reduce(function(html, fieldType) {
+        Object.keys(formData).reduce(function (html, fieldType) {
           return (
             html +
             '<input type="' +
@@ -73,7 +73,7 @@ describe('text.formControlValue', function() {
       );
       axe.utils
         .querySelectorAll(axe._tree[0], '#fixture input')
-        .forEach(function(target) {
+        .forEach(function (target) {
           var expected = formData[getNodeType(target.actualNode)];
           assert.isDefined(expected);
           var actual = nativeTextboxValue(target);
@@ -85,7 +85,7 @@ describe('text.formControlValue', function() {
         });
     });
 
-    it('returns `` for non-text input elements', function() {
+    it('returns `` for non-text input elements', function () {
       fixtureSetup(
         '<input type="button" value="foo">' +
           '<input type="checkbox" value="foo">' +
@@ -100,7 +100,7 @@ describe('text.formControlValue', function() {
       );
       axe.utils
         .querySelectorAll(axe._tree[0], '#fixture input')
-        .forEach(function(target) {
+        .forEach(function (target) {
           // Safari and IE11 do not support the color input type
           // and thus treat them as text inputs. ignore fallback
           // inputs
@@ -116,16 +116,16 @@ describe('text.formControlValue', function() {
         });
     });
 
-    it('returns the value of DOM nodes', function() {
+    it('returns the value of DOM nodes', function () {
       fixture.innerHTML = '<input value="foo">';
       axe.utils.getFlattenedTree(fixture);
       assert.equal(nativeTextboxValue(fixture.querySelector('input')), 'foo');
     });
 
-    it('returns `` for other elements', function() {
+    it('returns `` for other elements', function () {
       // some random elements:
       ['div', 'span', 'h1', 'output', 'summary', 'style', 'template'].forEach(
-        function(nodeName) {
+        function (nodeName) {
           var target = document.createElement(nodeName);
           target.value = 'foo'; // That shouldn't do anything
           fixture.appendChild(target);
@@ -136,11 +136,11 @@ describe('text.formControlValue', function() {
     });
   });
 
-  describe('nativeSelectValue', function() {
+  describe('nativeSelectValue', function () {
     var nativeSelectValue =
       axe.commons.text.formControlValueMethods.nativeSelectValue;
 
-    it('returns the selected option text', function() {
+    it('returns the selected option text', function () {
       var target = queryFixture(
         '<select id="target">' +
           '  <option>foo</option>' +
@@ -150,7 +150,7 @@ describe('text.formControlValue', function() {
       assert.equal(nativeSelectValue(target), 'baz');
     });
 
-    it('returns the selected option text after selection', function() {
+    it('returns the selected option text after selection', function () {
       injectIntoFixture(
         '<select id="target">' +
           '  <option value="foo" selected>foo</option>' +
@@ -163,7 +163,7 @@ describe('text.formControlValue', function() {
       assert.equal(nativeSelectValue(target), 'baz');
     });
 
-    it('returns multiple options, space seperated', function() {
+    it('returns multiple options, space seperated', function () {
       // Can't apply multiple "selected" props without setting "multiple"
       var target = queryFixture(
         '<select id="target" multiple>' +
@@ -178,7 +178,7 @@ describe('text.formControlValue', function() {
       assert.equal(nativeSelectValue(target), 'foo bar baz');
     });
 
-    it('returns options from within optgroup elements', function() {
+    it('returns options from within optgroup elements', function () {
       var target = queryFixture(
         '<select id="target" multiple>' +
           '  <option>oof</option>' +
@@ -196,7 +196,7 @@ describe('text.formControlValue', function() {
       assert.equal(nativeSelectValue(target), 'foo bar baz');
     });
 
-    it('returns the first option when there are no selected options', function() {
+    it('returns the first option when there are no selected options', function () {
       // Browser automatically selectes the first option
       var target = queryFixture(
         '<select id="target">' +
@@ -207,10 +207,10 @@ describe('text.formControlValue', function() {
       assert.equal(nativeSelectValue(target), 'foo');
     });
 
-    it('returns `` for other elements', function() {
+    it('returns `` for other elements', function () {
       // some random elements:
       ['div', 'span', 'h1', 'output', 'summary', 'style', 'template'].forEach(
-        function(nodeName) {
+        function (nodeName) {
           var target = document.createElement(nodeName);
           target.value = 'foo'; // That shouldn't do anything
           fixture.appendChild(target);
@@ -221,21 +221,21 @@ describe('text.formControlValue', function() {
     });
   });
 
-  describe('ariaTextboxValue', function() {
+  describe('ariaTextboxValue', function () {
     var ariaTextboxValue =
       axe.commons.text.formControlValueMethods.ariaTextboxValue;
 
-    it('returns the text of role=textbox elements', function() {
+    it('returns the text of role=textbox elements', function () {
       var target = queryFixture('<div id="target" role="textbox">foo</div>');
       assert.equal(ariaTextboxValue(target), 'foo');
     });
 
-    it('returns `` for elements without role=textbox', function() {
+    it('returns `` for elements without role=textbox', function () {
       var target = queryFixture('<div id="target" role="combobox">foo</div>');
       assert.equal(ariaTextboxValue(target), '');
     });
 
-    it('ignores text hidden with CSS', function() {
+    it('ignores text hidden with CSS', function () {
       var target = queryFixture(
         '<div id="target" role="textbox">' +
           '<span>foo</span>' +
@@ -246,7 +246,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaTextboxValue(target), 'foo');
     });
 
-    it('ignores elements with hidden content', function() {
+    it('ignores elements with hidden content', function () {
       var target = queryFixture(
         '<div id="target" role="textbox">' +
           '<span>span</span>' +
@@ -260,7 +260,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaTextboxValue(target), 'spanh1');
     });
 
-    it('does not return HTML or comments', function() {
+    it('does not return HTML or comments', function () {
       var target = queryFixture(
         '<div id="target" role="textbox">' +
           '<i>foo</i>' +
@@ -270,7 +270,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaTextboxValue(target), 'foo');
     });
 
-    it('returns the entire text content if the textbox is hidden', function() {
+    it('returns the entire text content if the textbox is hidden', function () {
       var target = queryFixture(
         '<div id="target" role="textbox" style="display:none">' +
           // Yes, this is how it works in browsers :-(
@@ -281,11 +281,11 @@ describe('text.formControlValue', function() {
     });
   });
 
-  describe('ariaListboxValue', function() {
+  describe('ariaListboxValue', function () {
     var ariaListboxValue =
       axe.commons.text.formControlValueMethods.ariaListboxValue;
 
-    it('returns the selected option when the element is a listbox', function() {
+    it('returns the selected option when the element is a listbox', function () {
       var target = queryFixture(
         '<div id="target" role="listbox">' +
           '  <div role="option">foo</div>' +
@@ -296,7 +296,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaListboxValue(target), 'bar');
     });
 
-    it('returns `` when the element is not a listbox', function() {
+    it('returns `` when the element is not a listbox', function () {
       var target = queryFixture(
         '<div id="target" role="combobox">' +
           '  <div role="option">foo</div>' +
@@ -307,7 +307,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    it('returns `` when there is no selected option', function() {
+    it('returns `` when there is no selected option', function () {
       var target = queryFixture(
         '<div id="target" role="listbox">' +
           '  <div role="option">foo</div>' +
@@ -318,7 +318,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    it('returns `` when aria-selected is not true option', function() {
+    it('returns `` when aria-selected is not true option', function () {
       var target = queryFixture(
         '<div id="target" role="listbox">' +
           '  <div role="option" aria-selected="false">foo</div>' +
@@ -330,7 +330,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    it('returns selected options from aria-owned', function() {
+    it('returns selected options from aria-owned', function () {
       var target = queryFixture(
         '<div id="target" role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
           '<div role="option" id="opt1">foo</div>' +
@@ -340,7 +340,7 @@ describe('text.formControlValue', function() {
       assert.equal(ariaListboxValue(target), 'bar');
     });
 
-    it('ignores aria-selected for elements that are not options', function() {
+    it('ignores aria-selected for elements that are not options', function () {
       var target = queryFixture(
         '<div id="target" role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
           '<div id="opt1">foo</div>' +
@@ -350,8 +350,8 @@ describe('text.formControlValue', function() {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    describe('with multiple aria-selected', function() {
-      it('returns the first selected option from children', function() {
+    describe('with multiple aria-selected', function () {
+      it('returns the first selected option from children', function () {
         var target = queryFixture(
           '<div id="target" role="listbox">' +
             '  <div role="option">foo</div>' +
@@ -362,7 +362,7 @@ describe('text.formControlValue', function() {
         assert.equal(ariaListboxValue(target), 'bar');
       });
 
-      it('returns the first selected option in aria-owned (as opposed to in the DOM order)', function() {
+      it('returns the first selected option in aria-owned (as opposed to in the DOM order)', function () {
         var target = queryFixture(
           '<div id="target" role="listbox" aria-owns="opt3 opt2 opt1"></div>' +
             '<div role="option" id="opt1" aria-selected="true">foo</div>' +
@@ -372,7 +372,7 @@ describe('text.formControlValue', function() {
         assert.equal(ariaListboxValue(target), 'bar');
       });
 
-      it('returns the a selected child before a selected aria-owned element', function() {
+      it('returns the a selected child before a selected aria-owned element', function () {
         var target = queryFixture(
           '<div id="target" role="listbox" aria-owns="opt2 opt3">' +
             '  <div role="option" aria-selected="true">foo</div>' +
@@ -383,7 +383,7 @@ describe('text.formControlValue', function() {
         assert.equal(ariaListboxValue(target), 'foo');
       });
 
-      it('ignores aria-multiselectable=true', function() {
+      it('ignores aria-multiselectable=true', function () {
         // aria-multiselectable doesn't add additional content to the accessible name
         var target = queryFixture(
           '<div id="target" role="listbox" aria-owns="opt2 opt3" aria-multiselectable="true">' +
@@ -397,7 +397,7 @@ describe('text.formControlValue', function() {
     });
   });
 
-  describe('ariaComboboxValue', function() {
+  describe('ariaComboboxValue', function () {
     var ariaComboboxValue =
       axe.commons.text.formControlValueMethods.ariaComboboxValue;
 
@@ -408,15 +408,15 @@ describe('text.formControlValue', function() {
       '  <div role="option" aria-selected="true">bar</div>' +
       '</div>';
 
-    it('returns the text of role=combobox elements', function() {
+    it('returns the text of role=combobox elements', function () {
       var target = queryFixture(
         '<div id="target" role="combobox">' + comboboxContent + '</div>'
       );
       assert.equal(ariaComboboxValue(target), 'bar');
     });
 
-    it('returns `` for elements without role=combobox', function() {
-      queryFixture('<div role="combobox">' + comboboxContent + '</div>');
+    it('returns `` for elements without role=combobox', function () {
+      fixtureSetup('<div role="combobox">' + comboboxContent + '</div>');
       var target = axe.utils.querySelectorAll(
         axe._tree[0],
         '[role=listbox]'
@@ -424,14 +424,14 @@ describe('text.formControlValue', function() {
       assert.equal(ariaComboboxValue(target), '');
     });
 
-    it('passes child listbox to `ariaListboxValue` and returns its result', function() {
+    it('passes child listbox to `ariaListboxValue` and returns its result', function () {
       var target = queryFixture(
         '<div id="target" role="combobox">' + comboboxContent + '</div>'
       );
       assert.equal(ariaComboboxValue(target), 'bar');
     });
 
-    it('passes aria-owned listbox to `ariaListboxValue` and returns its result', function() {
+    it('passes aria-owned listbox to `ariaListboxValue` and returns its result', function () {
       var target = queryFixture(
         '<div id="target" role="combobox" aria-owns="text list"></div>' +
           comboboxContent
@@ -440,19 +440,19 @@ describe('text.formControlValue', function() {
     });
   });
 
-  describe('ariaRangeValue', function() {
+  describe('ariaRangeValue', function () {
     var rangeRoles = ['progressbar', 'scrollbar', 'slider', 'spinbutton'];
     var ariaRangeValue =
       axe.commons.text.formControlValueMethods.ariaRangeValue;
 
-    it('returns `` for roles that are not ranges', function() {
+    it('returns `` for roles that are not ranges', function () {
       var target = queryFixture('<div id="target" role="textbox">foo</div>');
       assert.equal(ariaRangeValue(target), '');
     });
 
-    rangeRoles.forEach(function(role) {
-      describe('with ' + role, function() {
-        it('returns the result of aria-valuenow', function() {
+    rangeRoles.forEach(function (role) {
+      describe('with ' + role, function () {
+        it('returns the result of aria-valuenow', function () {
           var target = queryFixture(
             '<div id="target" role="' +
               role +
@@ -461,14 +461,14 @@ describe('text.formControlValue', function() {
           assert.equal(ariaRangeValue(target), '123');
         });
 
-        it('returns `0` if aria-valuenow is not a number', function() {
+        it('returns `0` if aria-valuenow is not a number', function () {
           var target = queryFixture(
             '<div id="target" role="' + role + '" aria-valuenow="abc">foo</div>'
           );
           assert.equal(ariaRangeValue(target), '0');
         });
 
-        it('returns decimal numbers', function() {
+        it('returns decimal numbers', function () {
           var target = queryFixture(
             '<div id="target" role="' +
               role +
@@ -477,7 +477,7 @@ describe('text.formControlValue', function() {
           assert.equal(ariaRangeValue(target), '1.5678');
         });
 
-        it('returns negative numbers', function() {
+        it('returns negative numbers', function () {
           var target = queryFixture(
             '<div id="target" role="' +
               role +

--- a/test/commons/text/form-control-value.js
+++ b/test/commons/text/form-control-value.js
@@ -416,11 +416,10 @@ describe('text.formControlValue', function () {
     });
 
     it('returns `` for elements without role=combobox', function () {
-      fixtureSetup('<div role="combobox">' + comboboxContent + '</div>');
-      var target = axe.utils.querySelectorAll(
-        axe._tree[0],
+      var target = queryFixture(
+        '<div role="combobox">' + comboboxContent + '</div>',
         '[role=listbox]'
-      )[0];
+      );
       assert.equal(ariaComboboxValue(target), '');
     });
 

--- a/test/commons/text/native-text-alternative.js
+++ b/test/commons/text/native-text-alternative.js
@@ -1,46 +1,47 @@
-describe('text.nativeTextAlternative', function() {
+describe('text.nativeTextAlternative', function () {
   var text = axe.commons.text;
+  var fixtureSetup = axe.testUtils.fixtureSetup;
   var queryFixture = axe.testUtils.queryFixture;
   var nativeTextAlternative = text.nativeTextAlternative;
 
-  it('runs accessible text methods specified for the native element', function() {
+  it('runs accessible text methods specified for the native element', function () {
     var vNode = queryFixture('<button id="target">foo</button>');
     assert.equal(nativeTextAlternative(vNode), 'foo');
   });
 
-  it('returns the accessible text of the first method that returns something', function() {
+  it('returns the accessible text of the first method that returns something', function () {
     var vNode = queryFixture(
       '<input id="target" type="image" alt="foo" value="bar" title="baz">'
     );
     assert.equal(nativeTextAlternative(vNode), 'foo');
   });
 
-  it('returns `` when no method matches', function() {
+  it('returns `` when no method matches', function () {
     var vNode = queryFixture('<div id="target">baz</div>');
     assert.equal(nativeTextAlternative(vNode), '');
   });
 
-  it('returns `` when no accessible text method returned something', function() {
-    queryFixture('<div class="baz">baz</div>');
+  it('returns `` when no accessible text method returned something', function () {
+    fixtureSetup('<div class="baz">baz</div>');
     var div = axe.utils.querySelectorAll(axe._tree[0], '.baz')[0];
     assert.equal(nativeTextAlternative(div), '');
   });
 
-  it('returns `` when the node is not an element', function() {
-    queryFixture('foo bar baz');
+  it('returns `` when the node is not an element', function () {
+    fixtureSetup('foo bar baz');
     var fixture = axe.utils.querySelectorAll(axe._tree[0], '#fixture')[0];
     assert.equal(fixture.children[0].actualNode.nodeType, 3);
     assert.equal(nativeTextAlternative(fixture.children[0]), '');
   });
 
-  it('returns `` when the element has role=presentation', function() {
+  it('returns `` when the element has role=presentation', function () {
     var vNode = queryFixture(
       '<img id="target" alt="foo" role="presentation" />'
     );
     assert.equal(nativeTextAlternative(vNode), '');
   });
 
-  it('returns `` when the element has role=none', function() {
+  it('returns `` when the element has role=none', function () {
     var vNode = queryFixture('<img id="target" alt="foo" role="none" />');
     assert.equal(nativeTextAlternative(vNode), '');
   });

--- a/test/commons/text/native-text-alternative.js
+++ b/test/commons/text/native-text-alternative.js
@@ -22,8 +22,7 @@ describe('text.nativeTextAlternative', function () {
   });
 
   it('returns `` when no accessible text method returned something', function () {
-    fixtureSetup('<div class="baz">baz</div>');
-    var div = axe.utils.querySelectorAll(axe._tree[0], '.baz')[0];
+    var div = queryFixture('<div id="target">baz</div>');
     assert.equal(nativeTextAlternative(div), '');
   });
 

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,8 +1,5 @@
 /* global axe, checks */
 
-import { Context } from 'mocha';
-import AbstractVirtualNode from '../lib/core/base/virtual-node/abstract-virtual-node';
-
 // Let the user know they need to disable their axe/attest extension before running the tests.
 if (window.__AXE_EXTENSION__) {
   throw new Error(

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -416,7 +416,7 @@ testUtils.assertStylesheet = function assertStylesheet(
   }
 };
 
-/*
+/**
  * Injecting content into a fixture and return queried element within fixture
  *
  * @param {String|Node} content to go into the fixture (html or DOM node)

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -420,6 +420,7 @@ testUtils.assertStylesheet = function assertStylesheet(
  * Injecting content into a fixture and return queried element within fixture
  *
  * @param {String|Node} content to go into the fixture (html or DOM node)
+ * @param {String?} query - the CSS selector query to find target DOM node
  * @return HTMLElement
  */
 testUtils.queryFixture = function queryFixture(html, query) {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -452,7 +452,6 @@ testUtils.getCheckEvaluate = function getCheckEvaluate(checkId, testOptions) {
    * @param {*} options
    * @param {VirtualNode} virtualNode
    * @param {Context} context
-   * @returns {Boolean|undefined}
    */
   var evaluateWrapper = function (node, options, virtualNode, context) {
     var opts = check.getOptions(options);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -419,8 +419,8 @@ testUtils.assertStylesheet = function assertStylesheet(
 /**
  * Injecting content into a fixture and return queried element within fixture
  *
- * @param {String?} query - the CSS selector query to find target DOM node
  * @param {String|Node} html - content to go into the fixture (html or DOM node)
+ * @param {String} [query=#target] - the CSS selector query to find target DOM node
  * @return HTMLElement
  */
 testUtils.queryFixture = function queryFixture(html, query) {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,5 +1,8 @@
 /* global axe, checks */
 
+import { Context } from 'mocha';
+import AbstractVirtualNode from '../lib/core/base/virtual-node/abstract-virtual-node';
+
 // Let the user know they need to disable their axe/attest extension before running the tests.
 if (window.__AXE_EXTENSION__) {
   throw new Error(
@@ -35,8 +38,8 @@ function verifyIsNoneCheck(check) {
   }
 }
 
-axe._audit.rules.forEach(function(rule) {
-  rule.none.forEach(function(check) {
+axe._audit.rules.forEach(function (rule) {
+  rule.none.forEach(function (check) {
     check = check.id || check;
     if (noneChecks.indexOf(check) === -1) {
       noneChecks.push(check);
@@ -44,7 +47,7 @@ axe._audit.rules.forEach(function(rule) {
   });
 });
 
-axe._audit.rules.forEach(function(rule) {
+axe._audit.rules.forEach(function (rule) {
   rule.any.forEach(verifyIsNoneCheck);
   rule.all.forEach(verifyIsNoneCheck);
 });
@@ -54,7 +57,7 @@ axe._audit.rules.forEach(function(rule) {
  *
  * @return Object
  */
-testUtils.MockCheckContext = function() {
+testUtils.MockCheckContext = function () {
   'use strict';
   return {
     _relatedNodes: [],
@@ -62,20 +65,20 @@ testUtils.MockCheckContext = function() {
     // When using this.async() in a check, assign a function to _onAsync
     // to catch the response.
     _onAsync: null,
-    async: function() {
+    async: function () {
       var self = this;
-      return function(result) {
+      return function (result) {
         // throws if _onAsync isn't set
         self._onAsync(result, self);
       };
     },
-    data: function(d) {
+    data: function (d) {
       this._data = d;
     },
-    relatedNodes: function(nodes) {
+    relatedNodes: function (nodes) {
       this._relatedNodes = Array.isArray(nodes) ? nodes : [nodes];
     },
-    reset: function() {
+    reset: function () {
       this._data = null;
       this._relatedNodes = [];
       this._onAsync = null;
@@ -89,7 +92,7 @@ testUtils.MockCheckContext = function() {
  * @param HTMLDocumentElement		The document of the current context
  * @return Object
  */
-testUtils.shadowSupport = (function(document) {
+testUtils.shadowSupport = (function (document) {
   'use strict';
   var v0 =
       document.body && typeof document.body.createShadowRoot === 'function',
@@ -109,7 +112,7 @@ testUtils.shadowSupport = (function(document) {
  * Return the fixture element
  * @return HTMLElement
  */
-testUtils.getFixture = function() {
+testUtils.getFixture = function () {
   'use strict';
   return fixture;
 };
@@ -119,7 +122,7 @@ testUtils.getFixture = function() {
  * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
  * @return HTMLElement
  */
-testUtils.injectIntoFixture = function(content) {
+testUtils.injectIntoFixture = function (content) {
   'use strict';
   if (typeof content !== 'undefined') {
     fixture.innerHTML = '';
@@ -130,7 +133,7 @@ testUtils.injectIntoFixture = function(content) {
   } else if (content instanceof Node) {
     fixture.appendChild(content);
   } else if (Array.isArray(content)) {
-    content.forEach(function(node) {
+    content.forEach(function (node) {
       fixture.appendChild(node);
     });
   }
@@ -145,7 +148,7 @@ testUtils.injectIntoFixture = function(content) {
  * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
  * @return HTMLElement
  */
-testUtils.fixtureSetup = function(content) {
+testUtils.fixtureSetup = function (content) {
   'use strict';
   testUtils.injectIntoFixture(content);
   axe.teardown();
@@ -160,7 +163,7 @@ testUtils.fixtureSetup = function(content) {
  * @param String				Target for the check, CSS selector (default: '#target')
  * @return Array
  */
-testUtils.checkSetup = function(content, options, target) {
+testUtils.checkSetup = function (content, options, target) {
   'use strict';
   // Normalize the params
   if (typeof options !== 'object') {
@@ -192,7 +195,7 @@ testUtils.checkSetup = function(content, options, target) {
  * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
  * @return Array
  */
-testUtils.shadowCheckSetup = function(
+testUtils.shadowCheckSetup = function (
   content,
   shadowContent,
   options,
@@ -246,7 +249,7 @@ testUtils.shadowCheckSetup = function(
  * @param Node   Stuff to go in the flat tree
  * @returns vNode[]
  */
-testUtils.flatTreeSetup = function(content) {
+testUtils.flatTreeSetup = function (content) {
   axe._tree = axe.utils.getFlattenedTree(content);
   return axe._tree;
 };
@@ -267,7 +270,7 @@ testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb) {
   var q = axe.utils.queue();
 
   // Wait for page load
-  q.defer(function(resolve) {
+  q.defer(function (resolve) {
     if (document.readyState === 'complete') {
       resolve();
     } else {
@@ -276,14 +279,14 @@ testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb) {
   });
 
   // Wait for all frames to be loaded
-  Array.from(document.querySelectorAll('iframe')).forEach(function(frame) {
-    q.defer(function(resolve) {
+  Array.from(document.querySelectorAll('iframe')).forEach(function (frame) {
+    q.defer(function (resolve) {
       return awaitNestedLoad(frame.contentWindow, resolve);
     });
   });
 
   // Complete (don't pass the args on to the callback)
-  q.then(function() {
+  q.then(function () {
     cb();
   });
 };
@@ -303,7 +306,7 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
   var doc = rootNode ? rootNode : document;
   var q = axe.utils.queue();
   if (data.href) {
-    q.defer(function(resolve, reject) {
+    q.defer(function (resolve, reject) {
       var link = doc.createElement('link');
       link.rel = 'stylesheet';
       link.href = data.href;
@@ -313,18 +316,18 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
       if (data.mediaPrint) {
         link.media = 'print';
       }
-      link.onload = function() {
-        setTimeout(function() {
+      link.onload = function () {
+        setTimeout(function () {
           resolve();
         });
       };
-      link.onerror = function() {
+      link.onerror = function () {
         reject();
       };
       doc.head.appendChild(link);
     });
   } else {
-    q.defer(function(resolve) {
+    q.defer(function (resolve) {
       var style = doc.createElement('style');
       if (data.id) {
         style.id = data.id;
@@ -332,7 +335,7 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
       style.type = 'text/css';
       style.appendChild(doc.createTextNode(data.text));
       doc.head.appendChild(style);
-      setTimeout(function() {
+      setTimeout(function () {
         resolve();
       }, 100); // -> note: gives firefox to load (document.stylesheets), other browsers are fine.
     });
@@ -348,7 +351,7 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
  */
 testUtils.addStyleSheets = function addStyleSheets(sheets, rootNode) {
   var q = axe.utils.queue();
-  sheets.forEach(function(data) {
+  sheets.forEach(function (data) {
     q.defer(axe.testUtils.addStyleSheet(data, rootNode));
   });
   return q;
@@ -361,8 +364,8 @@ testUtils.addStyleSheets = function addStyleSheets(sheets, rootNode) {
  */
 testUtils.removeStyleSheets = function removeStyleSheets(sheets) {
   var q = axe.utils.queue();
-  sheets.forEach(function(data) {
-    q.defer(function(resolve, reject) {
+  sheets.forEach(function (data) {
+    q.defer(function (resolve, reject) {
       var node = document.getElementById(data.id);
       if (!node || !node.parentNode) {
         reject();
@@ -423,21 +426,39 @@ testUtils.assertStylesheet = function assertStylesheet(
  * @return HTMLElement
  */
 testUtils.queryFixture = function queryFixture(html, query) {
+  query = query || '#target';
   var rootNode = testUtils.fixtureSetup(html);
+  var vNode = axe.utils.querySelectorAll(rootNode, query)[0];
+  assert.exists(
+    vNode,
+    'Node does not exist in query `' +
+      query +
+      '`. This is usually fixed by adding the default target (`id="target"`) to your html parameter'
+  );
   return axe.utils.querySelectorAll(rootNode, query || '#target')[0];
 };
 
 /**
  * Return the checks evaluate method and apply default options
- * @param {String} checkId - ID of the check
- * @return Function
+ * @param {string} checkId - ID of the check
+ * @param {} testOptions - Options for the test
+ * @returns {evaluateWrapper} evaluateWrapper - Check evaluation wrapper
  */
 testUtils.getCheckEvaluate = function getCheckEvaluate(checkId, testOptions) {
   var check = checks[checkId];
   testOptions = testOptions || {};
 
-  return function evaluateWrapper(node, options, virtualNode, context) {
+  /**
+   * Wraps a check for evaluation using .call()
+   * @param {HTMLElement} node
+   * @param {*} options
+   * @param {VirtualNode} virtualNode
+   * @param {Context} context
+   * @returns {string}
+   */
+  var evaluateWrapper = function (node, options, virtualNode, context) {
     var opts = check.getOptions(options);
+
     var result = check.evaluate.call(this, node, opts, virtualNode, context);
 
     // ensure that every result has a corresponding message
@@ -513,6 +534,7 @@ testUtils.getCheckEvaluate = function getCheckEvaluate(checkId, testOptions) {
 
     return result;
   };
+  return evaluateWrapper;
 };
 
 /**
@@ -528,7 +550,7 @@ testUtils.isIE11 = (function isIE11(navigator) {
 axe.testUtils = testUtils;
 
 if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
-  beforeEach(function() {
+  beforeEach(function () {
     // reset from axe._load overriding
     checks = originalChecks;
     axe._audit = originalAudit;
@@ -536,7 +558,7 @@ if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
     commons = axe.commons = originalCommons;
   });
 
-  afterEach(function() {
+  afterEach(function () {
     axe.teardown();
     fixture.innerHTML = '';
 
@@ -557,7 +579,7 @@ if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
 }
 
 testUtils.captureError = function captureError(cb, errorHandler) {
-  return function() {
+  return function () {
     try {
       cb.apply(null, arguments);
     } catch (e) {
@@ -577,7 +599,7 @@ testUtils.runPartialRecursive = function runPartialRecursive(
   var frameContexts = axe.utils.getFrameContexts(context);
   var promiseResults = [axe.runPartial(context, options)];
 
-  frameContexts.forEach(function(c) {
+  frameContexts.forEach(function (c) {
     var frame = testUtils.shadowQuerySelector(c.frameSelector, win.document);
     var frameWin = frame.contentWindow;
     var frameResults = testUtils.runPartialRecursive(
@@ -594,7 +616,7 @@ testUtils.shadowQuerySelector = function shadowQuerySelector(axeSelector, doc) {
   var elm;
   doc = doc || document;
   axeSelector = Array.isArray(axeSelector) ? axeSelector : [axeSelector];
-  axeSelector.forEach(function(selectorStr) {
+  axeSelector.forEach(function (selectorStr) {
     elm = doc && doc.querySelector(selectorStr);
     doc = elm && elm.shadowRoot;
   });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -452,7 +452,7 @@ testUtils.getCheckEvaluate = function getCheckEvaluate(checkId, testOptions) {
    * @param {*} options
    * @param {VirtualNode} virtualNode
    * @param {Context} context
-   * @returns {string}
+   * @returns {Boolean|undefined}
    */
   var evaluateWrapper = function (node, options, virtualNode, context) {
     var opts = check.getOptions(options);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -431,7 +431,7 @@ testUtils.queryFixture = function queryFixture(html, query) {
     vNode,
     'Node does not exist in query `' +
       query +
-      '`. This is usually fixed by adding the default target (`id="target"`) to your html parameter'
+      '`. This is usually fixed by adding the default target (`id="target"`) to your html parameter. If you do not intend on querying the fixture for #target, consider using `axe.testUtils.fixtureSetup()` instead.'
   );
   return axe.utils.querySelectorAll(rootNode, query || '#target')[0];
 };

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -421,7 +421,7 @@ testUtils.assertStylesheet = function assertStylesheet(
  *
  * @param {String|Node} html - content to go into the fixture (html or DOM node)
  * @param {String} [query=#target] - the CSS selector query to find target DOM node
- * @return HTMLElement
+ * @return {VirtualNode}
  */
 testUtils.queryFixture = function queryFixture(html, query) {
   query = query || '#target';
@@ -433,7 +433,7 @@ testUtils.queryFixture = function queryFixture(html, query) {
       query +
       '`. This is usually fixed by adding the default target (`id="target"`) to your html parameter. If you do not intend on querying the fixture for #target, consider using `axe.testUtils.fixtureSetup()` instead.'
   );
-  return axe.utils.querySelectorAll(rootNode, query || '#target')[0];
+  return vNode;
 };
 
 /**

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -419,8 +419,8 @@ testUtils.assertStylesheet = function assertStylesheet(
 /**
  * Injecting content into a fixture and return queried element within fixture
  *
- * @param {String|Node} content to go into the fixture (html or DOM node)
  * @param {String?} query - the CSS selector query to find target DOM node
+ * @param {String|Node} html - content to go into the fixture (html or DOM node)
  * @return HTMLElement
  */
 testUtils.queryFixture = function queryFixture(html, query) {


### PR DESCRIPTION
- Adds an assert to the `axe.testUtils.queryFixture()` to guide developers in usage of the fixture helper.
- Refactor to help VS Code pick up correct signatures
- Add JSDoc
- Whitespace fixes