### PR TITLE
chore: create action to auto-label extension and linting issues

### DIFF
--- a/.github/workflows/label-extension-linter-issues.yml
+++ b/.github/workflows/label-extension-linter-issues.yml
@@ -3,8 +3,6 @@ name: Add extension and linting labels to associated opened issues
 on:
   issues:
     types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
 
 jobs:
   label_extension_linting_issues:

--- a/.github/workflows/label-extension-linter-issues.yml
+++ b/.github/workflows/label-extension-linter-issues.yml
@@ -1,0 +1,26 @@
+name: Add extension and linting labels to associated opened issues
+
+on:
+  issues:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+jobs:
+  label_extension_linting_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label Extension Issues
+        uses: andymckay/labeler@1.0.4
+        if: contains(toJson(github.event.issue.body), '### Product\n\naxe Extension\n\n')
+        with:
+          add-labels: "extension"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Label Linting Issues
+        uses: andymckay/labeler@1.0.4
+        if: contains(toJson(github.event.issue.body), '### Product\n\naxe Linter\n\n')
+        with:
+          add-labels: "linting"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With the new issue forms, we can now auto-assign opened issues with the `extension` or `linting`  labels based on the Product dropdown. It was difficult to figure out the proper matching of newline characters. 

You can see it working https://github.com/straker/issue-template-tests/issues and https://github.com/straker/issue-template-tests/actions