### PR TITLE
feat: deprecate presentation-role-conflict-matches

### DIFF
--- a/lib/rules/presentation-role-conflict-matches.js
+++ b/lib/rules/presentation-role-conflict-matches.js
@@ -1,5 +1,8 @@
 import { getImplicitRole } from '../commons/aria';
 
+/**
+ * @deprecated Will be removed in axe-core 5.0.0
+ */
 function presentationRoleConflictMatches(node, virtualNode) {
   return getImplicitRole(virtualNode, { chromiumRoles: true }) !== null;
 }


### PR DESCRIPTION
This matches method is no longer in used. No need to keep it.

Closes issue: #3591
