### PR TITLE
ci: fix sri-validation job regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ workflows:
           filters:
             branches:
               only:
-                - /release-*/
+                - /^release-.+/
                 - master
       # Hold for approval
       - hold_release:


### PR DESCRIPTION
Missed the `.` when writing the regex to have it properly run on `release-` branches. While there, also made it match the start of the string only.