### PR TITLE
test: correct path to iframe for meta-viewport integration test

### DIFF
--- a/test/integration/rules/meta-viewport/meta-viewport-pass3.html
+++ b/test/integration/rules/meta-viewport/meta-viewport-pass3.html
@@ -7,6 +7,8 @@
   <body>
     <div id="mocha"></div>
     <!-- iframe with zooming disabled should not fail the rule-->
-    <iframe src="frames/iframe-with-zooming-disabled"></iframe>
+    <iframe
+      src="/integration/rules/meta-viewport/frames/iframe-with-zooming-disabled.html"
+    ></iframe>
   </body>
 </html>


### PR DESCRIPTION
Noticed this while looking through flakey tests. The iframe path 404 which means the test itself wasn't running correctly.