### PR TITLE
fix: allow axe to run in certain configurations of jsdom

### DIFF
--- a/lib/core/utils/pollyfills.js
+++ b/lib/core/utils/pollyfills.js
@@ -348,7 +348,7 @@ if (!Array.prototype.flat) {
 
 // linked from MDN docs on isConnected
 // @see https://gist.github.com/eligrey/f109a6d0bf4efe3461201c3d7b745e8f
-if (window.Node && !('isConnected' in Node.prototype)) {
+if (window.Node && !('isConnected' in window.Node.prototype)) {
   Object.defineProperty(Node.prototype, 'isConnected', {
     get() {
       return (


### PR DESCRIPTION
A subtle bug that prevented axe-core from working in certain configuration settings of jsdom. 