### PR TITLE
docs(api.md): update list of allowed tags

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -83,7 +83,7 @@ The `experimental`, `ACT` and `section508` tags are only added to some rules. Ea
 | `wcag2aaa`       | WCAG 2.0 Level AAA                                   |
 | `wcag21a`        | WCAG 2.1 Level A                                     |
 | `wcag21aa`       | WCAG 2.1 Level AA                                    |
-| `wcag21aaa`      | WCAG 2.1 Level AAA                                   |
+| `wcag22aa`       | WCAG 2.2 Level AA                                    |
 | `best-practice`  | Common accessibility best practices                  |
 | `wcag***`        | WCAG success criterion e.g. wcag111 maps to SC 1.1.1 |
 | `ACT`            | W3C approved Accessibility Conformance Testing rules |


### PR DESCRIPTION
We don't have any `wcag21aaa` rules and we recently introduced our first `wcag22aa` rule.