### PR TITLE
fix: update `frameSelector` type to `CrossTreeSelector`

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -298,7 +298,7 @@ declare namespace axe {
   }
   type PartialResults = Array<PartialResult | null>;
   interface FrameContext {
-    frameSelector: UnlabelledFrameSelector;
+    frameSelector: CrossTreeSelector;
     frameContext: SerialContextObject;
   }
   interface Utils {


### PR DESCRIPTION
<< Describe the changes >>

Closes issue:
