### PR TITLE
ci: checkout before installing chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-browser-tools
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,8 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-browser-tools
       - <<: *restore_dependency_cache_unix
       - <<: *restore_build
       - run: npm run test -- --browsers Firefox
@@ -108,8 +108,8 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-browser-tools
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -120,8 +120,8 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-browser-tools
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -132,8 +132,8 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-browser-tools
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -144,8 +144,8 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-browser-tools
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -156,8 +156,8 @@ jobs:
     <<: *defaults
     <<: *unix_box
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-browser-tools
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build


### PR DESCRIPTION
For some reason if you don't run the `checkout` step before installing browser tools it fails due to `license.Chromedriver` existing in `~/axe-core` 
Ref: https://app.circleci.com/pipelines/github/dequelabs/axe-core/4791/workflows/1fd9a6d9-2420-4129-b164-eb085503f53d/jobs/53640

