### PR TITLE
ci: fix nightly apg tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/runtime-corejs3": "^7.20.7",
         "@deque/dot": "^1.1.5",
-        "aria-practices": "github:w3c/aria-practices#edbf534",
+        "aria-practices": "github:w3c/aria-practices#ce0336bd82d7d3651abcbde86af644197ddbc629",
         "aria-query": "^5.1.3",
         "browser-driver-manager": "1.0.4",
         "chai": "^4.3.7",
         "chalk": "^4.x",
-        "chromedriver": "latest",
+        "chromedriver": "^111.0.0",
         "clone": "^2.1.2",
         "conventional-commits-parser": "^3.2.4",
         "core-js": "^3.27.1",
@@ -2466,13 +2466,14 @@
     },
     "node_modules/aria-practices": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/w3c/aria-practices.git#edbf534c7d4decd5d52d518b703a2463a2342e08",
+      "resolved": "git+ssh://git@github.com/w3c/aria-practices.git#ce0336bd82d7d3651abcbde86af644197ddbc629",
+      "integrity": "sha512-YeAp8bT7jWtWQMW5svlRzvHp0STw1cGW0xgy/MrapgA+oaW85NDnz7/YFrBGZbWrOp3xLujTSHSv+YGgnFT4KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/rest": "^18.9.1",
-        "dotenv": "^8.2.0",
-        "node-html-parser": "^3.1.4"
+        "@octokit/rest": "^18.12.0",
+        "dotenv": "^16.0.3",
+        "node-html-parser": "^5.2.0"
       }
     },
     "node_modules/aria-query": {
@@ -2578,9 +2579,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -3057,14 +3058,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "107.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-107.0.3.tgz",
-      "integrity": "sha512-jmzpZgctCRnhYAn0l/NIjP4vYN3L8GFVbterTrRr2Ly3W5rFMb9H8EKGuM5JCViPKSit8FbE718kZTEt3Yvffg==",
+      "version": "111.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
+      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.1.3",
+        "axios": "^1.2.1",
         "compare-versions": "^5.0.1",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
@@ -4177,12 +4178,12 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotgitignore": {
@@ -8644,12 +8645,12 @@
       }
     },
     "node_modules/node-html-parser": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-3.3.6.tgz",
-      "integrity": "sha512-VkWDHvNgFGB3mbQGMyzqRE1i/BG7TKX9wRXC8e/v8kL0kZR/Oy6RjYxXH91K6/+m3g8iQ8dTqRy75lTYoA2Cjg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.2.tgz",
+      "integrity": "sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==",
       "dev": true,
       "dependencies": {
-        "css-select": "^4.1.3",
+        "css-select": "^4.2.1",
         "he": "1.2.0"
       }
     },
@@ -13824,13 +13825,14 @@
       "dev": true
     },
     "aria-practices": {
-      "version": "git+ssh://git@github.com/w3c/aria-practices.git#edbf534c7d4decd5d52d518b703a2463a2342e08",
+      "version": "git+ssh://git@github.com/w3c/aria-practices.git#ce0336bd82d7d3651abcbde86af644197ddbc629",
+      "integrity": "sha512-YeAp8bT7jWtWQMW5svlRzvHp0STw1cGW0xgy/MrapgA+oaW85NDnz7/YFrBGZbWrOp3xLujTSHSv+YGgnFT4KQ==",
       "dev": true,
-      "from": "aria-practices@github:w3c/aria-practices#edbf534",
+      "from": "aria-practices@github:w3c/aria-practices#ce0336bd82d7d3651abcbde86af644197ddbc629",
       "requires": {
-        "@octokit/rest": "^18.9.1",
-        "dotenv": "^8.2.0",
-        "node-html-parser": "^3.1.4"
+        "@octokit/rest": "^18.12.0",
+        "dotenv": "^16.0.3",
+        "node-html-parser": "^5.2.0"
       }
     },
     "aria-query": {
@@ -13909,9 +13911,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
@@ -14273,13 +14275,13 @@
       }
     },
     "chromedriver": {
-      "version": "107.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-107.0.3.tgz",
-      "integrity": "sha512-jmzpZgctCRnhYAn0l/NIjP4vYN3L8GFVbterTrRr2Ly3W5rFMb9H8EKGuM5JCViPKSit8FbE718kZTEt3Yvffg==",
+      "version": "111.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
+      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.1.3",
+        "axios": "^1.2.1",
         "compare-versions": "^5.0.1",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
@@ -15138,9 +15140,9 @@
       }
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "dev": true
     },
     "dotgitignore": {
@@ -18519,12 +18521,12 @@
       }
     },
     "node-html-parser": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-3.3.6.tgz",
