### PR TITLE
fix(label): avoid passing labels because of an input[value]

### DIFF
--- a/lib/checks/label/explicit-evaluate.js
+++ b/lib/checks/label/explicit-evaluate.js
@@ -3,32 +3,39 @@ import { accessibleText } from '../../commons/text';
 import { escapeSelector } from '../../core/utils';
 
 function explicitEvaluate(node, options, virtualNode) {
-  if (virtualNode.attr('id')) {
-    if (!virtualNode.actualNode) {
-      return undefined;
-    }
-
-    const root = getRootNode(virtualNode.actualNode);
-    const id = escapeSelector(virtualNode.attr('id'));
-    const labels = Array.from(root.querySelectorAll(`label[for="${id}"]`));
-
-    if (labels.length) {
-      try {
-        return labels.some(label => {
-          // defer to hidden-explicit-label check for better messaging
-          if (!isVisibleOnScreen(label)) {
-            return true;
-          } else {
-            return !!accessibleText(label);
-          }
-        });
-      } catch (e) {
-        return undefined;
-      }
-    }
+  if (!virtualNode.attr('id')) {
+    return false;
+  }
+  if (!virtualNode.actualNode) {
+    return undefined;
   }
 
-  return false;
+  const root = getRootNode(virtualNode.actualNode);
+  const id = escapeSelector(virtualNode.attr('id'));
+  const labels = Array.from(root.querySelectorAll(`label[for="${id}"]`));
+  this.relatedNodes(labels);
+
+  if (!labels.length) {
+    return false;
+  }
+
+  try {
+    return labels.some(label => {
+      // defer to hidden-explicit-label check for better messaging
+      if (!isVisibleOnScreen(label)) {
+        return true;
+      } else {
+        const explicitLabel = accessibleText(label, {
+          inControlContext: true,
+          startNode: virtualNode
+        }).trim();
+        this.data({ explicitLabel });
+        return !!explicitLabel;
+      }
+    });
+  } catch (e) {
+    return undefined;
+  }
 }
 
 export default explicitEvaluate;

--- a/lib/checks/label/explicit-evaluate.js
+++ b/lib/checks/label/explicit-evaluate.js
@@ -1,5 +1,5 @@
 import { getRootNode, isVisibleOnScreen } from '../../commons/dom';
-import { accessibleText } from '../../commons/text';
+import { accessibleText, sanitize } from '../../commons/text';
 import { escapeSelector } from '../../core/utils';
 
 function explicitEvaluate(node, options, virtualNode) {
@@ -25,10 +25,12 @@ function explicitEvaluate(node, options, virtualNode) {
       if (!isVisibleOnScreen(label)) {
         return true;
       } else {
-        const explicitLabel = accessibleText(label, {
-          inControlContext: true,
-          startNode: virtualNode
-        }).trim();
+        const explicitLabel = sanitize(
+          accessibleText(label, {
+            inControlContext: true,
+            startNode: virtualNode
+          })
+        );
         this.data({ explicitLabel });
         return !!explicitLabel;
       }

--- a/lib/checks/label/implicit-evaluate.js
+++ b/lib/checks/label/implicit-evaluate.js
@@ -11,7 +11,9 @@ function implicitEvaluate(node, options, virtualNode) {
           startNode: virtualNode
         })
       );
-      this.relatedNodes([label.actualNode]);
+      if (label.actualNode) {
+        this.relatedNodes([label.actualNode]);
+      }
       this.data({ implicitLabel });
       return !!implicitLabel;
     }

--- a/lib/checks/label/implicit-evaluate.js
+++ b/lib/checks/label/implicit-evaluate.js
@@ -1,11 +1,19 @@
 import { closest } from '../../core/utils';
