### PR TITLE
fix(is-icon-ligature): prevent canvas2d warning willReadFrequently

### DIFF
--- a/lib/commons/text/is-icon-ligature.js
+++ b/lib/commons/text/is-icon-ligature.js
@@ -85,7 +85,9 @@ function isIconLigature(
   }
 
   const canvasContext = cache.get('canvasContext', () =>
-    document.createElement('canvas').getContext('2d')
+    document
+      .createElement('canvas')
+      .getContext('2d', { willReadFrequently: true })
   );
   const canvas = canvasContext.canvas;
 


### PR DESCRIPTION
Removes the console warning related to font-icon checking and improves the speed of multiple readback operations, as mentioned in the warning.

> Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently

Closes: [3900](https://github.com/dequelabs/axe-core/issues/3900)
