### PR TITLE
ci: fix release script not installing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           echo "Branch: $Branch"
           git checkout -b "$Branch"
 
+          npm run ci
           npm run release
 
           git push origin "$Branch" --force


### PR DESCRIPTION
Release script doesn't work. I think because install isn't happening:
https://github.com/dequelabs/axe-core/actions/runs/3659002795/jobs/6184493234#step:5:41