### PR TITLE
fix(color-contrast): ignore overlapping elements that do not interfere with the background color

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -10,11 +10,10 @@ import {
   getForegroundColor,
   incompleteData,
   getContrast,
-  getOwnBackgroundColor,
   getTextShadowColors,
   flattenShadowColors
 } from '../../commons/color';
-import { memoize } from '../../core/utils';
+import { findPseudoElement } from '../../commons/dom';
 
 export default function colorContrastEvaluate(node, options, virtualNode) {
   const {
@@ -72,7 +71,11 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
   }
 
   const bgNodes = [];
-  const bgColor = getBackgroundColor(node, bgNodes, shadowOutlineEmMax);
+  const bgColor = getBackgroundColor(node, bgNodes, {
+    shadowOutlineEmMax,
+    ignorePseudo,
+    pseudoSizeThreshold
+  });
   const fgColor = getForegroundColor(node, false, bgColor);
   // Thin shadows only. Thicker shadows are included in the background instead
   const shadowColors = getTextShadowColors(node, {
@@ -162,70 +165,10 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
   return isValid;
 }
 
-function findPseudoElement(
-  vNode,
-  { pseudoSizeThreshold = 0.25, ignorePseudo = false }
-) {
-  if (ignorePseudo) {
-    return;
-  }
-  const rect = vNode.boundingClientRect;
-  const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
-  do {
-    const beforeSize = getPseudoElementArea(vNode.actualNode, ':before');
-    const afterSize = getPseudoElementArea(vNode.actualNode, ':after');
-    if (beforeSize + afterSize > minimumSize) {
-      return vNode; // Combined area of before and after exceeds the minimum size
-    }
-  } while ((vNode = vNode.parent));
-}
-
-const getPseudoElementArea = memoize(function getPseudoElementArea(
-  node,
-  pseudo
-) {
-  const style = window.getComputedStyle(node, pseudo);
-  const matchPseudoStyle = (prop, value) =>
-    style.getPropertyValue(prop) === value;
-  if (
-    matchPseudoStyle('content', 'none') ||
-    matchPseudoStyle('display', 'none') ||
-    matchPseudoStyle('visibility', 'hidden') ||
-    matchPseudoStyle('position', 'absolute') === false
-  ) {
-    return 0; // The pseudo element isn't visible
-  }
-
-  if (
-    getOwnBackgroundColor(style).alpha === 0 &&
-    matchPseudoStyle('background-image', 'none')
-  ) {
-    return 0; // There is no background
-  }
-
-  // Find the size of the pseudo element;
-  const pseudoWidth = parseUnit(style.getPropertyValue('width'));
-  const pseudoHeight = parseUnit(style.getPropertyValue('height'));
-  if (pseudoWidth.unit !== 'px' || pseudoHeight.unit !== 'px') {
-    // IE doesn't normalize to px. Infinity gets everything to undefined
-    return pseudoWidth.value === 0 || pseudoHeight.value === 0 ? 0 : Infinity;
-  }
-  return pseudoWidth.value * pseudoHeight.value;
-});
-
 function textIsEmojis(visibleText) {
   const options = { nonBmp: true };
   const hasUnicodeChars = hasUnicode(visibleText, options);
   const hasNonUnicodeChars =
     sanitize(removeUnicode(visibleText, options)) === '';
   return hasUnicodeChars && hasNonUnicodeChars;
-}
-
-function parseUnit(str) {
-  const unitRegex = /^([0-9.]+)([a-z]+)$/i;
-  const [, value = '', unit = ''] = str.match(unitRegex) || [];
-  return {
-    value: parseFloat(value),
-    unit: unit.toLowerCase()
-  };
 }

--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -18,19 +18,27 @@ import visuallyContains from '../dom/visually-contains';
  * @param  {Element} elm Element to determine background color
  * @param  {Array}   [bgElms=[]] elements to inspect
  * @param  {Number}  shadowOutlineEmMax Thickness of `text-shadow` at which it becomes a background color
+ * @param  {Object}  options
+ * @deprecated shadowOutlineEmMax parameter. Pass an object instead with shadowOutlineEmMax as property.
  * @returns {Color}
  */
 export default function getBackgroundColor(
   elm,
   bgElms = [],
-  shadowOutlineEmMax = 0.1
+  shadowOutlineEmMax,
+  options
 ) {
+  if (['undefined', 'object'].includes(typeof shadowOutlineEmMax)) {
+    options = shadowOutlineEmMax ?? {};
+    shadowOutlineEmMax = options.shadowOutlineEmMax ?? 0.1;
+  }
+
   let bgColors = getTextShadowColors(elm, { minRatio: shadowOutlineEmMax });
   if (bgColors.length) {
     bgColors = [{ color: bgColors.reduce(flattenShadowColors) }];
   }
 
-  const elmStack = getBackgroundStack(elm);
+  const elmStack = getBackgroundStack(elm, options);
 
   // Search the stack until we have an alpha === 1 background
   (elmStack || []).some(bgElm => {

--- a/lib/commons/color/get-background-stack.js
+++ b/lib/commons/color/get-background-stack.js
@@ -3,50 +3,37 @@ import elementHasImage from './element-has-image';
 import getOwnBackgroundColor from './get-own-background-color';
 import incompleteData from './incomplete-data';
 import reduceToElementsBelowFloating from '../dom/reduce-to-elements-below-floating';
+import visibleTextNodes from '../text/visible-text-nodes';
+import findPseudoElement from '../dom/find-pseudo-element';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
- * Determine if element B is an inline descendant of A
- * @private
- * @param {Element} node
- * @param {Element} descendant
- * @return {Boolean}
+ * Get all elements rendered underneath the current element,
+ * In the order they are displayed (front to back)
+ *
+ * @method getBackgroundStack
+ * @memberof axe.commons.color
+ * @param {Element} elm
+ * @param {Object} options
+ * @return {Array}
  */
-function isInlineDescendant(node, descendant) {
-  const CONTAINED_BY = Node.DOCUMENT_POSITION_CONTAINED_BY;
-  // eslint-disable-next-line no-bitwise
-  if (!(node.compareDocumentPosition(descendant) & CONTAINED_BY)) {
-    return false;
-  }
-  const style = window.getComputedStyle(descendant);
-  const display = style.getPropertyValue('display');
-  if (!display.includes('inline')) {
-    return false;
-  }
-  // IE needs this; It doesn't set display:block when position is set
-  const position = style.getPropertyValue('position')
-  return position === 'static';
-}
+export default function getBackgroundStack(elm, options) {
+  let elmStack = filteredRectStack(elm);
 
-/**
- * Determine if the element obscures / overlaps with the text
- * @private
- * @param {Number} elmIndex
- * @param {Array} elmStack
- * @param {Element} originalElm
- * @return {Number|undefined}
- */
-function calculateObscuringElement(elmIndex, elmStack, originalElm) {
-  // Reverse order, so that we can safely splice
-  for (let i = elmIndex - 1; i >= 0; i--) {
-    if (!isInlineDescendant(originalElm, elmStack[i])) {
-      return true;
-    }
-    // Ignore inline descendants, for example:
-    // <p>text <img></p>; We don't care about the <img> element,
-    // since it does not overlap the text inside of <p>
-    elmStack.splice(i, 1);
+  if (elmStack === null) {
+    return null;
   }
-  return false;
+  elmStack = reduceToElementsBelowFloating(elmStack, elm);
+  elmStack = sortPageBackground(elmStack);
+
+  // Return all elements BELOW the current element, null if the element is undefined
+  const elmIndex = elmStack.indexOf(elm);
+  if (calculateObscuringElement(elmIndex, elmStack, elm, options)) {
+    // if the total of the elements above our element results in total obscuring, return null
+    incompleteData.set('bgColor', 'bgOverlap');
+    return null;
+  }
+  return elmIndex !== -1 ? elmStack : null;
 }
 
 /**
@@ -95,31 +82,89 @@ function sortPageBackground(elmStack) {
 }
 
 /**
- * Get all elements rendered underneath the current element,
- * In the order they are displayed (front to back)
- *
- * @method getBackgroundStack
- * @memberof axe.commons.color
- * @param {Element} elm
- * @return {Array}
+ * Determine if the element obscures / overlaps with the text
+ * @private
+ * @param {Number} elmIndex
+ * @param {Array} elmStack
+ * @param {Element} originalElm
+ * @param {Object} options
+ * @return {Number|undefined}
  */
-function getBackgroundStack(elm) {
-  let elmStack = filteredRectStack(elm);
-
-  if (elmStack === null) {
-    return null;
+function calculateObscuringElement(elmIndex, elmStack, originalElm, options) {
+  // Reverse order, so that we can safely splice
+  for (let i = elmIndex - 1; i >= 0; i--) {
+    if (
+      !isInlineDescendant(originalElm, elmStack[i]) &&
+      !isEmptyElement(elmStack[i], options)
+    ) {
+      return true;
+    }
+    // Ignore inline descendants, for example:
+    // <p>text <img></p>; We don't care about the <img> element,
+    // since it does not overlap the text inside of <p>
+    elmStack.splice(i, 1);
   }
-  elmStack = reduceToElementsBelowFloating(elmStack, elm);
-  elmStack = sortPageBackground(elmStack);
-
-  // Return all elements BELOW the current element, null if the element is undefined
-  const elmIndex = elmStack.indexOf(elm);
-  if (calculateObscuringElement(elmIndex, elmStack, elm)) {
-    // if the total of the elements above our element results in total obscuring, return null
-    incompleteData.set('bgColor', 'bgOverlap');
-    return null;
-  }
-  return elmIndex !== -1 ? elmStack : null;
+  return false;
 }
 
-export default getBackgroundStack;
+/**
+ * Determine if element B is an inline descendant of A
+ * @private
+ * @param {Element} node
+ * @param {Element} descendant
+ * @return {Boolean}
+ */
+function isInlineDescendant(node, descendant) {
+  const CONTAINED_BY = Node.DOCUMENT_POSITION_CONTAINED_BY;
+  // eslint-disable-next-line no-bitwise
+  if (!(node.compareDocumentPosition(descendant) & CONTAINED_BY)) {
+    return false;
+  }
+  const style = window.getComputedStyle(descendant);
+  const display = style.getPropertyValue('display');
+  if (!display.includes('inline')) {
+    return false;
+  }
+  // IE needs this; It doesn't set display:block when position is set
+  const position = style.getPropertyValue('position');
+  return position === 'static';
+}
+
+/**
+ * Determine if an element is empty and would not contribute to the background color
+ * @see https://github.com/dequelabs/axe-core/issues/3464
+ * @private
+ * @param {Element} node
+ * @param {Object} options
+ */
+function isEmptyElement(node, { pseudoSizeThreshold, ignorePseudo }) {
+  const vNode = getNodeFromTree(node);
+  const style = window.getComputedStyle(node);
+  const bgColor = getOwnBackgroundColor(style);
+  const hasPseudoElement = !!findPseudoElement(vNode, {
+    pseudoSizeThreshold,
+    ignorePseudo,
+    recurse: false
+  });
+  // IE11 does not support border, border-width, or
+  // outline computed shorthand properties
+  const hasBorder = [
+    'border-bottom-width',
+    'border-top-width',
+    'border-left-width',
+    'border-right-width',
+    'outline-width'
+  ].some(prop => parseInt(vNode.getComputedStylePropertyValue(prop), 10) !== 0);
+
+  if (
+    visibleTextNodes(vNode).length === 0 &&
+    bgColor.alpha === 0 &&
+    !elementHasImage(node, style) &&
+    !hasPseudoElement &&
+    !hasBorder
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/lib/commons/dom/find-pseudo-element.js
+++ b/lib/commons/dom/find-pseudo-element.js
@@ -1,0 +1,71 @@
+import memoize from '../../core/utils/memoize';
+import getOwnBackgroundColor from '../color/get-own-background-color';
+
+/**
+ * Find the pseudo element of node that meets the minimum size threshold.
+ * @method findPseudoElement
+ * @memberof axe.commons.dom
+ * @instance
+ * @param {VirtualNode} vNode The VirtualNode to find pseudo elements for
+ * @param {Object} options
+ * @returns {VirtualNode|undefined} The VirtualNode which has matching pseudo elements.
+ */
+export default function findPseudoElement(
+  vNode,
+  { pseudoSizeThreshold = 0.25, ignorePseudo = false, recurse = true } = {}
+) {
+  if (ignorePseudo) {
+    return;
+  }
+  const rect = vNode.boundingClientRect;
+  const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
+  do {
+    const beforeSize = getPseudoElementArea(vNode.actualNode, ':before');
+    const afterSize = getPseudoElementArea(vNode.actualNode, ':after');
+    if (beforeSize + afterSize > minimumSize) {
+      return vNode; // Combined area of before and after exceeds the minimum size
+    }
+  } while (recurse && (vNode = vNode.parent));
+}
+
+const getPseudoElementArea = memoize(function getPseudoElementArea(
+  node,
+  pseudo
+) {
+  const style = window.getComputedStyle(node, pseudo);
+  const matchPseudoStyle = (prop, value) =>
+    style.getPropertyValue(prop) === value;
+  if (
+    matchPseudoStyle('content', 'none') ||
+    matchPseudoStyle('display', 'none') ||
+    matchPseudoStyle('visibility', 'hidden') ||
+    matchPseudoStyle('position', 'absolute') === false
+  ) {
+    return 0; // The pseudo element isn't visible
+  }
+
+  if (
+    getOwnBackgroundColor(style).alpha === 0 &&
+    matchPseudoStyle('background-image', 'none')
+  ) {
+    return 0; // There is no background
+  }
+
+  // Find the size of the pseudo element;
+  const pseudoWidth = parseUnit(style.getPropertyValue('width'));
+  const pseudoHeight = parseUnit(style.getPropertyValue('height'));
+  if (pseudoWidth.unit !== 'px' || pseudoHeight.unit !== 'px') {
+    // IE doesn't normalize to px. Infinity gets everything to undefined
+    return pseudoWidth.value === 0 || pseudoHeight.value === 0 ? 0 : Infinity;
+  }
+  return pseudoWidth.value * pseudoHeight.value;
+});
+
+function parseUnit(str) {
+  const unitRegex = /^([0-9.]+)([a-z]+)$/i;
+  const [, value = '', unit = ''] = str.match(unitRegex) || [];
+  return {
+    value: parseFloat(value),
+    unit: unit.toLowerCase()
+  };
+}

--- a/lib/commons/dom/index.js
+++ b/lib/commons/dom/index.js
@@ -4,6 +4,7 @@
  * @memberof axe.commons
  */
 export { default as findElmsInContext } from './find-elms-in-context';
+export { default as findPseudoElement } from './find-pseudo-element';
 export { default as findUpVirtual } from './find-up-virtual';
 export { default as findUp } from './find-up';
 export { default as getComposedParent } from './get-composed-parent';

--- a/lib/commons/standards/get-element-spec.js
+++ b/lib/commons/standards/get-element-spec.js
@@ -6,7 +6,10 @@ import matchesFn from '../../commons/matches';
  * @param {VirtualNode} vNode The VirtualNode to get the spec for.
  * @return {Object} The standard spec object
  */
-function getElementSpec(vNode, { noMatchAccessibleName = false } = {}) {
+export default function getElementSpec(
+  vNode,
+  { noMatchAccessibleName = false } = {}
+) {
   const standard = standards.htmlElms[vNode.props.nodeName];
 
   // invalid element name (could be an svg or custom element name)
@@ -57,5 +60,3 @@ function getElementSpec(vNode, { noMatchAccessibleName = false } = {}) {
 
   return spec;
 }
-
-export default getElementSpec;

--- a/lib/commons/standards/get-element-spec.js
+++ b/lib/commons/standards/get-element-spec.js
@@ -6,10 +6,7 @@ import matchesFn from '../../commons/matches';
  * @param {VirtualNode} vNode The VirtualNode to get the spec for.
  * @return {Object} The standard spec object
  */
-export default function getElementSpec(
-  vNode,
-  { noMatchAccessibleName = false } = {}
-) {
+function getElementSpec(vNode, { noMatchAccessibleName = false } = {}) {
   const standard = standards.htmlElms[vNode.props.nodeName];
 
   // invalid element name (could be an svg or custom element name)
@@ -60,3 +57,5 @@ export default function getElementSpec(
 
   return spec;
 }
+
+export default getElementSpec;

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -1,4 +1,4 @@
-describe('color.getBackgroundColor', function() {
+describe('color.getBackgroundColor', function () {
   'use strict';
 
   var fixture = document.getElementById('fixture');
@@ -8,12 +8,12 @@ describe('color.getBackgroundColor', function() {
   var origBodyBg;
   var origHtmlBg;
 
-  before(function() {
+  before(function () {
     origBodyBg = document.body.style.background;
     origHtmlBg = document.documentElement.style.background;
   });
 
-  afterEach(function() {
+  afterEach(function () {
     document.body.style.background = origBodyBg;
     document.documentElement.style.background = origHtmlBg;
 
@@ -21,7 +21,7 @@ describe('color.getBackgroundColor', function() {
     axe._tree = undefined;
   });
 
-  it('should return the blended color if it has no background set', function() {
+  it('should return the blended color if it has no background set', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; background-color: #800000;">' +
       '<div id="target" style="height: 20px; width: 15px;">' +
@@ -39,7 +39,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should return the blended color if it is transparent and positioned', function() {
+  it('should return the blended color if it is transparent and positioned', function () {
     fixture.innerHTML =
       '<div style="position: absolute; top: 0px; left: 0px; height: 100px; ' +
       'width: 90px; background-color: #000080;">' +
@@ -64,7 +64,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [target, pos]);
   });
 
-  it('should do alpha blending from the back forward', function() {
+  it('should do alpha blending from the back forward', function () {
     fixture.innerHTML =
       '<div id="under" style="height: 20px; width: 15px; background-color: #800000;">' +
       '<div id="transparent" style="height: 20px; width: 15px; background-color: rgba(0, 0, 0, 0);">' +
@@ -83,7 +83,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [target, under]);
   });
 
-  it('should only look at what is underneath original element when blended and positioned', function() {
+  it('should only look at what is underneath original element when blended and positioned', function () {
     fixture.innerHTML =
       '<div style="position: absolute; top: 0px; left: 0px; height: 100px; ' +
       'width: 90px; background-color: #000080;">' +
@@ -110,7 +110,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [target, under]);
   });
 
-  it('should return the proper blended color if it has alpha set', function() {
+  it('should return the proper blended color if it has alpha set', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; background-color: #800000;">' +
       '<div id="target" style="height: 20px; width: 15px; background-color: rgba(0, 128, 0, 0.5);">' +
@@ -128,7 +128,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [target, parent]);
   });
 
-  it('should return the blended color if it has opacity set', function() {
+  it('should return the blended color if it has opacity set', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; background-color: #800000;">' +
       '<div id="target" style="height: 20px; width: 15px; opacity: 0.5; background-color: green;">' +
@@ -146,7 +146,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [target, parent]);
   });
 
-  it('should return null if containing parent has a background image and is non-opaque', function() {
+  it('should return null if containing parent has a background image and is non-opaque', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px;' +
       'background-color: #800000; background-image: url(image.png);">' +
@@ -162,7 +162,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
   });
 
-  it('should return white if transparency goes all the way up to document', function() {
+  it('should return white if transparency goes all the way up to document', function () {
     fixture.innerHTML = '<div id="target" style="height: 10px; width: 30px;">';
     var target = fixture.querySelector('#target');
     axe.testUtils.flatTreeSetup(fixture);
@@ -174,7 +174,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(actual.alpha, expected.alpha);
   });
 
-  it('should return null if there is a background image', function() {
+  it('should return null if there is a background image', function () {
     fixture.innerHTML =
       '<div style="height: 40px; width: 30px; background-color: #800000;">' +
       '<div id="target" style="height: 20px; width: 15px; background-color: green; background-image: url(image.png);">' +
@@ -188,7 +188,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
   });
 
-  it('should return null if something non-opaque is obscuring it', function() {
+  it('should return null if something non-opaque is obscuring it', function () {
     fixture.innerHTML =
       '<div style="width:100%; height: 100px; background: #000"></div>' +
       '<div id="target" style="position: relative; top: -50px; z-index:-1;color:#fff;">Hello</div>';
@@ -201,7 +201,7 @@ describe('color.getBackgroundColor', function() {
     assert.isNull(actual);
   });
 
-  it('should return null if something non-opaque is obscuring it, scrolled out of view', function() {
+  it('should return null if something non-opaque is obscuring it, scrolled out of view', function () {
     fixture.innerHTML =
       '<div style="height: 1em; overflow: auto; position: relative;">' +
       '  <div style="background: rgba(0, 255, 255, 0.7); ' +
@@ -216,7 +216,7 @@ describe('color.getBackgroundColor', function() {
     assert.isNull(actual);
   });
 
-  it('should return an actual if something opaque is obscuring it', function() {
+  it('should return an actual if something opaque is obscuring it', function () {
     fixture.innerHTML =
       '<div style="width:100%; height: 100px; background: rgba(0, 0, 0, 0.5)"></div>' +
       '<div id="target" style="position: relative; top: -50px; z-index:-1;color:#fff;">Hello</div>';
@@ -229,7 +229,7 @@ describe('color.getBackgroundColor', function() {
     assert.isNull(actual);
   });
 
-  it('should return the bgcolor if it is solid', function() {
+  it('should return the bgcolor if it is solid', function () {
     fixture.innerHTML =
       '<div style="height: 40px; width: 30px; background-color: red;">' +
       '<div id="target" style="height: 20px; width: 15px; background-color: green;">' +
@@ -246,7 +246,195 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [target]);
   });
 
-  it('should return a bgcolor for a multiline inline element fully covering the background', function() {
+  describe('overlapping element', function () {
+    it('should return bgcolor if an empty element is obscuring it', function () {
+      fixture.innerHTML =
+        '<a href="#" aria-hidden="true" tabindex="-1" style="width: 100%; height: 100px; position: absolute; z-index:1;"></a>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.isNotNull(actual);
+    });
+
+    it('should null if element has text', function () {
+      fixture.innerHTML =
+        '<div style="width: 100%; height: 100px; position: absolute; z-index:1;">Hell world</div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element has a background color', function () {
+      fixture.innerHTML =
+        '<div style="width: 100%; height: 100px; position: absolute; z-index:1; background: red"></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element has a background image', function () {
+      fixture.innerHTML =
+        '<div style="width: 100%; height: 100px; position: absolute; z-index:1; background-image: url(foobar.png)"></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element is an image element', function () {
+      fixture.innerHTML =
+        '<img src="foobar.png" style="width: 100%; height: 100px; position: absolute; z-index:1;"/>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element is an embedded content element', function () {
+      fixture.innerHTML =
+        '<canvas style="width: 100%; height: 100px; position: absolute; z-index:1;"/></canvas>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element has a border', function () {
+      fixture.innerHTML =
+        '<div style="width: 100%; height: 100px; position: absolute; z-index:1; border: 1px solid black;"/></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element has a single border', function () {
+      fixture.innerHTML =
+        '<div style="width: 100%; height: 100px; position: absolute; z-index:1; border-left: 1px solid black;"/></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element has an outline', function () {
+      fixture.innerHTML =
+        '<div style="width: 100%; height: 100px; position: absolute; z-index:1; outline: 1px solid black;"/></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should null if element has a pseudo element with a background', function () {
+      fixture.innerHTML =
+        '<style>.pseudo::after { content: ""; width: 100%; height: 100px; position: absolute; background: black; }</style>' +
+        '<div class="pseudo" style="width: 100%; height: 100px; position: absolute; z-index:1;"/></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.equal(
+        axe.commons.color.incompleteData.get('bgColor'),
+        'bgOverlap'
+      );
+      assert.isNull(actual);
+    });
+
+    it('should return bgcolor if element has a pseudo element without a background', function () {
+      fixture.innerHTML =
+        '<style>.pseudo::after { content: ""; width: 100%; height: 100px; position: absolute; }</style>' +
+        '<div class="pseudo" style="width: 100%; height: 100px; position: absolute; z-index:1;"/></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.isNotNull(actual);
+    });
+
+    it('should return bgcolor if element is non-opaque', function () {
+      fixture.innerHTML =
+        '<div style="width: 100%; height: 100px; position: absolute; z-index:1; background: red; opacity: 0"></div>' +
+        '<div id="target" style="color:#fff;">Hello</div>';
+      var target = fixture.querySelector('#target');
+      axe.testUtils.flatTreeSetup(fixture);
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      assert.isNotNull(actual);
+    });
+
+    describe('options', function () {
+      it('should ignore pseudo elements with "ignorePseudo"', function () {
+        fixture.innerHTML =
+          '<style>.pseudo::after { content: ""; width: 100%; height: 100px; position: absolute; }</style>' +
+          '<div class="pseudo" style="width: 100%; height: 100px; position: absolute; z-index:1;"/></div>' +
+          '<div id="target" style="color:#fff;">Hello</div>';
+        var target = fixture.querySelector('#target');
+        axe.testUtils.flatTreeSetup(fixture);
+        var actual = axe.commons.color.getBackgroundColor(target, [], {
+          ignorePseudo: true
+        });
+        assert.isNotNull(actual);
+      });
+
+      it('should find pseudo elements with "pseudoSizeThreshold"', function () {
+        fixture.innerHTML =
+          '<style>.pseudo::after { content: ""; width: 25px; height: 25px; position: absolute; }</style>' +
+          '<div class="pseudo" style="width: 100px; height: 100px; position: absolute; z-index:1;"/></div>' +
+          '<div id="target" style="color:#fff;">Hello</div>';
+        var target = fixture.querySelector('#target');
+        axe.testUtils.flatTreeSetup(fixture);
+        var actual = axe.commons.color.getBackgroundColor(target, [], {
+          pseudoSizeThreshold: 0.05
+        });
+        assert.isNotNull(actual);
+      });
+    });
+  });
+
+  it('should return a bgcolor for a multiline inline element fully covering the background', function () {
     fixture.innerHTML =
       '<div style="position:relative;">' +
       '<div style="background-color:rgba(0,0,0,1);position:absolute;width:300px;height:200px;"></div>' +
@@ -263,7 +451,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(Math.round(actual.green), 0);
   });
 
-  it('should return null if a multiline inline element does not fully cover background', function() {
+  it('should return null if a multiline inline element does not fully cover background', function () {
     fixture.innerHTML =
       '<div style="position:relative;">' +
       '<div style="background-color:rgba(0,0,0,1);position:absolute;width:300px;height:20px;"></div>' +
@@ -281,7 +469,7 @@ describe('color.getBackgroundColor', function() {
     );
   });
 
-  it('should return an actual if an absolutely positioned element does not cover background', function() {
+  it('should return an actual if an absolutely positioned element does not cover background', function () {
     fixture.innerHTML =
       '<div style="background-color:black; height:20px; position:relative;">' +
       '<div style="color:#333; position:absolute; top:21px;" id="target">Text</div>' +
@@ -296,7 +484,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(Math.round(actual.green), 255);
   });
 
-  it('should return null if an absolutely positioned element partially obsures background', function() {
+  it('should return null if an absolutely positioned element partially obsures background', function () {
     fixture.innerHTML =
       '<div style="height:40px; position:relative;">' +
       '<div style="background-color:black; height:20px;"></div>' +
@@ -314,7 +502,7 @@ describe('color.getBackgroundColor', function() {
     );
   });
 
-  it('should count a TR as a background element for TD', function() {
+  it('should count a TR as a background element for TD', function () {
     fixture.innerHTML =
       '<div style="background-color:#007acc;">' +
       '<table style="width:100%">' +
@@ -336,7 +524,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should count a TR as a background element for TH', function() {
+  it('should count a TR as a background element for TH', function () {
     fixture.innerHTML =
       '<div style="background-color:#007acc;">' +
       '<table style="width:100%">' +
@@ -358,7 +546,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should count a TR as a background element for a child element', function() {
+  it('should count a TR as a background element for a child element', function () {
     fixture.innerHTML =
       '<div style="background-color:#007acc;">' +
       '<table style="width:100%">' +
@@ -380,7 +568,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should count a THEAD as a background element for a child element', function() {
+  it('should count a THEAD as a background element for a child element', function () {
     fixture.innerHTML =
       '<div style="background-color:#007acc;">' +
       '<table style="width:100%">' +
@@ -402,7 +590,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should count a TBODY as a background element for a child element', function() {
+  it('should count a TBODY as a background element for a child element', function () {
     fixture.innerHTML =
       '<div style="background-color:#007acc;">' +
       '<table style="width:100%">' +
@@ -424,7 +612,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should count a TFOOT as a background element for a child element', function() {
+  it('should count a TFOOT as a background element for a child element', function () {
     fixture.innerHTML =
       '<div style="background-color:#007acc;">' +
       '<table style="width:100%">' +
@@ -446,7 +634,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it("should ignore TR elements that don't overlap", function() {
+  it("should ignore TR elements that don't overlap", function () {
     fixture.innerHTML =
       '<table style="position:relative; width:100%;">' +
       '<tr style="background-color:black; height:10px; width:100%;" id="parent">' +
@@ -465,7 +653,7 @@ describe('color.getBackgroundColor', function() {
     assert.notEqual(bgNodes, [parent]);
   });
 
-  it('should count an implicit label as a background element', function() {
+  it('should count an implicit label as a background element', function () {
     fixture.innerHTML =
       '<label id="target" style="background-color: #000;">My label' +
       '<input type="text">' +
@@ -481,7 +669,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(actual.alpha, expected.alpha);
   });
 
-  it('handles nested inline elements in the middle of a text', function() {
+  it('handles nested inline elements in the middle of a text', function () {
     fixture.innerHTML =
       '<div style="height: 1em; overflow:auto; background: cyan">' +
       '  <br>' +
@@ -500,7 +688,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(actual.alpha, 1);
   });
 
-  it('should return null for inline elements with position:absolute', function() {
+  it('should return null for inline elements with position:absolute', function () {
     fixture.innerHTML =
       '<div style="height: 1em; overflow:auto; position: relative">' +
       '  <br>' +
@@ -515,7 +703,7 @@ describe('color.getBackgroundColor', function() {
     assert.isNull(actual);
   });
 
-  it('should ignore inline ancestors of non-overlapping elements', function() {
+  it('should ignore inline ancestors of non-overlapping elements', function () {
     fixture.innerHTML =
       '<div style="position:relative;">' +
       '<label style="background-color:black;" id="parent">Label' +
@@ -534,7 +722,7 @@ describe('color.getBackgroundColor', function() {
     assert.notEqual(bgNodes, [parent]);
   });
 
-  it('should handle multiple ancestors of the same name', function() {
+  it('should handle multiple ancestors of the same name', function () {
     fixture.innerHTML =
       '<div style="background-color: #007acc;">' +
       '<table style="width: 100%;">' +
@@ -560,7 +748,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should use hierarchical DOM traversal if possible', function() {
+  it('should use hierarchical DOM traversal if possible', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; ' +
       ' background-color: white;">' +
@@ -583,7 +771,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should ignore 0-height elements', function() {
+  it('should ignore 0-height elements', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; ' +
       'background-color: white; position: relative; z-index: 5">' +
@@ -604,7 +792,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('should use visual traversal when needed', function() {
+  it('should use visual traversal when needed', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; ' +
       ' background-color: white; position: relative; z-index: 5">' +
@@ -628,7 +816,7 @@ describe('color.getBackgroundColor', function() {
     assert.closeTo(actual.alpha, expected.alpha, 0.1);
   });
 
-  it('should return null when encountering background images during visual traversal', function() {
+  it('should return null when encountering background images during visual traversal', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; ' +
       ' background-color: white; position: relative; z-index: 5"> ' +
@@ -648,7 +836,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
   });
 
-  it('should return null when encountering image nodes during visual traversal', function() {
+  it('should return null when encountering image nodes during visual traversal', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; ' +
       ' background-color: white; position: relative; z-index: 5"> ' +
@@ -668,7 +856,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'imgNode');
   });
 
-  it('returns elements with negative z-index', function() {
+  it('returns elements with negative z-index', function () {
     fixture.innerHTML =
       '<div id="sibling" ' +
       'style="z-index:-1; position:absolute; width:100%; height:2em; background: #000"></div>' +
@@ -688,7 +876,7 @@ describe('color.getBackgroundColor', function() {
     assert.closeTo(actual.alpha, expected.alpha, 0.1);
   });
 
-  it('returns negative z-index elements when body has a background', function() {
+  it('returns negative z-index elements when body has a background', function () {
     fixture.innerHTML =
       '<div id="sibling" ' +
       'style="z-index:-1; position:absolute; width:100%; height:2em; background: #000"></div>' +
@@ -709,7 +897,7 @@ describe('color.getBackgroundColor', function() {
     assert.closeTo(actual.alpha, expected.alpha, 0.1);
   });
 
-  it('should return null for negative z-index element when html and body have a background', function() {
+  it('should return null for negative z-index element when html and body have a background', function () {
     fixture.innerHTML =
       '<div style="width: 200px; height: 200px;"></div>' +
       '<div id="target" ' +
@@ -729,7 +917,7 @@ describe('color.getBackgroundColor', function() {
   // Test is flakey in IE11, timing out regularly
   (isIE11 ? xit : it)(
     'should return background color for inline elements that do not fit the viewport',
-    function() {
+    function () {
       var html = '';
       for (var i = 0; i < 300; i++) {
         html += 'foo<br />';
@@ -746,7 +934,7 @@ describe('color.getBackgroundColor', function() {
     }
   );
 
-  it('should return the body bgColor when content does not overlap', function() {
+  it('should return the body bgColor when content does not overlap', function () {
     fixture.innerHTML =
       '<div style="height: 20px; width: 30px; background-color: red;">' +
       '<div id="target" style="height:20px; top: 25px; width: 45px; position:absolute;">Text' +
@@ -761,7 +949,7 @@ describe('color.getBackgroundColor', function() {
     assert.closeTo(actual.alpha, 1, 0);
   });
 
-  it('should return the html canvas inherited from body bgColor when element content does not overlap with body', function() {
+  it('should return the html canvas inherited from body bgColor when element content does not overlap with body', function () {
     fixture.innerHTML =
       '<div id="target" style="position: relative; top: 2px; height: 10px;">Text</div>';
 
@@ -785,7 +973,7 @@ describe('color.getBackgroundColor', function() {
     document.body.style.margin = originalMargin;
   });
 
-  it('should return the html canvas bgColor when element content does not overlap with body', function() {
+  it('should return the html canvas bgColor when element content does not overlap with body', function () {
     fixture.innerHTML =
       '<div id="target" style="position: relative; top: 2px;">Text</div>';
 
@@ -807,28 +995,31 @@ describe('color.getBackgroundColor', function() {
     document.body.style.height = originalHeight;
   });
 
-  (shadowSupported ? it : xit)('finds colors in shadow boundaries', function() {
-    fixture.innerHTML = '<div id="container"></div>';
-    var container = fixture.querySelector('#container');
-    var shadow = container.attachShadow({ mode: 'open' });
-    shadow.innerHTML =
-      '<div style="background-color: black;">' +
-      '<span id="shadowTarget" style="color: #ccc;">Text</span>' +
-      '</div>';
-    axe.testUtils.flatTreeSetup(fixture);
+  (shadowSupported ? it : xit)(
+    'finds colors in shadow boundaries',
+    function () {
+      fixture.innerHTML = '<div id="container"></div>';
+      var container = fixture.querySelector('#container');
+      var shadow = container.attachShadow({ mode: 'open' });
+      shadow.innerHTML =
+        '<div style="background-color: black;">' +
+        '<span id="shadowTarget" style="color: #ccc;">Text</span>' +
+        '</div>';
+      axe.testUtils.flatTreeSetup(fixture);
 
-    var target = shadow.querySelector('#shadowTarget');
-    var actual = axe.commons.color.getBackgroundColor(target, []);
+      var target = shadow.querySelector('#shadowTarget');
+      var actual = axe.commons.color.getBackgroundColor(target, []);
 
-    assert.closeTo(actual.red, 0, 0);
-    assert.closeTo(actual.green, 0, 0);
-    assert.closeTo(actual.blue, 0, 0);
-    assert.closeTo(actual.alpha, 1, 0);
-  });
+      assert.closeTo(actual.red, 0, 0);
+      assert.closeTo(actual.green, 0, 0);
+      assert.closeTo(actual.blue, 0, 0);
+      assert.closeTo(actual.alpha, 1, 0);
+    }
+  );
 
   (shadowSupported ? it : xit)(
     'finds colors across shadow boundaries',
-    function() {
+    function () {
       fixture.innerHTML =
         '<div id="container" style="background-color:black;"></div>';
       var container = fixture.querySelector('#container');
@@ -849,7 +1040,7 @@ describe('color.getBackgroundColor', function() {
 
   (shadowSupported ? it : xit)(
     'should count an implicit label as a background element inside shadow dom',
-    function() {
+    function () {
       fixture.innerHTML = '<div id="container"></div>';
       var container = fixture.querySelector('#container');
       var shadow = container.attachShadow({ mode: 'open' });
@@ -870,7 +1061,7 @@ describe('color.getBackgroundColor', function() {
 
   (shadowSupported ? it : xit)(
     'finds colors for absolutely positioned elements across shadow boundaries',
-    function() {
+    function () {
       fixture.innerHTML =
         '<div id="container" style="background-color:black; height:20px; position:relative;"></div>';
       var container = fixture.querySelector('#container');
@@ -891,7 +1082,7 @@ describe('color.getBackgroundColor', function() {
 
   (shadowSupported ? it : xit)(
     'finds a color for absolutely positioned content when background is in shadow dom',
-    function() {
+    function () {
       fixture.innerHTML =
         '<div id="elm1" style="width:10em; height:0; position:absolute;"></div>' +
         '<div id="elm2" style="color:green; position:absolute;">Text</div>';
@@ -912,7 +1103,7 @@ describe('color.getBackgroundColor', function() {
 
   (shadowSupported ? it : xit)(
     'finds colors for content rendered across multiple shadow boundaries',
-    function() {
+    function () {
       fixture.innerHTML =
         '<div style="position:relative;"><div id="elm1" style="width:10em;"></div>' +
         '<div id="elm2"></div></div>';
@@ -941,7 +1132,7 @@ describe('color.getBackgroundColor', function() {
 
   (shadowSupported ? it : xit)(
     'finds colors for multiline elements across shadow boundaries',
-    function() {
+    function () {
       fixture.innerHTML =
         '<div id="container" style="background-color:black; height:40px;"></div>';
       var container = fixture.querySelector('#container');
@@ -960,7 +1151,7 @@ describe('color.getBackgroundColor', function() {
 
   (shadowSupported ? xit : xit)(
     'returns null for multiline elements not fully covering parents across shadow boundaries',
-    function() {
+    function () {
       fixture.innerHTML =
         '<div id="container" style="background-color:black; height:20px;"></div>';
       var container = fixture.querySelector('#container');
@@ -976,7 +1167,7 @@ describe('color.getBackgroundColor', function() {
 
   (shadowSupported ? it : xit)(
     'returns a color for slotted content',
-    function() {
+    function () {
       fixture.innerHTML = '<div id="container"></div>';
       var div = fixture.querySelector('#container');
       div.innerHTML = '<a href="">Link</a>';
@@ -992,7 +1183,7 @@ describe('color.getBackgroundColor', function() {
     }
   );
 
-  it('should return the text-shadow mixed in with the background', function() {
+  it('should return the text-shadow mixed in with the background', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; background-color: #800000;">' +
       '<div id="target" style="height: 20px; width: 15px; text-shadow: red 0 0 1em">foo' +
@@ -1012,7 +1203,7 @@ describe('color.getBackgroundColor', function() {
     assert.deepEqual(bgNodes, [parent]);
   });
 
-  it('ignores thin text-shadows', function() {
+  it('ignores thin text-shadows', function () {
     fixture.innerHTML =
       '<div id="parent" style="height: 40px; width: 30px; background-color: #000;">' +
       '<div id="target" style="height: 20px; width: 15px; text-shadow: red 0 0 0.05em">foo' +
@@ -1028,7 +1219,7 @@ describe('color.getBackgroundColor', function() {
     assert.equal(actual.alpha, 1);
   });
 
-  it('ignores text-shadows thinner than shadowOutlineEmMax', function() {
+  it('ignores text-shadows thinner than shadowOutlineEmMax', function () {
     fixture.innerHTML =
       '<div style="height: 40px; width: 30px; background-color: #800000;">' +
       '<div id="target" style="height: 20px; width: 15px; text-shadow: red 0 0 1em, green 0 0 0.5em">foo' +
@@ -1046,8 +1237,8 @@ describe('color.getBackgroundColor', function() {
     assert.closeTo(actual.alpha, expected.alpha, 0.1);
   });
 
-  describe('body and document', function() {
-    it('returns the body background', function() {
+  describe('body and document', function () {
+    it('returns the body background', function () {
       fixture.innerHTML = '<div id="target">elm</div>';
       document.body.style.background = '#F00';
 
@@ -1064,7 +1255,7 @@ describe('color.getBackgroundColor', function() {
       assert.closeTo(actual.alpha, expected.alpha, 0.1);
     });
 
-    it('returns the body background even when the body is MUCH larger than the screen', function() {
+    it('returns the body background even when the body is MUCH larger than the screen', function () {
       fixture.innerHTML = '<div id="target" style="height:20000px;">elm</div>';
       document.body.style.background = '#F00';
 
@@ -1081,7 +1272,7 @@ describe('color.getBackgroundColor', function() {
       assert.closeTo(actual.alpha, expected.alpha, 0.1);
     });
 
-    it('returns the html background', function() {
+    it('returns the html background', function () {
       fixture.innerHTML = '<div id="target"><label>elm<input></label></div>';
       document.documentElement.style.background = '#0F0';
 
@@ -1098,7 +1289,7 @@ describe('color.getBackgroundColor', function() {
       assert.closeTo(actual.alpha, expected.alpha, 0.1);
     });
 
-    it('returns the html background when body does not cover the element', function() {
+    it('returns the html background when body does not cover the element', function () {
       fixture.innerHTML =
         '<div id="target" style="position: absolute; top: 1000px;">elm<input></div>';
       document.documentElement.style.background = '#0F0';
@@ -1117,7 +1308,7 @@ describe('color.getBackgroundColor', function() {
       assert.closeTo(actual.alpha, expected.alpha, 0.1);
     });
 
-    it('returns the body background when body does cover the element', function() {
+    it('returns the body background when body does cover the element', function () {
       fixture.innerHTML = '<div id="target"><label>elm<input></label></div>';
       document.documentElement.style.background = '#0F0';
       document.body.style.background = '#00F';
@@ -1135,7 +1326,7 @@ describe('color.getBackgroundColor', function() {
       assert.closeTo(actual.alpha, expected.alpha, 0.1);
     });
 
-    it('returns both the html and body background if the body has alpha', function() {
+    it('returns both the html and body background if the body has alpha', function () {
       fixture.innerHTML = '<div id="target"><label>elm<input></label></div>';
       document.documentElement.style.background = '#0F0';
       document.body.style.background = 'rgba(0, 0, 255, 0.5)';

--- a/test/commons/dom/find-pseudo-element.js
+++ b/test/commons/dom/find-pseudo-element.js
@@ -1,0 +1,169 @@
+describe('dom.findPseudoElement', function () {
+  var queryFixture = axe.testUtils.queryFixture;
+  var findPseudoElement = axe.commons.dom.findPseudoElement;
+
+  var pseudoElms = ['::before', '::after'];
+  for (var i = 0; i < pseudoElms.length; i++) {
+    var pseudoElm = pseudoElms[i];
+    describe(pseudoElm, function () {
+      it('should return the element with a pseudo element (background color)', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; background: red; position: absolute; }</style>' +
+            '<div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.equal(vNode, actual);
+      });
+
+      it('should return the element with a pseudo element (background image)', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; background-image: url(foo.png); position: absolute; }</style>' +
+            '<div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.equal(vNode, actual);
+      });
+
+      it('should return a parent element with a pseudo element', function () {
+        var vNode = queryFixture(
+          '<style>.parent' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; background: red; position: absolute; }</style><div class="parent"><div><div id="target" style="height: 100px;"></div></div></div>'
+        );
+        var target = axe.utils.querySelectorAll(axe._tree, '.parent')[0];
+        var actual = findPseudoElement(vNode);
+        assert.equal(target, actual);
+      });
+
+      it('should return undefined if pseudo element has no content', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ width: 100%; height: 100px; background: red; position: absolute; }</style><div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return undefined if pseudo element is hidden (display: none)', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; background: red; position: absolute; display: none; }</style><div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return undefined if pseudo element is hidden (visibility: hidden)', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; background: red; position: absolute; visibility: hidden; }</style><div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return undefined if pseudo element is hidden (position not absolute)', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; background: red; position: relative; }</style><div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return undefined if pseudo element does not have a background', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; position: absolute; }</style><div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return undefined if pseudo element has a transparent background', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 100%; height: 100px; position: absolute; background: rgba(0,0,0,0); }</style><div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return undefined if pseudo element is too small', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 1px; height: 1px; position: absolute; background: red; }</style><div id="target" style="height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return undefined if pseudo size is equal to "pseudoSizeThreshold"', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 50px; height: 50px; background: red; position: absolute; }</style>' +
+            '<div id="target" style="width: 100px; height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.isUndefined(actual);
+      });
+
+      it('should return the element if pseudo size is greater than "pseudoSizeThreshold"', function () {
+        var vNode = queryFixture(
+          '<style>#target' +
+            pseudoElm +
+            '{ content: ""; width: 50px; height: 51px; background: red; position: absolute; }</style>' +
+            '<div id="target" style="width: 100px; height: 100px;"></div>'
+        );
+        var actual = findPseudoElement(vNode);
+        assert.equal(vNode, actual);
+      });
+
+      describe('options', function () {
+        it('should return undefined if passed "ignorePseudo: true"', function () {
+          var vNode = queryFixture(
+            '<style>#target' +
+              pseudoElm +
+              '{ content: ""; width: 100%; height: 100px; background: red; position: absolute; }</style>' +
+              '<div id="target" style="height: 100px;"></div>'
+          );
+          var actual = findPseudoElement(vNode, { ignorePseudo: true });
+          assert.isUndefined(actual);
+        });
+
+        it('should return the element for "pseudoSizeThreshold"', function () {
+          var vNode = queryFixture(
+            '<style>#target' +
+              pseudoElm +
+              '{ content: ""; width: 25px; height: 25px; background: red; position: absolute; }</style>' +
+              '<div id="target" style="width: 100px; height: 100px;"></div>'
+          );
+          var actual = findPseudoElement(vNode, { pseudoSizeThreshold: 0.05 });
+          assert.equal(vNode, actual);
+        });
+
+        it('should return undefined for parent with pseudo if passed "recurse: false"', function () {
+          var vNode = queryFixture(
+            '<style>.parent' +
+              pseudoElm +
+              '{ content: ""; width: 100%; height: 100px; background: red; position: absolute; }</style><div class="parent"><div><div id="target" style="height: 100px;"></div></div></div>'
+          );
+          var actual = findPseudoElement(vNode, { recurse: false });
+          assert.isUndefined(actual);
+        });
+      });
+    });
+  }
+});

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -1,17 +1,22 @@
 <div id="pass1" style="background-color: white; color: black">
   This is a pass.
 </div>
-<div id="pass2" style="background-color: gray; color: white; font-size: 40px;">
+<div id="pass2" style="background-color: gray; color: white; font-size: 40px">
   This is a pass.
 </div>
 <div
   id="pass3"
-  style="background-color: gray; color: white; font-size: 20px; font-weight: bold"
+  style="
+    background-color: gray;
+    color: white;
+    font-size: 20px;
+    font-weight: bold;
+  "
 >
   This is a pass.
 </div>
 
-<div style="background-color: black;">
+<div style="background-color: black">
   <div
     style="color: transparent; text-shadow: 0 0 0 white"
     id="text-shadow-fg-pass"
@@ -20,23 +25,23 @@
   </div>
 </div>
 
-<div id="fail1" style="background-color: gray; color: white; font-size: 20px;">
+<div id="fail1" style="background-color: gray; color: white; font-size: 20px">
   This is a fail.<b id="pass4">But this is a pass.</b>
 </div>
 
-<div style="background-color: black;">
+<div style="background-color: black">
   <div
-    style="background-color: rgba(255, 255, 255, 0.1); color: white;"
+    style="background-color: rgba(255, 255, 255, 0.1); color: white"
     id="pass5"
   >
     Pass.
   </div>
 </div>
 
-<div style="position:relative; height: 40px;">
-  <label style="background-color:black; color: white;" id="pass7">
+<div style="position: relative; height: 40px">
+  <label style="background-color: black; color: white" id="pass7">
     Label
-    <input style="position:absolute; top:20px;" />
+    <input style="position: absolute; top: 20px" />
   </label>
 </div>
 
@@ -47,13 +52,10 @@
   Hello world
 </div>
 
-<div id="fail2" style="background-color: gray; color: white; font-size: 8px;">
+<div id="fail2" style="background-color: gray; color: white; font-size: 8px">
   This is a fail.
 </div>
-<div
-  id="fail3"
-  style="background-color: yellow; color: white; font-size: 40px;"
->
+<div id="fail3" style="background-color: yellow; color: white; font-size: 40px">
   This is a fail.
 </div>
 
@@ -65,7 +67,7 @@
 
 <div
   id="fail7"
-  style="color: #000; background: #777; text-shadow: black 0 0 .2em"
+  style="color: #000; background: #777; text-shadow: black 0 0 0.2em"
 >
   Hello world
 </div>
@@ -99,7 +101,13 @@
 
 <div
   id="ignore6"
-  style="color: yellow; width: 100px; overflow: hidden; text-indent: 200px; background-color: white;"
+  style="
+    color: yellow;
+    width: 100px;
+    overflow: hidden;
+    text-indent: 200px;
+    background-color: white;
+  "
 >
   text
 </div>
@@ -122,44 +130,63 @@
 </label>
 
 <div
-  style="background-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)"
+  style="
+    background-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7);
+  "
 >
   <div style="color: white" id="canttell1">Background image</div>
 </div>
 
-<div style="height:40px; position: relative;">
+<div style="height: 40px; position: relative">
   <div
-    style="background-color: white; height: 60px; width: 40px;border: 1px solid;"
+    style="
+      background-color: white;
+      height: 60px;
+      width: 40px;
+      border: 1px solid;
+    "
   >
     <div
       id="canttell2"
-      style="color: white; height: 40px; width: 60px; border: 1px solid red;"
+      style="color: white; height: 40px; width: 60px; border: 1px solid red"
     >
       Outside parent
     </div>
   </div>
 </div>
 
-<div style="background-color: white; height: 60px; width: 40px;">
-  <div id="canttell3" style="color: white; height: 40px; width: 60px;">
+<div style="background-color: white; height: 60px; width: 40px">
+  <div id="canttell3" style="color: white; height: 40px; width: 60px">
     Background overlap
   </div>
 </div>
 
 <div
-  style="background-color: white; height: 60px; width: 80px; border:1px solid;position: relative;"
+  style="
+    background-color: white;
+    height: 60px;
+    width: 80px;
+    border: 1px solid;
+    position: relative;
+  "
 >
   <div
     id="canttell4"
-    style="color: white; height: 40px; width: 60px; border:1px solid red;"
+    style="color: white; height: 40px; width: 60px; border: 1px solid red"
   >
     Element overlap
   </div>
   <div
-    style="position: absolute; top: 0; width: 60px; height: 40px;background-color: #000"
+    style="
+      position: absolute;
+      top: 0;
+      width: 60px;
+      height: 40px;
+      background-color: #000;
+    "
   ></div>
 </div>
-<div style="background-color: white;">
+<div style="background-color: white">
   <div
     style="background-color: rgba(255, 255, 255, 0.1); color: white"
     id="canttell5"
@@ -228,8 +255,8 @@
   text
 </div>
 
-<div style="background-color: white; height: 60px; width: 80px;">
-  <div id="canttell18" style="color: white; height: 40px; width: 60px;">Hi</div>
+<div style="background-color: white; height: 60px; width: 80px">
+  <div id="canttell18" style="color: white; height: 40px; width: 60px">Hi</div>
 </div>
 
 <div
@@ -237,14 +264,14 @@
 >
   <div
     id="canttell19"
-    style="margin-left: 80px; color: white; height: 80px; width: 90px;"
+    style="margin-left: 80px; color: white; height: 80px; width: 90px"
   >
     Hi
   </div>
 </div>
 
-<div style="background-color: #FFF;">
-  <div id="canttell20" style="color:#DDD;">
+<div style="background-color: #fff">
+  <div id="canttell20" style="color: #ddd">
     &#x20A0; &#x20A1; &#x20A2; &#x20A3;
   </div>
 </div>
@@ -256,7 +283,13 @@
 </div>
 
 <p
-  style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap; max-width: 200px; background-color: #FFF"
+  style="
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    max-width: 200px;
+    background-color: #fff;
+  "
 >
   <span id="pass9" style="color: #000">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed et sollicitudin
@@ -273,3 +306,41 @@
     felis ante non libero.
   </span>
 </p>
+
+<div style="position: relative">
+  <a
+    href="#"
+    role="presentation"
+    tabindex="-1"
+    aria-hidden="true"
+    style="position: absolute; top: 0; left: 0; bottom: 0; right: 0"
+  ></a>
+  <span id="pass10">Hello</span>
+</div>
+
+<style>
+  .pseudo::before {
+    content: '';
+    top: calc(50% - 100%);
+    left: calc(50% - 100%);
+    width: 200%;
+    height: 200%;
+    z-index: 1;
+    position: absolute;
+    opacity: 0;
+  }
+</style>
+<button style="position: relative; padding: 0 16px; height: 39px">
+  <span id="pass11">Button</span>
+  <span
+    class="pseudo"
+    style="
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      overflow: hidden;
+      top: 0;
+      left: 0;
+    "
+  ></span>
+</button>

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -330,7 +330,10 @@
     opacity: 0;
   }
 </style>
-<button style="position: relative; padding: 0 16px; height: 39px">
+<!-- IE11 default background for button is a gradient so we need to override that otherwise this will incomplete with "bgGradient" message -->
+<button
+  style="position: relative; padding: 0 16px; height: 39px; background: #eee"
+>
   <span id="pass11">Button</span>
   <span
     class="pseudo"

--- a/test/integration/rules/color-contrast/color-contrast.json
+++ b/test/integration/rules/color-contrast/color-contrast.json
@@ -12,7 +12,9 @@
     ["#pass7 > input"],
     ["#pass8"],
     ["#text-shadow-fg-pass"],
-    ["#pass9"]
+    ["#pass9"],
+    ["#pass10"],
+    ["#pass11"]
   ],
   "incomplete": [
     ["#canttell1"],


### PR DESCRIPTION
This should drastically decrease the number of overlapping element incompletes axe-core generates, especially for anyone who uses Material Button on their site. I moved `findPseudoElement` to it's own function so it could be used in both `color-contrast-evaluate` and `calculateObscuringElement`. 

I also moved `getBackgroundStack` to the top to match our default export style. The main parts of that file change are the addition of `isEmptyElement` that goes with the `isInlineDescendant` check.

Closes issue: #3464
