### PR TITLE
fix: prevent undefined relatedNodes from halting axe

### DIFF
--- a/lib/core/reporters/helpers/process-aggregate.js
+++ b/lib/core/reporters/helpers/process-aggregate.js
@@ -10,19 +10,19 @@ function normalizeRelatedNodes(node, options) {
       .forEach(checkRes => {
         checkRes.relatedNodes = checkRes.relatedNodes.map(relatedNode => {
           var res = {
-            html: relatedNode.source
+            html: relatedNode?.source ?? 'Undefined'
           };
           if (options.elementRef && !relatedNode.fromFrame) {
-            res.element = relatedNode.element;
+            res.element = relatedNode?.element ?? null;
           }
           if (options.selectors !== false || relatedNode.fromFrame) {
-            res.target = relatedNode.selector;
+            res.target = relatedNode?.selector ?? ':root';
           }
           if (options.ancestry) {
-            res.ancestry = relatedNode.ancestry;
+            res.ancestry = relatedNode.ancestry ?? ':root';
           }
           if (options.xpath) {
-            res.xpath = relatedNode.xpath;
+            res.xpath = relatedNode.xpath ?? '/';
           }
           return res;
         });

--- a/lib/core/reporters/helpers/process-aggregate.js
+++ b/lib/core/reporters/helpers/process-aggregate.js
@@ -12,17 +12,17 @@ function normalizeRelatedNodes(node, options) {
           var res = {
             html: relatedNode?.source ?? 'Undefined'
           };
-          if (options.elementRef && !relatedNode.fromFrame) {
+          if (options.elementRef && !relatedNode?.fromFrame) {
             res.element = relatedNode?.element ?? null;
           }
-          if (options.selectors !== false || relatedNode.fromFrame) {
+          if (options.selectors !== false || relatedNode?.fromFrame) {
             res.target = relatedNode?.selector ?? ':root';
           }
           if (options.ancestry) {
-            res.ancestry = relatedNode.ancestry ?? ':root';
+            res.ancestry = relatedNode?.ancestry ?? ':root';
           }
           if (options.xpath) {
-            res.xpath = relatedNode.xpath ?? '/';
+            res.xpath = relatedNode?.xpath ?? '/';
           }
           return res;
         });

--- a/test/core/reporters/helpers/process-aggregate.js
+++ b/test/core/reporters/helpers/process-aggregate.js
@@ -160,11 +160,18 @@ describe('helpers.processAggregate', function () {
   it('handles when a relatedNode is undefined', () => {
     // Add undefined to failed-rule
     results[1].violations[0].any[0].relatedNodes.unshift(undefined);
-    const resultObject = helpers.processAggregate(results, {});
+    const resultObject = helpers.processAggregate(results, {
+      xpath: true,
+      elementRef: true,
+      ancestry: true
+    });
     const { relatedNodes } = resultObject.violations[0].nodes[0].any[0];
     assert.deepEqual(relatedNodes[0], {
       html: 'Undefined',
-      target: ':root'
+      target: ':root',
+      ancestry: ':root',
+      xpath: '/',
+      element: null
     });
   });
 

--- a/test/core/reporters/helpers/process-aggregate.js
+++ b/test/core/reporters/helpers/process-aggregate.js
@@ -157,6 +157,17 @@ describe('helpers.processAggregate', function () {
     assert.isUndefined(ruleResult.nodes[0].node);
   });
 
+  it('handles when a relatedNode is undefined', () => {
+    // Add undefined to failed-rule
+    results[1].violations[0].any[0].relatedNodes.unshift(undefined);
+    const resultObject = helpers.processAggregate(results, {});
+    const { relatedNodes } = resultObject.violations[0].nodes[0].any[0];
+    assert.deepEqual(relatedNodes[0], {
+      html: 'Undefined',
+      target: ':root'
+    });
+  });
+
   describe('`options` argument', function () {
     describe('`resultTypes` option', function () {
       it('should reduce the unwanted result types to 1 in the `resultObject`', function () {


### PR DESCRIPTION
This PR fixes the reporter throwing an error when the relatedNode is undefined.

Instead the source is now reported as "Undefined"

Closes issues #3733 and #3627