### PR TITLE
feat(doc-has-single-title): add doc-has-single-title

### DIFF
--- a/lib/checks/shared/doc-has-single-title-evaluate.js
+++ b/lib/checks/shared/doc-has-single-title-evaluate.js
@@ -1,0 +1,6 @@
+function docHasSingleTitleEvaluate() {
+  var titles = document.getElementsByTagName('title');
+  return titles.length === 1;
+}
+
+export default docHasSingleTitleEvaluate;

--- a/lib/checks/shared/doc-has-single-title.json
+++ b/lib/checks/shared/doc-has-single-title.json
@@ -1,0 +1,11 @@
+{
+  "id": "doc-has-single-title",
+  "evaluate": "doc-has-single-title-evaluate",
+  "metadata": {
+    "impact": "serious",
+    "messages": {
+      "pass": "Document has only one <title> element",
+      "fail": "Document does not have only one <title> element"
+    }
+  }
+}

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -890,6 +890,10 @@
       "fail": "Element does not have inner text that is visible to screen readers",
       "incomplete": "Unable to determine if element has children"
     },
+    "doc-has-single-title": {
+      "pass": "Document has only one <title> element",
+      "fail": "Document does not have only one <title> element"
+    },
     "doc-has-title": {
       "pass": "Document has a non-empty <title> element",
       "fail": "Document does not have a non-empty <title> element"

--- a/test/checks/shared/doc-has-single-title.js
+++ b/test/checks/shared/doc-has-single-title.js
@@ -1,0 +1,46 @@
+describe('doc-has-single-title', function () {
+  'use strict';
+
+  var fixture = document.getElementById('fixture');
+
+  afterEach(function () {
+    fixture.innerHTML = '';
+    // test runner has its own title, so we must remove it first to evaluate
+    Array.from(document.getElementsByTagName('title')).forEach(function (elem) {
+      document.head.removeChild(elem);
+    });
+  });
+
+  it('should return false if there is not only 1 title', function () {
+    var orig = document.title;
+
+    var title1 = document.createElement('title');
+    title1.text = 'Bananas';
+    document.head.appendChild(title1);
+
+    var title2 = document.createElement('title');
+    title2.text = 'Apples';
+    document.title = title2.text;
+    document.head.appendChild(title2);
+
+    assert.isFalse(
+      axe.testUtils.getCheckEvaluate('doc-has-single-title')(fixture)
+    );
+    document.title = orig;
+    document.head.removeChild(title1);
+    document.head.removeChild(title2);
+  });
+
+  it('should return true if there is only 1 title', function () {
+    var orig = document.title;
+    var title1 = document.createElement('title');
+    title1.text = 'Bananas';
+    document.head.appendChild(title1);
+
+    assert.isTrue(
+      axe.testUtils.getCheckEvaluate('doc-has-single-title')(fixture)
+    );
+    document.title = orig;
+    document.head.removeChild(title1);
+  });
+});


### PR DESCRIPTION
This adds a check that the html document only has 1 title. It's impossible to assign multiple titles to the document api, however it is still possible to have multiple `<title>` elements within the HTML itself, which is a bad practice
