### PR TITLE
test: prevent setting read-only properties on DOMRect

### DIFF
--- a/test/testutils.js
+++ b/test/testutils.js
@@ -562,6 +562,18 @@ testUtils.getCheckEvaluate = function getCheckEvaluate(checkId, testOptions) {
 axe.testUtils = testUtils;
 
 if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
+  // prevent setting read-only properties
+  // @see https://github.com/dequelabs/axe-core/issues/3837
+  const readonlyRect = new DOMRectReadOnly();
+  const proto = Object.getPrototypeOf(readonlyRect);
+  ['left', 'right', 'top', 'bottom'].forEach(prop => {
+    Object.defineProperty(proto, prop, {
+      set(value) {
+        throw new TypeError(`setting getter-only property "${prop}"`);
+      }
+    });
+  });
+
   beforeEach(function () {
     // reset from axe._load overriding
     checks = originalChecks;


### PR DESCRIPTION
Overriding the prototype for `DOMRectReadOnly` to throw errors on setting `left`, `right`, `top`, and `bottom` properties to match what happens in an extension context.

```js
const test = $0.getBoundingClientRect();
test.right = 1;  // Uncaught TypeError: setting getter-only property "right"
```

This should fail tests any time we do this now. If I try to set the `right` property in `get-background-color`, multiple tests fail:

<img width="528" alt="screenshot of test output showing 3 failing tests caused by 'TypeError: setting getter-only property right'" src="https://user-images.githubusercontent.com/2433219/212781267-c61d9d20-6509-46e2-b645-b4e6d2ef981e.png">

Closes: https://github.com/dequelabs/axe-core/issues/3837
