### PR TITLE
ci: verify sri-history in release pr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
       - run: npm publish --tag=next
 
   # Release a "production" version
-  release:
+  verify_sri:
     <<: *defaults
     <<: *unix_box
     steps:
@@ -240,6 +240,15 @@ jobs:
       - <<: *restore_dependency_cache_unix
       - run: npm run build
       - run: npm run sri-validate
+
+  # Release a "production" version
+  release:
+    <<: *defaults
+    <<: *unix_box
+    steps:
+      - checkout
+      - <<: *set_npm_auth
+      - <<: *restore_dependency_cache_unix
       - run: .circleci/verify-release.sh
       - run: npm publish
 
@@ -317,6 +326,13 @@ workflows:
       - test_node:
           requires:
             - test_chrome
+      # Verify the sir history is correct
+      - verify_sri:
+          requires:
+            - dependencies_unix
+          filters:
+            branches:
+              only: /release-.*/
       # Hold for approval
       - hold:
           type: approval
@@ -328,6 +344,7 @@ workflows:
             - build_api_docs
             - test_rule_help_version
             - test_node
+            - verify_sri
           filters:
             branches:
               only:
@@ -357,6 +374,7 @@ workflows:
             - build_api_docs
             - test_rule_help_version
             - test_node
+            - verify_sri
             - hold
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ workflows:
       - test_node:
           requires:
             - test_chrome
-      # Verify the sir history is correct
+      # Verify the sri history is correct
       - verify_sri:
           requires:
             - dependencies_unix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,9 @@ workflows:
             - dependencies_unix
           filters:
             branches:
-              only: /release-.*/
+              only:
+                - /release-*/
+                - master
       # Hold for approval
       - hold:
           type: approval


### PR DESCRIPTION
In order to help prevent the release bot from releasing a bad sri sha (cause still unknown), we'll verify the sha in the circle job [against branches that start with `release-`](https://circleci.com/docs/configuration-reference/#jobfilters). That way we should be able to prevent merging bad shas into master.