### PR TITLE
chore(eslint): allow es2021 in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,7 +113,7 @@ module.exports = {
       files: ['test/**/*.js'],
       excludedFiles: ['test/act-rules/**/*.js', 'test/aria-practices/**/*.js'],
       parserOptions: {
-        ecmaVersion: 5
+        ecmaVersion: 2021
       },
       env: {
         browser: true,


### PR DESCRIPTION
Since axe-core no longer needs to run tests in IE11, we can rely on modern javascript natively supported by browsers.