### PR TITLE
tests: refactor is-focusable tests

### DIFF
--- a/lib/commons/dom/index.js
+++ b/lib/commons/dom/index.js
@@ -7,6 +7,7 @@ export { default as findElmsInContext } from './find-elms-in-context';
 export { default as findUpVirtual } from './find-up-virtual';
 export { default as findUp } from './find-up';
 export { default as findNearbyElms } from './find-nearby-elms';
+export { default as focusDisabled } from './focus-disabled';
 export { default as getComposedParent } from './get-composed-parent';
 export { default as getElementByReference } from './get-element-by-reference';
 export { default as getElementCoordinates } from './get-element-coordinates';

--- a/test/commons/dom/focus-disabled.js
+++ b/test/commons/dom/focus-disabled.js
@@ -1,0 +1,66 @@
+describe('dom.focus-disabled', () => {
+  const focusDisabled = axe.commons.dom.focusDisabled;
+  const { queryFixture, queryShadowFixture } = axe.testUtils;
+
+  it('returns false for non-disabled element', () => {
+    const vNode = queryFixture('<span id="target"></span>');
+
+    assert.isFalse(focusDisabled(vNode));
+  });
+
+  it('returns true for disabled element which is allowed to be disabled', () => {
+    const vNode = queryFixture('<button id="target" disabled></button>');
+
+    assert.isTrue(focusDisabled(vNode));
+  });
+
+  it('returns false for disabled element which is not allowed to be disabled', () => {
+    const vNode = queryFixture('<span id="target" disabled></span>');
+
+    assert.isFalse(focusDisabled(vNode));
+  });
+
+  it('returns true if parent fieldset is disabled', () => {
+    const vNode = queryFixture(
+      '<fieldset disabled><input id="target"/></fieldset>'
+    );
+
+    assert.isTrue(focusDisabled(vNode));
+  });
+
+  it('returns false if element is inside a legend inside a disabled fieldset', () => {
+    const vNode = queryFixture(
+      '<fieldset disabled><legend><input id="target"/></legend></fieldset>'
+    );
+
+    assert.isFalse(focusDisabled(vNode));
+  });
+
+  it('returns false for disabled fieldset outside shadow tree', () => {
+    const vNode = queryShadowFixture(
+      '<fieldset disabled><div id="shadow"></div></fieldset>',
+      '<input id="target"/>'
+    );
+
+    assert.isFalse(focusDisabled(vNode));
+  });
+
+  it('returns true if element is hidden for everyone', () => {
+    const vNode = queryFixture('<button id="target" hidden></button>');
+
+    assert.isTrue(focusDisabled(vNode));
+  });
+
+  describe('SerialVirtualNode', () => {
+    it('returns false if element is hidden for everyone', () => {
+      const vNode = new axe.SerialVirtualNode({
+        nodeName: 'button',
+        attributes: {
+          hidden: true
+        }
+      });
+
+      assert.isFalse(focusDisabled(vNode));
+    });
+  });
+});

