### PR TITLE
chore: Update ACT test cases to run from W3C site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       # install ACT rules
       # install first as for some reason installing a single package
       # also re-installs all repo dependencies as well
-      - run: npm install act-rules/act-rules.github.io#master
+      - run: npm install w3c/wcag-act-rules#main
       - run: npx browser-driver-manager install chromedriver --verbose
       - run: npm run build
       - run: npm run test:act

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@babel/preset-env": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@deque/dot": "^1.1.5",
-        "act-rules.github.io": "github:act-rules/act-rules.github.io#a759e99f",
         "aria-practices": "github:w3c/aria-practices#edbf534",
         "aria-query": "^5.0.0",
         "browser-driver-manager": "1.0.4",
@@ -74,6 +73,7 @@
         "typedarray": "^0.0.6",
         "typescript": "^4.7.4",
         "uglify-js": "^3.16.2",
+        "wcag-act-rules": "github:w3c/wcag-act-rules#0383f2a",
         "weakmap-polyfill": "^2.0.4"
       },
       "engines": {
@@ -2319,12 +2319,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/act-rules.github.io": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/act-rules/act-rules.github.io.git#a5d7336e020fd04fd429f94c651102f8ab255f01",
-      "integrity": "sha512-Y9/RGuK/U0FGQzOpawRB6j0quvRQw/7RmgcMeuCjYVJaMhrs9OJPQ/DU1R4z6qNQE2GDKi2FhNPnV8E8aI0UEg==",
-      "dev": true
     },
     "node_modules/add-stream": {
       "version": "1.0.0",
@@ -11667,6 +11661,10 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "node_modules/wcag-act-rules": {
+      "resolved": "git+ssh://git@github.com/w3c/wcag-act-rules.git#0383f2a4ebd1b8768ccec2347251fed64dad3129",
+      "dev": true
+    },
     "node_modules/weakmap-polyfill": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
@@ -13673,12 +13671,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
-    },
-    "act-rules.github.io": {
-      "version": "git+ssh://git@github.com/act-rules/act-rules.github.io.git#a5d7336e020fd04fd429f94c651102f8ab255f01",
-      "integrity": "sha512-Y9/RGuK/U0FGQzOpawRB6j0quvRQw/7RmgcMeuCjYVJaMhrs9OJPQ/DU1R4z6qNQE2GDKi2FhNPnV8E8aI0UEg==",
-      "dev": true,
-      "from": "act-rules.github.io@github:act-rules/act-rules.github.io#a759e99f"
     },
     "add-stream": {
       "version": "1.0.0",
@@ -20729,6 +20721,11 @@
           }
         }
       }
+    },
+    "wcag-act-rules": {
+      "version": "git+ssh://git@github.com/w3c/wcag-act-rules.git#0383f2a4ebd1b8768ccec2347251fed64dad3129",
+      "dev": true,
+      "from": "wcag-act-rules@github:w3c/wcag-act-rules#0383f2a"
     },
     "weakmap-polyfill": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "@babel/preset-env": "^7.18.6",
     "@babel/runtime-corejs3": "^7.18.6",
     "@deque/dot": "^1.1.5",
-    "act-rules.github.io": "github:act-rules/act-rules.github.io#a759e99f",
     "aria-practices": "github:w3c/aria-practices#edbf534",
     "aria-query": "^5.0.0",
     "browser-driver-manager": "1.0.4",
@@ -174,6 +173,7 @@
     "typedarray": "^0.0.6",
     "typescript": "^4.7.4",
     "uglify-js": "^3.16.2",
+    "wcag-act-rules": "github:w3c/wcag-act-rules#0383f2a",
     "weakmap-polyfill": "^2.0.4"
   },
   "lint-staged": {

--- a/test/act-mapping/aria-attr-valid.json
+++ b/test/act-mapping/aria-attr-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "5f99a7",
+  "title": "ARIA attribute is defined in WAI-ARIA",
+  "axeRules": ["aria-valid-attr"]
+}

--- a/test/act-mapping/aria-hidden-no-focus.json
+++ b/test/act-mapping/aria-hidden-no-focus.json
@@ -1,0 +1,5 @@
+{
+  "id": "6cfa84",
+  "title": "Element with aria-hidden has no content in sequential focus navigation",
+  "axeRules": ["aria-hidden-focus"]
+}

--- a/test/act-mapping/aria-props-allowed.json
+++ b/test/act-mapping/aria-props-allowed.json
@@ -1,0 +1,5 @@
+{
+  "id": "5c01ea",
+  "title": "ARIA state or property is permitted",
+  "axeRules": ["aria-allowed-attr"]
+}

--- a/test/act-mapping/aria-required-owned.json
+++ b/test/act-mapping/aria-required-owned.json
@@ -1,0 +1,5 @@
+{
+  "id": "bc4a75",
+  "title": "ARIA required owned elements",
+  "axeRules": ["aria-required-children"]
+}

--- a/test/act-mapping/aria-required-props.json
+++ b/test/act-mapping/aria-required-props.json
@@ -1,0 +1,5 @@
+{
+  "id": "4e8ab6",
+  "title": "Element with role attribute has required states and properties",
+  "axeRules": ["aria-required-attr"]
+}

