### PR TITLE
feat(commons): deprecate flattenShadowColors in favor of flattenColors

### DIFF
--- a/lib/commons/color/flatten-shadow-colors.js
+++ b/lib/commons/color/flatten-shadow-colors.js
@@ -2,6 +2,7 @@ import Color from './color';
 
 /**
  * Combine the two given shadow colors according to alpha blending.
+ * @deprecated Use axe.commons.color.flattenColors instead
  * @method flattenColors
  * @memberof axe.commons.color.Color
  * @instance
@@ -9,7 +10,7 @@ import Color from './color';
  * @param {Color} bgColor Background color
  * @return {Color} Blended color
  */
-function flattenColors(fgColor, bgColor) {
+export default function flattenShadowColors(fgColor, bgColor) {
   var alpha = fgColor.alpha;
   var r = (1 - alpha) * bgColor.red + alpha * fgColor.red;
   var g = (1 - alpha) * bgColor.green + alpha * fgColor.green;
@@ -18,5 +19,3 @@ function flattenColors(fgColor, bgColor) {
 
   return new Color(r, g, b, a);
 }
-
-export default flattenColors;


### PR DESCRIPTION
As of PR #3791, the flattenShadowColors method is no longer in use.

Closes #3199
