### PR TITLE
refactor: change or remove visibility functions as needed

### DIFF
--- a/lib/checks/keyboard/accesskeys-evaluate.js
+++ b/lib/checks/keyboard/accesskeys-evaluate.js
@@ -1,7 +1,7 @@
-import { isVisibleOnScreen } from '../../commons/dom';
+import { isHiddenForEveryone } from '../../commons/dom';
 
 function accesskeysEvaluate(node) {
-  if (isVisibleOnScreen(node)) {
+  if (!isHiddenForEveryone(node)) {
     this.data(node.getAttribute('accesskey'));
     this.relatedNodes([node]);
   }

--- a/lib/checks/label/multiple-label-evaluate.js
+++ b/lib/checks/label/multiple-label-evaluate.js
@@ -1,6 +1,6 @@
 import {
   getRootNode,
-  isVisibleOnScreen,
+  isHiddenForEveryone,
   isVisibleForScreenreader,
   idrefs
 } from '../../commons/dom';
@@ -15,7 +15,7 @@ function multipleLabelEvaluate(node) {
 
   if (labels.length) {
     // filter out CSS hidden labels because they're fine
-    labels = labels.filter(label => isVisibleOnScreen(label));
+    labels = labels.filter(label => !isHiddenForEveryone(label));
   }
 
   while (parent) {

--- a/lib/checks/shared/is-on-screen-evaluate.js
+++ b/lib/checks/shared/is-on-screen-evaluate.js
@@ -1,8 +1,8 @@
-import { isVisibleOnScreen, isOffscreen } from '../../commons/dom';
+import { isVisibleOnScreen } from '../../commons/dom';
 
 function isOnScreenEvaluate(node) {
   // From a visual perspective
-  return isVisibleOnScreen(node) && !isOffscreen(node);
+  return isVisibleOnScreen(node);
 }
 
 export default isOnScreenEvaluate;

--- a/lib/rules/landmark-unique-matches.js
+++ b/lib/rules/landmark-unique-matches.js
@@ -1,4 +1,5 @@
-import { findUpVirtual, isVisibleForScreenreader } from '../commons/dom';
+import { isVisibleForScreenreader } from '../commons/dom';
+import { closest } from '../core/utils';
 import { getRole } from '../commons/aria';
 import { getAriaRolesByType } from '../commons/standards';
 import { accessibleTextVirtual } from '../commons/text';
@@ -17,7 +18,7 @@ function landmarkUniqueMatches(node, virtualNode) {
     'section'
   ].join(',');
   function isHeaderFooterLandmark(headerFooterElement) {
-    return !findUpVirtual(
+    return !closest(
       headerFooterElement,
       excludedParentsForHeaderFooterLandmarks
     );


### PR DESCRIPTION
Also updated `landmark-unique-matches.js` to use `closest` instead of the deprecated `findUp` while I was in the code looking at the use of `isVisibleForScreenreader`

Part of: https://github.com/dequelabs/axe-core/issues/3655