-      "integrity": "sha512-VkWDHvNgFGB3mbQGMyzqRE1i/BG7TKX9wRXC8e/v8kL0kZR/Oy6RjYxXH91K6/+m3g8iQ8dTqRy75lTYoA2Cjg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.2.tgz",
+      "integrity": "sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==",
       "dev": true,
       "requires": {
-        "css-select": "^4.1.3",
+        "css-select": "^4.2.1",
         "he": "1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/runtime-corejs3": "^7.20.7",
     "@deque/dot": "^1.1.5",
-    "aria-practices": "github:w3c/aria-practices#edbf534",
+    "aria-practices": "github:w3c/aria-practices#ce0336bd82d7d3651abcbde86af644197ddbc629",
     "aria-query": "^5.1.3",
     "browser-driver-manager": "1.0.4",
     "chai": "^4.3.7",

--- a/test/aria-practices/apg.spec.js
+++ b/test/aria-practices/apg.spec.js
@@ -6,12 +6,15 @@ const { assert } = require('chai');
 const globby = require('globby');
 
 describe('aria-practices', function () {
-  // Use path.resolve rather than require.resolve because APG has no package.json
+  // Use path.resolve rather than require.resolve because APG package.json main file does not exist
   const apgPath = path.resolve(__dirname, '../../node_modules/aria-practices/');
-  const filePaths = globby.sync(`${apgPath}/examples/**/*.html`);
-  const testFiles = filePaths.map(
-    fileName => fileName.split('/aria-practices/examples/')[1]
+  const filePaths = globby.sync(
+    `${apgPath}/content/patterns/*/**/examples/*.html`
   );
+  const testFiles = filePaths.map(
+    fileName => fileName.split('/aria-practices/content/patterns/')[1]
+  );
+
   const addr = `http://localhost:9876/node_modules/aria-practices/`;
   let driver, axeSource;
   this.timeout(50000);
@@ -32,56 +35,40 @@ describe('aria-practices', function () {
       'color-contrast',
       'target-size',
       'heading-order', // w3c/aria-practices#2119
-      'list', // w3c/aria-practices#2118
       'scrollable-region-focusable' // w3c/aria-practices#2114
-    ],
-    'feed/feedDisplay.html': ['page-has-heading-one'], // w3c/aria-practices#2120
-    // "page within a page" type thing going on
-    'menubar/menubar-navigation.html': [
-      'aria-allowed-role',
-      'landmark-banner-is-top-level',
-      'landmark-contentinfo-is-top-level'
-    ],
-    // "page within a page" type thing going on
-    'treeview/treeview-navigation.html': [
-      'aria-allowed-role',
-      'landmark-banner-is-top-level',
-      'landmark-contentinfo-is-top-level'
-    ],
-    // https://github.com/w3c/aria-practices/issues/2199
-    'button/button_idl.html': ['aria-allowed-attr'],
-    // https://github.com/w3c/aria-practices/issues/2285
-    'checkbox/checkbox.html': ['empty-table-header'],
-    'dialog-modal/datepicker-dialog.html': ['empty-table-header'],
-    // https://github.com/w3c/aria-practices/issues/2505
-    'landmarks/search.html': ['link-in-text-block']
+    ]
   };
 
   // Not an actual content file
   const skippedPages = [
-    'index.html', // Not an example, just an index file
-    'js/notice.html', // Embedded into another page
-    'toolbar/help.html' // Embedded into another page
+    'toolbar/examples/help.html' // Embedded into another page
   ];
+
+  it('finds examples', () => {
+    assert.isTrue(testFiles.length > 0);
+  });
 
   testFiles
     .filter(filePath => !skippedPages.includes(filePath))
     .forEach(filePath => {
       it(`finds no issue in "${filePath}"`, async () => {
-        await driver.get(`${addr}/examples/${filePath}`);
+        await driver.get(`${addr}content/patterns/${filePath}`);
 
-        const builder = new AxeBuilder(driver, axeSource);
-        builder.disableRules([
-          ...disabledRules['*'],
-          ...(disabledRules[filePath] || [])
-        ]);
+        const builder = new AxeBuilder(driver, axeSource)
+          // Support table has no title and has duplicate ids
+          .exclude('#at-support')
+          .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+          .disableRules([
+            ...disabledRules['*'],
+            ...(disabledRules[filePath] || [])
+          ]);
 
         const { violations } = await builder.analyze();
         const issues = violations.map(({ id, nodes }) => ({
           id,
           issues: nodes.length
         }));
-        assert.lengthOf(issues, 0);
+        assert.lengthOf(issues, 0, issues.map(({ id }) => id).join(', '));
       });
     });
 });


### PR DESCRIPTION
The apg tests weren't running due to the github repo completely changing structure in https://github.com/w3c/aria-practices/pull/2417. I updated the paths to the new structure and was able to remove a lot of the skipped rules for specific pages as well. I also set the tags to only run wcag21aa and below so we don't get best practice rules or aaa rules running. 

Lastly, I wanted to pin the repo to their last release, but they changed the structure after that release so instead just pinned to the latest commit (as it would be a lot of spaghetti code to try to maintain two directory structures for the test).