### PR TITLE
chore(origin): fix CDP Page.setDocumentContent origin null crashing a…

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -18,11 +18,12 @@ const dotRegex = /\{\{.+?\}\}/g;
 function getDefaultOrigin() {
   // @see https://html.spec.whatwg.org/multipage/webappapis.html#dom-origin-dev
   // window.origin does not exist in ie11
-  if (window.origin) {
+  // prevent origin default "null" string on CDP `Page.setDocumentContent` https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDocumentContent
+  if (window.origin && window.origin !== "null") {
     return window.origin;
   }
   // window.location does not exist in node when we run the build
-  if (window.location && window.location.origin) {
+  if (window.location && window.location.origin && window.location.origin !== "null") {
     return window.location.origin;
   }
 }


### PR DESCRIPTION
* fix issue with  test hanging on allowedOrigins unhandled exception when using CDP `Page.setDocumentContent`

--- Notes

The following issue occurs when using axe-core to test HTML markup created over  CDP `Page.setDocumentContent` or `puppeteer.setContent`. 

```
[0213/121447.712165:INFO:CONSOLE(15)] "Uncaught (in promise) Error: allowedOrigins value "null" is not a valid origin", source: pptr://__puppeteer_evaluation_script__ (15)
```

Example test showing the crash repro https://github.com/a11ywatch/a11y/blob/main/tests/basic-axe.ts.
You also need to comment out the following block https://github.com/a11ywatch/a11y/blob/main/lib/runners/axe.ts#L16 that allowing test to run after setting the `origin` manually.

