### PR TITLE
fix(d.ts): add optional include to ContextObject

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -78,6 +78,7 @@ declare namespace axe {
       }
     | {
         exclude: Selector | SelectorList;
+        include?: Selector | SelectorList;
       };
   type ElementContext = Selector | SelectorList | ContextObject;
 

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -66,6 +66,23 @@ export async function runAsync() {
     ]
   });
 }
+
+let ctxt: axe.ContextObject;
+// @ts-expect-error
+ctxt = {};
+ctxt = { exclude: ['foo'] };
+ctxt.include = ['bard'];
+ctxt = { include: ['foo'] };
+ctxt.exclude = ['bar'];
+
+let serialContext: axe.SerialContextObject;
+// @ts-expect-error
+serialContext = {};
+serialContext = { exclude: ['foo'] };
+serialContext.include = ['bard'];
+serialContext = { include: ['foo'] };
+serialContext.exclude = ['bar'];
+
 axe.run(
   { exclude: [$fixture[0]] },
   {},


### PR DESCRIPTION
Address is minor "break" in the types caused by 4.6.0.