### PR TITLE
fix(color-contrast): fix color-contrast check when running in an extension

### DIFF
--- a/lib/commons/color/get-background-color.js
+++ b/lib/commons/color/get-background-color.js
@@ -141,6 +141,7 @@ function fullyEncompasses(node, rects) {
   rects = Array.isArray(rects) ? rects : [rects];
 
   const nodeRect = node.getBoundingClientRect();
+  let { right, bottom } = nodeRect;
   const style = window.getComputedStyle(node);
   const overflow = style.getPropertyValue('overflow');
 
@@ -148,18 +149,16 @@ function fullyEncompasses(node, rects) {
     ['scroll', 'auto'].includes(overflow) ||
     node instanceof window.HTMLHtmlElement
   ) {
-    nodeRect.width = node.scrollWidth;
-    nodeRect.height = node.scrollHeight;
-    nodeRect.right = nodeRect.left + nodeRect.width;
-    nodeRect.bottom = nodeRect.top + nodeRect.height;
+    right = nodeRect.left + node.scrollWidth;
+    bottom = nodeRect.top + node.scrollHeight;
   }
 
   return rects.every(rect => {
     return (
       rect.top >= nodeRect.top &&
-      rect.bottom <= nodeRect.bottom &&
+      rect.bottom <= bottom &&
       rect.left >= nodeRect.left &&
-      rect.right <= nodeRect.right
+      rect.right <= right
     );
   });
 }


### PR DESCRIPTION
`axe-core` was setting a read-only property, resulting in errors when run from an extension.

Closes: https://github.com/dequelabs/axe-core/issues/3837
