### PR TITLE
fix(scrollable-region-focusable): skip native controls

### DIFF
--- a/lib/rules/scrollable-region-focusable.json
+++ b/lib/rules/scrollable-region-focusable.json
@@ -1,5 +1,6 @@
 {
   "id": "scrollable-region-focusable",
+  "selector": "*:not(select,textarea)",
   "matches": "scrollable-region-focusable-matches",
   "tags": ["cat.keyboard", "wcag2a", "wcag211"],
   "actIds": ["0ssw9k"],

--- a/test/integration/rules/scrollable-region-focusable/scrollable-region-focusable.html
+++ b/test/integration/rules/scrollable-region-focusable/scrollable-region-focusable.html
@@ -132,3 +132,15 @@
     <p>Content</p>
   </div>
 </div>
+
+<select size="2" id="inapplicable11">
+  <option value="First">First</option>
+  <option value="Second">Second</option>
+  <option value="Third">Third</option>
+</select>
+
+<textarea rows="2" cols="20" id="inapplicable12">
+  test
+  test
+  test
+</textarea>


### PR DESCRIPTION
This rule isn't intended to test native controls. I'm honestly surprised that `getScroll()` doesn't cause `select` and `textarea` to be skipped like it does for `input` elements with lengthy texts. I suppose browsers did that to give the things their scrollbar, which `input` never gets.


Closes #3692,  closes #3691, closes #3701
