### PR TITLE
chore: update typo for possible-bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/possible-bug.yml
+++ b/.github/ISSUE_TEMPLATE/possible-bug.yml
@@ -27,7 +27,7 @@ body:
   - type: checkboxes
     id: latest-axe
     attributes:
-      label: Lastest Version
+      label: Latest Version
       options:
         - label: I have tested the issue with the latest version of the product
           required: true


### PR DESCRIPTION
<< Describe the changes >>
Change associated label for id: latest-axe to `Latest Version` instead of `Lastest Version`. If spelling was intentional, feel free to close!

Closes issue: N/A
