### PR TITLE
fix(td-headers-attr): ignore table elements with their role changed

### DIFF
--- a/lib/checks/tables/td-headers-attr-evaluate.js
+++ b/lib/checks/tables/td-headers-attr-evaluate.js
@@ -1,4 +1,5 @@
 import { tokenList } from '../../core/utils';
+import { isVisibleForScreenreader } from '../../commons/dom';
 
 function tdHeadersAttrEvaluate(node) {
   const cells = [];
@@ -24,7 +25,7 @@ function tdHeadersAttrEvaluate(node) {
     let isSelf = false;
     let notOfTable = false;
 
-    if (!cell.hasAttribute('headers')) {
+    if (!cell.hasAttribute('headers') || !isVisibleForScreenreader(cell)) {
       return;
     }
 

--- a/lib/rules/table-or-grid-role-matches.js
+++ b/lib/rules/table-or-grid-role-matches.js
@@ -1,0 +1,6 @@
+import { getRole } from '../commons/aria';
+
+export default function tableOrGridRoleMatches(_, vNode) {
+  const role = getRole(vNode);
+  return ['treegrid', 'grid', 'table'].includes(role);
+}

--- a/lib/rules/td-headers-attr.json
+++ b/lib/rules/td-headers-attr.json
@@ -1,6 +1,7 @@
 {
   "id": "td-headers-attr",
   "selector": "table",
+  "matches": "table-or-grid-role-matches",
   "tags": ["cat.tables", "wcag2a", "wcag131", "section508", "section508.22.g"],
   "actIds": ["a25f45"],
   "metadata": {

--- a/test/checks/tables/td-headers-attr.js
+++ b/test/checks/tables/td-headers-attr.js
@@ -1,124 +1,126 @@
-describe('td-headers-attr', function() {
+describe('td-headers-attr', function () {
   'use strict';
 
   var fixture = document.getElementById('fixture');
   var checkContext = axe.testUtils.MockCheckContext();
+  var fixtureSetup = axe.testUtils.fixtureSetup;
+  var check = axe.testUtils.getCheckEvaluate('td-headers-attr');
 
-  afterEach(function() {
-    fixture.innerHTML = '';
+  afterEach(function () {
     checkContext.reset();
   });
 
-  it('returns true no headers attribute is present', function() {
-    fixture.innerHTML =
+  it('returns true no headers attribute is present', function () {
+    fixtureSetup(
       '<table>' +
-      '  <tr> <th>hi</th> <td>hello</td> </tr>' +
-      '  <tr> <th>hi</th> <td>hello</td> </tr>' +
-      '</table>';
+        '  <tr> <th>hi</th> <td>hello</td> </tr>' +
+        '  <tr> <th>hi</th> <td>hello</td> </tr>' +
+        '</table>'
+    );
 
     var node = fixture.querySelector('table');
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
-    );
+    assert.isTrue(check.call(checkContext, node));
   });
 
-  it('returns true if a valid header is present', function() {
-    fixture.innerHTML =
+  it('returns true if a valid header is present', function () {
+    fixtureSetup(
       '<table>' +
-      '  <tr> <th id="hi">hello</th> </tr>' +
-      '  <tr> <td headers="hi">goodbye</td> </tr>' +
-      '</table>';
+        '  <tr> <th id="hi">hello</th> </tr>' +
+        '  <tr> <td headers="hi">goodbye</td> </tr>' +
+        '</table>'
+    );
 
     var node = fixture.querySelector('table');
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
-    );
+    assert.isTrue(check.call(checkContext, node));
   });
 
-  it('returns true if multiple valid headers are present', function() {
-    fixture.innerHTML =
+  it('returns true if multiple valid headers are present', function () {
+    fixtureSetup(
       '<table>' +
-      '  <tr> <th id="hi1">hello</th> <th id="hi2">hello</th> </tr>' +
-      '  <tr> <td headers="hi1 \t\n hi2">goodbye</td> </tr>' +
-      '</table>';
+        '  <tr> <th id="hi1">hello</th> <th id="hi2">hello</th> </tr>' +
+        '  <tr> <td headers="hi1 \t\n hi2">goodbye</td> </tr>' +
+        '</table>'
+    );
 
     var node = fixture.querySelector('table');
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
-    );
+    assert.isTrue(check.call(checkContext, node));
   });
 
-  it('returns true with an empty header', function() {
-    fixture.innerHTML =
+  it('returns true with an empty header', function () {
+    fixtureSetup(
       '<table>' +
-      '  <tr> <th id="hi1"></th> </tr>' +
-      '  <tr> <td headers="hi1">goodbye</td> </tr>' +
-      '</table>';
+        '  <tr> <th id="hi1"></th> </tr>' +
+        '  <tr> <td headers="hi1">goodbye</td> </tr>' +
+        '</table>'
+    );
 
     var node = fixture.querySelector('table');
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
-    );
+    assert.isTrue(check.call(checkContext, node));
   });
 
-  it('returns undefined if headers is empty', function() {
-    fixture.innerHTML =
+  it('returns undefined if headers is empty', function () {
+    fixtureSetup(
       '<table>' +
-      '  <tr> <th id="hi"> </th> </tr>' +
-      '  <tr> <td headers="">goodbye</td> </tr>' +
-      '</table>';
+        '  <tr> <th id="hi"> </th> </tr>' +
+        '  <tr> <td headers="">goodbye</td> </tr>' +
+        '</table>'
+    );
 
     var node = fixture.querySelector('table');
-    assert.isUndefined(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
-    );
+    assert.isUndefined(check.call(checkContext, node));
   });
 
-  it('returns false if the header is a table cell', function() {
+  it('returns false if the header is a table cell', function () {
     var node;
 
-    fixture.innerHTML =
+    fixtureSetup(
       '<table>' +
-      '  <tr> <th> <span id="hi">hello</span> </th> </tr>' +
-      '  <tr> <td headers="h1">goodbye</td> </tr>' +
-      '</table>';
-    node = fixture.querySelector('table');
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
+        '  <tr> <th> <span id="hi">hello</span> </th> </tr>' +
+        '  <tr> <td headers="h1">goodbye</td> </tr>' +
+        '</table>'
     );
+    node = fixture.querySelector('table');
+    assert.isFalse(check.call(checkContext, node));
 
-    fixture.innerHTML =
+    fixtureSetup(
       '<span id="hi">hello</span>' +
-      '<table>' +
-      '  <tr> <th></th> </tr>' +
-      '  <tr> <td headers="h1">goodbye</td> </tr>' +
-      '</table>';
-    node = fixture.querySelector('table');
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
+        '<table>' +
+        '  <tr> <th></th> </tr>' +
+        '  <tr> <td headers="h1">goodbye</td> </tr>' +
+        '</table>'
     );
+    node = fixture.querySelector('table');
+    assert.isFalse(check.call(checkContext, node));
 
-    fixture.innerHTML =
+    fixtureSetup(
       '<table id="hi">' +
-      '  <tr> <th>hello</th> </tr>' +
-      '  <tr> <td headers="h1">goodbye</td> </tr>' +
-      '</table>';
-    node = fixture.querySelector('table');
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
+        '  <tr> <th>hello</th> </tr>' +
+        '  <tr> <td headers="h1">goodbye</td> </tr>' +
+        '</table>'
     );
+    node = fixture.querySelector('table');
+    assert.isFalse(check.call(checkContext, node));
   });
 
-  it('returns false if the header refers to the same cell', function() {
-    fixture.innerHTML =
+  it('returns false if the header refers to the same cell', function () {
+    fixtureSetup(
       '<table id="hi">' +
-      '  <tr> <th>hello</th> </tr>' +
-      '  <tr> <td id="bye" headers="bye">goodbye</td> </tr>' +
-      '</table>';
+        '  <tr> <th>hello</th> </tr>' +
+        '  <tr> <td id="bye" headers="bye">goodbye</td> </tr>' +
+        '</table>'
+    );
 
     var node = fixture.querySelector('table');
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('td-headers-attr').call(checkContext, node)
+    assert.isFalse(check.call(checkContext, node));
+  });
+
+  it('returns true if td[headers] is hidden', function () {
+    fixtureSetup(
+      '<table>' +
+        '  <tr> <th>Hello</th> <td headers="h1" hidden>goodbye</td> </tr>' +
+        '</table>'
     );
+    var node = fixture.querySelector('table');
+    assert.isTrue(check.call(checkContext, node));
   });
 });

--- a/test/integration/rules/td-headers-attr/td-headers-attr.html
+++ b/test/integration/rules/td-headers-attr/td-headers-attr.html
@@ -1,0 +1,45 @@
+<table id="pass1">
+  <th>Hello</th>
+  <td>World</td>
+</table>
+
+<table id="pass2" role="grid">
+  <th id="p2h">Hello</th>
+  <td headers="p2h">World</td>
+</table>
+
+<table id="pass3" role="treegrid">
+  <th id="p3h1">Hello</th>
+  <th id="p3h2">Hello</th>
+  <td headers="p3h1 p3h2">World</td>
+</table>
+
+<table id="pass4" role="treegrid">
+  <th id="p4h">Hello</th>
+  <td id="self" headers="self" hidden>World</td>
+</table>
+
+<table id="fail1">
+  <th id="f1h1">Hello</th>
+  <td headers="f1h1 non-existing">World</td>
+</table>
+
+<table id="fail2" role="table">
+  <td id="self" headers="self">World</td>
+</table>
+
+<table id="fail3" role="none" tabindex="0">
+  <td id="self" headers="self">World</td>
+</table>
+
+<table id="inapplicable1" role="none">
+  <td id="self" headers="self">World</td>
+</table>
+
+<table id="inapplicable2" role="presentation">
+  <td id="self" headers="self">World</td>
+</table>
+
+<table id="inapplicable3" role="region">
+  <td id="self" headers="self">World</td>
+</table>

--- a/test/integration/rules/td-headers-attr/td-headers-attr.json
+++ b/test/integration/rules/td-headers-attr/td-headers-attr.json
@@ -1,0 +1,6 @@
+{
+  "description": "td-headers-attr test",
+  "rule": "td-headers-attr",
+  "violations": [["#fail1"], ["#fail2"], ["#fail3"]],
+  "passes": [["#pass1"], ["#pass2"], ["#pass3"], ["#pass4"]]
+}

--- a/test/rule-matches/table-or-grid-role-matches.js
+++ b/test/rule-matches/table-or-grid-role-matches.js
@@ -1,0 +1,51 @@
+describe('table-or-grid-role-matches', () => {
+  const { queryFixture } = axe.testUtils;
+  const rule = axe.utils.getRule('td-headers-attr');
+
+  it(`returns true for tables without role`, () => {
+    const vNode = queryFixture(`<table id="target">
+        <th id="h">foo</th> <td headers="h">bar</td>
+      </table>`);
+    assert.isTrue(rule.matches(vNode.actualNode, vNode));
+  });
+
+  ['table', 'grid', 'treegrid'].forEach(role => {
+    it(`returns true for tables with role=${role}`, () => {
+      const vNode = queryFixture(`<table id="target" role="${role}">
+          <th id="h">foo</th> <td headers="h">bar</td>
+        </table>`);
+      assert.isTrue(rule.matches(vNode.actualNode, vNode));
+    });
+  });
+
+  ['region', 'presentation', 'none'].forEach(role => {
+    it(`returns false for tables with role=${role}`, () => {
+      const vNode = queryFixture(`<table id="target" role="${role}">
+          <th id="h">foo</th> <td headers="h">bar</td>
+        </table>`);
+      assert.isFalse(rule.matches(vNode.actualNode, vNode));
+    });
+  });
+
+  it(`returns true for tables with an invalid role`, () => {
+    const vNode = queryFixture(`<table id="target" role="invalid-aria-role">
+        <th id="h">foo</th> <td headers="h">bar</td>
+      </table>`);
+    assert.isTrue(rule.matches(vNode.actualNode, vNode));
+  });
+
+  it(`returns true for focusable tables with role=none`, () => {
+    const vNode = queryFixture(`<table id="target" role="none" tabindex="0">
+        <th id="h">foo</th> <td headers="h">bar</td>
+      </table>`);
+    assert.isTrue(rule.matches(vNode.actualNode, vNode));
+  });
+
+  it(`returns true for tables with role=none but with a global ARIA attribute`, () => {
+    const vNode =
+      queryFixture(`<table id="target" role="none" aria-live="assertive">
+        <th id="h">foo</th> <td headers="h">bar</td>
+      </table>`);
+    assert.isTrue(rule.matches(vNode.actualNode, vNode));
+  });
+});


### PR DESCRIPTION
- Only test tables with an implicit or explicit role of table, grid, or treegrid
- Ignore hidden cells with a headers attribute
- Add integration tests

Closes issue: #3654
