### PR TITLE
chore: improve type definitions

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -81,12 +81,28 @@ declare namespace axe {
       };
   type ElementContext = Selector | SelectorList | ContextObject;
 
-  interface SerialContextObject {
+  type SerialSelector =
+    | BaseSelector
+    | LabelledShadowDomSelector
+    | LabelledFramesSelector;
+  type SerialSelectorList = Array<SerialSelector | FramesSelector>;
+
+  type SerialContextObject =
+    | {
+        include: SerialSelector | SerialSelectorList;
+        exclude?: SerialSelector | SerialSelectorList;
+      }
+    | {
+        exclude: SerialSelector | SerialSelectorList;
+        include?: SerialSelector | SerialSelectorList;
+      };
+
+  interface FrameContextObject {
     include: UnlabelledFrameSelector[];
     exclude: UnlabelledFrameSelector[];
   }
 
-  type RunCallback = (error: Error, results: AxeResults) => void;
+  type RunCallback<T = AxeResults> = (error: Error, results: T) => void;
 
   interface TestEngine {
     name: string;
@@ -298,8 +314,8 @@ declare namespace axe {
   }
   type PartialResults = Array<PartialResult | null>;
   interface FrameContext {
-    frameSelector: UnlabelledFrameSelector;
-    frameContext: SerialContextObject;
+    frameSelector: CrossTreeSelector;
+    frameContext: FrameContextObject;
   }
   interface Utils {
     getFrameContexts: (
@@ -339,19 +355,27 @@ declare namespace axe {
    * @param   {RunCallback}    callback Optional The function to invoke when analysis is complete.
    * @returns {Promise<AxeResults>|void} If the callback was not defined, axe will return a Promise.
    */
-  function run(context?: ElementContext): Promise<AxeResults>;
-  function run(options: RunOptions): Promise<AxeResults>;
-  function run(callback: (error: Error, results: AxeResults) => void): void;
-  function run(context: ElementContext, callback: RunCallback): void;
-  function run(options: RunOptions, callback: RunCallback): void;
-  function run(
+  function run<T = AxeResults>(context?: ElementContext): Promise<T>;
+  function run<T = AxeResults>(options: RunOptions): Promise<T>;
+  function run<T = AxeResults>(
+    callback: (error: Error, results: T) => void
+  ): void;
+  function run<T = AxeResults>(
+    context: ElementContext,
+    callback: RunCallback<T>
+  ): void;
+  function run<T = AxeResults>(
+    options: RunOptions,
+    callback: RunCallback<T>
+  ): void;
+  function run<T = AxeResults>(
     context: ElementContext,
     options: RunOptions
-  ): Promise<AxeResults>;
-  function run(
+  ): Promise<T>;
+  function run<T = AxeResults>(
     context: ElementContext,
     options: RunOptions,
-    callback: RunCallback
+    callback: RunCallback<T>
   ): void;
 
   /**

--- a/axe.d.ts
+++ b/axe.d.ts
@@ -85,7 +85,8 @@ declare namespace axe {
     | BaseSelector
     | LabelledShadowDomSelector
     | LabelledFramesSelector;
-  type SerialSelectorList = Array<SerialSelector | FramesSelector>;
+  type SerialFrameSelector = SerialSelector | FramesSelector;
+  type SerialSelectorList = Array<SerialFrameSelector>;
 
   type SerialContextObject =
     | {

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -73,6 +73,43 @@ axe.run(
     console.log(error || results);
   }
 );
+
+export async function frameContextTypes() {
+  let { frameContext, frameSelector } = axe.utils.getFrameContexts()[0];
+  await axe.run(frameContext);
+  await axe.runPartial(frameContext, {});
+  axe.utils.shadowSelect(frameSelector);
+}
+
+export async function serialContextType() {
+  // @ts-expect-error
+  const exclude: axe.SerialSelector = document.body;
+  // @ts-expect-error
+  const include: axe.SerialSelectorList = [document.body];
+
+  let serialContext: axe.SerialContextObject;
+  // @ts-expect-error
+  serialContext = {}; // At lease one of the props is required
+  serialContext = { include, exclude };
+  serialContext = { include };
+  serialContext = { exclude };
+  await axe.runPartial(serialContext, {});
+}
+
+export async function customReporters() {
+  type MyReport = { issues: any[] };
+  let report: MyReport;
+
+  report = await axe.run<MyReport>();
+  report = await axe.run<MyReport>(document);
+  report = await axe.run<MyReport>({});
+  report = await axe.run<MyReport>(document, {});
+  axe.run<MyReport>((_, results) => (report = results));
+  axe.run<MyReport>(document, (_, results) => (report = results));
+  axe.run<MyReport>({}, (_, results) => (report = results));
+  axe.run<MyReport>(document, {}, (_, results) => (report = results));
+}
+
 // additional configuration options
 axe.run(context, options, (error: Error, results: axe.AxeResults) => {
   console.log(error || results.passes.length);


### PR DESCRIPTION
Address some issues introduced in #3798

1. Separate SerialContextObject from FrameContextObject
2. Allow changing the reporter type
3. Fix issue with the frameSelector type -- This should have been a CrossTreeSelector

