### PR TITLE
chore: add deprecated jsdoc to na reporter

### DIFF
--- a/lib/core/reporters/na.js
+++ b/lib/core/reporters/na.js
@@ -1,6 +1,7 @@
 import { processAggregate } from './helpers';
 import { getEnvironmentData } from '../utils';
 
+// @deprecated
 const naReporter = (results, options, callback) => {
   console.warn(
     '"na" reporter will be deprecated in axe v4.0. Use the "v2" reporter instead.'


### PR DESCRIPTION
na reporter was deprecated in [3.3.0](https://github.com/dequelabs/axe-core/blob/develop/CHANGELOG.md#330-2019-07-08) but we forgot to add the jsDoc `@deprecated` comment so we missed removing it in 4.0 as we planned. Just adding the doc comment in so we don't forget to remove it in 5.0.