### PR TITLE
chore: npm ci for generated files action

### DIFF
--- a/.github/workflows/update-generated-files.yaml
+++ b/.github/workflows/update-generated-files.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Build
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Check for changes


### PR DESCRIPTION
Run `npm ci` instead of `npm install` so `package-lock.json` isn't updated during the action. This caused [the action to think there was new changes](https://github.com/dequelabs/axe-core/actions/runs/3299227438/jobs/5442346330#step:4:10) to generated files even though there wasn't, thus failing.