### PR TITLE
tests: support fail case for testutils.awaitNestedLoad

### DIFF
--- a/test/integration/full/isolated-env/isolated-env.html
+++ b/test/integration/full/isolated-env/isolated-env.html
@@ -4,7 +4,7 @@
     <title>all rules test</title>
     <meta charset="utf8" />
     <meta http-equiv="refresh" content="foo" />
-    <meta name="viewport" content="maximum-scale=2;" />
+    <meta name="viewport" content="maximum-scale=2" />
     <link
       rel="stylesheet"
       type="text/css"
@@ -52,7 +52,7 @@
         </div>
         <audio id="caption"><track kind="captions" /></audio>
         <input autocomplete="username" />
-        <p id="fail1" style="line-height: 1.5 !important;">Banana error</p>
+        <p id="fail1" style="line-height: 1.5 !important">Banana error</p>
         <p><blink>text</blink></p>
         <button id="text">Name</button>
         <dl>
@@ -83,7 +83,7 @@
         <object title="This object has text"></object>
         <li role="presentation" aria-label="My Heading">Hello</li>
         <div role="img" aria-label="blah"></div>
-        <div style="overflow-y: scroll; height: 5px;">
+        <div style="overflow-y: scroll; height: 5px">
           <input type="text" />
         </div>
         <select aria-label="foo"></select>

--- a/test/integration/full/isolated-env/isolated-env.js
+++ b/test/integration/full/isolated-env/isolated-env.js
@@ -1,6 +1,6 @@
 /* global chai */
 
