### PR TITLE
ci: fix sri-validation job regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ workflows:
           filters:
             branches:
               only:
-                - /release-*/
+                - /release-.+/
                 - master
       # Hold for approval
       - hold_release:


### PR DESCRIPTION
Missed the `.` when writing the regex so the job did not run on `release-` branches.