### PR TITLE
chore: release axe-core 4.5.0 (sri-history corrected)

### DIFF
--- a/sri-history.json
+++ b/sri-history.json
@@ -312,7 +312,7 @@
     "axe.min.js": "sha256-aX6mx+3/D+KJt7vs8f97kBUkm8g0tAmjSM0GDfgK66A="
   },
   "4.5.0": {
-    "axe.js": "sha256-3qMljzgfOeQURJq41oSAVhxxsaXTkIVHVr3Ncq33Bqk=",
-    "axe.min.js": "sha256-+Kt3efyVI8+FHf/a2YyHjfyEKsysakzdQ7+bV46Ycyw="
+    "axe.js": "sha256-m1NAEdLUn23mr479Xr+xltD6RWp0nVxg8X6hBEt9PvQ=",
+    "axe.min.js": "sha256-qQZzRL18quE725YaNkPsvrQl/OVMKazMxTMMye48tac="
   }
 }


### PR DESCRIPTION
Had an issue with sri-history.json because we did the release a bit out of order.

