### PR TITLE
fix: prevent crash on jsdom when preloading CSSOM

### DIFF
--- a/lib/core/utils/preload-cssom.js
+++ b/lib/core/utils/preload-cssom.js
@@ -187,9 +187,13 @@ function getStylesheetsFromDocumentFragment(rootNode, convertDataToStylesheet) {
  * @returns {Array<Object>}
  */
 function getStylesheetsFromDocument(rootNode) {
-  return Array.from(rootNode.styleSheets).filter(sheet =>
-    filterMediaIsPrint(sheet.media.mediaText)
-  );
+  return Array.from(rootNode.styleSheets).filter(sheet => {
+    if (!sheet.media) {
+      return false;
+    }
+
+    return filterMediaIsPrint(sheet.media.mediaText);
+  });
 }
 
 /**


### PR DESCRIPTION
- cssom package does not implement StyleSheet.media

<< Describe the changes >>

Adds a simple `if` to check whether `StyleSheet` has `media`.

Closes #3753