### PR TITLE
chore: update datalist spec to disallow aria attrs

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -182,6 +182,7 @@ const htmlElms = {
   datalist: {
     contentTypes: ['phrasing', 'flow'],
     allowedRoles: false,
+    noAriaAttrs: true,
     implicitAttrs: {
       // Note: even though the value of aria-multiselectable is based
       // on the attributes, we don't currently need to know the


### PR DESCRIPTION
`datalist` is not visible (even when the list is "open") so this change won't report anything (thus the `chore`). Just keeping up with the spec changes so we aren't out of date.

Closes: #3322
