### PR TITLE
feat: Deprecate only-dlitems-evaluate & only-listitems-evaluate methods

### DIFF
--- a/lib/checks/lists/only-dlitems-evaluate.js
+++ b/lib/checks/lists/only-dlitems-evaluate.js
@@ -1,6 +1,9 @@
 import { isVisibleToScreenReaders } from '../../commons/dom';
 import { getRole, getExplicitRole } from '../../commons/aria';
 
+/**
+ * @deprecated
+ */
 function onlyDlitemsEvaluate(node, options, virtualNode) {
   const ALLOWED_ROLES = ['definition', 'term', 'list'];
   const base = {

--- a/lib/checks/lists/only-listitems-evaluate.js
+++ b/lib/checks/lists/only-listitems-evaluate.js
@@ -1,6 +1,9 @@
 import { isVisibleToScreenReaders } from '../../commons/dom';
 import { getRole } from '../../commons/aria';
 
+/**
+ * @deprecated
+ */
 function onlyListitemsEvaluate(node, options, virtualNode) {
   let hasNonEmptyTextNode = false;
   let atLeastOneListitem = false;


### PR DESCRIPTION
Instead of #3709