### PR TITLE
feat(list/definition-list): only allow required owned roles

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -35,6 +35,7 @@
   - [target-size](#target-size)
   - [region](#region)
   - [inline-style-property](#inline-style-property)
+  - [invalid-children](#invalid-children)
 
 ## How Checks Work
 
@@ -526,3 +527,13 @@ This evaluate method is used in the following checks. Default vary between check
 | `normalValue`    | The value to use when `normal` is set, defaults to `0`                        |
 
 If `minValue` and `maxValue` are both undefined, the check returns `false` if the property is used with !important. If done along with `noImportant: true`, the check returns false if the property is set at all in the style attribute.
+
+### invalid-children
+
+This evaluation method is used in the `list` and `definition-list` rule to determine whether its child nodes are allowed.
+
+| Option           | Description                                                                         |
+| ---------------- | :---------------------------------------------------------------------------------- |
+| `validNodeNames` | Nodes without role allowed as children                                              |
+| `validRoles`     | Roles allowed on child elements                                                     |
+| `divGroups`      | Whether the child nodes can be grouped in a div without any role (false by default) |

--- a/lib/checks/lists/invalid-children-evaluate.js
+++ b/lib/checks/lists/invalid-children-evaluate.js
@@ -1,0 +1,75 @@
+import { isVisibleToScreenReaders } from '../../commons/dom';
+import { getExplicitRole } from '../../commons/aria';
+
+export default function invalidChildrenEvaluate(
+  node,
+  options = {},
+  virtualNode
+) {
+  const relatedNodes = [];
+  const issues = [];
+  if (!virtualNode.children) {
+    return undefined;
+  }
+
+  const vChildren = mapWithNested(virtualNode.children);
+  while (vChildren.length) {
+    const { vChild, nested } = vChildren.shift();
+    if (options.divGroups && !nested && isDivGroup(vChild)) {
+      if (!vChild.children) {
+        return undefined;
+      }
+      const vGrandChildren = mapWithNested(vChild.children, true);
+      vChildren.push(...vGrandChildren);
+      continue;
+    }
+
+    const issue = isInvalidChild(vChild, nested, options);
+    if (!issue) {
+      continue;
+    }
+    if (!issues.includes(issue)) {
+      issues.push(issue);
+    }
+    if (vChild?.actualNode?.nodeType === 1) {
+      relatedNodes.push(vChild.actualNode);
+    }
+  }
+  if (issues.length === 0) {
+    return false;
+  }
+
+  this.data({ values: issues.join(', ') });
+  this.relatedNodes(relatedNodes);
+  return true;
+}
+
+function isInvalidChild(
+  vChild,
+  nested,
+  { validRoles = [], validNodeNames = [] }
+) {
+  const { nodeName, nodeType, nodeValue } = vChild.props;
+  const selector = nested ? 'div > ' : '';
+  if (nodeType === 3 && nodeValue.trim() !== '') {
+    return selector + `#text`;
+  }
+  if (nodeType !== 1 || !isVisibleToScreenReaders(vChild)) {
+    return false;
+  }
+
+  const role = getExplicitRole(vChild);
+  if (role) {
+    return validRoles.includes(role) ? false : selector + `[role=${role}]`;
+  } else {
+    return validNodeNames.includes(nodeName) ? false : selector + nodeName;
+  }
+}
+
+function isDivGroup(vNode) {
+  return vNode.props.nodeName === 'div' && getExplicitRole(vNode) === null;
+}
+
+function mapWithNested(vNodes, nested = false) {
+  return vNodes.map(vChild => ({ vChild, nested }));
+}

--- a/lib/checks/lists/invalid-children-evaluate.js
+++ b/lib/checks/lists/invalid-children-evaluate.js
@@ -24,7 +24,7 @@ export default function invalidChildrenEvaluate(
       continue;
     }
 
-    const issue = isInvalidChild(vChild, nested, options);
+    const issue = getInvalidSelector(vChild, nested, options);
     if (!issue) {
       continue;
     }
@@ -44,7 +44,7 @@ export default function invalidChildrenEvaluate(
   return true;
 }
 
-function isInvalidChild(
+function getInvalidSelector(
   vChild,
   nested,
   { validRoles = [], validNodeNames = [] }

--- a/lib/checks/lists/only-dlitems.json
+++ b/lib/checks/lists/only-dlitems.json
@@ -1,11 +1,16 @@
 {
   "id": "only-dlitems",
-  "evaluate": "only-dlitems-evaluate",
+  "evaluate": "invalid-children-evaluate",
+  "options": {
+    "validRoles": ["definition", "term", "listitem"],
+    "validNodeNames": ["dt", "dd"],
+    "divGroups": true
+  },
   "metadata": {
     "impact": "serious",
     "messages": {
-      "pass": "List element only has direct children that are allowed inside <dt> or <dd> elements",
-      "fail": "List element has direct children that are not allowed inside <dt> or <dd> elements"
+      "pass": "dl element only has direct children that are allowed inside; <dt>, <dd>, or <div> elements",
+      "fail": "dl element has direct children that are not allowed: ${data.values}"
     }
   }
 }

--- a/lib/checks/lists/only-listitems.json
+++ b/lib/checks/lists/only-listitems.json
@@ -1,14 +1,15 @@
 {
   "id": "only-listitems",
-  "evaluate": "only-listitems-evaluate",
+  "evaluate": "invalid-children-evaluate",
+  "options": {
+    "validRoles": ["listitem"],
+    "validNodeNames": ["li"]
+  },
   "metadata": {
     "impact": "serious",
     "messages": {
       "pass": "List element only has direct children that are allowed inside <li> elements",
-      "fail": {
-        "default": "List element has direct children that are not allowed inside <li> elements",
-        "roleNotValid": "List element has direct children with a role that is not allowed: ${data.roles}"
-      }
+      "fail": "List element has direct children that are not allowed: ${data.values}"
     }
   }
 }

--- a/lib/rules/no-role-matches.js
+++ b/lib/rules/no-role-matches.js
@@ -1,5 +1,5 @@
-function noRoleMatches(node) {
-  return !node.getAttribute('role');
+function noRoleMatches(node, vNode) {
+  return !vNode.attr('role');
 }
 
 export default noRoleMatches;

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -782,15 +782,12 @@
       }
     },
     "only-dlitems": {
-      "pass": "List element only has direct children that are allowed inside <dt> or <dd> elements",
-      "fail": "List element has direct children that are not allowed inside <dt> or <dd> elements"
+      "pass": "dl element only has direct children that are allowed inside; <dt>, <dd>, or <div> elements",
+      "fail": "dl element has direct children that are not allowed: ${data.values}"
     },
     "only-listitems": {
       "pass": "List element only has direct children that are allowed inside <li> elements",
-      "fail": {
-        "default": "List element has direct children that are not allowed inside <li> elements",
-        "roleNotValid": "List element has direct children with a role that is not allowed: ${data.roles}"
-      }
+      "fail": "List element has direct children that are not allowed: ${data.values}"
     },
     "structured-dlitems": {
       "pass": "When not empty, element has both <dt> and <dd> elements",

--- a/test/checks/lists/only-dlitems.js
+++ b/test/checks/lists/only-dlitems.js
@@ -1,349 +1,227 @@
-describe('only-dlitems', function () {
-  'use strict';
+describe('only-dlitems', () => {
+  const fixture = document.getElementById('fixture');
+  const checkSetup = axe.testUtils.checkSetup;
+  const checkContext = axe.testUtils.MockCheckContext();
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('only-dlitems');
 
-  var fixture = document.getElementById('fixture');
-  var checkSetup = axe.testUtils.checkSetup;
-  var shadowSupport = axe.testUtils.shadowSupport;
-  var checkContext = axe.testUtils.MockCheckContext();
-
-  afterEach(function () {
-    fixture.innerHTML = '';
+  afterEach(() => {
     checkContext.reset();
   });
 
-  it('should return false if the list has no contents', function () {
-    var checkArgs = checkSetup('<dl id="target"></dl>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has no contents', () => {
+    const checkArgs = checkSetup('<dl id="target"></dl>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if the list has non-dd/dt contents', function () {
-    var checkArgs = checkSetup('<dl id="target"><p>Not a list</p></dl>');
+  it('should return true if the list has non-dd/dt contents', () => {
+    const checkArgs = checkSetup('<dl id="target"><p>Not a list</p></dl>');
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
     assert.deepEqual(checkContext._relatedNodes, [fixture.querySelector('p')]);
+    assert.deepEqual(checkContext._data, { values: 'p' });
   });
 
-  it('should return true if the list has non-dd content through role change', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list has non-dd content through role change', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><dd role="menuitem">Not a list</dd></dl>'
     );
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: '[role=menuitem]' });
   });
 
-  it('should return true if the list has non-dt content through role change', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list has non-dt content through role change', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><dt role="menuitem">Not a list</dt></dl>'
     );
-
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: '[role=menuitem]' });
   });
 
-  it('should return false if the list has only a dd', function () {
-    var checkArgs = checkSetup('<dl id="target"><dd>A list</dd></dl>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has only a dd', () => {
+    const checkArgs = checkSetup('<dl id="target"><dd>A list</dd></dl>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if <link> is used along side dt with its role changed', function () {
-    var checkArgs = checkSetup(
+  it('should return true if <link> is used along side dt with its role changed', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><link rel="stylesheet" href="theme.css"><dt role="menuitem">A list</dt></dl>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: '[role=menuitem]' });
   });
 
-  it('should return false if the list has only a dt', function () {
-    var checkArgs = checkSetup('<dl id="target"><dt>A list</dt></dl>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has only a dt', () => {
+    const checkArgs = checkSetup('<dl id="target"><dt>A list</dt></dl>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has dt and dd with child content', function () {
-    var checkArgs = checkSetup(
+  it('should return false if the list has dt and dd with child content', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><dt><p>An item</p></dt><dd>A list</dd></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has dt and dd', function () {
-    var checkArgs = checkSetup(
+  it('should return false if the list has dt and dd', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><dt>An item</dt><dd>A list</dd></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has dt, dd and a comment', function () {
-    var checkArgs = checkSetup(
+  it('should return false if the list has dt, dd and a comment', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><dt>An item</dt><dd>A list</dd><!-- foo --></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if the list has a dt and dd with other content', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list has a dt and dd with other content', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><dt>Item one</dt><dd>Description</dd><p>Not a list</p></dl>'
     );
-
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
     assert.deepEqual(checkContext._relatedNodes, [fixture.querySelector('p')]);
+    assert.deepEqual(checkContext._data, { values: 'p' });
   });
 
-  it('should return true if the list has a textNode as a child', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list has a textNode as a child', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><!--hi--><dt>hi</dt>hello<dd>hi</dd></dl>'
     );
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
     assert.deepEqual(checkContext._relatedNodes, []);
+    assert.deepEqual(checkContext._data, { values: '#text' });
   });
 
-  it('should return false if <link> is used along side dt', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <link> is used along side dt', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><link rel="stylesheet" href="theme.css"><dt>A list</dt></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <meta> is used along side dt', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <meta> is used along side dt', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><meta name="description" content=""><dt>A list</dt></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <script> is used along side dt', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <script> is used along side dt', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><script src="script.js"></script><dt>A list</dt></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <style> is used along side dt', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <style> is used along side dt', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><style></style><dt>A list</dt></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <template> is used along side dt', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <template> is used along side dt', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><template></template><dt>A list</dt></dl>'
     );
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has dt and dd inside a div group', function () {
-    var checkArgs = checkSetup(
+  it('should return false if the list has dt and dd inside a div group', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><div><dt>An item</dt><dd>A list</dd></div></dl>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if the list has dt and dd inside a div group with a role', function () {
-    var checkArgs = checkSetup(
-      '<dl id="target"><div role="listitem"><dt>An item</dt><dd>A list</dd></div></dl>'
+  it('should return true if the list has dt and dd inside a div group with a role', () => {
+    const checkArgs = checkSetup(
+      '<dl id="target"><div role="list"><dt>An item</dt><dd>A list</dd></div></dl>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: '[role=list]' });
   });
 
-  it('should return true if the list mixed items inside a div group with a role', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list mixed items inside a div group with a role', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"><div><dt>An item</dt><dd>A list</dd><p>Not a list</p></div></dl>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: 'div > p' });
   });
 
-  it('should return false if there is an empty div', function () {
-    var checkArgs = checkSetup('<dl id="target"><div></div></dl>');
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if there is an empty div', () => {
+    const checkArgs = checkSetup('<dl id="target"><div></div></dl>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('returns false if there are display:none elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns false if there are display:none elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"> <dt>An item</dt> <dd>A list</dd> <h1 style="display:none">heading</h1> </dl>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if there is a div with text', function () {
-    var checkArgs = checkSetup('<dl id="target"><div>text</div></dl>');
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return true if there is a div with text', () => {
+    const checkArgs = checkSetup('<dl id="target"><div>text</div></dl>');
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: 'div > #text' });
   });
 
-  it('returns false if there are visibility:hidden elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns false if there are visibility:hidden elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"> <dt>An item</dt> <dd>A list</dd> <h1 style="visibility:hidden">heading</h1> </dl>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if there is a div with non-dd / dt elements', function () {
-    var checkArgs = checkSetup('<dl id="target"><div> <p>text</p> </div></dl>');
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
+  it('should return true if there is a div with non-dd / dt elements', () => {
+    const checkArgs = checkSetup(
+      '<dl id="target"><div> <p>text</p> </div></dl>'
     );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: 'div > p' });
   });
 
-  it('returns false if there are aria-hidden=true elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns false if there are aria-hidden=true elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"> <dt>An item</dt> <dd>A list</dd> <h1 aria-hidden="true">heading</h1> </dl>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('returns true if there are aria-hidden=false elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns true if there are aria-hidden=false elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<dl id="target"> <dt>An item</dt> <dd>A list</dd> <h1 aria-hidden="false">heading</h1> </dl>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-dlitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, { values: 'h1' });
   });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return false in a shadow DOM pass',
-    function () {
-      var node = document.createElement('div');
+  describe('shadow DOM', () => {
+    it('should return false in a shadow DOM pass', () => {
+      const node = document.createElement('div');
       node.innerHTML = '<dt>My list item </dt>';
-      var shadow = node.attachShadow({ mode: 'open' });
+      const shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<dl><slot></slot></dl>';
 
-      var checkArgs = checkSetup(node, 'dl');
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('only-dlitems')
-          .apply(checkContext, checkArgs)
-      );
-    }
-  );
+      const checkArgs = checkSetup(node, 'dl');
+      assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
+    });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return true in a shadow DOM fail',
-    function () {
-      var node = document.createElement('div');
+    it('should return true in a shadow DOM fail', () => {
+      const node = document.createElement('div');
       node.innerHTML = '<p>Not a list</p>';
-      var shadow = node.attachShadow({ mode: 'open' });
+      const shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<dl><slot></slot></dl>';
 
-      var checkArgs = checkSetup(node, 'dl');
-      assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('only-dlitems')
-          .apply(checkContext, checkArgs)
-      );
-    }
-  );
+      const checkArgs = checkSetup(node, 'dl');
+      assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+      assert.deepEqual(checkContext._data, { values: 'p' });
+    });
+  });
 });

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -122,7 +122,6 @@ describe('only-listitems', () => {
     );
 
     assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
-    console.log(checkContext._data);
     assert.deepEqual(checkContext._data, {
       values: '[role=menuitem]'
     });

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -1,160 +1,114 @@
-describe('only-listitems', function () {
-  'use strict';
+describe('only-listitems', () => {
+  const fixture = document.getElementById('fixture');
+  const checkSetup = axe.testUtils.checkSetup;
+  const checkContext = axe.testUtils.MockCheckContext();
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('only-listitems');
 
-  var fixture = document.getElementById('fixture');
-  var checkSetup = axe.testUtils.checkSetup;
-  var shadowSupport = axe.testUtils.shadowSupport;
-  var checkContext = axe.testUtils.MockCheckContext();
-
-  afterEach(function () {
-    fixture.innerHTML = '';
+  afterEach(() => {
     checkContext.reset();
   });
 
-  it('should return false if the list has no contents', function () {
-    var checkArgs = checkSetup('<ol id="target"></ol>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has no contents', () => {
+    const checkArgs = checkSetup('<ol id="target"></ol>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has only spaces as content', function () {
-    var checkArgs = checkSetup('<ol id="target">   </ol>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has only spaces as content', () => {
+    const checkArgs = checkSetup('<ol id="target">   </ol>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has whitespace', function () {
-    var checkArgs = checkSetup('<ol id="target"><li>Item</li>    </ol>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has whitespace', () => {
+    const checkArgs = checkSetup('<ol id="target"><li>Item</li>    </ol>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has only an element with role listitem', function () {
-    var checkArgs = checkSetup(
+  it('should return false if the list has only an element with role listitem', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><div role="listitem">A list</div></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has only multiple mixed elements with role listitem', function () {
-    var checkArgs = checkSetup(
+  it('should return false if the list has only multiple mixed elements with role listitem', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><div role="listitem">list</div><li role="listitem">list</li><div role="listitem">list</div></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has non-li comments', function () {
-    var checkArgs = checkSetup(
+  it('should return false if the list has non-li comments', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><li>Item</li><!--comment--></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if the list has non-li text contents', function () {
-    var checkArgs = checkSetup('<ol id="target"><li>Item</li>Not an item</ol>');
-
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
+  it('should return true if the list has non-li text contents', () => {
+    const checkArgs = checkSetup(
+      '<ol id="target"><li>Item</li>Not an item</ol>'
     );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, {
+      values: '#text'
+    });
   });
 
-  it('should return true if the list has non-li contents', function () {
-    var checkArgs = checkSetup('<ol id="target"><p>Not a list</p></ol>');
-
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return true if the list has non-li contents', () => {
+    const checkArgs = checkSetup('<ol id="target"><p>Not a list</p></ol>');
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
     assert.deepEqual(checkContext._relatedNodes, [fixture.querySelector('p')]);
+    assert.deepEqual(checkContext._data, {
+      values: 'p'
+    });
   });
 
-  it('should return false if the list has only an li with child content', function () {
-    var checkArgs = checkSetup('<ol id="target"><li>A <i>list</i></li></ol>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has only an li with child content', () => {
+    const checkArgs = checkSetup('<ol id="target"><li>A <i>list</i></li></ol>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if the list has only an li', function () {
-    var checkArgs = checkSetup('<ol id="target"><li>A list</li></ol>');
-
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+  it('should return false if the list has only an li', () => {
+    const checkArgs = checkSetup('<ol id="target"><li>A list</li></ol>');
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true if the list has an li with other content', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list has an li with other content', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><li>A list</li><p>Not a list</p></ol>'
     );
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
     assert.deepEqual(checkContext._relatedNodes, [fixture.querySelector('p')]);
+    assert.deepEqual(checkContext._data, {
+      values: 'p'
+    });
   });
 
-  it('should return false if the list has at least one li while others have their roles changed', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list has at least one li while others have their roles changed', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><li >A list item</li><li role="menuitem">Not a list item</li></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._relatedNodes, [
+      fixture.querySelector('[role="menuitem"]')
+    ]);
+    assert.deepEqual(checkContext._data, {
+      values: '[role=menuitem]'
+    });
   });
 
-  it('should return true if the list has only li items with their roles changed', function () {
-    var checkArgs = checkSetup(
+  it('should return true if the list has only li items with their roles changed', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><li id="fail1" role="menuitem">Not a list item</li><li id="fail2" role="menuitem">Not a list item</li></ol>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
     assert.deepEqual(checkContext._data, {
-      messageKey: 'roleNotValid',
-      roles: 'menuitem'
+      values: '[role=menuitem]'
     });
     assert.deepEqual(checkContext._relatedNodes, [
       fixture.querySelector('#fail1'),
@@ -162,153 +116,133 @@ describe('only-listitems', function () {
     ]);
   });
 
-  it('should return true if <link> is used along side only li items with their roles changed', function () {
-    var checkArgs = checkSetup(
+  it('should return true if <link> is used along side only li items with their roles changed', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><link rel="stylesheet" href="theme.css"><li role="menuitem">Not a list item</li></ol>'
     );
 
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    console.log(checkContext._data);
+    assert.deepEqual(checkContext._data, {
+      values: '[role=menuitem]'
+    });
   });
 
-  it('should return false if <link> is used along side li', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <link> is used along side li', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><link rel="stylesheet" href="theme.css"><li>A list</li></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <meta> is used along side li', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <meta> is used along side li', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><meta name="description" content=""><li>A list</li></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <script> is used along side li', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <script> is used along side li', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><script src="script.js"></script><li>A list</li></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <style> is used along side li', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <style> is used along side li', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><style></style><li>A list</li></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return false if <template> is used along side li', function () {
-    var checkArgs = checkSetup(
+  it('should return false if <template> is used along side li', () => {
+    const checkArgs = checkSetup(
       '<ol id="target"><template></template><li>A list</li></ol>'
     );
 
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('returns false if there are display:none elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns false if there are display:none elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<ul id="target"> <li>An item</li> <h1 style="display:none">heading</h1> </ul>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('returns false if there are visibility:hidden elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns false if there are visibility:hidden elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<ul id="target"> <li>An item</li> <h1 style="visibility:hidden">heading</h1> </ul>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('returns false if there are aria-hidden=true elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns false if there are aria-hidden=true elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<ul id="target"> <li>An item</li> <h1 aria-hidden="true">heading</h1> </ul>'
     );
-    assert.isFalse(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('returns true if there are aria-hidden=false elements that normally would not be allowed', function () {
-    var checkArgs = checkSetup(
+  it('returns true if there are aria-hidden=false elements that normally would not be allowed', () => {
+    const checkArgs = checkSetup(
       '<ul id="target"> <li>An item</li> <h1 aria-hidden="false">heading</h1> </ul>'
     );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('only-listitems')
-        .apply(checkContext, checkArgs)
-    );
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+    assert.deepEqual(checkContext._data, {
+      values: 'h1'
+    });
   });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return false in a shadow DOM pass',
-    function () {
-      var node = document.createElement('div');
+  describe('nodeNames', () => {
+    it('returns multiple node names', () => {
+      const checkArgs = checkSetup(
+        '<ul id="target"> <a></a><b></b><s></s> </ul>'
+      );
+      assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+      assert.deepEqual(checkContext._data, {
+        values: 'a, b, s'
+      });
+    });
+
+    it('does only shows unique nodes names', () => {
+      const checkArgs = checkSetup(
+        '<ul id="target"> <a></a><b></b><a></a> </ul>'
+      );
+      assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+      assert.deepEqual(checkContext._data, {
+        values: 'a, b'
+      });
+    });
+  });
+
+  describe('shadow DOM', () => {
+    it('should return false in a shadow DOM pass', () => {
+      const node = document.createElement('div');
       node.innerHTML = '<li>My list item </li>';
-      var shadow = node.attachShadow({ mode: 'open' });
+      const shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<ul><slot></slot></ul>';
 
-      var checkArgs = checkSetup(node, 'ul');
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('only-listitems')
-          .apply(checkContext, checkArgs)
-      );
-    }
-  );
+      const checkArgs = checkSetup(node, 'ul');
+      assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
+    });
 
-  (shadowSupport.v1 ? it : xit)(
-    'should return true in a shadow DOM fail',
-    function () {
-      var node = document.createElement('div');
+    it('should return true in a shadow DOM fail', () => {
+      const node = document.createElement('div');
       node.innerHTML = '<p>Not a list item</p>';
-      var shadow = node.attachShadow({ mode: 'open' });
+      const shadow = node.attachShadow({ mode: 'open' });
       shadow.innerHTML = '<ul><slot></slot></ul>';
 
-      var checkArgs = checkSetup(node, 'ul');
-      assert.isTrue(
-        axe.testUtils
-          .getCheckEvaluate('only-listitems')
-          .apply(checkContext, checkArgs)
-      );
-    }
-  );
+      const checkArgs = checkSetup(node, 'ul');
+      assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+      assert.deepEqual(checkContext._data, {
+        values: 'p'
+      });
+    });
+  });
 });

--- a/test/integration/rules/list/list.json
+++ b/test/integration/rules/list/list.json
@@ -7,7 +7,9 @@
     ["#divol"],
     ["#mixedol"],
     ["#ulrolledallli"],
-    ["#olrolledallli"]
+    ["#olrolledallli"],
+    ["#ulrolledli"],
+    ["#olrolledli"]
   ],
   "passes": [
     ["#emptyul"],
@@ -17,8 +19,6 @@
     ["#emptyol"],
     ["#scriptemptyol"],
     ["#properol"],
-    ["#scriptproperol"],
-    ["#ulrolledli"],
-    ["#olrolledli"]
+    ["#scriptproperol"]
   ]
 }

--- a/test/integration/virtual-rules/definition-list.js
+++ b/test/integration/virtual-rules/definition-list.js
@@ -1,5 +1,5 @@
 describe('definition-list virtual-rule', () => {
-  it('passes when there is an invalid child nodes', () => {
+  it('passes when there are no invalid child nodes', () => {
     const dl = new axe.SerialVirtualNode({ nodeName: 'dl' });
     const dt = new axe.SerialVirtualNode({ nodeName: 'dt' });
     const dd = new axe.SerialVirtualNode({ nodeName: 'dd' });
@@ -22,7 +22,6 @@ describe('definition-list virtual-rule', () => {
     dd2.parent = dl;
 
     const results = axe.runVirtualRule('definition-list', dl);
-    console.log(JSON.stringify(results.violations, null, 2));
     assert.lengthOf(results.passes, 0);
     assert.lengthOf(results.violations, 1);
     assert.lengthOf(results.incomplete, 0);

--- a/test/integration/virtual-rules/definition-list.js
+++ b/test/integration/virtual-rules/definition-list.js
@@ -1,0 +1,53 @@
+describe('definition-list virtual-rule', () => {
+  it('passes when there is an invalid child nodes', () => {
+    const dl = new axe.SerialVirtualNode({ nodeName: 'dl' });
+    const dt = new axe.SerialVirtualNode({ nodeName: 'dt' });
+    const dd = new axe.SerialVirtualNode({ nodeName: 'dd' });
+    dl.children = [dt, dd];
+    dt.parent = dl;
+    dd.parent = dl;
+
+    const results = axe.runVirtualRule('definition-list', dl);
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('fails when there no dd / dt pair', () => {
+    const dl = new axe.SerialVirtualNode({ nodeName: 'dl' });
+    const dd1 = new axe.SerialVirtualNode({ nodeName: 'dd' });
+    const dd2 = new axe.SerialVirtualNode({ nodeName: 'dd' });
+    dl.children = [dd1, dd2];
+    dd1.parent = dl;
+    dd2.parent = dl;
+
+    const results = axe.runVirtualRule('definition-list', dl);
+    console.log(JSON.stringify(results.violations, null, 2));
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('fails when there is an invalid child nodes', () => {
+    const dl = new axe.SerialVirtualNode({ nodeName: 'dl' });
+    const span = new axe.SerialVirtualNode({
+      nodeName: 'span',
+      attributes: {}
+    });
+    dl.children = [span];
+    span.parent = dl;
+
+    const results = axe.runVirtualRule('definition-list', dl);
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('is incomplete without child nodes', () => {
+    const dl = new axe.SerialVirtualNode({ nodeName: 'dl' });
+    const results = axe.runVirtualRule('definition-list', dl);
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 1);
+  });
+});

--- a/test/integration/virtual-rules/list.js
+++ b/test/integration/virtual-rules/list.js
@@ -1,0 +1,36 @@
+describe('list virtual-rule', () => {
+  it('passes when there is an invalid child nodes', () => {
+    const ul = new axe.SerialVirtualNode({ nodeName: 'ul' });
+    const li = new axe.SerialVirtualNode({ nodeName: 'li' });
+    ul.children = [li];
+    li.parent = ul;
+
+    const results = axe.runVirtualRule('list', ul);
+    assert.lengthOf(results.passes, 1);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('fails when there is an invalid child nodes', () => {
+    const ul = new axe.SerialVirtualNode({ nodeName: 'ul' });
+    const span = new axe.SerialVirtualNode({
+      nodeName: 'span',
+      attributes: {}
+    });
+    ul.children = [span];
+    span.parent = ul;
+
+    const results = axe.runVirtualRule('list', ul);
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
+  it('is incomplete without child nodes', () => {
+    const ul = new axe.SerialVirtualNode({ nodeName: 'ul' });
+    const results = axe.runVirtualRule('list', ul);
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 1);
+  });
+});

--- a/test/integration/virtual-rules/list.js
+++ b/test/integration/virtual-rules/list.js
@@ -1,5 +1,5 @@
 describe('list virtual-rule', () => {
-  it('passes when there is an invalid child nodes', () => {
+  it('passes when there are no invalid child nodes', () => {
     const ul = new axe.SerialVirtualNode({ nodeName: 'ul' });
     const li = new axe.SerialVirtualNode({ nodeName: 'li' });
     ul.children = [li];
@@ -11,7 +11,7 @@ describe('list virtual-rule', () => {
     assert.lengthOf(results.incomplete, 0);
   });
 
-  it('fails when there is an invalid child nodes', () => {
+  it('fails when there is an invalid child node', () => {
     const ul = new axe.SerialVirtualNode({ nodeName: 'ul' });
     const span = new axe.SerialVirtualNode({
       nodeName: 'span',

--- a/test/rule-matches/no-role-matches.js
+++ b/test/rule-matches/no-role-matches.js
@@ -1,32 +1,19 @@
-describe('link-in-text-block-matches', function() {
-  'use strict';
+describe('link-in-text-block-matches', () => {
+  const rule = axe.utils.getRule('definition-list');
+  const { queryFixture } = axe.testUtils;
 
-  var fixture = document.getElementById('fixture');
-  var rule;
-
-  beforeEach(function() {
-    rule = axe.utils.getRule('definition-list');
+  it('should return true if element does not have a role attribute', () => {
+    const vNode = queryFixture('<div id="target"></div>');
+    assert.isTrue(rule.matches(null, vNode));
   });
 
-  afterEach(function() {
-    fixture.innerHTML = '';
+  it('should return true if element has an empty role attribute', () => {
+    const vNode = queryFixture('<div role="" id="target"></div>');
+    assert.isTrue(rule.matches(null, vNode));
   });
 
-  it('should return true if element does not have a role attribute', function() {
-    fixture.innerHTML = '<div></div>';
-    var node = fixture.firstChild;
-    assert.isTrue(rule.matches(node));
-  });
-
-  it('should return true if element has an empty role attribute', function() {
-    fixture.innerHTML = '<div role=""></div>';
-    var node = fixture.firstChild;
-    assert.isTrue(rule.matches(node));
-  });
-
-  it('should return false if element has a role attribute', function() {
-    fixture.innerHTML = '<div role="button"></div>';
-    var node = fixture.firstChild;
-    assert.isFalse(rule.matches(node));
+  it('should return false if element has a role attribute', () => {
+    const vNode = queryFixture('<div role="button" id="target"></div>');
+    assert.isFalse(rule.matches(null, vNode));
   });
 });


### PR DESCRIPTION
Improve on messages reported by the `list` and `definition-list` checks. Since they had so much in common I unified them into a new `invalid-children-evaluate` method. That got me 95% of the way to running their rules on virtual nodes, so I then also updated the matches method to run on virtual. 

This rule gets rid of the (minor) exception on `list`, where if you have `li` elements, where some have a role and others do not, the rule will pass. I don't recall why we put that in, but it doesn't make too much sense to me.

The `only-dlitems-evaluate` and `only-listitems-evaluate` methods need to be deprecated, but this belongs in a separate PR.

Closes issue: #3559
