### PR TITLE
fix(aria-valid-attr-value): report empty values as incomplete

### DIFF
--- a/lib/checks/aria/aria-valid-attr-value-evaluate.js
+++ b/lib/checks/aria/aria-valid-attr-value-evaluate.js
@@ -1,4 +1,5 @@
 import { validateAttrValue } from '../../commons/aria';
+import standards from '../../standards';
 
 /**
  * Check that each ARIA attribute on an element has a valid value.
@@ -24,7 +25,7 @@ import { validateAttrValue } from '../../commons/aria';
  * @memberof checks
  * @return {Mixed} True if all ARIA attributes have a valid value. Undefined for invalid `aria-current` or `aria-describedby` values. False otherwise.
  */
-function ariaValidAttrValueEvaluate(node, options, virtualNode) {
+export default function ariaValidAttrValueEvaluate(node, options, virtualNode) {
   options = Array.isArray(options.value) ? options.value : [];
 
   let needsReview = '';
@@ -106,30 +107,35 @@ function ariaValidAttrValueEvaluate(node, options, virtualNode) {
     } catch (e) {
       needsReview = `${attrName}="${attrValue}"`;
       messageKey = 'idrefs';
+      return;
     }
 
     if (
       (preChecks[attrName] ? preChecks[attrName](validValue) : true) &&
       !validValue
     ) {
-      invalid.push(`${attrName}="${attrValue}"`);
+      if (attrValue === '' && !isStringType(attrName)) {
+        needsReview = attrName;
+        messageKey = 'empty';
+      } else {
+        invalid.push(`${attrName}="${attrValue}"`);
+      }
     }
   });
-
-  if (needsReview) {
-    this.data({
-      messageKey,
-      needsReview
-    });
-    return undefined;
-  }
 
   if (invalid.length) {
     this.data(invalid);
     return false;
   }
 
+  if (needsReview) {
+    this.data({ messageKey, needsReview });
+    return undefined;
+  }
+
   return true;
 }
 
-export default ariaValidAttrValueEvaluate;
+function isStringType(attrName) {
+  return standards.ariaAttrs[attrName]?.type === 'string';
+}

--- a/lib/checks/aria/aria-valid-attr-value.json
+++ b/lib/checks/aria/aria-valid-attr-value.json
@@ -14,7 +14,8 @@
         "noId": "ARIA attribute element ID does not exist on the page: ${data.needsReview}",
         "noIdShadow": "ARIA attribute element ID does not exist on the page or is a descendant of a different shadow DOM tree: ${data.needsReview}",
         "ariaCurrent": "ARIA attribute value is invalid and will be treated as \"aria-current=true\": ${data.needsReview}",
-        "idrefs": "Unable to determine if ARIA attribute element ID exists on the page: ${data.needsReview}"
+        "idrefs": "Unable to determine if ARIA attribute element ID exists on the page: ${data.needsReview}",
+        "empty": "ARIA attribute value is ignored while empty: ${data.needsReview}"
       }
     }
   }

--- a/lib/standards/aria-attrs.js
+++ b/lib/standards/aria-attrs.js
@@ -94,7 +94,6 @@ const ariaAttrs = {
   },
   'aria-invalid': {
     type: 'nmtoken',
-    allowEmpty: true,
     values: ['grammar', 'false', 'spelling', 'true'],
     global: true
   },

