### PR TITLE
chore: run prettier after develop build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+var execSync = require('child_process').execSync;
+
 /*eslint
 camelcase: ["error", {"properties": "never"}]
 */
@@ -231,7 +233,7 @@ module.exports = function (grunt) {
       axe: {
         options: { spawn: false },
         files: ['lib/**/*', 'Gruntfile.js'],
-        tasks: ['build', 'notify', 'test']
+        tasks: ['build', 'prettier', 'notify', 'test']
       },
       tests: {
         options: { spawn: false },
@@ -256,6 +258,11 @@ module.exports = function (grunt) {
     }
   });
 
+  grunt.registerTask('prettier', '', function () {
+    const results = execSync('npm run postbuild');
+    grunt.log.writeln(results);
+  });
+
   grunt.registerTask('translate', [
     'validate',
     'esbuild',
@@ -272,6 +279,7 @@ module.exports = function (grunt) {
     'uglify',
     'aria-supported',
     'add-locale:template',
+    'prettier',
     'bytesize'
   ]);
   grunt.registerTask('default', ['build']);


### PR DESCRIPTION
In #3631, moving the prettier step out of the Gruntfile and into a `postbuild` script only solved half the problem. Running `npm run develop` would not cause the `build` npm script to run so the `locales/_template` file would still be out-of-sync. 

This change is minimal in order to use what we have already created and still get prettier to run after running `develop`.