### PR TITLE
feat(checks/label-content-name-mismatch): deprecate occuranceThreshold option in favor of occurrenceThreshold to fix typo

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -341,9 +341,9 @@ th</code></pre>
 
 ### label-content-name-mismatch
 
-| Option               | Default | Description                                                                                                                                                               |
-| -------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `pixelThreshold`     | `0.1`   | Percent of difference in pixel data or pixel width required to determine if a font is a ligature font. Ligature fonts are ignored when comparing the label to the content |
+| Option                | Default | Description                                                                                                                                                               |
+| --------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pixelThreshold`      | `0.1`   | Percent of difference in pixel data or pixel width required to determine if a font is a ligature font. Ligature fonts are ignored when comparing the label to the content |
 | `occurrenceThreshold` | `3`     | Number of times the font is encountered before auto-assigning the font as a ligature or not                                                                               |
 
 ### has-lang

--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -344,7 +344,7 @@ th</code></pre>
 | Option               | Default | Description                                                                                                                                                               |
 | -------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `pixelThreshold`     | `0.1`   | Percent of difference in pixel data or pixel width required to determine if a font is a ligature font. Ligature fonts are ignored when comparing the label to the content |
-| `occuranceThreshold` | `3`     | Number of times the font is encountered before auto-assigning the font as a ligature or not                                                                               |
+| `occurrenceThreshold` | `3`     | Number of times the font is encountered before auto-assigning the font as a ligature or not                                                                               |
 
 ### has-lang
 

--- a/lib/checks/label/label-content-name-mismatch-evaluate.js
+++ b/lib/checks/label/label-content-name-mismatch-evaluate.js
@@ -38,7 +38,7 @@ function curateString(str) {
 }
 
 function labelContentNameMismatchEvaluate(node, options, virtualNode) {
-  const { pixelThreshold, occuranceThreshold } = options || {};
+  const { pixelThreshold, occurrenceThreshold } = options || {};
 
   const accText = accessibleText(node).toLowerCase();
   if (isHumanInterpretable(accText) < 1) {
@@ -50,7 +50,7 @@ function labelContentNameMismatchEvaluate(node, options, virtualNode) {
       subtreeDescendant: true,
       ignoreIconLigature: true,
       pixelThreshold,
-      occuranceThreshold
+      occurrenceThreshold
     })
   ).toLowerCase();
   if (!visibleText) {

--- a/lib/checks/label/label-content-name-mismatch-evaluate.js
+++ b/lib/checks/label/label-content-name-mismatch-evaluate.js
@@ -38,7 +38,8 @@ function curateString(str) {
 }
 
 function labelContentNameMismatchEvaluate(node, options, virtualNode) {
-  const { pixelThreshold, occurrenceThreshold } = options || {};
+  const pixelThreshold = options?.pixelThreshold;
+  const occurrenceThreshold = options?.occurrenceThreshold ?? options.occuranceThreshold;
 
   const accText = accessibleText(node).toLowerCase();
   if (isHumanInterpretable(accText) < 1) {

--- a/lib/checks/label/label-content-name-mismatch-evaluate.js
+++ b/lib/checks/label/label-content-name-mismatch-evaluate.js
@@ -39,7 +39,7 @@ function curateString(str) {
 
 function labelContentNameMismatchEvaluate(node, options, virtualNode) {
   const pixelThreshold = options?.pixelThreshold;
-  const occurrenceThreshold = options?.occurrenceThreshold ?? options.occuranceThreshold;
+  const occurrenceThreshold = options?.occurrenceThreshold ?? options?.occuranceThreshold;
 
   const accText = accessibleText(node).toLowerCase();
   if (isHumanInterpretable(accText) < 1) {

--- a/lib/checks/label/label-content-name-mismatch.json
+++ b/lib/checks/label/label-content-name-mismatch.json
@@ -3,7 +3,7 @@
   "evaluate": "label-content-name-mismatch-evaluate",
   "options": {
     "pixelThreshold": 0.1,
-    "occuranceThreshold": 3
+    "occurrenceThreshold": 3
   },
   "metadata": {
     "impact": "serious",

--- a/lib/checks/mobile/css-orientation-lock-evaluate.js
+++ b/lib/checks/mobile/css-orientation-lock-evaluate.js
@@ -108,7 +108,7 @@ function cssOrientationLockEvaluate(node, options, virtualNode, context) {
     }
 
     /**
-     * get last match/occurence of a transformation function that can affect rotation along Z axis
+     * get last match/occurrence of a transformation function that can affect rotation along Z axis
      */
     const matches = transformStyle.match(
       /(rotate|rotateZ|rotate3d|matrix|matrix3d)\(([^)]+)\)(?!.*(rotate|rotateZ|rotate3d|matrix|matrix3d))/

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -104,7 +104,8 @@ function shouldIgnoreHidden(virtualNode, context) {
  * @return {Boolean}
  */
 function shouldIgnoreIconLigature(virtualNode, context) {
-  const { ignoreIconLigature, pixelThreshold, occurrenceThreshold } = context;
+  const { ignoreIconLigature, pixelThreshold } = context;
+  const occurrenceThreshold = context.occurrenceThreshold ?? context.occuranceThreshold
   if (virtualNode.props.nodeType !== 3 || !ignoreIconLigature) {
     return false;
   }

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -104,11 +104,11 @@ function shouldIgnoreHidden(virtualNode, context) {
  * @return {Boolean}
  */
 function shouldIgnoreIconLigature(virtualNode, context) {
-  const { ignoreIconLigature, pixelThreshold, occuranceThreshold } = context;
+  const { ignoreIconLigature, pixelThreshold, occurrenceThreshold } = context;
   if (virtualNode.props.nodeType !== 3 || !ignoreIconLigature) {
     return false;
   }
-  return isIconLigature(virtualNode, pixelThreshold, occuranceThreshold);
+  return isIconLigature(virtualNode, pixelThreshold, occurrenceThreshold);
 }
 
 /**

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -105,7 +105,7 @@ function shouldIgnoreHidden(virtualNode, context) {
  */
 function shouldIgnoreIconLigature(virtualNode, context) {
   const { ignoreIconLigature, pixelThreshold } = context;
-  const occurrenceThreshold = context.occurrenceThreshold ?? context.occuranceThreshold
+  const occurrenceThreshold = context.occurrenceThreshold ?? context.occuranceThreshold;
   if (virtualNode.props.nodeType !== 3 || !ignoreIconLigature) {
     return false;
   }

--- a/lib/commons/text/is-icon-ligature.js
+++ b/lib/commons/text/is-icon-ligature.js
@@ -9,14 +9,14 @@ import cache from '../../core/base/cache';
  * @memberof axe.commons.text
  * @instance
  * @param {VirtualNode} textVNode The virtual text node
- * @param {Number} occuranceThreshold Number of times the font is encountered before auto-assigning the font as a ligature or not
+ * @param {Number} occurrenceThreshold Number of times the font is encountered before auto-assigning the font as a ligature or not
  * @param {Number} differenceThreshold Percent of differences in pixel data or pixel width needed to determine if a font is a ligature font
  * @return {Boolean}
  */
 function isIconLigature(
   textVNode,
   differenceThreshold = 0.15,
-  occuranceThreshold = 3
+  occurrenceThreshold = 3
 ) {
   /**
    * Determine if the visible text is a ligature by comparing the
@@ -101,7 +101,7 @@ function isIconLigature(
 
   if (!fonts[fontFamily]) {
     fonts[fontFamily] = {
-      occurances: 0,
+      occurrences: 0,
       numLigatures: 0
     };
   }
@@ -109,9 +109,9 @@ function isIconLigature(
 
   // improve the performance by only comparing the image data of a font
   // a certain number of times
-  if (font.occurances >= occuranceThreshold) {
+  if (font.occurrences >= occurrenceThreshold) {
     // if the font has always been a ligature assume it's a ligature font
-    if (font.numLigatures / font.occurances === 1) {
+    if (font.numLigatures / font.occurrences === 1) {
       return true;
     }
     // inversely, if it's never been a ligature assume it's not a ligature font
@@ -124,7 +124,7 @@ function isIconLigature(
     // other times. in these cases we would need to always check the text
     // to know if it's an icon or not
   }
-  font.occurances++;
+  font.occurrences++;
 
   // 30px was chosen to account for common ligatures in normal fonts
   // such as fi, ff, ffi. If a ligature would add a single column of

--- a/test/commons/text/is-icon-ligature.js
+++ b/test/commons/text/is-icon-ligature.js
@@ -213,7 +213,7 @@ describe('text.isIconLigature', function () {
     );
   });
 
-  describe('occuranceThreshold', function () {
+  describe('occurrenceThreshold', function () {
     (fontApiSupport ? it : it.skip)(
       'should change the number of times a font is seen before returning',
       function () {


### PR DESCRIPTION
Fixes typos of the word "occurrence" throughout axe-core.
