### PR TITLE
chore(release): v4.6.2

### DIFF
--- a/sri-history.json
+++ b/sri-history.json
@@ -332,7 +332,7 @@
     "axe.min.js": "sha256-8CV1yJR7ZBS/j8HkUf1OwOEib+WUH+QovSg8xOh9MVI="
   },
   "4.6.2": {
-    "axe.js": "sha256-s0nxznqMAZruIUcLdAZH24jit50KGy70xAjZn76l2qM=",
-    "axe.min.js": "sha256-EelQqyCeeroeVZcV89KAYgp8M/ZuqvmHQ+r67BBL5eA="
+    "axe.js": "sha256-6BCLF6TcLdHG7Ok3yyV7HOKF/Se1yJQgzgAiz3AnzX0=",
+    "axe.min.js": "sha256-US+MWxPC7r+aFzKfSCl+effrzN0Qoz4tS2wxlIpmsCM="
   }
 }


### PR DESCRIPTION
The sri-history sha was incorrect from our bot process. Re-releasing the release with a corrected sha.