### PR TITLE
refactor(accessible-text-virtual): finalize virtualNode

### DIFF
--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -19,7 +19,6 @@ import isIconLigature from '../text/is-icon-ligature';
  * @return {string}
  */
 function accessibleTextVirtual(virtualNode, context = {}) {
-  const { actualNode } = virtualNode;
   context = prepareContext(virtualNode, context);
 
   // Step 2A, check visibility
@@ -56,7 +55,7 @@ function accessibleTextVirtual(virtualNode, context = {}) {
   }, '');
 
   if (context.debug) {
-    axe.log(accName || '{empty-value}', actualNode, context);
+    axe.log(accName || '{empty-value}', virtualNode.actualNode, context);
   }
   return accName;
 }
@@ -80,21 +79,21 @@ function textNodeValue(virtualNode) {
  * @property {VirtualNode[]} processed
  * @return {Boolean}
  */
-function shouldIgnoreHidden({ actualNode }, context) {
-  if (!actualNode) {
+function shouldIgnoreHidden(virtualNode, context) {
+  if (!virtualNode) {
     return false;
   }
 
   if (
     // If the parent isn't ignored, the text node should not be either
-    actualNode.nodeType !== 1 ||
+    virtualNode.props.nodeType !== 1 ||
     // If the target of aria-labelledby is hidden, ignore all descendents
     context.includeHidden
   ) {
     return false;
   }
 
-  return !isVisible(actualNode, true);
+  return !isVisible(virtualNode, true);
 }
 
 /**
@@ -119,12 +118,11 @@ function shouldIgnoreIconLigature(virtualNode, context) {
  * @return {Object} context object with defaults applied
  */
 function prepareContext(virtualNode, context) {
-  const { actualNode } = virtualNode;
   if (!context.startNode) {
     context = { startNode: virtualNode, ...context };
   }
 
-  if (!actualNode) {
+  if (!virtualNode) {
     return context;
   }
 
@@ -138,12 +136,12 @@ function prepareContext(virtualNode, context) {
    * This is done by setting `includeHidden` for the `aria-labelledby` reference.
    */
   if (
-    actualNode.nodeType === 1 &&
+    virtualNode.props.nodeType === 1 &&
     context.inLabelledByContext &&
     context.includeHidden === undefined
   ) {
     context = {
-      includeHidden: !isVisible(actualNode, true),
+      includeHidden: !isVisible(virtualNode, true),
       ...context
     };
   }

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -122,10 +122,6 @@ function prepareContext(virtualNode, context) {
     context = { startNode: virtualNode, ...context };
   }
 
-  if (!virtualNode) {
-    return context;
-  }
-
   /**
    * When `aria-labelledby` directly references a `hidden` element
    * the element needs to be included in the accessible name.

--- a/test/integration/virtual-rules/aria-toggle-field-name.js
+++ b/test/integration/virtual-rules/aria-toggle-field-name.js
@@ -1,5 +1,5 @@
-describe('aria-toggle-field-name virtual-rule', function() {
-  it('should pass for aria-label', function() {
+describe('aria-toggle-field-name virtual-rule', function () {
+  it('should pass for aria-label', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {
@@ -16,7 +16,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should incomplete for aria-labelledby', function() {
+  it('should incomplete for aria-labelledby', function () {
     var results = axe.runVirtualRule('aria-toggle-field-name', {
       nodeName: 'div',
       attributes: {
@@ -30,7 +30,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 1);
   });
 
-  it('should pass for title', function() {
+  it('should pass for title', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {
@@ -50,7 +50,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should pass for visible text content', function() {
+  it('should pass for visible text content', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {
@@ -72,7 +72,39 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should incomplete when children are missing', function() {
+  it('should fail for hidden text', function () {
+    var button = new axe.SerialVirtualNode({
+      nodeName: 'div',
+      attributes: {
+        role: 'radio'
+      }
+    });
+
+    var span = new axe.SerialVirtualNode({
+      nodeName: 'span',
+      attributes: {
+        'aria-hidden': true
+      }
+    });
+    span.parent = button;
+    button.children = [span];
+
+    var text = new axe.SerialVirtualNode({
+      nodeName: '#text',
+      nodeType: 3,
+      nodeValue: 'foobar'
+    });
+    text.parent = span;
+    span.children = [text];
+
+    var results = axe.runVirtualRule('aria-toggle-field-name', button);
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should incomplete when children are missing', function () {
     var results = axe.runVirtualRule('aria-toggle-field-name', {
       nodeName: 'div',
       attributes: {
@@ -85,7 +117,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 1);
   });
 
-  it('should fail children contain no visible text', function() {
+  it('should fail children contain no visible text', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {
@@ -101,7 +133,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail when aria-label contains only whitespace', function() {
+  it('should fail when aria-label contains only whitespace', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {
@@ -118,7 +150,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail when aria-label is empty', function() {
+  it('should fail when aria-label is empty', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {
@@ -135,7 +167,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail when title is empty', function() {
+  it('should fail when title is empty', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {
@@ -152,7 +184,7 @@ describe('aria-toggle-field-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should incomplete if has explicit and implicit label', function() {
+  it('should incomplete if has explicit and implicit label', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'div',
       attributes: {

--- a/test/integration/virtual-rules/button-name.js
+++ b/test/integration/virtual-rules/button-name.js
@@ -1,5 +1,5 @@
-describe('button-name virtual-rule', function() {
-  it('should pass for aria-label', function() {
+describe('button-name virtual-rule', function () {
+  it('should pass for aria-label', function () {
     var results = axe.runVirtualRule('button-name', {
       nodeName: 'button',
       attributes: {
@@ -12,7 +12,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should incomplete for aria-labelledby', function() {
+  it('should incomplete for aria-labelledby', function () {
     var results = axe.runVirtualRule('button-name', {
       nodeName: 'button',
       attributes: {
@@ -25,7 +25,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 1);
   });
 
-  it('should pass for title', function() {
+  it('should pass for title', function () {
     var results = axe.runVirtualRule('button-name', {
       nodeName: 'button',
       attributes: {
@@ -38,7 +38,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should pass for role=presentation when disabled', function() {
+  it('should pass for role=presentation when disabled', function () {
     var results = axe.runVirtualRule('button-name', {
       nodeName: 'button',
       attributes: {
@@ -52,7 +52,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should pass for role=none when disabled', function() {
+  it('should pass for role=none when disabled', function () {
     var results = axe.runVirtualRule('button-name', {
       nodeName: 'button',
       attributes: {
@@ -66,7 +66,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should pass for visible text content', function() {
+  it('should pass for visible text content', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button'
     });
@@ -84,7 +84,36 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should incomplete when alt and children are missing', function() {
+  it('should fail for hidden text', function () {
+    var button = new axe.SerialVirtualNode({
+      nodeName: 'button'
+    });
+
+    var span = new axe.SerialVirtualNode({
+      nodeName: 'span',
+      attributes: {
+        'aria-hidden': true
+      }
+    });
+    span.parent = button;
+    button.children = [span];
+
+    var text = new axe.SerialVirtualNode({
+      nodeName: '#text',
+      nodeType: 3,
+      nodeValue: 'foobar'
+    });
+    text.parent = span;
+    span.children = [text];
+
+    var results = axe.runVirtualRule('button-name', button);
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should incomplete when alt and children are missing', function () {
     var results = axe.runVirtualRule('button-name', {
       nodeName: 'button',
       attributes: {}
@@ -95,7 +124,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 1);
   });
 
-  it('should fail children contain no visible text', function() {
+  it('should fail children contain no visible text', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button'
     });
@@ -108,7 +137,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail when alt contains only whitespace', function() {
+  it('should fail when alt contains only whitespace', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button',
       attributes: {
@@ -124,7 +153,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail when aria-label is empty', function() {
+  it('should fail when aria-label is empty', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button',
       attributes: {
@@ -140,7 +169,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail when title is empty', function() {
+  it('should fail when title is empty', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button',
       attributes: {
@@ -156,7 +185,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail for role=presentation', function() {
+  it('should fail for role=presentation', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button',
       attributes: {
@@ -172,7 +201,7 @@ describe('button-name virtual-rule', function() {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('should fail for role=none', function() {
+  it('should fail for role=none', function () {
     var node = new axe.SerialVirtualNode({
       nodeName: 'button',
       attributes: {


### PR DESCRIPTION
Noticed that the `accessible-text-virtual` functions didn't all completely use virtual node and sometimes accessed the `actualNode` just to look at the `nodeType` and call `isVisible`. Updated to just use virtual nodes.