### PR TITLE
chore: add action to create pr for generated files

### DIFF
--- a/.github/workflows/update-generated-files.yaml
+++ b/.github/workflows/update-generated-files.yaml
@@ -18,7 +18,9 @@ jobs:
           fetch-depth: 0
 
       - name: Build
-        run: npm run build
+        run: |
+          npm install
+          npm run build
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/update-generated-files.yaml
+++ b/.github/workflows/update-generated-files.yaml
@@ -3,7 +3,7 @@ name: Update generated files
 on:
   push:
     branches:
-      - main
+      - develop
 
 jobs:
   update_genereated_files:
@@ -27,6 +27,6 @@ jobs:
           git checkout -b $branch_name
           git commit -m "chore: sync generated files"
           git push origin $branch_name
-          gh pr create --base main --head $branch_name --title "chore: sync generated files" --body ""
+          gh pr create --base develop --head $branch_name --title "chore: sync generated files" --body ""
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-generated-files.yaml
+++ b/.github/workflows/update-generated-files.yaml
@@ -1,0 +1,32 @@
+name: Update generated files
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_genereated_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: npm run build
+
+      - name: Create pull pull-requests
+        run: |
+          git status
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          branch_name="sync-generated-files-$(date +"%Y-%m-%dT%H-%M-%S%z")"
+          git add .
+          git checkout -b $branch_name
+          git commit -m "chore: sync generated files"
+          git push origin $branch_name
+          gh pr create --base main --head $branch_name --title "chore: sync generated files" --body ""
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-generated-files.yaml
+++ b/.github/workflows/update-generated-files.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+env:
+  BRANCH_NAME: sync-generated-files
+
 jobs:
   update_genereated_files:
     runs-on: ubuntu-latest
@@ -17,16 +20,47 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Create pull pull-requests
+      - name: Check for changes
+        id: changes
+        run: |
+          changes=$(git status --porcelain)
+          # see https://unix.stackexchange.com/a/509498
+          echo $changes | grep . && echo "Changes detected" || echo "No changes"
+          echo ::set-output name=changes::"$changes"
+
+      - name: Check branch exists
+        id: branchExists
+        if: steps.changes.outputs.changes
+        run: |
+          exists=$(git ls-remote --heads origin $BRANCH_NAME)
+          echo $exists | grep . && echo "Branch '$BRANCH_NAME' already exists on remote" || echo "Branch does not exists in remote"
+          echo ::set-output name=exists::"$exists"
+
+      - name: Create pull request
+        if: ${{ steps.changes.outputs.changes && !steps.branchExists.outputs.exists }}
         run: |
           git status
           git config user.name github-actions
           git config user.email github-actions@github.com
-          branch_name="sync-generated-files-$(date +"%Y-%m-%dT%H-%M-%S%z")"
           git add .
-          git checkout -b $branch_name
+          git checkout -b $BRANCH_NAME
           git commit -m "chore: sync generated files"
-          git push origin $branch_name
-          gh pr create --base develop --head $branch_name --title "chore: sync generated files" --body ""
+          git push origin $BRANCH_NAME
+          gh pr create --base develop --head $BRANCH_NAME --title "chore: sync generated files" --body ""
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update pull request
+        if: ${{ steps.changes.outputs.changes && steps.branchExists.outputs.exists }}
+        run: |
+          git reset HEAD --hard
+          git checkout $BRANCH_NAME
+          npm run build
+          git status
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "chore: sync generated files"
+          git push origin $BRANCH_NAME
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have two files that are automatically generated on build: `doc/rule-descriptions.md` and `locales/_template.json`. These files can easily become out-of-sync when a pull request makes changes to a rule or check metadata file. If a metadata file gets suggestions and the suggestions are accepted, the generated files would need to be rebuilt and redployed to the pr. Most of the time this doesn't happen and the changes aren't applied to the generated files. This causes any new builds on local branches to have new changes from develop.

This action will run the build on pushes to develop and make a pr with the built files if there are changes. You can see it working here: https://github.com/straker/issue-template-tests/pull/22. If there are no changes, the action will fail and not create a pr (as seen here https://github.com/straker/issue-template-tests/actions/runs/2922890704).