### PR TITLE
feat: deprecate color.filteredRectStack, color.getRectStack, and dom.visuallyContains

### DIFF
--- a/lib/commons/color/filtered-rect-stack.js
+++ b/lib/commons/color/filtered-rect-stack.js
@@ -3,6 +3,7 @@ import incompleteData from './incomplete-data';
 
 /**
  * Get filtered stack of block and inline elements, excluding line breaks
+ * @deprecated use color.getBackgroundStack instead
  * @method filteredRectStack
  * @memberof axe.commons.color
  * @param {Element} elm

--- a/lib/commons/color/get-rect-stack.js
+++ b/lib/commons/color/get-rect-stack.js
@@ -3,6 +3,7 @@ import getTextElementStack from '../dom/get-text-element-stack';
 
 /**
  * Get relevant stacks of block and inline elements, excluding line breaks
+ * @deprecated use color.getBackgroundStack instead
  * @method getRectStack
  * @memberof axe.commons.color
  * @param {Element} elm

--- a/lib/commons/dom/visually-contains.js
+++ b/lib/commons/dom/visually-contains.js
@@ -3,6 +3,7 @@ import { getNodeFromTree, getScroll } from '../../core/utils';
 /**
  * Checks whether a parent element visually contains its child, either directly or via scrolling.
  * Assumes that |parent| is an ancestor of |node|.
+ * @deprecated
  * @method visuallyContains
  * @memberof axe.commons.dom
  * @instance


### PR DESCRIPTION
Use `color.getBackgroundStack` instead of `color.filteredRectStack` or `color.getRectStack`. `dom.visuallyContains` has no replacement.

Closes: https://github.com/dequelabs/axe-core/issues/3833
