### PR TITLE
chore: fix buffer size of git logs for cherry-pick script

### DIFF
--- a/build/cherry-pick.js
+++ b/build/cherry-pick.js
@@ -45,7 +45,11 @@ let targetVersion = releaseType === 'patch' ? version : `${major}.${minor}.0`;
 
 // get all commits from a branch
 function getCommits(branch) {
-  const stdout = execSync(`git log ${branch || ''} --abbrev-commit`).toString();
+  // all commits are too large for execSync buffer size so we'll just get since the last 3 years
+  const date = new Date(new Date().setFullYear(new Date().getFullYear() - 3));
+  const stdout = execSync(
+    `git log ${branch || ''} --abbrev-commit --since=${date.getFullYear()}`
+  ).toString();
   const allCommits = stdout
     .split(/commit (?=[\w\d]{8}[\n\r])/)
     .filter(commit => !!commit);


### PR DESCRIPTION
Tried to use this today and it broke due to the git logs [exceeding the buffer size of `exec`](https://nodejs.org/api/child_process.html#child_processexecsynccommand-options). Instead of setting the `maxBuffer` to an arbitrary number that could break in the future, we'll just reduce the amount of commits that log outputs. 3 years should be sufficient to find previous `feat` commits while not exceeding the buffer.