--- a/test/act-mapping/headers-attr-has-cells.json
+++ b/test/act-mapping/headers-attr-has-cells.json
@@ -1,0 +1,5 @@
+{
+  "id": "a25f45",
+  "title": "Headers attribute specified on a cell refers to cells in the same table element",
+  "axeRules": ["td-headers-attr"]
+}

--- a/test/act-mapping/heading-has-name.json
+++ b/test/act-mapping/heading-has-name.json
@@ -1,0 +1,5 @@
+{
+  "id": "ffd0e9",
+  "title": "Heading has non-empty accessible name",
+  "axeRules": ["empty-heading"]
+}

--- a/test/act-mapping/orientation-not-css-restricted.json
+++ b/test/act-mapping/orientation-not-css-restricted.json
@@ -1,0 +1,5 @@
+{
+  "actRuleId": "b33eff",
+  "title": "Orientation of the page is not restricted using CSS transform property",
+  "axeRules": ["css-orientation-lock"]
+}

--- a/test/act-mapping/page-non-empty-title.json
+++ b/test/act-mapping/page-non-empty-title.json
@@ -1,0 +1,5 @@
+{
+  "actRuleId": "2779a5",
+  "title": "HTML page has non-empty title",
+  "axeRules": ["document-title"]
+}

--- a/test/act-mapping/preprocessor.js
+++ b/test/act-mapping/preprocessor.js
@@ -2,8 +2,12 @@ var path = require('path');
 var fs = require('fs');
 var template = fs.readFileSync(path.resolve(__dirname, 'runner.js'), 'utf-8');
 
-var actRepoDir = 'node_modules/act-rules.github.io/';
-var testcaseFilePath = path.resolve(actRepoDir, 'testcases.json');
+var actRepoDir = 'node_modules/wcag-act-rules/';
+var testcaseRootDir = path.resolve(
+  actRepoDir,
+  'content-assets/wcag-act-rules/'
+);
+var testcaseFilePath = path.resolve(testcaseRootDir, 'testcases.json');
 var testcaseContent = require(testcaseFilePath);
 var testcases = testcaseContent.testcases;
 
@@ -12,7 +16,7 @@ createActPreprocessor.$inject = ['logger'];
 function createActPreprocessor(logger) {
   var log = logger.create('preprocessor.act');
 
-  return function(actRuleJson, file, done) {
+  return function (actRuleJson, file, done) {
     try {
       log.debug('Processing "%s".', file.originalPath);
       file.path = file.originalPath.replace(/\.json$/, '.js');
@@ -37,11 +41,11 @@ module.exports = {
 function applyTestCases(actRule) {
   actRule = Object.assign({}, actRule);
 
-  actRule.testcases = testcases.filter(function(testcase) {
+  actRule.testcases = testcases.filter(function (testcase) {
     return testcase.ruleId === actRule.id;
   });
-  actRule.testcases.forEach(function(testcase) {
-    var testcasePath = path.resolve(actRepoDir, testcase.relativePath);
+  actRule.testcases.forEach(function (testcase) {
+    var testcasePath = path.resolve(testcaseRootDir, testcase.relativePath);
     testcase.html = fs.readFileSync(testcasePath, 'utf-8');
   });
 

--- a/test/act-mapping/presentational-children-no-focus.json
+++ b/test/act-mapping/presentational-children-no-focus.json
@@ -1,0 +1,5 @@
+{
+  "actRuleId": "307n5z",
+  "title": "Element with presentational children has no focusable content",
+  "axeRules": ["nested-interactive"]
+}

--- a/test/act-mapping/scrollable-element-keyboard.json
+++ b/test/act-mapping/scrollable-element-keyboard.json
@@ -1,0 +1,5 @@
+{
+  "id": "0ssw9k",
+  "title": "Scrollable element is keyboard accessible",
+  "axeRules": ["scrollable-region-focusable"]
+}

--- a/test/act-mapping/text-contrast-enhanced.json
+++ b/test/act-mapping/text-contrast-enhanced.json
@@ -1,0 +1,5 @@
+{
+  "actRuleId": "09o5cg",
+  "title": "Text has enhanced contrast",
+  "axeRules": ["color-contrast-enhanced"]
+}

--- a/test/act-mapping/text-contrast-minimum.json
+++ b/test/act-mapping/text-contrast-minimum.json
@@ -1,0 +1,5 @@
+{
+  "actRuleId": "afw4f7",
+  "title": "Text has minimum contrast",
+  "axeRules": ["color-contrast"]
+}

--- a/test/act-mapping/visible-label-in-name.json
+++ b/test/act-mapping/visible-label-in-name.json
@@ -1,0 +1,5 @@
+{
+  "actRuleId": "2ee8b8",
+  "title": "Visible label is part of accessible name",
+  "axeRules": ["label-content-name-mismatch"]
+}


### PR DESCRIPTION
Closes issue: #3499

Enable tests for all rules axe-core has currently implemented, except for 1 (see https://github.com/dequelabs/axe-core/issues/3636)