-describe('isolated-env test', function() {
+describe('isolated-env test', function () {
   'use strict';
   var fixture = document.querySelector('#fixture');
   var isIE11 = axe.testUtils.isIE11;
@@ -25,7 +25,7 @@ describe('isolated-env test', function() {
 
   function setEmptyReporter() {
     win.axeConfigure({
-      reporter: function(results, options, callback) {
+      reporter: function (results, options, callback) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -35,46 +35,51 @@ describe('isolated-env test', function() {
     });
   }
 
-  before(function(done) {
+  before(function (done) {
     if (isIE11) {
       return this.skip();
     }
 
-    var nestedLoadPromise = new Promise(function(resolve) {
-      axe.testUtils.awaitNestedLoad(resolve);
+    var nestedLoadPromise = new Promise(function (resolve, reject) {
+      axe.testUtils.awaitNestedLoad(resolve, reject);
     });
 
-    var isloadedPromise = new Promise(function(resolve) {
-      window.addEventListener('message', function(msg) {
+    var isloadedPromise = new Promise(function (resolve, reject) {
+      window.addEventListener('message', function (msg) {
         if (msg.data === 'axe-loaded') {
           resolve();
         }
       });
+      setTimeout(function () {
+        reject(new Error('axe-loaded message not called'));
+      }, 5000);
     });
 
-    Promise.all([nestedLoadPromise, isloadedPromise]).then(function() {
-      win = fixture.querySelector('#isolated-frame').contentWindow;
-      var focusableFrame = fixture.querySelector('#focusable-iframe');
+    Promise.all([nestedLoadPromise, isloadedPromise])
+      .then(function () {
+        win = fixture.querySelector('#isolated-frame').contentWindow;
+        var focusableFrame = fixture.querySelector('#focusable-iframe');
 
-      // trigger frame-focusable-content rule
-      var iframePromise = focusableFrame.contentWindow.axe.runPartial({
-        include: [],
-        exclude: [],
-        initiator: false,
-        focusable: false,
-        size: { width: 10, height: 10 }
-      });
+        // trigger frame-focusable-content rule
+        var iframePromise = focusableFrame.contentWindow.axe.runPartial({
+          include: [],
+          exclude: [],
+          initiator: false,
+          focusable: false,
+          size: { width: 10, height: 10 }
+        });
 
-      Promise.all([axe.runPartial(), iframePromise])
-        .then(function(r) {
-          origPartialResults = r;
-          done();
-        })
-        .catch(done);
-    });
+        Promise.all([axe.runPartial(), iframePromise])
+          .then(function (r) {
+            origPartialResults = r;
+            done();
+          })
+          .catch(done);
+      })
+      .catch(done);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     // calling axe.finishRun mutates the partial results
     // object and prevents calling finishRun again with
     // the same object
@@ -85,56 +90,56 @@ describe('isolated-env test', function() {
     }
   });
 
-  it('successfully isolates axe object in iframe', function() {
+  it('successfully isolates axe object in iframe', function () {
     assert.isUndefined(win.axe);
     assert.isDefined(win.axeFinishRun);
     assert.isDefined(win.axeConfigure);
   });
 
-  it('after methods do not error by calling window or DOM methods', function(done) {
+  it('after methods do not error by calling window or DOM methods', function (done) {
     setEmptyReporter();
 
     win
       .axeFinishRun(partialResults)
-      .then(function(results) {
+      .then(function (results) {
         assert.isDefined(results);
         done();
       })
-      .catch(function(err) {
+      .catch(function (err) {
         doesNotThrow(err, done);
       });
   });
 
-  it('runs all rules and after methods', function(done) {
+  it('runs all rules and after methods', function (done) {
     win
       .axeFinishRun(partialResults)
-      .then(function(results) {
+      .then(function (results) {
         assert.lengthOf(results.inapplicable, 0);
         done();
       })
-      .catch(function(err) {
+      .catch(function (err) {
         doesNotThrow(err, done);
       });
   });
 
-  describe('reporters', function() {
+  describe('reporters', function () {
     var reporters = axe._thisWillBeDeletedDoNotUse.public.reporters;
-    Object.keys(reporters).forEach(function(reporterName) {
+    Object.keys(reporters).forEach(function (reporterName) {
       it(
         reporterName +
           ' reporter does not error by calling window or DOM methods',
-        function(done) {
+        function (done) {
           win.axeConfigure({
             reporter: reporterName
           });
 
           win
             .axeFinishRun(partialResults)
-            .then(function(results) {
+            .then(function (results) {
               assert.isDefined(results);
               done();
             })
-            .catch(function(err) {
+            .catch(function (err) {
               doesNotThrow(err, done);
             });
         }

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -35,8 +35,8 @@ function verifyIsNoneCheck(check) {
   }
 }
 
-axe._audit.rules.forEach(function(rule) {
-  rule.none.forEach(function(check) {
+axe._audit.rules.forEach(function (rule) {
+  rule.none.forEach(function (check) {
     check = check.id || check;
     if (noneChecks.indexOf(check) === -1) {
       noneChecks.push(check);
@@ -44,7 +44,7 @@ axe._audit.rules.forEach(function(rule) {
   });
 });
 
-axe._audit.rules.forEach(function(rule) {
+axe._audit.rules.forEach(function (rule) {
   rule.any.forEach(verifyIsNoneCheck);
   rule.all.forEach(verifyIsNoneCheck);
 });
@@ -54,7 +54,7 @@ axe._audit.rules.forEach(function(rule) {
  *
  * @return Object
  */
-testUtils.MockCheckContext = function() {
+testUtils.MockCheckContext = function () {
   'use strict';
   return {
     _relatedNodes: [],
@@ -62,20 +62,20 @@ testUtils.MockCheckContext = function() {
     // When using this.async() in a check, assign a function to _onAsync
     // to catch the response.
     _onAsync: null,
-    async: function() {
+    async: function () {
       var self = this;
-      return function(result) {
+      return function (result) {
         // throws if _onAsync isn't set
         self._onAsync(result, self);
       };
     },
-    data: function(d) {
+    data: function (d) {
       this._data = d;
     },
-    relatedNodes: function(nodes) {
+    relatedNodes: function (nodes) {
       this._relatedNodes = Array.isArray(nodes) ? nodes : [nodes];
     },
-    reset: function() {
+    reset: function () {
       this._data = null;
       this._relatedNodes = [];
       this._onAsync = null;
@@ -89,7 +89,7 @@ testUtils.MockCheckContext = function() {
  * @param HTMLDocumentElement		The document of the current context
  * @return Object
  */
-testUtils.shadowSupport = (function(document) {
+testUtils.shadowSupport = (function (document) {
   'use strict';
   var v0 =
       document.body && typeof document.body.createShadowRoot === 'function',
@@ -109,7 +109,7 @@ testUtils.shadowSupport = (function(document) {
  * Return the fixture element
  * @return HTMLElement
  */
-testUtils.getFixture = function() {
+testUtils.getFixture = function () {
   'use strict';
   return fixture;
 };
@@ -119,7 +119,7 @@ testUtils.getFixture = function() {
  * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
  * @return HTMLElement
  */
-testUtils.injectIntoFixture = function(content) {
+testUtils.injectIntoFixture = function (content) {
   'use strict';
   if (typeof content !== 'undefined') {
     fixture.innerHTML = '';
@@ -130,7 +130,7 @@ testUtils.injectIntoFixture = function(content) {
   } else if (content instanceof Node) {
     fixture.appendChild(content);
   } else if (Array.isArray(content)) {
-    content.forEach(function(node) {
+    content.forEach(function (node) {
       fixture.appendChild(node);
     });
   }
@@ -145,7 +145,7 @@ testUtils.injectIntoFixture = function(content) {
  * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
  * @return HTMLElement
  */
-testUtils.fixtureSetup = function(content) {
+testUtils.fixtureSetup = function (content) {
   'use strict';
   testUtils.injectIntoFixture(content);
   axe.teardown();
@@ -160,7 +160,7 @@ testUtils.fixtureSetup = function(content) {
  * @param String				Target for the check, CSS selector (default: '#target')
  * @return Array
  */
-testUtils.checkSetup = function(content, options, target) {
+testUtils.checkSetup = function (content, options, target) {
   'use strict';
   // Normalize the params
   if (typeof options !== 'object') {
@@ -192,7 +192,7 @@ testUtils.checkSetup = function(content, options, target) {
  * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
  * @return Array
  */
-testUtils.shadowCheckSetup = function(
+testUtils.shadowCheckSetup = function (
   content,
   shadowContent,
   options,
@@ -246,7 +246,7 @@ testUtils.shadowCheckSetup = function(
  * @param Node   Stuff to go in the flat tree
  * @returns vNode[]
  */
-testUtils.flatTreeSetup = function(content) {
+testUtils.flatTreeSetup = function (content) {
   axe._tree = axe.utils.getFlattenedTree(content);
   return axe._tree;
 };
@@ -256,10 +256,12 @@ testUtils.flatTreeSetup = function(content) {
  *
  * @param Object				Window to wait for (optional)
  * @param function			Callback, called once resolved
+ * @param function      Callback, called once rejected
  */
-testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb) {
+testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb, errCb) {
   'use strict';
   if (typeof win === 'function') {
+    errCb = cb;
     cb = win;
     win = window;
   }
@@ -267,7 +269,7 @@ testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb) {
   var q = axe.utils.queue();
 
   // Wait for page load
-  q.defer(function(resolve) {
+  q.defer(function (resolve) {
     if (document.readyState === 'complete') {
       resolve();
     } else {
@@ -276,15 +278,19 @@ testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb) {
   });
 
   // Wait for all frames to be loaded
-  Array.from(document.querySelectorAll('iframe')).forEach(function(frame) {
-    q.defer(function(resolve) {
+  Array.from(document.querySelectorAll('iframe')).forEach(function (frame) {
+    q.defer(function (resolve) {
       return awaitNestedLoad(frame.contentWindow, resolve);
     });
   });
 
   // Complete (don't pass the args on to the callback)
-  q.then(function() {
+  q.then(function () {
     cb();
+  }).catch(function (err) {
+    if (errCb) {
+      errCb(err);
+    }
   });
 };
 
@@ -303,7 +309,7 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
   var doc = rootNode ? rootNode : document;
   var q = axe.utils.queue();
   if (data.href) {
-    q.defer(function(resolve, reject) {
+    q.defer(function (resolve, reject) {
       var link = doc.createElement('link');
       link.rel = 'stylesheet';
       link.href = data.href;
@@ -313,18 +319,18 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
       if (data.mediaPrint) {
         link.media = 'print';
       }
-      link.onload = function() {
-        setTimeout(function() {
+      link.onload = function () {
+        setTimeout(function () {
           resolve();
         });
       };
-      link.onerror = function() {
+      link.onerror = function () {
         reject();
       };
       doc.head.appendChild(link);
     });
   } else {
-    q.defer(function(resolve) {
+    q.defer(function (resolve) {
       var style = doc.createElement('style');
       if (data.id) {
         style.id = data.id;
@@ -332,7 +338,7 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
       style.type = 'text/css';
       style.appendChild(doc.createTextNode(data.text));
       doc.head.appendChild(style);
-      setTimeout(function() {
+      setTimeout(function () {
         resolve();
       }, 100); // -> note: gives firefox to load (document.stylesheets), other browsers are fine.
     });
@@ -348,7 +354,7 @@ testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
  */
 testUtils.addStyleSheets = function addStyleSheets(sheets, rootNode) {
   var q = axe.utils.queue();
-  sheets.forEach(function(data) {
+  sheets.forEach(function (data) {
     q.defer(axe.testUtils.addStyleSheet(data, rootNode));
   });
   return q;
@@ -361,8 +367,8 @@ testUtils.addStyleSheets = function addStyleSheets(sheets, rootNode) {
  */
 testUtils.removeStyleSheets = function removeStyleSheets(sheets) {
   var q = axe.utils.queue();
-  sheets.forEach(function(data) {
-    q.defer(function(resolve, reject) {
+  sheets.forEach(function (data) {
+    q.defer(function (resolve, reject) {
       var node = document.getElementById(data.id);
       if (!node || !node.parentNode) {
         reject();
@@ -528,7 +534,7 @@ testUtils.isIE11 = (function isIE11(navigator) {
 axe.testUtils = testUtils;
 
 if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
-  beforeEach(function() {
+  beforeEach(function () {
     // reset from axe._load overriding
     checks = originalChecks;
     axe._audit = originalAudit;
@@ -536,7 +542,7 @@ if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
     commons = axe.commons = originalCommons;
   });
 
-  afterEach(function() {
+  afterEach(function () {
     axe.teardown();
     fixture.innerHTML = '';
 
@@ -557,7 +563,7 @@ if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
 }
 
 testUtils.captureError = function captureError(cb, errorHandler) {
-  return function() {
+  return function () {
     try {
       cb.apply(null, arguments);
     } catch (e) {
@@ -577,7 +583,7 @@ testUtils.runPartialRecursive = function runPartialRecursive(
   var frameContexts = axe.utils.getFrameContexts(context);
   var promiseResults = [axe.runPartial(context, options)];
 
-  frameContexts.forEach(function(c) {
+  frameContexts.forEach(function (c) {
     var frame = testUtils.shadowQuerySelector(c.frameSelector, win.document);
     var frameWin = frame.contentWindow;
     var frameResults = testUtils.runPartialRecursive(
@@ -594,7 +600,7 @@ testUtils.shadowQuerySelector = function shadowQuerySelector(axeSelector, doc) {
   var elm;
   doc = doc || document;
   axeSelector = Array.isArray(axeSelector) ? axeSelector : [axeSelector];
-  axeSelector.forEach(function(selectorStr) {
+  axeSelector.forEach(function (selectorStr) {
     elm = doc && doc.querySelector(selectorStr);
     doc = elm && elm.shadowRoot;
   });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -287,11 +287,11 @@ testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb, errCb) {
   // Complete (don't pass the args on to the callback)
   q.then(function () {
     cb();
-  }).catch(function (err) {
-    if (errCb) {
-      errCb(err);
-    }
   });
+
+  if (errCb) {
+    q.catch(errCb);
+  }
 };
 
 /**


### PR DESCRIPTION
The `awaitNestedLoad` function never took a fail callback, so if the queue for whatever reason failed, it would go to the default fail function which was just to log the error to console. Since we don't see console logs when we run the full tests, and since the fail case was never reported back to the promise, our tests could easily timeout with no clue as to why.

Added a fail callback and made sure each promise in the isolated-env code (which [had a timeout](https://app.circleci.com/pipelines/github/dequelabs/axe-core/3855/workflows/8c57f2be-1832-4a49-b963-dc0f15416242/jobs/45110)) had a `catch` clause that reported the error back Mocha. Hopefully if the code does fail now we'll get a helpful error rather than a test timeout.

Part of #3561