### PR TITLE
feat: add axe.utils.memoizeObjectArgs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,10 +71,7 @@ module.exports = {
   overrides: [
     {
       files: ['lib/**/*.js'],
-      excludedFiles: [
-        'lib/core/reporters/**/*.js',
-        'lib/**/*-after.js'
-      ],
+      excludedFiles: ['lib/core/reporters/**/*.js', 'lib/**/*-after.js'],
       parserOptions: {
         sourceType: 'module'
       },
@@ -94,10 +91,7 @@ module.exports = {
     },
     {
       // after functions and reporters will not be run inside the same context as axe.run so should not access browser globals that require context specific information (window.location, window.getComputedStyles, etc.)
-      files: [
-        'lib/**/*-after.js',
-        'lib/core/reporters/**/*.js'
-      ],
+      files: ['lib/**/*-after.js', 'lib/core/reporters/**/*.js'],
       parserOptions: {
         sourceType: 'module'
       },
@@ -110,9 +104,7 @@ module.exports = {
       }
     },
     {
-      files: [
-        'test/aria-practices/**/*.js'
-      ],
+      files: ['test/aria-practices/**/*.js'],
       env: {
         mocha: true
       }
@@ -120,12 +112,9 @@ module.exports = {
     {
       files: ['test/**/*.js'],
       excludedFiles: 'test/aria-practices/**/*.js',
-      parserOptions: {
-        ecmaVersion: 5
-      },
       env: {
         browser: true,
-        es6: false,
+        es6: true,
         mocha: true
       },
       globals: {

--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -2,6 +2,7 @@ import { CssSelectorParser } from 'css-selector-parser';
 import doT from '@deque/dot';
 import emojiRegexText from 'emoji-regex';
 import memoize from 'memoizee';
+import deepEqual from 'fast-deep-equal/es6';
 
 import es6promise from 'es6-promise';
 import { Uint32Array } from 'typedarray';
@@ -40,4 +41,4 @@ if (window.Uint32Array) {
  * @namespace imports
  * @memberof axe
  */
-export { CssSelectorParser, doT, emojiRegexText, memoize };
+export { CssSelectorParser, doT, emojiRegexText, memoize, deepEqual };

--- a/lib/core/utils/index.js
+++ b/lib/core/utils/index.js
@@ -56,7 +56,7 @@ export {
   convertSelector
 } from './matches';
 export { default as matchAncestry } from './match-ancestry';
-export { default as memoize } from './memoize';
+export { default as memoize, memoizeObjectArgs } from './memoize';
 export { default as mergeResults } from './merge-results';
 export { default as nodeSorter } from './node-sorter';
 export { default as parseCrossOriginStylesheet } from './parse-crossorigin-stylesheet';

--- a/lib/core/utils/memoize.js
+++ b/lib/core/utils/memoize.js
@@ -1,4 +1,5 @@
 import memoize from 'memoizee';
+import deepEqual from 'fast-deep-equal/es6';
 
 /**
  * Memoize a function.
@@ -9,14 +10,53 @@ import memoize from 'memoizee';
  */
 // TODO: es-modules._memoziedFns
 axe._memoizedFns = [];
-function memoizeImplementation(fn) {
+export default function memoizeImplementation(fn, options) {
   // keep track of each function that is memoized so it can be cleared at
   // the end of a run. each memoized function has its own cache, so there is
   // no method to clear all memoized caches. instead, we have to clear each
   // individual memoized function ourselves.
-  const memoized = memoize(fn);
+  const memoized = memoize(fn, options);
   axe._memoizedFns.push(memoized);
   return memoized;
 }
 
-export default memoizeImplementation;
+/**
+ * Memoize a function that accepts parameters that can be strictly equal as well as parameters which can be deep equal (such as an options object).
+ * @method memoizeWithFlexObject
+ * @memberof axe.utils
+ * @param {Function} fn Function to memoize
+ * @return {Function}
+ */
+export function memoizeObjectArgs(fn, options) {
+  /*
+    memoize works by having each parameter resolve with a strict equals. this means that if the function you want to memoize takes an object which is created at call time (such as an options object), then memoize will not work for the function (as every call creates a unique parameter).
+    to memoize these types of functions we need to pass the `normalizer` option to memoize which lets us create a custom way to resolve the function parameters to a unique index
+  */
+  let argMap = [];
+  const memoized = memoize(fn, {
+    ...options,
+    normalizer: {
+      get(args) {
+        const index = argMap.findIndex(entry => {
+          return entry.every((item, i) => {
+            if (args[i]?.constructor === Object) {
+              return deepEqual(item, args[i]);
+            }
+
+            return item === args[i];
+          });
+        });
+        return index === -1 ? null : index;
+      },
+      set(args) {
+        argMap.push([...args]);
+        return argMap.length - 1;
+      },
+      clear() {
+        argMap = [];
+      }
+    }
+  });
+  axe._memoizedFns.push(memoized);
+  return memoized;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-mocha-no-only": "^1.1.1",
         "execa": "5.x",
+        "fast-deep-equal": "^3.1.3",
         "globby": "11.x",
         "grunt": "^1.5.3",
         "grunt-babel": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-mocha-no-only": "^1.1.1",
     "execa": "5.x",
+    "fast-deep-equal": "^3.1.3",
     "globby": "11.x",
     "grunt": "^1.5.3",
     "grunt-babel": "^8.0.0",

--- a/test/core/utils/memoize.js
+++ b/test/core/utils/memoize.js
@@ -1,10 +1,134 @@
-describe('axe.utils.memoize', function() {
-  'use strict';
+describe('axe.utils.memoize', () => {
+  it('should add the function to axe._memoizedFns', () => {
+    const length = axe._memoizedFns.length;
 
-  it('should add the function to axe._memoizedFns', function() {
-    axe._memoizedFns.length = 0;
+    axe.utils.memoize(() => {});
+    assert.equal(axe._memoizedFns.length, length + 1);
+  });
 
-    axe.utils.memoize(function myFn() {});
-    assert.equal(axe._memoizedFns.length, 1);
+  describe('memoizeObjectArgs', () => {
+    it('should add the function to axe._memoizedFns', () => {
+      const length = axe._memoizedFns.length;
+
+      axe.utils.memoizeObjectArgs(() => {});
+      assert.equal(axe._memoizedFns.length, length + 1);
+    });
+
+    it('should memoize function with primitives', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized(1, '2', 'three');
+      memoized(1, '2', 'three');
+      memoized(1, '2', 'three');
+      assert.equal(spy.callCount, 1);
+    });
+
+    it('should memoize function with object', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized(1, '2', { one: 1 });
+      memoized(1, '2', { one: 1 });
+      memoized(1, '2', { one: 1 });
+      assert.equal(spy.callCount, 1);
+    });
+
+    it('should not cache unique object values', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized(1, '2', { one: 1 });
+      memoized(1, '2', { one: 2 });
+      memoized(1, '2', { one: '1' });
+      assert.equal(spy.callCount, 3);
+    });
+
+    it('should work with arrays', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      const array = [1, 2];
+      memoized(1, '2', array);
+      memoized(1, '2', array);
+      assert.equal(spy.callCount, 1);
+
+      memoized(1, '2', [1, 2]);
+      assert.equal(spy.callCount, 2);
+    });
+
+    it('should work with null values', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized(1, null);
+      memoized(1, null);
+      assert.equal(spy.callCount, 1);
+    });
+
+    it('should work with undefined values', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized(1, undefined);
+      memoized(1, undefined);
+      assert.equal(spy.callCount, 1);
+    });
+
+    it('should work with no parameters', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized();
+      memoized();
+      memoized(undefined);
+      assert.equal(spy.callCount, 1);
+    });
+
+    it('should work with functions', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      const foo = () => {};
+      memoized(1, foo);
+      memoized(1, foo);
+      assert.equal(spy.callCount, 1);
+
+      memoized(1, () => {});
+      assert.equal(spy.callCount, 2);
+    });
+
+    it('should work with classes', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      class FooClass {}
+      const foo = new FooClass();
+      memoized(1, foo);
+      memoized(1, foo);
+      assert.equal(spy.callCount, 1);
+
+      memoized(1, new FooClass());
+      assert.equal(spy.callCount, 2);
+    });
+
+    it('should work missing args', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized(1);
+      memoized(1, undefined);
+      assert.equal(spy.callCount, 1);
+    });
+
+    it('should work with nested objects', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      memoized(1, { one: 1, two: { three: 3 } });
+      memoized(1, { one: 1, two: { three: 3 } });
+      assert.equal(spy.callCount, 1);
+    });
+
+    it('should work with nested objects with functions', () => {
+      const spy = sinon.spy();
+      const memoized = axe.utils.memoizeObjectArgs(spy);
+      const foo = () => {};
+      memoized(1, { one: 1, two: { three: foo } });
+      memoized(1, { one: 1, two: { three: foo } });
+      assert.equal(spy.callCount, 1);
+
+      memoized(1, { one: 1, two: {} });
+      assert.equal(spy.callCount, 2);
+    });
   });
 });


### PR DESCRIPTION
This adds a function which allows us to memoize functions that take objects as parameters which are created at call time.

For example, the following does not memoize correctly and would call the function two times

```js
const foo = memoize(function({ optionA, optionB }) {})

foo({ optionA: 1, optionB: 2 })
foo({ optionA: 1, optionB: 2 })
```

The fix was to pass the `normalizer` option to memoize which lets us specify how to resolve the arguments. The normalizer uses `deepEqual` to compare objects rather than strict equal comparison, letting us memoize objects correctly.

This PR also removes the ES5 requirement from our tests now that we no longer run in IE11