### PR TITLE
ci: restore_build before publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,7 @@ jobs:
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache_unix
+      - <<: *restore_build
       - run: .circleci/verify-release.sh
       - run: npm publish
 


### PR DESCRIPTION
Because the 4.6.3 release failed: https://app.circleci.com/pipelines/github/dequelabs/axe-core/4837/workflows/247dc1d3-6f4a-44fc-ac3e-da401b297e1e/jobs/54136