--- a/test/checks/aria/aria-required-attr.js
+++ b/test/checks/aria/aria-required-attr.js
@@ -1,48 +1,72 @@
-describe('aria-required-attr', function() {
+describe('aria-required-attr', function () {
   'use strict';
 
   var queryFixture = axe.testUtils.queryFixture;
   var checkContext = axe.testUtils.MockCheckContext();
   var options = undefined;
+  var requiredAttrCheck = axe.testUtils.getCheckEvaluate('aria-required-attr');
 
-  afterEach(function() {
+  afterEach(function () {
     checkContext.reset();
     axe.reset();
   });
 
-  it('should detect missing attributes', function() {
-    var vNode = queryFixture('<div id="target" role="switch" tabindex="1">');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-required-attr')
-        .call(checkContext, vNode.actualNode, options, vNode)
+  it('returns true for valid attributes', function () {
+    var vNode = queryFixture(
+      '<div id="target" role="switch" tabindex="1" aria-checked="false">'
     );
-    assert.deepEqual(checkContext._data, ['aria-checked']);
-  });
-
-  it('should return true if there is no role', function() {
-    var vNode = queryFixture('<div id="target">');
-
     assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-required-attr')
-        .call(checkContext, vNode.actualNode, options, vNode)
+      requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
     );
     assert.isNull(checkContext._data);
   });
 
-  it('should pass aria-valuenow if element has value property', function() {
+  it('returns false for missing attributes', function () {
+    var vNode = queryFixture('<div id="target" role="switch" tabindex="1">');
+    assert.isFalse(
+      requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
+    );
+    assert.deepEqual(checkContext._data, ['aria-checked']);
+  });
+
+  it('returns false for null attributes', function () {
+    var vNode = queryFixture(
+      '<div id="target" role="switch" tabindex="1" aria-checked>'
+    );
+    assert.isFalse(
+      requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
+    );
+    assert.deepEqual(checkContext._data, ['aria-checked']);
+  });
+
+  it('returns false for empty attributes', function () {
+    var vNode = queryFixture(
+      '<div id="target" role="switch" tabindex="1" aria-checked="">'
+    );
+    assert.isFalse(
+      requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
+    );
+    assert.deepEqual(checkContext._data, ['aria-checked']);
+  });
+
+  it('should return true if there is no role', function () {
+    var vNode = queryFixture('<div id="target">');
+
+    assert.isTrue(
+      requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
+    );
+    assert.isNull(checkContext._data);
+  });
+
+  it('should pass aria-valuenow if element has value property', function () {
     var vNode = queryFixture('<input id="target" type="range" role="slider">');
 
     assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-required-attr')
-        .call(checkContext, vNode.actualNode, options, vNode)
+      requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
     );
   });
 
-  it('should pass aria-checkbox if element has checked property', function() {
+  it('should pass aria-checkbox if element has checked property', function () {
     var vNode = queryFixture(
       '<input id="target" type="checkbox" role="switch">'
     );
@@ -57,66 +81,56 @@ describe('aria-required-attr', function() {
     );
   });
 
-  describe('combobox special case', function() {
-    it('should pass comboboxes that have aria-expanded="false"', function() {
+  describe('combobox special case', function () {
+    it('should pass comboboxes that have aria-expanded="false"', function () {
       var vNode = queryFixture(
         '<div id="target" role="combobox" aria-expanded="false"></div>'
       );
 
       assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
+        requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
       );
     });
 
-    it('should pass comboboxes that have aria-owns and aria-expanded', function() {
+    it('should pass comboboxes that have aria-owns and aria-expanded', function () {
       var vNode = queryFixture(
         '<div id="target" role="combobox" aria-expanded="true" aria-owns="ownedchild"></div>'
       );
 
       assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
+        requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
       );
     });
 
-    it('should pass comboboxes that have aria-controls and aria-expanded', function() {
+    it('should pass comboboxes that have aria-controls and aria-expanded', function () {
       var vNode = queryFixture(
         '<div id="target" role="combobox" aria-expanded="true" aria-controls="test"></div>'
       );
 
       assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
+        requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
       );
     });
 
-    it('should fail comboboxes that have no required attributes', function() {
+    it('should fail comboboxes that have no required attributes', function () {
       var vNode = queryFixture('<div id="target" role="combobox"></div>');
 
       assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
+        requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
       );
     });
 
-    it('should fail comboboxes that have aria-expanded only', function() {
+    it('should fail comboboxes that have aria-expanded only', function () {
       var vNode = queryFixture(
         '<div id="target" role="combobox" aria-expanded="true"></div>'
       );
 
       assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
+        requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
       );
     });
 
-    it('should report missing of multiple attributes correctly', function() {
+    it('should report missing of multiple attributes correctly', function () {
       axe.configure({
         standards: {
           ariaRoles: {
@@ -131,16 +145,14 @@ describe('aria-required-attr', function() {
         '<div id="target" role="combobox" aria-expanded="false"></div>'
       );
       assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
+        requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
       );
       assert.deepEqual(checkContext._data, ['aria-label']);
     });
   });
 
-  describe('options', function() {
-    it('should require provided attribute names for a role', function() {
+  describe('options', function () {
+    it('should require provided attribute names for a role', function () {
       axe.configure({
         standards: {
           ariaRoles: {
@@ -156,9 +168,7 @@ describe('aria-required-attr', function() {
         mccheddarton: ['aria-snuggles']
       };
       assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('aria-required-attr')
-          .call(checkContext, vNode.actualNode, options, vNode)
+        requiredAttrCheck.call(checkContext, vNode.actualNode, options, vNode)
       );
       assert.deepEqual(checkContext._data, ['aria-snuggles', 'aria-valuemax']);
     });

--- a/test/checks/aria/valid-attr-value.js
+++ b/test/checks/aria/valid-attr-value.js
@@ -1,4 +1,4 @@
-describe('aria-valid-attr-value', function() {
+describe('aria-valid-attr-value', function () {
   'use strict';
 
   var fixture = document.getElementById('fixture');
@@ -7,210 +7,143 @@ describe('aria-valid-attr-value', function() {
   var fixtureSetup = axe.testUtils.fixtureSetup;
   var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
   var shadowSupported = axe.testUtils.shadowSupport.v1;
+  var validAttrValueCheck = axe.testUtils.getCheckEvaluate(
+    'aria-valid-attr-value'
+  );
 
-  afterEach(function() {
+  afterEach(function () {
     fixture.innerHTML = '';
     checkContext.reset();
   });
 
-  it('should not check the validity of attribute names', function() {
+  it('should not check the validity of attribute names', function () {
     var vNode = queryFixture(
       '<div id="target" aria-cats="true" aria-selected="true"></div>'
     );
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
     assert.isNull(checkContext._data);
   });
 
-  it('should return true if all values are valid', function() {
+  it('should return true if all values are valid', function () {
     var vNode = queryFixture(
       '<div id="target" aria-selected="true" aria-checked="true" aria-relevant="additions removals"></div>'
     );
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
     assert.isNull(checkContext._data);
   });
 
-  it('should return true if idref(s) values are valid', function() {
+  it('should return true if idref(s) values are valid', function () {
     var vNode = queryFixture(
       '<div id="target" aria-owns="test_tgt1 test_tgt2" aria-activedescendant="test_tgt1"></div>' +
         '<div id="test_tgt1"></div>' +
         '<div id="test_tgt2"></div>'
     );
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
     assert.isNull(checkContext._data);
   });
 
-  it('should return false if any values are invalid', function() {
+  it('should return false if any values are invalid', function () {
     var vNode = queryFixture(
       '<div id="target" aria-live="polite" aria-selected="0"></div>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
     assert.deepEqual(checkContext._data, ['aria-selected="0"']);
   });
 
-  it('should allow empty strings rather than idref', function() {
+  it('should allow empty strings rather than idref', function () {
     var tree = fixtureSetup(
       '<button aria-controls="">Button</button>' +
         '<div aria-activedescendant=""></div>'
     );
     var passing1 = tree.children[0];
     var passing2 = tree.children[1];
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, passing1)
-    );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, passing2)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, passing1));
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, passing2));
   });
 
-  it('should allow empty strings rather than idrefs', function() {
+  it('should allow empty strings rather than idrefs', function () {
     var tree = fixtureSetup(
       '<button aria-labelledby="">Button</button>' + '<div aria-owns=""></div>'
     );
     var passing1 = tree.children[0];
     var passing2 = tree.children[1];
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, passing1)
-    );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, passing2)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, passing1));
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, passing2));
   });
 
-  it('should pass on aria-controls and aria-expanded=false when the element is not in the DOM', function() {
+  it('should pass on aria-controls and aria-expanded=false when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-controls="test" aria-expanded="false">Button</button>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should pass on aria-controls and aria-selected=false when the element is not in the DOM', function() {
+  it('should pass on aria-controls and aria-selected=false when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-controls="test" aria-selected="false">Button</button>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should fail on aria-controls and aria-expanded=true when the element is not in the DOM', function() {
+  it('should fail on aria-controls and aria-expanded=true when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-controls="test" aria-expanded="true">Button</button>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should fail on aria-controls and aria-selected=true when the element is not in the DOM', function() {
+  it('should fail on aria-controls and aria-selected=true when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-controls="test" aria-selected="true">Button</button>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should fail on aria-controls when the element is not in the DOM', function() {
+  it('should fail on aria-controls when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-controls="test">Button</button>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should pass on aria-owns and aria-expanded=false when the element is not in the DOM', function() {
+  it('should pass on aria-owns and aria-expanded=false when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-owns="test" aria-expanded="false">Button</button>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should fail on aria-owns and aria-expanded=true when the element is not in the DOM', function() {
+  it('should fail on aria-owns and aria-expanded=true when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-owns="test" aria-expanded="true">Button</button>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should fail on aria-owns when the element is not in the DOM', function() {
+  it('should fail on aria-owns when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-owns="test">Button</button>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should fail on aria-level when the value is less than 1', function() {
+  it('should fail on aria-level when the value is less than 1', function () {
     var vNode = queryFixture(
       '<div id="target" role="heading" aria-level="0">Heading</div>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should return undefined on aria-describedby when the element is not in the DOM', function() {
+  it('should return undefined on aria-describedby when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-describedby="test">Button</button>'
     );
     assert.isUndefined(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
+      validAttrValueCheck.call(checkContext, null, null, vNode)
     );
     assert.deepEqual(checkContext._data, {
       messageKey: 'noId',
@@ -220,16 +153,12 @@ describe('aria-valid-attr-value', function() {
 
   (shadowSupported ? it : xit)(
     'should return undefined on aria-describedby when the element is in a different shadow tree',
-    function() {
+    function () {
       var params = shadowCheckSetup(
         '<div></div>',
         '<button id="target" aria-describedby="test">Button</button>'
       );
-      assert.isUndefined(
-        axe.testUtils
-          .getCheckEvaluate('aria-valid-attr-value')
-          .apply(checkContext, params)
-      );
+      assert.isUndefined(validAttrValueCheck.apply(checkContext, params));
       assert.deepEqual(checkContext._data, {
         messageKey: 'noIdShadow',
         needsReview: 'aria-describedby="test"'
@@ -237,14 +166,12 @@ describe('aria-valid-attr-value', function() {
     }
   );
 
-  it('should return undefined on aria-labelledby when the element is not in the DOM', function() {
+  it('should return undefined on aria-labelledby when the element is not in the DOM', function () {
     var vNode = queryFixture(
       '<button id="target" aria-labelledby="test">Button</button>'
     );
     assert.isUndefined(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
+      validAttrValueCheck.call(checkContext, null, null, vNode)
     );
     assert.deepEqual(checkContext._data, {
       messageKey: 'noId',
@@ -254,16 +181,12 @@ describe('aria-valid-attr-value', function() {
 
   (shadowSupported ? it : xit)(
     'should return undefined on aria-labelledby when the element is in a different shadow tree',
-    function() {
+    function () {
       var params = shadowCheckSetup(
         '<div></div>',
         '<button id="target" aria-labelledby="test">Button</button>'
       );
-      assert.isUndefined(
-        axe.testUtils
-          .getCheckEvaluate('aria-valid-attr-value')
-          .apply(checkContext, params)
-      );
+      assert.isUndefined(validAttrValueCheck.apply(checkContext, params));
       assert.deepEqual(checkContext._data, {
         messageKey: 'noIdShadow',
         needsReview: 'aria-labelledby="test"'
@@ -271,66 +194,103 @@ describe('aria-valid-attr-value', function() {
     }
   );
 
-  it('should return undefined on aria-current with invalid value', function() {
+  it('should return undefined on aria-current with invalid value', function () {
     var vNode = queryFixture(
       '<button id="target" aria-current="test">Button</button>'
     );
     assert.isUndefined(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
+      validAttrValueCheck.call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true on valid aria-labelledby value within img elm', function() {
+  it('should return true on valid aria-labelledby value within img elm', function () {
     var vNode = queryFixture(
       '<div id="foo">hello world</div>' +
         '<img id="target" role="button" aria-labelledby="foo"/>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
-    );
+    assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
   });
 
-  it('should return undefined on invalid aria-labelledby value within img elm', function() {
+  it('should return undefined on invalid aria-labelledby value within img elm', function () {
     var vNode = queryFixture(
       '<div id="foo">hello world</div>' +
         '<img id="target" role="button" aria-labelledby="hazaar"/>'
     );
     assert.isUndefined(
-      axe.testUtils
-        .getCheckEvaluate('aria-valid-attr-value')
-        .call(checkContext, null, null, vNode)
+      validAttrValueCheck.call(checkContext, null, null, vNode)
     );
   });
 
-  describe('options', function() {
-    it('should exclude supplied attributes', function() {
+  describe('null values', function () {
+    it('returns undefined when a boolean attribute is null', function () {
+      var vNode = queryFixture(
+        '<div id="target" role="checkbox" aria-checked></div>'
+      );
+      assert.isUndefined(
+        validAttrValueCheck.call(checkContext, null, null, vNode)
+      );
+      assert.deepEqual(checkContext._data, {
+        messageKey: 'empty',
+        needsReview: 'aria-checked'
+      });
+    });
+
+    it('returns undefined when a boolean attribute is empty', function () {
+      var vNode = queryFixture(
+        '<div id="target" role="checkbox" aria-checked=""></div>'
+      );
+      assert.isUndefined(
+        validAttrValueCheck.call(checkContext, null, null, vNode)
+      );
+      assert.deepEqual(checkContext._data, {
+        messageKey: 'empty',
+        needsReview: 'aria-checked'
+      });
+    });
+
+    it('returns false for empty string values that are not allowed to be empty', function () {
+      var vNode = queryFixture(
+        '<div id="target" aria-valuetext="" role="range"></div>'
+      );
+      assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
+    });
+
+    it('returns false if there are other issues', function () {
+      var vNode = queryFixture(
+        '<div id="target" role="checkbox" aria-checked aria-invalid="none"></div>'
+      );
+      assert.isFalse(validAttrValueCheck.call(checkContext, null, null, vNode));
+      assert.deepEqual(checkContext._data, ['aria-invalid="none"']);
+    });
+  });
+
+  describe('options', function () {
+    it('should exclude supplied attributes', function () {
       var vNode = queryFixture(
         '<div id="target" aria-live="nope" aria-describedby="no exist k thx"></div>'
       );
       assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('aria-valid-attr-value')
-          .call(checkContext, null, ['aria-live', 'aria-describedby'], vNode)
+        validAttrValueCheck.call(
+          checkContext,
+          null,
+          ['aria-live', 'aria-describedby'],
+          vNode
+        )
       );
     });
   });
 
-  describe('SerialVirtualNode', function() {
-    it('should return undefined for idref attribute', function() {
+  describe('SerialVirtualNode', function () {
+    it('should return undefined for idref attribute', function () {
       var vNode = new axe.SerialVirtualNode({
         nodeName: 'button',
         attributes: {
           'aria-owns': 'test'
         }
       });
+
       assert.isUndefined(
-        axe.testUtils
-          .getCheckEvaluate('aria-valid-attr-value')
-          .call(checkContext, null, null, vNode)
+        validAttrValueCheck.call(checkContext, null, null, vNode)
       );
       assert.deepEqual(checkContext._data, {
         messageKey: 'idrefs',
@@ -338,18 +298,14 @@ describe('aria-valid-attr-value', function() {
       });
     });
 
-    it('should return true for empty idref attribute', function() {
+    it('should return true for empty idref attribute', function () {
       var vNode = new axe.SerialVirtualNode({
         nodeName: 'button',
         attributes: {
           'aria-owns': ''
         }
       });
-      assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('aria-valid-attr-value')
-          .call(checkContext, null, null, vNode)
-      );
+      assert.isTrue(validAttrValueCheck.call(checkContext, null, null, vNode));
     });
   });
 });

--- a/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.html
+++ b/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.html
@@ -299,15 +299,14 @@
     hi
   </div>
 
+  <!-- Allowed empty -->
   <div aria-activedescendant="" id="pass171">hi</div>
   <div aria-current="" id="pass172">hi</div>
-  <div aria-invalid="" id="pass173">hi</div>
   <div aria-controls="" id="pass174">hi</div>
   <div aria-describedby="" id="pass175">hi</div>
   <div aria-errormessage="" id="pass176" aria-invalid="true">hi</div>
   <div aria-flowto="" id="pass177">hi</div>
   <div aria-haspopup="" id="pass178">hi</div>
-  <div aria-invalid="" id="pass179">hi</div>
   <div aria-keyshortcuts="" id="pass180">hi</div>
   <div aria-label="" id="pass181">hi</div>
   <div aria-labelledby="" id="pass182">hi</div>
@@ -353,4 +352,7 @@
   <div aria-labelledby="stuff" id="incomplete3">hi</div>
   <div aria-level="22" id="incomplete4">hi</div>
   <div aria-level="+22" id="incomplete5">hi</div>
+  <div role="checkbox" id="incomplete6" aria-checked>I'm not checked</div>
+  <div role="textbox" id="incomplete7" aria-invalid="">I'm actually valid</div>
+  <div role="textbox" id="incomplete8" aria-hidden>I'm not really gone</div>
 </div>

--- a/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.json
+++ b/test/integration/rules/aria-valid-attr-value/aria-valid-attr-value.json
@@ -211,13 +211,11 @@
     ["#pass170"],
     ["#pass171"],
     ["#pass172"],
-    ["#pass173"],
     ["#pass174"],
     ["#pass175"],
     ["#pass176"],
     ["#pass177"],
     ["#pass178"],
-    ["#pass179"],
     ["#pass180"],
     ["#pass181"],
     ["#pass182"],
@@ -235,6 +233,9 @@
     ["#incomplete2"],
     ["#incomplete3"],
     ["#incomplete4"],
-    ["#incomplete5"]
+    ["#incomplete5"],
+    ["#incomplete6"],
+    ["#incomplete7"],
+    ["#incomplete8"]
   ]
 }


### PR DESCRIPTION
There is no real difference between an empty ARIA attribute, a null attribute, and not having the attribute at all. Failing empty ARIA attributes therefor seems a little strict. They shouldn't be passed either though, since it is pretty easy to mistakenly assume `<input aria-invalid>` means the input is invalid. Reporting `incomplete` seems more appropriate. This PR makes that change, along with:

- String type attributes, like aria-valuenow are still not allowed empty
- `aria-invalid` is now reported as incomplete when empty, rather than passed
- Extra tests were added to aria-required-attr to ensure empty attributes when required are failed there

Closes issue: #3489