--- a/test/commons/dom/inserted-into-focus-order.js
+++ b/test/commons/dom/inserted-into-focus-order.js
@@ -1,0 +1,211 @@
+describe('dom.insertedIntoFocusOrder', () => {
+  const fixture = document.getElementById('fixture');
+  const { fixtureSetup } = axe.testUtils;
+  const insertedIntoFocusOrder = axe.commons.dom.insertedIntoFocusOrder;
+
+  function hideByClipping(el) {
+    el.style.cssText =
+      'position: absolute !important;' +
+      ' clip: rect(0px 0px 0px 0px); /* IE6, IE7 */' +
+      ' clip: rect(0px, 0px, 0px, 0px);';
+  }
+
+  function hideByMovingOffScreen(el) {
+    el.style.cssText =
+      'position:absolute;' +
+      ' left:-10000px;' +
+      ' top:auto;' +
+      ' width:1px;' +
+      ' height:1px;' +
+      ' overflow:hidden;';
+  }
+
+  it('should return true for span with tabindex 0', () => {
+    fixtureSetup('<span id="spanTabindex0" tabindex="0"></span>');
+    const node = fixture.querySelector('#spanTabindex0');
+
+    assert.isTrue(insertedIntoFocusOrder(node));
+  });
+
+  it('should return true for clipped span with tabindex 0', () => {
+    fixtureSetup('<span id="clippedSpanTabindex0" tabindex="0"></span>');
+    const node = fixture.querySelector('#clippedSpanTabindex0');
+    hideByClipping(node);
+
+    assert.isTrue(insertedIntoFocusOrder(node));
+  });
+
+  it('should return true for off screen span with tabindex 0', () => {
+    fixtureSetup('<span id="offScreenSpanTabindex0" tabindex="0"></span>');
+    const node = fixture.querySelector('#offScreenSpanTabindex0');
+    hideByMovingOffScreen(node);
+
+    assert.isTrue(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for span with negative tabindex', () => {
+    fixtureSetup('<span id="spanNegativeTabindex" tabindex="-1"></span>');
+    const node = fixture.querySelector('#spanNegativeTabindex');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for native button with tabindex 0', () => {
+    fixtureSetup('<button id="nativeButtonTabindex0" tabindex="0"></button>');
+    const node = fixture.querySelector('#nativeButtonTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for native button with tabindex implicitly 0', () => {
+    fixtureSetup('<button id="nativeButtonTabindexImplicitly0"></button>');
+    const node = fixture.querySelector('#nativeButtonTabindexImplicitly0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for anchor with href and positive tabindex', () => {
+    fixtureSetup(
+      '<a id="anchorWithHrefAndPositiveTabindex" href="javascript:void(0)" tabindex="1"></a>'
+    );
+    const node = fixture.querySelector('#anchorWithHrefAndPositiveTabindex');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for input with tabindex 0', () => {
+    fixtureSetup('<input id="inputWithTabindex0" tabindex="0">');
+    const node = fixture.querySelector('#inputWithTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for off screen native button with tabindex 0', () => {
+    fixtureSetup(
+      '<button id="offScreenNativeButtonTabindex0" tabindex="0"></button>'
+    );
+    const node = fixture.querySelector('#offScreenNativeButtonTabindex0');
+    hideByMovingOffScreen(node);
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for off screen anchor with href and tabindex 1', () => {
+    fixtureSetup(
+      '<a id="offScreenAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
+    );
+    const node = fixture.querySelector('#offScreenAnchorWithHrefTabindex1');
+    hideByMovingOffScreen(node);
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for off screen input with tabindex 0', () => {
+    fixtureSetup('<input id="offScreenInputWithTabindex0" tabindex="0">');
+    const node = fixture.querySelector('#offScreenInputWithTabindex0');
+    hideByMovingOffScreen(node);
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for clipped native button with tabindex 0', () => {
+    fixtureSetup(
+      '<button id="clippedNativeButtonTabindex0" tabindex="0"></button>'
+    );
+    const node = fixture.querySelector('#clippedNativeButtonTabindex0');
+    hideByClipping(node);
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for display none native button with tabindex 0', () => {
+    fixtureSetup(
+      '<button id="displayNoneNativeButtonTabindex0" tabindex="0"></button>'
+    );
+    const node = fixture.querySelector('#displayNoneNativeButtonTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for clipped anchor with href and tabindex 1', () => {
+    fixtureSetup(
+      '<a id="clippedAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
+    );
+    const node = fixture.querySelector('#clippedAnchorWithHrefTabindex1');
+    hideByClipping(node);
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for display none anchor with href and tabindex 1', () => {
+    fixtureSetup(
+      '<a id="displayNoneAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
+    );
+    const node = fixture.querySelector('#displayNoneAnchorWithHrefTabindex1');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for clipped input with tabindex 0', () => {
+    fixtureSetup('<input id="clippedInputWithTabindex0" tabindex="0">');
+    const node = fixture.querySelector('#clippedInputWithTabindex0');
+    hideByClipping(node);
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for display none input with tabindex 0', () => {
+    fixtureSetup('<input id="displayNoneInputWithTabindex0" tabindex="0">');
+    const node = fixture.querySelector('#displayNoneInputWithTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for hidden native button with tabindex 0', () => {
+    fixtureSetup(
+      '<button id="hiddenNativeButtonTabindex0" tabindex="0"></button>'
+    );
+    const node = fixture.querySelector('#hiddenNativeButtonTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for hidden anchor with href and tabindex 1', () => {
+    fixtureSetup(
+      '<a id="hiddenAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
+    );
+    const node = fixture.querySelector('#hiddenAnchorWithHrefTabindex1');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for hidden input with tabindex 0', () => {
+    fixtureSetup('<input id="hiddenInputWithTabindex0" tabindex="0">');
+    const node = fixture.querySelector('#hiddenInputWithTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for disabled native button with tabindex 0', () => {
+    fixtureSetup(
+      '<button id="disabledNativeButtonTabindex0" tabindex="0" disabled></button>'
+    );
+    const node = fixture.querySelector('#disabledNativeButtonTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for disabled input with tabindex 0', () => {
+    fixtureSetup('<input id="disabledInputTabindex0" tabindex="0" disabled>');
+    const node = fixture.querySelector('#disabledInputTabindex0');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+
+  it('should return false for an invalid tabindex', () => {
+    fixtureSetup('<span id="spanTabindexInvalid" tabindex="invalid"></span>');
+    const node = fixture.querySelector('#spanTabindexInvalid');
+
+    assert.isFalse(insertedIntoFocusOrder(node));
+  });
+});

--- a/test/commons/dom/is-focusable.js
+++ b/test/commons/dom/is-focusable.js
@@ -1,665 +1,167 @@
-describe('is-focusable', function () {
-  function hideByClipping(el) {
-    el.style.cssText =
-      'position: absolute !important;' +
-      ' clip: rect(0px 0px 0px 0px); /* IE6, IE7 */' +
-      ' clip: rect(0px, 0px, 0px, 0px);';
-  }
+describe('dom.isFocusable', () => {
+  const flatTreeSetup = axe.testUtils.flatTreeSetup;
+  const fixture = document.getElementById('fixture');
 
-  function hideByMovingOffScreen(el) {
-    el.style.cssText =
-      'position:absolute;' +
-      ' left:-10000px;' +
-      ' top:auto;' +
-      ' width:1px;' +
-      ' height:1px;' +
-      ' overflow:hidden;';
-  }
+  it('should return true for visible, enabled textareas', () => {
+    fixture.innerHTML = '<textarea id="target"></textarea>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-  var fixtureSetup = axe.testUtils.fixtureSetup;
-  var flatTreeSetup = axe.testUtils.flatTreeSetup;
-
-  describe('dom.isFocusable', function () {
-    'use strict';
-
-    var fixture = document.getElementById('fixture');
-
-    afterEach(function () {
-      document.getElementById('fixture').innerHTML = '';
-    });
-
-    it('should return true for visible, enabled textareas', function () {
-      fixture.innerHTML = '<textarea id="target"></textarea>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for visible, enabled selects', function () {
-      fixture.innerHTML = '<select id="target"></select>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for visible, enabled buttons', function () {
-      fixture.innerHTML = '<button id="target"></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for visible, enabled, non-hidden inputs', function () {
-      fixture.innerHTML = '<input type="text" id="target">';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for non-element nodes', function () {
-      fixture.innerHTML = '<span id="target">Hello World</span>';
-      flatTreeSetup(fixture);
-      var el = document.getElementById('target').childNodes[0];
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for disabled elements', function () {
-      fixture.innerHTML = '<input type="text" id="target" disabled>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for hidden inputs', function () {
-      fixture.innerHTML = '<input type="hidden" id="target">';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for hidden inputs with tabindex', function () {
-      fixture.innerHTML = '<input type="hidden" tabindex="1" id="target">';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for hidden buttons with tabindex', function () {
-      fixture.innerHTML =
-        '<button style="visibility:hidden" tabindex="0" id="target"></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for disabled buttons with tabindex', function () {
-      fixture.innerHTML = '<button tabindex="0" id="target" disabled></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for non-visible elements', function () {
-      fixture.innerHTML =
-        '<input type="text" id="target" style="display: none">';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for an anchor with an href', function () {
-      fixture.innerHTML = '<a href="something.html" id="target"></a>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for an anchor with no href', function () {
-      fixture.innerHTML = '<a name="anchor" id="target"></a>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for a div with a tabindex with spaces', function () {
-      fixture.innerHTML = '<div id="target" tabindex="	  0   "></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for a div with a tabindex', function () {
-      fixture.innerHTML = '<div id="target" tabindex="0"></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for a div with a non-numeric tabindex', function () {
-      fixture.innerHTML = '<div id="target" tabindex="x"></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for a summary element', function () {
-      fixture.innerHTML =
-        '<details><summary id="target">Summary</summary><p>Detail</p></details>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for a details element without a summary element', function () {
-      fixture.innerHTML = '<details id="target"><p>Detail</p></details>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for a details element with a summary element', function () {
-      fixture.innerHTML =
-        '<details id="target"><summary>Summary</summary><p>Detail</p></details>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for a div with no tabindex', function () {
-      fixture.innerHTML = '<div id="target"></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
   });
 
-  describe('dom.isNativelyFocusable', function () {
-    'use strict';
-
-    var fixture = document.getElementById('fixture');
-
-    afterEach(function () {
-      document.getElementById('fixture').innerHTML = '';
-    });
-
-    it('should return true for buttons with redundant tabindex', function () {
-      fixture.innerHTML = '<button tabindex="0" id="target"></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for buttons with tabindex -1', function () {
-      fixture.innerHTML = '<button tabindex="-1" id="target"></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for visible, enabled textareas', function () {
-      fixture.innerHTML = '<textarea id="target"></textarea>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for visible, enabled selects', function () {
-      fixture.innerHTML = '<select id="target"></select>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for visible, enabled buttons', function () {
-      fixture.innerHTML = '<button id="target"></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for visible, enabled, non-hidden inputs', function () {
-      fixture.innerHTML = '<input type="text" id="target">';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for disabled elements', function () {
-      fixture.innerHTML = '<input type="text" id="target" disabled>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for hidden inputs', function () {
-      fixture.innerHTML = '<input type="hidden" id="target">';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for elements hidden with display:none', function () {
-      fixture.innerHTML =
-        '<button id="target" style="display: none">button</button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for elements hidden with visibility:hidden', function () {
-      fixture.innerHTML =
-        '<button id="target" style="visibility: hidden">button</button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for elements collapsed with visibility:collapse', function () {
-      fixture.innerHTML =
-        '<button id="target" style="visibility: collapse">button</button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for clipped elements', function () {
-      fixture.innerHTML = '<button id="target">button</button>';
-      var el = document.getElementById('target');
-      hideByClipping(el);
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for elements positioned off screen', function () {
-      fixture.innerHTML = '<button id="target">button</button>';
-      var el = document.getElementById('target');
-      hideByMovingOffScreen(el);
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for elements hidden with display:none on an ancestor', function () {
-      fixture.innerHTML =
-        '<div id="parent" style="display:none"><button id="target">button</button></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for elements hidden with visibility:hidden on an ancestor', function () {
-      fixture.innerHTML =
-        '<div id="parent" style="visibility: hidden"><button id="target">button</button></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for elements collapsed with visibility:collapse on an ancestor', function () {
-      fixture.innerHTML =
-        '<div id="parent" style="visibility: collapse"><button id="target">button</button></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for elements with a clipped ancestor', function () {
-      fixture.innerHTML =
-        '<div id="parent"><button id="target">button</button></div>';
-      hideByClipping(document.getElementById('parent'));
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for elements off-screened by an ancestor', function () {
-      fixture.innerHTML =
-        '<div id="parent"><button id="target">button</button></div>';
-      hideByMovingOffScreen(document.getElementById('parent'));
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for hidden inputs with tabindex', function () {
-      fixture.innerHTML = '<input type="hidden" tabindex="1" id="target">';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for disabled inputs with tabindex', function () {
-      fixture.innerHTML = '<input tabindex="1" id="target" disabled>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for hidden buttons with tabindex', function () {
-      fixture.innerHTML =
-        '<button style="visibility:hidden" tabindex="0" id="target"></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for disabled buttons with tabindex', function () {
-      fixture.innerHTML = '<button tabindex="0" id="target" disabled></button>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for an anchor with an href', function () {
-      fixture.innerHTML = '<a href="something.html" id="target"></a>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for an anchor with no href', function () {
-      fixture.innerHTML = '<a name="anchor" id="target"></a>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for a div with a tabindex with spaces', function () {
-      fixture.innerHTML = '<div id="target" tabindex="0"></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for a div with a tabindex', function () {
-      fixture.innerHTML = '<div id="target" tabindex="0"></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return false for a div with a non-numeric tabindex', function () {
-      fixture.innerHTML = '<div id="target" tabindex="x"></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
-
-    it('should return true for a summary element', function () {
-      fixture.innerHTML =
-        '<details><summary id="target">Summary</summary><p>Detail</p></details>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return true for a details element without a summary element', function () {
-      fixture.innerHTML = '<details id="target"><p>Detail</p></details>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isTrue(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for a details element with a summary element', function () {
-      fixture.innerHTML =
-        '<details id="target"><summary>Summary</summary><p>Detail</p></details>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isFocusable(el));
-    });
-
-    it('should return false for a div with no tabindex', function () {
-      fixture.innerHTML = '<div id="target"></div>';
-      var el = document.getElementById('target');
-      flatTreeSetup(fixture);
-
-      assert.isFalse(axe.commons.dom.isNativelyFocusable(el));
-    });
+  it('should return true for visible, enabled selects', () => {
+    fixture.innerHTML = '<select id="target"></select>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(axe.commons.dom.isFocusable(el));
   });
 
-  describe('dom.insertedIntoFocusOrder', function () {
-    var fixture = document.getElementById('fixture');
+  it('should return true for visible, enabled buttons', () => {
+    fixture.innerHTML = '<button id="target"></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-    beforeEach(function () {
-      fixture.innerHTML = '';
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return true for span with tabindex 0', function () {
-      fixtureSetup('<span id="spanTabindex0" tabindex="0"></span>');
-      var node = fixture.querySelector('#spanTabindex0');
+  it('should return true for visible, enabled, non-hidden inputs', () => {
+    fixture.innerHTML = '<input type="text" id="target">';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isTrue(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return true for clipped span with tabindex 0', function () {
-      fixtureSetup('<span id="clippedSpanTabindex0" tabindex="0"></span>');
-      var node = fixture.querySelector('#clippedSpanTabindex0');
-      hideByClipping(node);
+  it('should return false for non-element nodes', () => {
+    fixture.innerHTML = '<span id="target">Hello World</span>';
+    flatTreeSetup(fixture);
+    const el = document.getElementById('target').childNodes[0];
 
-      assert.isTrue(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return true for off screen span with tabindex 0', function () {
-      fixtureSetup('<span id="offScreenSpanTabindex0" tabindex="0"></span>');
-      var node = fixture.querySelector('#offScreenSpanTabindex0');
-      hideByMovingOffScreen(node);
+  it('should return false for disabled elements', () => {
+    fixture.innerHTML = '<input type="text" id="target" disabled>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isTrue(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for span with negative tabindex', function () {
-      fixtureSetup('<span id="spanNegativeTabindex" tabindex="-1"></span>');
-      var node = fixture.querySelector('#spanNegativeTabindex');
+  it('should return false for hidden inputs', () => {
+    fixture.innerHTML = '<input type="hidden" id="target">';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for native button with tabindex 0', function () {
-      fixtureSetup('<button id="nativeButtonTabindex0" tabindex="0"></button>');
-      var node = fixture.querySelector('#nativeButtonTabindex0');
+  it('should return false for hidden inputs with tabindex', () => {
+    fixture.innerHTML = '<input type="hidden" tabindex="1" id="target">';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for native button with tabindex implicitly 0', function () {
-      fixtureSetup('<button id="nativeButtonTabindexImplicitly0"></button>');
-      var node = fixture.querySelector('#nativeButtonTabindexImplicitly0');
+  it('should return false for hidden buttons with tabindex', () => {
+    fixture.innerHTML =
+      '<button style="visibility:hidden" tabindex="0" id="target"></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for anchor with href and positive tabindex', function () {
-      fixtureSetup(
-        '<a id="anchorWithHrefAndPositiveTabindex" href="javascript:void(0)" tabindex="1"></a>'
-      );
-      var node = fixture.querySelector('#anchorWithHrefAndPositiveTabindex');
+  it('should return false for disabled buttons with tabindex', () => {
+    fixture.innerHTML = '<button tabindex="0" id="target" disabled></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for input with tabindex 0', function () {
-      fixtureSetup('<input id="inputWithTabindex0" tabindex="0">');
-      var node = fixture.querySelector('#inputWithTabindex0');
+  it('should return false for non-visible elements', () => {
+    fixture.innerHTML = '<input type="text" id="target" style="display: none">';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for off screen native button with tabindex 0', function () {
-      fixtureSetup(
-        '<button id="offScreenNativeButtonTabindex0" tabindex="0"></button>'
-      );
-      var node = fixture.querySelector('#offScreenNativeButtonTabindex0');
-      hideByMovingOffScreen(node);
+  it('should return true for an anchor with an href', () => {
+    fixture.innerHTML = '<a href="something.html" id="target"></a>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for off screen anchor with href and tabindex 1', function () {
-      fixtureSetup(
-        '<a id="offScreenAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
-      );
-      var node = fixture.querySelector('#offScreenAnchorWithHrefTabindex1');
-      hideByMovingOffScreen(node);
+  it('should return false for an anchor with no href', () => {
+    fixture.innerHTML = '<a name="anchor" id="target"></a>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for off screen input with tabindex 0', function () {
-      fixtureSetup('<input id="offScreenInputWithTabindex0" tabindex="0">');
-      var node = fixture.querySelector('#offScreenInputWithTabindex0');
-      hideByMovingOffScreen(node);
+  it('should return true for a div with a tabindex with spaces', () => {
+    fixture.innerHTML = '<div id="target" tabindex="	  0   "></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for clipped native button with tabindex 0', function () {
-      fixtureSetup(
-        '<button id="clippedNativeButtonTabindex0" tabindex="0"></button>'
-      );
-      var node = fixture.querySelector('#clippedNativeButtonTabindex0');
-      hideByClipping(node);
+  it('should return true for a div with a tabindex', () => {
+    fixture.innerHTML = '<div id="target" tabindex="0"></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for display none native button with tabindex 0', function () {
-      fixtureSetup(
-        '<button id="displayNoneNativeButtonTabindex0" tabindex="0"></button>'
-      );
-      var node = fixture.querySelector('#displayNoneNativeButtonTabindex0');
+  it('should return false for a div with a non-numeric tabindex', () => {
+    fixture.innerHTML = '<div id="target" tabindex="x"></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for clipped anchor with href and tabindex 1', function () {
-      fixtureSetup(
-        '<a id="clippedAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
-      );
-      var node = fixture.querySelector('#clippedAnchorWithHrefTabindex1');
-      hideByClipping(node);
+  it('should return true for a summary element', () => {
+    fixture.innerHTML =
+      '<details><summary id="target">Summary</summary><p>Detail</p></details>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for display none anchor with href and tabindex 1', function () {
-      fixtureSetup(
-        '<a id="displayNoneAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
-      );
-      var node = fixture.querySelector('#displayNoneAnchorWithHrefTabindex1');
+  it('should return true for a details element without a summary element', () => {
+    fixture.innerHTML = '<details id="target"><p>Detail</p></details>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for clipped input with tabindex 0', function () {
-      fixtureSetup('<input id="clippedInputWithTabindex0" tabindex="0">');
-      var node = fixture.querySelector('#clippedInputWithTabindex0');
-      hideByClipping(node);
+  it('should return false for a details element with a summary element', () => {
+    fixture.innerHTML =
+      '<details id="target"><summary>Summary</summary><p>Detail</p></details>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
 
-    it('should return false for display none input with tabindex 0', function () {
-      fixtureSetup('<input id="displayNoneInputWithTabindex0" tabindex="0">');
-      var node = fixture.querySelector('#displayNoneInputWithTabindex0');
+  it('should return false for a div with no tabindex', () => {
+    fixture.innerHTML = '<div id="target"></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
 
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
-
-    it('should return false for hidden native button with tabindex 0', function () {
-      fixtureSetup(
-        '<button id="hiddenNativeButtonTabindex0" tabindex="0"></button>'
-      );
-      var node = fixture.querySelector('#hiddenNativeButtonTabindex0');
-
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
-
-    it('should return false for hidden anchor with href and tabindex 1', function () {
-      fixtureSetup(
-        '<a id="hiddenAnchorWithHrefTabindex1" href="javascript:void(0)" tabindex="1"></a>'
-      );
-      var node = fixture.querySelector('#hiddenAnchorWithHrefTabindex1');
-
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
-
-    it('should return false for hidden input with tabindex 0', function () {
-      fixtureSetup('<input id="hiddenInputWithTabindex0" tabindex="0">');
-      var node = fixture.querySelector('#hiddenInputWithTabindex0');
-
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
-
-    it('should return false for disabled native button with tabindex 0', function () {
-      fixtureSetup(
-        '<button id="disabledNativeButtonTabindex0" tabindex="0" disabled></button>'
-      );
-      var node = fixture.querySelector('#disabledNativeButtonTabindex0');
-
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
-
-    it('should return false for disabled input with tabindex 0', function () {
-      fixtureSetup('<input id="disabledInputTabindex0" tabindex="0" disabled>');
-      var node = fixture.querySelector('#disabledInputTabindex0');
-
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
-
-    it('should return false for an invalid tabindex', function () {
-      fixtureSetup('<span id="spanTabindexInvalid" tabindex="invalid"></span>');
-      var node = fixture.querySelector('#spanTabindexInvalid');
-
-      assert.isFalse(axe.commons.dom.insertedIntoFocusOrder(node));
-    });
+    assert.isFalse(axe.commons.dom.isFocusable(el));
   });
 });

--- a/test/commons/dom/is-natively-focusable.js
+++ b/test/commons/dom/is-natively-focusable.js
@@ -1,0 +1,285 @@
+describe('dom.isNativelyFocusable', () => {
+  const fixture = document.getElementById('fixture');
+  const isNativelyFocusable = axe.commons.dom.isNativelyFocusable;
+  const { flatTreeSetup } = axe.testUtils;
+
+  function hideByClipping(el) {
+    el.style.cssText =
+      'position: absolute !important;' +
+      ' clip: rect(0px 0px 0px 0px); /* IE6, IE7 */' +
+      ' clip: rect(0px, 0px, 0px, 0px);';
+  }
+
+  function hideByMovingOffScreen(el) {
+    el.style.cssText =
+      'position:absolute;' +
+      ' left:-10000px;' +
+      ' top:auto;' +
+      ' width:1px;' +
+      ' height:1px;' +
+      ' overflow:hidden;';
+  }
+
+  it('should return true for buttons with redundant tabindex', () => {
+    fixture.innerHTML = '<button tabindex="0" id="target"></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return true for buttons with tabindex -1', () => {
+    fixture.innerHTML = '<button tabindex="-1" id="target"></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return true for visible, enabled textareas', () => {
+    fixture.innerHTML = '<textarea id="target"></textarea>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return true for visible, enabled selects', () => {
+    fixture.innerHTML = '<select id="target"></select>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return true for visible, enabled buttons', () => {
+    fixture.innerHTML = '<button id="target"></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return true for visible, enabled, non-hidden inputs', () => {
+    fixture.innerHTML = '<input type="text" id="target">';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return false for disabled elements', () => {
+    fixture.innerHTML = '<input type="text" id="target" disabled>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for hidden inputs', () => {
+    fixture.innerHTML = '<input type="hidden" id="target">';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for elements hidden with display:none', () => {
+    fixture.innerHTML =
+      '<button id="target" style="display: none">button</button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for elements hidden with visibility:hidden', () => {
+    fixture.innerHTML =
+      '<button id="target" style="visibility: hidden">button</button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for elements collapsed with visibility:collapse', () => {
+    fixture.innerHTML =
+      '<button id="target" style="visibility: collapse">button</button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return true for clipped elements', () => {
+    fixture.innerHTML = '<button id="target">button</button>';
+    const el = document.getElementById('target');
+    hideByClipping(el);
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return true for elements positioned off screen', () => {
+    fixture.innerHTML = '<button id="target">button</button>';
+    const el = document.getElementById('target');
+    hideByMovingOffScreen(el);
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return false for elements hidden with display:none on an ancestor', () => {
+    fixture.innerHTML =
+      '<div id="parent" style="display:none"><button id="target">button</button></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for elements hidden with visibility:hidden on an ancestor', () => {
+    fixture.innerHTML =
+      '<div id="parent" style="visibility: hidden"><button id="target">button</button></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for elements collapsed with visibility:collapse on an ancestor', () => {
+    fixture.innerHTML =
+      '<div id="parent" style="visibility: collapse"><button id="target">button</button></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return true for elements with a clipped ancestor', () => {
+    fixture.innerHTML =
+      '<div id="parent"><button id="target">button</button></div>';
+    hideByClipping(document.getElementById('parent'));
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return true for elements off-screened by an ancestor', () => {
+    fixture.innerHTML =
+      '<div id="parent"><button id="target">button</button></div>';
+    hideByMovingOffScreen(document.getElementById('parent'));
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return false for hidden inputs with tabindex', () => {
+    fixture.innerHTML = '<input type="hidden" tabindex="1" id="target">';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
+
+  it('should return false for disabled inputs with tabindex', () => {
+    fixture.innerHTML = '<input tabindex="1" id="target" disabled>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
+
+  it('should return false for hidden buttons with tabindex', () => {
+    fixture.innerHTML =
+      '<button style="visibility:hidden" tabindex="0" id="target"></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
+
+  it('should return false for disabled buttons with tabindex', () => {
+    fixture.innerHTML = '<button tabindex="0" id="target" disabled></button>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
+
+  it('should return true for an anchor with an href', () => {
+    fixture.innerHTML = '<a href="something.html" id="target"></a>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(isNativelyFocusable(el));
+  });
+
+  it('should return false for an anchor with no href', () => {
+    fixture.innerHTML = '<a name="anchor" id="target"></a>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for a div with a tabindex with spaces', () => {
+    fixture.innerHTML = '<div id="target" tabindex="0"></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for a div with a tabindex', () => {
+    fixture.innerHTML = '<div id="target" tabindex="0"></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return false for a div with a non-numeric tabindex', () => {
+    fixture.innerHTML = '<div id="target" tabindex="x"></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+
+  it('should return true for a summary element', () => {
+    fixture.innerHTML =
+      '<details><summary id="target">Summary</summary><p>Detail</p></details>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
+
+  it('should return true for a details element without a summary element', () => {
+    fixture.innerHTML = '<details id="target"><p>Detail</p></details>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isTrue(axe.commons.dom.isFocusable(el));
+  });
+
+  it('should return false for a details element with a summary element', () => {
+    fixture.innerHTML =
+      '<details id="target"><summary>Summary</summary><p>Detail</p></details>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
+
+  it('should return false for a div with no tabindex', () => {
+    fixture.innerHTML = '<div id="target"></div>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(isNativelyFocusable(el));
+  });
+});


### PR DESCRIPTION
Was starting to work on allowing the `inert` attribute to determine when things were focusable and noticed that there were no test files for `is-natively-focusable`, `inserted-into-focus-order` and `focus-disabled`. Turns out most of the tests were all part of the `is-focusable` test code so split them out into their own files. `focus-disabled` didn't have any dedicated tests even inside `is-focusable`, so had to add a bunch. This also meant that I needed to add `focus-disabled` to the `commons` object so I could access it like everything else.

Changes made:
- copied and pasted the `dom.isNativelyFocusable` and `dom.insertedIntoFocusOrder` describes into their own files (with updated es6 syntax for arrow functions and `const` instead of `var)
- created `focus-disabled` tests (all new). Will need verify they cover all cases
- added `focus-disabled` to the `commons` functions