### PR TITLE
feat: deprecate bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "axe-core",
   "version": "4.6.3",
+  "deprecated": true,
   "contributors": [
     {
       "name": "David Sturley",


### PR DESCRIPTION
Since bower has been deprecated for a while, it makes no sense for axe-core to continue support for it. When the next major version of axe-core is released the bowers.json file will be removed.

Closes: #3728
