### PR TITLE
fix(color-contrast): do not check contrast for inert elements

### DIFF
--- a/lib/rules/color-contrast-matches.js
+++ b/lib/rules/color-contrast-matches.js
@@ -1,6 +1,11 @@
 /* global document */
 import { getAccessibleRefs } from '../commons/aria';
-import { findUpVirtual, visuallyOverlaps, getRootNode } from '../commons/dom';
+import {
+  findUpVirtual,
+  visuallyOverlaps,
+  getRootNode,
+  isInert
+} from '../commons/dom';
 import {
   visibleVirtual,
   removeUnicode,
@@ -35,7 +40,7 @@ function colorContrastMatches(node, virtualNode) {
     return false;
   }
 
-  if (isDisabled(virtualNode)) {
+  if (isDisabled(virtualNode) || isInert(virtualNode)) {
     return false;
   }
 

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -440,3 +440,11 @@
     <span id="pass22">This div will be on top of the stack</span>
   </div>
 </div>
+
+<div id="ignore11" style="background: #000; color: #333" inert>hello</div>
+
+<div inert>
+  <div>
+    <div id="ignore12" style="background: #000; color: #333">hello</div>
+  </div>
+</div>

--- a/test/rule-matches/color-contrast-matches.js
+++ b/test/rule-matches/color-contrast-matches.js
@@ -404,6 +404,20 @@ describe('color-contrast-matches', function () {
     assert.isFalse(rule.matches(target, axe.utils.getNodeFromTree(target)));
   });
 
+  it('should not match inert', function () {
+    fixture.innerHTML = '<div inert>hi</div>';
+    var target = fixture.querySelector('div');
+    axe.testUtils.flatTreeSetup(fixture);
+    assert.isFalse(rule.matches(target, axe.utils.getNodeFromTree(target)));
+  });
+
+  it('should not match a descendant of inert', function () {
+    fixture.innerHTML = '<div inert><span>hi</span></div>';
+    var target = fixture.querySelector('span');
+    axe.testUtils.flatTreeSetup(fixture);
+    assert.isFalse(rule.matches(target, axe.utils.getNodeFromTree(target)));
+  });
+
   if (shadowSupport) {
     it('should match a descendant of an element across a shadow boundary', function () {
       fixture.innerHTML =


### PR DESCRIPTION
Finishes the work on supporting inert. One question I have is if we want to not check the color contrast of labels (implicit, explicit, etc.) for inputs that are inerted. So this example:

```html
<div id="t1"><span>Test</span></div>
<div role="textbox" aria-labelledby="bob t1 fred" inert></div>
```

We prevent checking this type of setup if the input is disabled (or `aria-disabled`). Do we need to do the same if the input has `inert`?

Closes: #3448 