-import { accessibleTextVirtual } from '../../commons/text';
+import { accessibleTextVirtual, sanitize } from '../../commons/text';
 
 function implicitEvaluate(node, options, virtualNode) {
   try {
     const label = closest(virtualNode, 'label');
     if (label) {
-      return !!accessibleTextVirtual(label, { inControlContext: true });
+      const implicitLabel = sanitize(
+        accessibleTextVirtual(label, {
+          inControlContext: true,
+          startNode: virtualNode
+        })
+      );
+      this.relatedNodes([label.actualNode]);
+      this.data({ implicitLabel });
+      return !!implicitLabel;
     }
     return false;
   } catch (e) {

--- a/test/checks/label/explicit.js
+++ b/test/checks/label/explicit.js
@@ -22,6 +22,15 @@ describe('explicit-label', () => {
     assert.isFalse(checkEvaluate.apply(checkContext, params));
   });
 
+  it('returns false if an empty label is present that uses aria-labelledby', () => {
+    const params = checkSetup(
+      '<input type="text" id="target">' +
+        '<label for="target" aria-labelledby="lbl"></label>' +
+        '<span id="lbl">aria label</span>'
+    );
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
+  });
+
   it('returns true if a non-empty label is present', () => {
     const params = checkSetup(
       '<label for="target">Text</label><input type="text" id="target">'

--- a/test/checks/label/explicit.js
+++ b/test/checks/label/explicit.js
@@ -1,136 +1,158 @@
-describe('explicit-label', function() {
-  'use strict';
+describe('explicit-label', () => {
+  const fixtureSetup = axe.testUtils.fixtureSetup;
+  const checkSetup = axe.testUtils.checkSetup;
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('explicit-label');
+  const checkContext = axe.testUtils.MockCheckContext();
 
-  var fixture = document.getElementById('fixture');
-  var fixtureSetup = axe.testUtils.fixtureSetup;
-  var queryFixture = axe.testUtils.queryFixture;
-  var shadowSupport = axe.testUtils.shadowSupport;
-
-  afterEach(function() {
-    fixture.innerHTML = '';
+  afterEach(() => {
+    checkContext.reset();
   });
 
-  it('should return false if an empty label is present', function() {
-    var vNode = queryFixture(
+  it('returns false if an empty label is present', () => {
+    const params = checkSetup(
       '<label for="target"></label><input type="text" id="target">'
     );
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
   });
 
-  it('should return true if a non-empty label is present', function() {
-    var vNode = queryFixture(
+  it('returns false if the label is empty except for the target value', () => {
+    const params = checkSetup(
+      '<label for="target"> <input type="text" id="target" value="snacks"> </label>'
+    );
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
+  });
+
+  it('returns true if a non-empty label is present', () => {
+    const params = checkSetup(
       '<label for="target">Text</label><input type="text" id="target">'
     );
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
   });
 
-  it('should return true if an invisible non-empty label is present, to defer to hidden-explicit-label', function() {
-    var vNode = queryFixture(
+  it('returns true if an invisible non-empty label is present, to defer to hidden-explicit-label', () => {
+    const params = checkSetup(
       '<label for="target" style="display: none;">Text</label><input type="text" id="target">'
     );
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
   });
 
-  it('should return false if a label is not present', function() {
-    var vNode = queryFixture('<input type="text" id="target" />');
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-    );
+  it('returns false if a label is not present', () => {
+    const params = checkSetup('<input type="text" id="target" />');
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
   });
 
-  it('should work for multiple labels', function() {
-    var vNode = queryFixture(
+  it('should work for multiple labels', () => {
+    const params = checkSetup(
       '<label for="target"></label><label for="target">Text</label><input type="text" id="target">'
     );
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
   });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return true if input and label are in the same shadow root',
-    function() {
-      var root = document.createElement('div');
-      var shadow = root.attachShadow({ mode: 'open' });
+  describe('.data', () => {
+    it('is null if there is no label', () => {
+      const params = checkSetup('<input type="text" id="target" />');
+      checkEvaluate.apply(checkContext, params);
+      assert.isNull(checkContext._data);
+    });
+
+    it('includes the `explicitLabel` text of the first non-empty label', () => {
+      const params = checkSetup(
+        '<label for="target">  </label>' +
+          '<label for="target"> text </label>' +
+          '<label for="target"> more text </label>' +
+          '<input type="text" id="target" />'
+      );
+      checkEvaluate.apply(checkContext, params);
+      assert.deepEqual(checkContext._data, { explicitLabel: 'text' });
+    });
+
+    it('is empty { explicitLabel: "" } if the label is empty', () => {
+      const params = checkSetup(
+        '<label for="target">  </label>' +
+          '<label for="target"></label>' +
+          '<input type="text" id="target" />'
+      );
+      checkEvaluate.apply(checkContext, params);
+      assert.deepEqual(checkContext._data, { explicitLabel: '' });
+    });
+  });
+
+  describe('related nodes', () => {
+    it('is empty when there are no labels', () => {
+      const params = checkSetup('<input type="text" id="target" />');
+      checkEvaluate.apply(checkContext, params);
+      assert.isEmpty(checkContext._relatedNodes);
+    });
+
+    it('includes each associated label', () => {
+      const params = checkSetup(
+        '<label for="target" id="lbl1"></label>' +
+          '<label for="target" id="lbl2"></label>' +
+          '<input type="text" id="target" />'
+      );
+      checkEvaluate.apply(checkContext, params);
+      const ids = checkContext._relatedNodes.map(node => '#' + node.id);
+      assert.deepEqual(ids, ['#lbl1', '#lbl2']);
+    });
+  });
+
+  describe('with shadow DOM', () => {
+    it('returns true if input and label are in the same shadow root', () => {
+      const root = document.createElement('div');
+      const shadow = root.attachShadow({ mode: 'open' });
       shadow.innerHTML =
         '<label for="target">American band</label><input id="target">';
       fixtureSetup(root);
 
-      var vNode = axe.utils.getNodeFromTree(shadow.querySelector('#target'));
-      assert.isTrue(
-        axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-      );
-    }
-  );
+      const vNode = axe.utils.getNodeFromTree(shadow.querySelector('#target'));
+      assert.isTrue(checkEvaluate.call(checkContext, null, {}, vNode));
+    });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return true if label content is slotted',
-    function() {
-      var root = document.createElement('div');
+    it('returns true if label content is slotted', () => {
+      const root = document.createElement('div');
       root.innerHTML = 'American band';
-      var shadow = root.attachShadow({ mode: 'open' });
+      const shadow = root.attachShadow({ mode: 'open' });
       shadow.innerHTML =
         '<label for="target"><slot></slot></label><input id="target">';
       fixtureSetup(root);
 
-      var vNode = axe.utils.getNodeFromTree(shadow.querySelector('#target'));
-      assert.isTrue(
-        axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-      );
-    }
-  );
+      const vNode = axe.utils.getNodeFromTree(shadow.querySelector('#target'));
+      assert.isTrue(checkEvaluate.call(checkContext, null, {}, vNode));
+    });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return false if input is inside shadow DOM and the label is not',
-    function() {
-      var root = document.createElement('div');
+    it('returns false if input is inside shadow DOM and the label is not', () => {
+      const root = document.createElement('div');
       root.innerHTML = '<label for="target">American band</label>';
-      var shadow = root.attachShadow({ mode: 'open' });
+      const shadow = root.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<slot></slot><input id="target">';
       fixtureSetup(root);
 
-      var vNode = axe.utils.getNodeFromTree(shadow.querySelector('#target'));
-      assert.isFalse(
-        axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-      );
-    }
-  );
+      const vNode = axe.utils.getNodeFromTree(shadow.querySelector('#target'));
+      assert.isFalse(checkEvaluate.call(checkContext, null, {}, vNode));
+    });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return false if label is inside shadow DOM and the input is not',
-    function() {
-      var root = document.createElement('div');
+    it('returns false if label is inside shadow DOM and the input is not', () => {
+      const root = document.createElement('div');
       root.innerHTML = '<input id="target">';
-      var shadow = root.attachShadow({ mode: 'open' });
+      const shadow = root.attachShadow({ mode: 'open' });
       shadow.innerHTML =
         '<label for="target">American band</label><slot></slot>';
       fixtureSetup(root);
 
-      var vNode = axe.utils.getNodeFromTree(root.querySelector('#target'));
-      assert.isFalse(
-        axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, vNode)
-      );
-    }
-  );
+      const vNode = axe.utils.getNodeFromTree(root.querySelector('#target'));
+      assert.isFalse(checkEvaluate.call(checkContext, null, {}, vNode));
+    });
+  });
 
-  describe('SerialVirtualNode', function() {
-    it('should return undefined', function() {
-      var virtualNode = new axe.SerialVirtualNode({
+  describe('SerialVirtualNode', () => {
+    it('returns undefined', () => {
+      const virtualNode = new axe.SerialVirtualNode({
         nodeName: 'input',
         attributes: {
           type: 'text'
         }
       });
-
-      assert.isFalse(
-        axe.testUtils.getCheckEvaluate('explicit-label')(null, {}, virtualNode)
-      );
+      assert.isFalse(checkEvaluate.call(checkContext, null, {}, virtualNode));
     });
   });
 });

--- a/test/checks/label/implicit.js
+++ b/test/checks/label/implicit.js
@@ -1,79 +1,109 @@
-describe('implicit-label', function() {
-  'use strict';
+describe('implicit-label', () => {
+  const fixtureSetup = axe.testUtils.fixtureSetup;
+  const checkSetup = axe.testUtils.checkSetup;
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('implicit-label');
+  const checkContext = axe.testUtils.MockCheckContext();
 
-  var fixture = document.getElementById('fixture');
-  var fixtureSetup = axe.testUtils.fixtureSetup;
-
-  afterEach(function() {
-    fixture.innerHTML = '';
-    axe._tree = undefined;
+  afterEach(() => {
+    checkContext.reset();
   });
 
-  it('should return false if an empty label is present', function() {
-    fixtureSetup('<label><input type="text" id="target"></label>');
-    var node = fixture.querySelector('#target');
-    var virtualNode = axe.utils.getNodeFromTree(node);
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('implicit-label')(null, {}, virtualNode)
+  it('returns false if an empty label is present', () => {
+    const params = checkSetup('<label><input type="text" id="target"></label>');
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
+  });
+
+  it('returns false on an empty label when then control has a value', () => {
+    const params = checkSetup(
+      '<label><input type="text" id="target" value="snacks"></label>'
     );
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
   });
 
-  it('should return false if an invisible non-empty label is present', function() {
-    fixtureSetup(
+  it('returns false if an invisible non-empty label is present', () => {
+    const params = checkSetup(
       '<label><span style="display: none">Text</span> <input type="text" id="target"></label>'
     );
-    var node = fixture.querySelector('#target');
-    var virtualNode = axe.utils.getNodeFromTree(node);
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('implicit-label')(null, {}, virtualNode)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
   });
 
-  it('should return true if a non-empty label is present', function() {
-    fixtureSetup('<label>Text <input type="text" id="target"></label>');
-    var node = fixture.querySelector('#target');
-    var virtualNode = axe.utils.getNodeFromTree(node);
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('implicit-label')(null, {}, virtualNode)
+  it('returns true if a non-empty label is present', () => {
+    const params = checkSetup(
+      '<label>Text <input type="text" id="target"></label>'
     );
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
   });
 
-  it('should return false if a label is not present', function() {
-    var node = document.createElement('input');
+  it('returns false if a label is not present', () => {
+    const node = document.createElement('input');
     node.type = 'text';
     fixtureSetup(node);
-
-    var virtualNode = axe.utils.getNodeFromTree(node);
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('implicit-label')(null, {}, virtualNode)
-    );
+    const virtualNode = axe.utils.getNodeFromTree(node);
+    assert.isFalse(checkEvaluate.call(checkContext, null, {}, virtualNode));
   });
 
-  describe('SerialVirtualNode', function() {
-    it('should return false if no implicit label', function() {
-      var virtualNode = new axe.SerialVirtualNode({
+  describe('data', () => {
+    it('is null if there is no label', () => {
+      const params = checkSetup('<input type="text" id="target">');
+      checkEvaluate.apply(checkContext, params);
+      assert.isNull(checkContext._data);
+    });
+
+    it('includes the implicit label if one is set', () => {
+      const params = checkSetup(
+        '<label>Some <input type="text" id="target"> text</label>'
+      );
+      checkEvaluate.apply(checkContext, params);
+      assert.deepEqual(checkContext._data, { implicitLabel: 'Some text' });
+    });
+
+    it('has { implicitLabel: "" } when the label is empty', () => {
+      const params = checkSetup(
+        '<label> <input type="text" id="target"> </label>'
+      );
+      checkEvaluate.apply(checkContext, params);
+      assert.deepEqual(checkContext._data, { implicitLabel: '' });
+    });
+  });
+
+  describe('relatedNodes', () => {
+    it('is null if there is no label', () => {
+      const params = checkSetup('<input type="text" id="target">');
+      checkEvaluate.apply(checkContext, params);
+      assert.isEmpty(checkContext._relatedNodes);
+    });
+
+    it('includes the nearest label as its related node', () => {
+      const params = checkSetup(
+        '<label id="lbl"> <input type="text" id="target"> </label>'
+      );
+      checkEvaluate.apply(checkContext, params);
+      const ids = checkContext._relatedNodes.map(node => '#' + node.id);
+      assert.deepEqual(ids, ['#lbl']);
+    });
+  });
+
+  describe('SerialVirtualNode', () => {
+    it('returns false if no implicit label', () => {
+      const virtualNode = new axe.SerialVirtualNode({
         nodeName: 'input',
         attributes: {
           type: 'text'
         }
       });
       virtualNode.parent = null;
-
-      assert.isFalse(
-        axe.testUtils.getCheckEvaluate('implicit-label')(null, {}, virtualNode)
-      );
+      assert.isFalse(checkEvaluate.call(checkContext, null, {}, virtualNode));
     });
 
-    it('should return undefined if tree is not complete', function() {
-      var virtualNode = new axe.SerialVirtualNode({
+    it('returns undefined if tree is not complete', () => {
+      const virtualNode = new axe.SerialVirtualNode({
         nodeName: 'input',
         attributes: {
           type: 'text'
         }
       });
-
       assert.isUndefined(
-        axe.testUtils.getCheckEvaluate('implicit-label')(null, {}, virtualNode)
+        checkEvaluate.call(checkContext, null, {}, virtualNode)
       );
     });
   });

--- a/test/checks/shared/aria-labelledby.js
+++ b/test/checks/shared/aria-labelledby.js
@@ -1,103 +1,84 @@
-describe('aria-labelledby', function() {
-  'use strict';
+describe('aria-labelledby', () => {
+  const queryFixture = axe.testUtils.queryFixture;
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('aria-labelledby');
 
-  var fixture = document.getElementById('fixture');
-  var queryFixture = axe.testUtils.queryFixture;
-
-  afterEach(function() {
-    fixture.innerHTML = '';
-  });
-
-  it('should return true if an aria-labelledby and its target is present', function() {
-    var node = queryFixture(
+  it('should return true if an aria-labelledby and its target is present', () => {
+    const node = queryFixture(
       '<div id="target" aria-labelledby="woohoo"></div><div id="woohoo">bananas</div>'
     );
-
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-    );
+    assert.isTrue(checkEvaluate(null, {}, node));
   });
 
-  it('should return true if only one element referenced by aria-labelledby has visible text', function() {
-    var node = queryFixture(
+  it('should return true if only one element referenced by aria-labelledby has visible text', () => {
+    const node = queryFixture(
       '<div id="target" aria-labelledby="woohoo noexist hehe"></div><div id="woohoo">bananas</div>'
     );
-
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-    );
+    assert.isTrue(checkEvaluate(null, {}, node));
   });
 
-  it('should return false if an aria-labelledby is not present', function() {
-    var node = queryFixture('<div id="target"></div>');
-
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-    );
+  it('should return false if an aria-labelledby is not present', () => {
+    const node = queryFixture('<div id="target"></div>');
+    assert.isFalse(checkEvaluate(null, {}, node));
   });
 
-  it('should return true if an aria-labelledby is present that references hidden elements', function() {
-    var node = queryFixture(
+  it('should return true if an aria-labelledby is present that references hidden elements', () => {
+    const node = queryFixture(
       '<div id="target" aria-labelledby="woohoo noexist hehe"></div><div id="woohoo" style="display:none">bananas</div>'
     );
-
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-    );
+    assert.isTrue(checkEvaluate(null, {}, node));
   });
 
-  it('should return false if an aria-labelledby is present, but references an element with only hidden content', function() {
-    var node = queryFixture(
+  it('should return false if an aria-labelledby is present, but references an element with only hidden content', () => {
+    const node = queryFixture(
       '<div id="target" aria-labelledby="woohoo noexist hehe"></div><div id="woohoo"><span style="display: none">bananas</span></div>'
     );
-
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-    );
+    assert.isFalse(checkEvaluate(null, {}, node));
   });
 
-  it('should return true if an aria-labelledby is present that references elements with has aria-hidden=true', function() {
-    var node = queryFixture(
+  it('returns false if aria-labelledby refers to the own element', () => {
+    const vNode = queryFixture(
+      '<input aria-labelledby="target" value="in the sky" id="target">'
+    );
+    assert.isFalse(checkEvaluate(null, {}, vNode));
+  });
+
+  it('returns false if aria-labelledby refers to parent, and there are no sibling', () => {
+    const vNode = queryFixture(
+      '<div id="lbl"> <input aria-labelledby="lbl" value="in the sky" id="target"> </div>'
+    );
+    assert.isFalse(checkEvaluate(null, {}, vNode));
+  });
+
+  it('should return true if an aria-labelledby is present that references elements with has aria-hidden=true', () => {
+    const node = queryFixture(
       '<div id="target" aria-labelledby="woohoo"></div><div id="woohoo" aria-hidden="true">bananas</div>'
     );
-
-    assert.isTrue(
-      axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-    );
+    assert.isTrue(checkEvaluate(null, {}, node));
   });
 
-  it('should return false if an aria-labelledby is present that references elements with has aria-hidden=true in the content', function() {
-    var node = queryFixture(
+  it('should return false if an aria-labelledby is present that references elements with has aria-hidden=true in the content', () => {
+    const node = queryFixture(
       '<div id="target" aria-labelledby="woohoo"></div><div id="woohoo"><span aria-hidden="true">bananas</span></div>'
     );
-
-    assert.isFalse(
-      axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-    );
+    assert.isFalse(checkEvaluate(null, {}, node));
   });
 
-  describe('SerialVirtualNode', function() {
-    it('should return false if an aria-labelledby is not present', function() {
-      var node = new axe.SerialVirtualNode({
+  describe('SerialVirtualNode', () => {
+    it('should return false if an aria-labelledby is not present', () => {
+      const node = new axe.SerialVirtualNode({
         nodeName: 'div'
       });
-
-      assert.isFalse(
-        axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-      );
+      assert.isFalse(checkEvaluate(null, {}, node));
     });
 
-    it('should return undefined if an aria-labelledby is present', function() {
-      var node = new axe.SerialVirtualNode({
+    it('should return undefined if an aria-labelledby is present', () => {
+      const node = new axe.SerialVirtualNode({
         nodeName: 'div',
         attributes: {
           'aria-labelledby': 'woohoo'
         }
       });
-
-      assert.isUndefined(
-        axe.testUtils.getCheckEvaluate('aria-labelledby')(null, {}, node)
-      );
+      assert.isUndefined(checkEvaluate(null, {}, node));
     });
   });
 });

--- a/test/integration/rules/label/label.html
+++ b/test/integration/rules/label/label.html
@@ -11,15 +11,15 @@
   <input type="text" aria-labelledby="label" id="pass4" />
   <textarea aria-labelledby="label" id="pass6"></textarea>
   <div id="label">Label</div>
-  <label>Label <input type="text" id="pass7"/></label>
+  <label>Label <input type="text" id="pass7" /></label>
   <label>Label <textarea id="pass9"></textarea></label>
 
-  <label><input type="text" id="fail4"/></label>
+  <label><input type="text" id="fail4" /></label>
   <label><textarea id="fail6"></textarea></label>
   <label for="fail7"></label><input type="text" id="fail7" />
   <label for="fail9"></label><textarea id="fail9"></textarea>
 
-  <label for="fail11" style="display: none;">Text</label
+  <label for="fail11" style="display: none">Text</label
   ><input type="text" id="fail11" /> <label for="pass10">Label</label
   ><input type="text" id="pass10" /> <label for="pass12">Label</label
   ><textarea id="pass12"></textarea>
@@ -28,7 +28,7 @@
   <textarea id="pass15" title="Label"></textarea>
 
   <label
-    ><label><input type="text" id="fail22"/></label
+    ><label><input type="text" id="fail22" /></label
   ></label>
 
   <div>
@@ -52,9 +52,7 @@
   </div>
 
   <div>
-    <label for="pass-gh1176" style="display:none">
-      Hello world
-    </label>
+    <label for="pass-gh1176" style="display: none"> Hello world </label>
     <input id="pass-gh1176" title="Hi" />
   </div>
 
@@ -63,4 +61,10 @@
 
   <div id="hiddenlabel" aria-hidden="true">Hidden label</div>
   <input type="text" id="pass18" aria-labelledby="hiddenlabel" />
+
+  <label> <input id="fail28" value="val" /></label>
+  <label for="fail29"> <input id="fail29" value="val" /></label>
+  <div id="lbl-f30">
+    <input id="fail30" value="val" aria-labelledby="lbl-f30" />
+  </div>
 </form>

--- a/test/integration/rules/label/label.html
+++ b/test/integration/rules/label/label.html
@@ -67,4 +67,5 @@
   <div id="lbl-f30">
     <input id="fail30" value="val" aria-labelledby="lbl-f30" />
   </div>
+  <label><textarea id="fail31"> value</textarea></label>
 </form>

--- a/test/integration/rules/label/label.json
+++ b/test/integration/rules/label/label.json
@@ -11,7 +11,10 @@
     ["#fail11"],
     ["#fail22"],
     ["#fail25"],
-    ["#fail27"]
+    ["#fail27"],
+    ["#fail28"],
+    ["#fail29"],
+    ["#fail30"]
   ],
   "passes": [
     ["#pass1"],

--- a/test/integration/rules/label/label.json
+++ b/test/integration/rules/label/label.json
@@ -14,7 +14,8 @@
     ["#fail27"],
     ["#fail28"],
     ["#fail29"],
-    ["#fail30"]
+    ["#fail30"],
+    ["#fail31"]
   ],
   "passes": [
     ["#pass1"],

--- a/test/integration/rules/select-name/select-name.html
+++ b/test/integration/rules/select-name/select-name.html
@@ -34,9 +34,19 @@
   <select id="pass6" role="presentation" disabled></select>
   <select id="pass7" role="none" disabled></select>
 
-  <label> <select id="fail7" value="val"></select> </label>
-  <label for="fail8"> <select id="fail8" value="val"></select> </label>
+  <label>
+    <select id="fail7">
+      <option>val</option>
+    </select>
+  </label>
+  <label for="fail8">
+    <select id="fail8">
+      <option>val</option>
+    </select>
+  </label>
   <div id="lbl-f9">
-    <select id="fail9" value="val" aria-labelledby="lbl-f9"></select>
+    <select id="fail9" aria-labelledby="lbl-f9">
+      <option>val</option>
+    </select>
   </div>
 </form>

--- a/test/integration/rules/select-name/select-name.html
+++ b/test/integration/rules/select-name/select-name.html
@@ -33,4 +33,10 @@
 
   <select id="pass6" role="presentation" disabled></select>
   <select id="pass7" role="none" disabled></select>
+
+  <label> <select id="fail7" value="val"></select> </label>
+  <label for="fail8"> <select id="fail8" value="val"></select> </label>
+  <div id="lbl-f9">
+    <select id="fail9" value="val" aria-labelledby="lbl-f9"></select>
+  </div>
 </form>

--- a/test/integration/rules/select-name/select-name.json
+++ b/test/integration/rules/select-name/select-name.json
@@ -7,7 +7,10 @@
     ["#fail3"],
     ["#fail4"],
     ["#fail5"],
-    ["#fail6"]
+    ["#fail6"],
+    ["#fail7"],
+    ["#fail8"],
+    ["#fail9"]
   ],
   "passes": [
     ["#pass1"],


### PR DESCRIPTION
Avoid the value of an input / textarea / select element getting picked up as its label.

This problem is specifically with how the checks are running a partial accessible name computation, and were doing it incorrectly. This issue only exists on the implicit-label and explicit-label checks. I added tests to aria-labelledby to prove it didn't have this issue.

Closes issue: #3686
