### PR TITLE
ci: nightly - build axe.js cache before tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,12 +437,15 @@ workflows:
                 - develop
     jobs:
       - dependencies_unix
+      - build_unix:
+          requires:
+            - dependencies_unix
       - test_nightly_browsers:
           requires:
-            - dependencies_unix
+            - build_unix
       - test_nightly_act:
           requires:
-            - dependencies_unix
+            - build_unix
       - test_nightly_aria_practices:
           requires:
-            - dependencies_unix
+            - build_unix


### PR DESCRIPTION
Seems I missed this when I did https://github.com/dequelabs/axe-core/pull/3846, and is now causing nightly to fail.