### PR TITLE
Add a rule to check if a page has a sign language widget

### DIFF
--- a/lib/checks/shared/doc-sign-language-widget-evaluate.js
+++ b/lib/checks/shared/doc-sign-language-widget-evaluate.js
@@ -1,0 +1,19 @@
+function docHasSignLanguageWidget() {
+  var signLanguageWidget = document.querySelectorAll("#DeafTranslate");
+    if (signLanguageWidget.length) return true;
+    signLanguageWidget = document.querySelectorAll("#SignLanguage");
+    if (signLanguageWidget.length) return true;
+    signLanguageWidget = document.querySelectorAll(".sign-language");
+    if (signLanguageWidget.length) return true;
+    signLanguageWidget = document.querySelectorAll(".mr-tooltip");
+    if (signLanguageWidget.length) return true;
+    signLanguageWidget = document.querySelectorAll("[alt='DEAF']");
+    if (signLanguageWidget.length) return true;
+
+    signLanguageWidget = document.querySelectorAll(
+      'script[src*="/integrator.js"],script[src*="/tooltip_add.js"],script[src*="/signsplayer.js"]'
+    );
+    return !!signLanguageWidget.length;
+}
+
+export default docHasSignLanguageWidget;

--- a/lib/checks/shared/doc-sign-language-widget.json
+++ b/lib/checks/shared/doc-sign-language-widget.json
@@ -1,0 +1,11 @@
+{
+  "id": "doc-sign-language-widget",
+  "evaluate": "doc-sign-language-widget-evaluate",
+  "metadata": {
+    "impact": "moderate",
+    "messages": {
+      "pass": "Document has a Sign Language Widget",
+      "fail": "Document does not have a Sign Language Widget"
+    }
+  }
+}

--- a/lib/rules/document-sign-language-widget.json
+++ b/lib/rules/document-sign-language-widget.json
@@ -1,0 +1,13 @@
+{
+  "id": "document-sign-language-widget",
+  "selector": "html",
+  "matches": "is-initiator-matches",
+  "tags": ["cat.text-alternatives", "wcag2a", "wcag242","ACT"],
+  "metadata": {
+    "description": "Ensures each HTML document contains a Sign Language Widget",
+    "help": "Documents must have a Sign Language Widget to help deaf people to understand and navigate the website"
+  },
+  "all": [],
+  "any": ["doc-sign-language-widget"],
+  "none": []
+}

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -133,6 +133,10 @@
       "description": "Ensures <dt> and <dd> elements are contained by a <dl>",
       "help": "<dt> and <dd> elements must be contained by a <dl>"
     },
+    "document-sign-language-widget": {
+      "description": "Ensures each HTML document contains a Sign Language Widget",
+      "help": "Documents must have a Sign Language Widget to help deaf people to understand and navigate the website"
+    },
     "document-title": {
       "description": "Ensures each HTML document contains a non-empty <title> element",
       "help": "Documents must have <title> element to aid in navigation"
@@ -927,6 +931,10 @@
     "doc-has-title": {
       "pass": "Document has a non-empty <title> element",
       "fail": "Document does not have a non-empty <title> element"
+    },
+    "doc-sign-language-widget": {
+      "pass": "Document has a Sign Language Widget",
+      "fail": "Document does not have a Sign Language Widget"
     },
     "exists": {
       "pass": "Element does not exist",


### PR DESCRIPTION
This rule is implemented currently for the Mind Rockets Sign Language Widget, but it could also be extended in the future for other automated Sign Language widgets.

In addition, it checks if there are any tags in the page which detects the page has anything related to deaf or sign language.