### PR TITLE
feat(commons/color): add opacity info

### DIFF
--- a/lib/checks/color/color-contrast-enhanced.json
+++ b/lib/checks/color/color-contrast-enhanced.json
@@ -27,9 +27,9 @@
     "messages": {
       "pass": "Element has sufficient color contrast of ${data.contrastRatio}",
       "fail": {
-        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
+        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
       },
       "incomplete": {
         "default": "Unable to determine contrast ratio",

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -8,6 +8,7 @@ import {
 import {
   getBackgroundColor,
   getForegroundColor,
+  getOpacity,
   incompleteData,
   getContrast,
   getOwnBackgroundColor,
@@ -74,6 +75,7 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
   const bgNodes = [];
   const bgColor = getBackgroundColor(node, bgNodes, shadowOutlineEmMax);
   const fgColor = getForegroundColor(node, false, bgColor, options);
+  const opacity = getOpacity(node, nodeStyle);
   // Thin shadows only. Thicker shadows are included in the background instead
   const shadowColors = getTextShadowColors(node, {
     minRatio: 0.001,
@@ -136,6 +138,7 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
   this.data({
     fgColor: fgColor ? fgColor.toHexString() : undefined,
     bgColor: bgColor ? bgColor.toHexString() : undefined,
+    opacity: opacity ? opacity.toFixed(2) : undefined,
     contrastRatio: truncatedResult,
     fontSize: `${((fontSize * 72) / 96).toFixed(1)}pt (${fontSize}px)`,
     fontWeight: bold ? 'bold' : 'normal',

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -28,9 +28,9 @@
         "hidden": "Element is hidden"
       },
       "fail": {
-        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
+        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
       },
       "incomplete": {
         "default": "Unable to determine contrast ratio",

--- a/lib/commons/color/get-foreground-color.js
+++ b/lib/commons/color/get-foreground-color.js
@@ -3,7 +3,7 @@ import getBackgroundColor from './get-background-color';
 import incompleteData from './incomplete-data';
 import flattenColors from './flatten-colors';
 import getTextShadowColors from './get-text-shadow-colors';
-import { getNodeFromTree } from '../../core/utils';
+import getOpacity from './get-opacity';
 
 /**
  * Returns the flattened foreground color of an element, or null if it can't be determined because
@@ -81,28 +81,4 @@ function getStrokeColor(nodeStyle, { textStrokeEmMin = 0 }) {
 
   const strokeColor = nodeStyle.getPropertyValue('-webkit-text-stroke-color');
   return new Color().parseString(strokeColor);
-}
-
-function getOpacity(node, nodeStyle) {
-  if (!node) {
-    return 1;
-  }
-
-  const vNode = getNodeFromTree(node);
-  if (vNode && vNode._opacity !== undefined && vNode._opacity !== null) {
-    return vNode._opacity;
-  }
-
-  nodeStyle ??= window.getComputedStyle(node);
-  const opacity = nodeStyle.getPropertyValue('opacity');
-  const finalOpacity = opacity * getOpacity(node.parentElement);
-
-  // cache the results of the getOpacity check on the parent tree
-  // so we don't have to look at the parent tree again for all its
-  // descendants
-  if (vNode) {
-    vNode._opacity = finalOpacity;
-  }
-
-  return finalOpacity;
 }

--- a/lib/commons/color/get-opacity.js
+++ b/lib/commons/color/get-opacity.js
@@ -1,0 +1,34 @@
+import { getNodeFromTree } from '../../core/utils';
+
+/**
+ * Returns the opacity of an element, or 1 if it can't be determined
+ * @method getOpacity
+ * @memberof axe.commons.color
+ * @instance
+ * @param {Element} node
+ * @param {CSSStyleDeclaration} nodeStyle
+ * @return {number}
+ */
+export default function getOpacity(node, nodeStyle) {
+  if (!node) {
+    return 1;
+  }
+
+  const vNode = getNodeFromTree(node);
+  if (vNode && vNode._opacity !== undefined && vNode._opacity !== null) {
+    return vNode._opacity;
+  }
+
+  nodeStyle ??= window.getComputedStyle(node);
+  const opacity = nodeStyle.getPropertyValue('opacity');
+  const finalOpacity = opacity * getOpacity(node.parentElement);
+
+  // cache the results of the getOpacity check on the parent tree
+  // so we don't have to look at the parent tree again for all its
+  // descendants
+  if (vNode) {
+    vNode._opacity = finalOpacity;
+  }
+
+  return finalOpacity;
+}

--- a/lib/commons/color/index.js
+++ b/lib/commons/color/index.js
@@ -19,3 +19,4 @@ export { default as getRectStack } from './get-rect-stack';
 export { default as hasValidContrastRatio } from './has-valid-contrast-ratio';
 export { default as incompleteData } from './incomplete-data';
 export { default as getTextShadowColors } from './get-text-shadow-colors';
+export { default as getOpacity } from './get-opacity';

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -567,9 +567,9 @@
     "color-contrast-enhanced": {
       "pass": "Element has sufficient color contrast of ${data.contrastRatio}",
       "fail": {
-        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
+        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
       },
       "incomplete": {
         "default": "Unable to determine contrast ratio",
@@ -593,9 +593,9 @@
         "hidden": "Element is hidden"
       },
       "fail": {
-        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
-        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
+        "default": "Element has insufficient color contrast of ${data.contrastRatio} (foreground color: ${data.fgColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "fgOnShadowColor": "Element has insufficient color contrast of ${data.contrastRatio} between the foreground and shadow color (foreground color: ${data.fgColor}, text-shadow color: ${data.shadowColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}",
+        "shadowOnBgColor": "Element has insufficient color contrast of ${data.contrastRatio} between the shadow color and background color (text-shadow color: ${data.shadowColor}, background color: ${data.bgColor}, opacity: ${data.opacity}, font size: ${data.fontSize}, font weight: ${data.fontWeight}). Expected contrast ratio of ${data.expectedContrastRatio}"
       },
       "incomplete": {
         "default": "Unable to determine contrast ratio",

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -46,6 +46,7 @@ describe('color-contrast', function () {
     assert.isTrue(contrastEvaluate.apply(checkContext, params));
     assert.equal(checkContext._data.bgColor, white.toHexString());
     assert.equal(checkContext._data.fgColor, black.toHexString());
+    assert.equal(checkContext._data.opacity, '1.00');
     assert.equal(checkContext._data.contrastRatio, '21.00');
     assert.equal(checkContext._data.fontWeight, 'bold');
     assert.isAtLeast(parseFloat(checkContext._data.fontSize), 14, 0.5);
@@ -99,6 +100,26 @@ describe('color-contrast', function () {
 
     assert.isFalse(contrastEvaluate.apply(checkContext, params));
     assert.deepEqual(checkContext._relatedNodes, [params[0]]);
+  });
+
+  it('should return true when there is sufficient contrast with specific opacity', function () {
+    var params = checkSetup(
+      '<div id="parent" style="background-color: white; opacity: 0.95">' +
+        '<span id="target" style="color: #0065b9">Oh Pass City</span>' +
+        '</div>'
+    );
+
+    assert.isTrue(contrastEvaluate.apply(checkContext, params));
+    assert.deepEqual(checkContext._relatedNodes, []);
+  });
+
+  it('should return false when there is not sufficient contrast because of opacity', function () {
+    var params = checkSetup(
+      '<div id="target" style="color: #0065b9; background-color: white; opacity: 0.85">Oh Fail City</div>'
+    );
+
+    assert.isFalse(contrastEvaluate.apply(checkContext, params));
+    assert.deepEqual(checkContext._relatedNodes[0], params[0]);
   });
 
   it('should return true when there is sufficient contrast with explicit transparency', function () {


### PR DESCRIPTION
## Description
Add opacity information to color contrast remediation text

## Changes
* Refactor `getOpacity` method to allow for use in `color-contrast-evaluate`
* Add opacity information to `color-contrast` and `color-contrast-enhanced` messages
* Update & add tests with opacity

Closes issue #3928