### PR TITLE
refactor(empty-table-header): use virtual node 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules
 npm-shrinkwrap.json
 doc/examples/*/package-lock.json
 .DS_Store
-.vscode
 .idea
 
 # tmp - `dev` time generated assets

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["deque-systems.vscode-axe-linter"]
+}

--- a/lib/commons/standards/implicit-html-roles.js
+++ b/lib/commons/standards/implicit-html-roles.js
@@ -134,7 +134,7 @@ const implicitHtmlRoles = {
       case '':
         return !suggestionsSourceElement ? 'textbox' : 'combobox';
 
-      default: 
+      default:
         return 'textbox';
     }
   },
@@ -171,10 +171,10 @@ const implicitHtmlRoles = {
   textarea: 'textbox',
   tfoot: 'rowgroup',
   th: vNode => {
-    if (isColumnHeader(vNode.actualNode)) {
+    if (isColumnHeader(vNode)) {
       return 'columnheader';
     }
-    if (isRowHeader(vNode.actualNode)) {
+    if (isRowHeader(vNode)) {
       return 'rowheader';
     }
   },

--- a/lib/commons/table/get-scope.js
+++ b/lib/commons/table/get-scope.js
@@ -1,6 +1,8 @@
 import toGrid from './to-grid';
 import getCellPosition from './get-cell-position';
-import findUp from '../dom/find-up';
+import { closest } from '../../core/utils';
+import AbstractVirtualNode from '../../core/base/virtual-node/abstract-virtual-node';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Determine if a `HTMLTableCellElement` is a column header, if so get the scope of the header
@@ -11,13 +13,13 @@ import findUp from '../dom/find-up';
  * @return {Boolean|String} Returns `false` if not a column header, or the scope of the column header element
  */
 function getScope(cell) {
-  var scope = cell.getAttribute('scope');
-  var role = cell.getAttribute('role');
+  if (!(cell instanceof AbstractVirtualNode)) {
+    cell = getNodeFromTree(cell);
+  }
+  var scope = cell.attr('scope');
+  var role = cell.attr('role');
 
-  if (
-    cell instanceof window.Element === false ||
-    ['TD', 'TH'].indexOf(cell.nodeName.toUpperCase()) === -1
-  ) {
+  if (['TD', 'TH'].indexOf(cell.props.nodeName.toUpperCase()) === -1) {
     throw new TypeError('Expected TD or TH element');
   }
 
@@ -27,15 +29,15 @@ function getScope(cell) {
     return 'row';
   } else if (scope === 'col' || scope === 'row') {
     return scope;
-  } else if (cell.nodeName.toUpperCase() !== 'TH') {
+  } else if (cell.props.nodeName.toUpperCase() !== 'TH') {
     return false;
   }
-  var tableGrid = toGrid(findUp(cell, 'table'));
+  var tableGrid = toGrid(closest(cell, 'table'));
   var pos = getCellPosition(cell, tableGrid);
 
   // The element is in a row with all th elements, that makes it a column header
   var headerRow = tableGrid[pos.y].reduce((headerRow, cell) => {
-    return headerRow && cell.nodeName.toUpperCase() === 'TH';
+    return headerRow && cell.props.nodeName.toUpperCase() === 'TH';
   }, true);
 
   if (headerRow) {
@@ -46,7 +48,7 @@ function getScope(cell) {
   var headerCol = tableGrid
     .map(col => col[pos.x])
     .reduce((headerCol, cell) => {
-      return headerCol && cell && cell.nodeName.toUpperCase() === 'TH';
+      return headerCol && cell && cell.props.nodeName.toUpperCase() === 'TH';
     }, true);
 
   if (headerCol) {

--- a/lib/commons/table/get-scope.js
+++ b/lib/commons/table/get-scope.js
@@ -31,7 +31,10 @@ function getScope(cell) {
     return scope;
   } else if (cell.props.nodeName.toUpperCase() !== 'TH') {
     return false;
+  } else if (cell.actualNode === undefined) {
+    return 'auto';
   }
+
   var tableGrid = toGrid(closest(cell, 'table'));
   var pos = getCellPosition(cell, tableGrid);
 

--- a/lib/commons/table/is-column-header.js
+++ b/lib/commons/table/is-column-header.js
@@ -1,4 +1,6 @@
 import getScope from './get-scope';
+import AbstractVirtualNode from '../../core/base/virtual-node/abstract-virtual-node';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Determine if a `HTMLTableCellElement` is a column header
@@ -9,6 +11,9 @@ import getScope from './get-scope';
  * @return {Boolean}
  */
 function isColumnHeader(element) {
+  if (!(element instanceof AbstractVirtualNode)) {
+    element = getNodeFromTree(element);
+  }
   return ['col', 'auto'].indexOf(getScope(element)) !== -1;
 }
 

--- a/lib/commons/table/is-row-header.js
+++ b/lib/commons/table/is-row-header.js
@@ -1,4 +1,6 @@
 import getScope from './get-scope';
+import AbstractVirtualNode from '../../core/base/virtual-node/abstract-virtual-node';
+import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Determine if a `HTMLTableCellElement` is a row header
@@ -9,6 +11,9 @@ import getScope from './get-scope';
  * @return {Boolean}
  */
 function isRowHeader(cell) {
+  if (!(cell instanceof AbstractVirtualNode)) {
+    cell = getNodeFromTree(cell);
+  }
   return ['row', 'auto'].includes(getScope(cell));
 }
 

--- a/lib/commons/table/to-grid.js
+++ b/lib/commons/table/to-grid.js
@@ -1,4 +1,8 @@
-import { memoize } from '../../core/utils';
+import AbstractVirtualNode from '../../core/base/virtual-node/abstract-virtual-node';
+import getNodeFromTree from '../../core/utils/get-node-from-tree';
+import { memoize, matches } from '../../core/utils';
+
+export default memoize(toGrid);
 
 /**
  * Converts a table to an Array of arrays, normalized for row and column spans
@@ -9,10 +13,17 @@ import { memoize } from '../../core/utils';
  * @return {Array<HTMLTableCellElement>} Array of HTMLTableCellElements
  */
 function toGrid(node) {
+  const vNode =
+    node instanceof AbstractVirtualNode ? node : getNodeFromTree(node);
+
   var table = [];
-  var rows = node.rows;
+  //TODO: this will need to be converted to a recursive lookup
+  // to handle the case of table > tbody > tr
+  var rows = vNode.children.filter(child => matches(child, 'tr'));
+
   for (var i = 0, rowLength = rows.length; i < rowLength; i++) {
-    var cells = rows[i].cells;
+    var cells = rows[i].children.filter(child => matches(child, 'td'));
+
     table[i] = table[i] || [];
 
     var columnIndex = 0;
@@ -44,5 +55,3 @@ function toGrid(node) {
 
   return table;
 }
-
-export default memoize(toGrid);

--- a/test/integration/virtual-rules/empty-table-header.js
+++ b/test/integration/virtual-rules/empty-table-header.js
@@ -1,0 +1,13 @@
+describe('empty-table-header virtual-rule', function () {
+  it('should pass with a table header');
+  it('should pass with a table definition of role rowheader');
+  it('should pass with a table definition of role rowheader');
+  it('should fail if table header has no child nodes');
+  it('should fail with a table header that only has hidden text');
+  it(
+    'should fail with a table definition of role rowheader that only has hidden text'
+  );
+  it(
+    'should fail with a table definition of role rowheader that only has hidden text'
+  );
+});

--- a/test/integration/virtual-rules/empty-table-header.js
+++ b/test/integration/virtual-rules/empty-table-header.js
@@ -1,13 +1,148 @@
 describe('empty-table-header virtual-rule', function () {
-  it('should pass with a table header');
-  it('should pass with a table definition of role rowheader');
-  it('should pass with a table definition of role rowheader');
-  it('should fail if table header has no child nodes');
-  it('should fail with a table header that only has hidden text');
-  it(
-    'should fail with a table definition of role rowheader that only has hidden text'
-  );
-  it(
-    'should fail with a table definition of role rowheader that only has hidden text'
-  );
+  it('should pass with a table header', function () {
+    var tableNode = new axe.SerialVirtualNode({
+      nodeName: 'table'
+    });
+
+    var trNode = new axe.SerialVirtualNode({
+      nodeName: 'tr'
+    });
+    trNode.parent = tableNode;
+
+    var thNode = new axe.SerialVirtualNode({
+      nodeName: 'th'
+    });
+    thNode.parent = trNode;
+
+    var textNode = new axe.SerialVirtualNode({
+      nodeName: '#text',
+      nodeType: 3,
+      nodeValue: 'foobar'
+    });
+    textNode.parent = thNode;
+
+    thNode.children = [textNode];
+    trNode.children = [thNode];
+    tableNode.children = [trNode];
+
+    var results = axe.runVirtualRule('empty-table-header', tableNode);
+
+    //TODO remove assert message
+    assert.lengthOf(
+      results.passes,
+      1,
+      results.incomplete[0].nodes[0].any[0].message
+    );
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should pass with scope of row', function () {
+    var tableNode = new axe.SerialVirtualNode({
+      nodeName: 'table'
+    });
+
+    var trNode = new axe.SerialVirtualNode({
+      nodeName: 'tr'
+    });
+    trNode.parent = tableNode;
+
+    var thNode = new axe.SerialVirtualNode({
+      nodeName: 'th',
+      attributes: {
+        scope: 'row'
+      }
+    });
+    thNode.parent = trNode;
+
+    var textNode = new axe.SerialVirtualNode({
+      nodeName: '#text',
+      nodeType: 3,
+      nodeValue: 'foobar'
+    });
+    textNode.parent = thNode;
+
+    thNode.children = [textNode];
+    trNode.children = [thNode];
+    tableNode.children = [trNode];
+
+    var results = axe.runVirtualRule('empty-table-header', thNode);
+
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should pass with scope of col', function () {
+    var tableNode = new axe.SerialVirtualNode({
+      nodeName: 'table'
+    });
+
+    var trNode = new axe.SerialVirtualNode({
+      nodeName: 'tr'
+    });
+    trNode.parent = tableNode;
+
+    var thNode = new axe.SerialVirtualNode({
+      nodeName: 'th',
+      attributes: {
+        scope: 'col'
+      }
+    });
+    thNode.parent = trNode;
+
+    var textNode = new axe.SerialVirtualNode({
+      nodeName: '#text',
+      nodeType: 3,
+      nodeValue: 'foobar'
+    });
+    textNode.parent = thNode;
+
+    thNode.children = [textNode];
+    trNode.children = [thNode];
+    tableNode.children = [trNode];
+
+    var results = axe.runVirtualRule('empty-table-header', thNode);
+
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should pass with a table definition of role rowheader', function () {
+    var node = new axe.SerialVirtualNode({
+      nodeName: 'td',
+      attributes: {
+        role: 'rowheader'
+      }
+    });
+    var child = new axe.SerialVirtualNode({
+      nodeName: '#text',
+      nodeType: 3,
+      nodeValue: 'foobar'
+    });
+    node.children = [child];
+
+    var results = axe.runVirtualRule('empty-table-header', node);
+
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('should fail if table header has no child nodes', function () {
+    var node = new axe.SerialVirtualNode({
+      nodeName: 'td',
+      attributes: {
+        role: 'rowheader'
+      }
+    });
+    node.children = [];
+
+    var results = axe.runVirtualRule('empty-table-header', node);
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
 });

--- a/test/integration/virtual-rules/empty-table-header.js
+++ b/test/integration/virtual-rules/empty-table-header.js
@@ -27,12 +27,7 @@ describe('empty-table-header virtual-rule', function () {
 
     var results = axe.runVirtualRule('empty-table-header', tableNode);
 
-    //TODO remove assert message
-    assert.lengthOf(
-      results.passes,
-      1,
-      results.incomplete[0].nodes[0].any[0].message
-    );
+    assert.lengthOf(results.passes, 1);
     assert.lengthOf(results.violations, 0);
     assert.lengthOf(results.incomplete, 0);
   });


### PR DESCRIPTION
- use virtual node
- replace deprecated `find-up` with `closest`

references: #3473 


