### PR TITLE
fix(link-in-text-block): set links with pseudo-content for review

### DIFF
--- a/lib/checks/color/link-in-text-block-style-evaluate.js
+++ b/lib/checks/color/link-in-text-block-style-evaluate.js
@@ -9,12 +9,8 @@ const blockLike = [
   'grid',
   'inline-block'
 ];
-function isBlock(elm) {
-  var display = window.getComputedStyle(elm).getPropertyValue('display');
-  return blockLike.indexOf(display) !== -1 || display.substr(0, 6) === 'table-';
-}
 
-function linkInTextBlockStyleEvaluate(node) {
+export default function linkInTextBlockStyleEvaluate(node) {
   if (isBlock(node)) {
     return false;
   }
@@ -30,7 +26,28 @@ function linkInTextBlockStyleEvaluate(node) {
 
   this.relatedNodes([parentBlock]);
 
-  return elementIsDistinct(node, parentBlock);
+  if (elementIsDistinct(node, parentBlock)) {
+    return true;
+  }
+  if (hasPseudoContent(node)) {
+    this.data({ messageKey: 'pseudoContent' });
+    return undefined;
+  }
+  return false;
 }
 
-export default linkInTextBlockStyleEvaluate;
+function isBlock(elm) {
+  var display = window.getComputedStyle(elm).getPropertyValue('display');
+  return blockLike.indexOf(display) !== -1 || display.substr(0, 6) === 'table-';
+}
+
+function hasPseudoContent(node) {
+  for (const pseudo of ['before', 'after']) {
+    const style = window.getComputedStyle(node, `:${pseudo}`);
+    const content = style.getPropertyValue('content');
+    if (content !== 'none') {
+      return true;
+    }
+  }
+  return false;
+}

--- a/lib/checks/color/link-in-text-block-style.json
+++ b/lib/checks/color/link-in-text-block-style.json
@@ -7,7 +7,7 @@
       "pass": "Links can be distinguished from surrounding text by visual styling",
       "incomplete": {
         "default": "Check if the link needs styling to distinguish it from nearby text",
-        "pseudoContent": "Check if the link's pseudo style are sufficient to distinguish it from the surrounding text"
+        "pseudoContent": "Check if the link's pseudo style is sufficient to distinguish it from the surrounding text"
       },
       "fail": "The link has no styling (such as underline) to distinguish it from the surrounding text"
     }

--- a/lib/checks/color/link-in-text-block-style.json
+++ b/lib/checks/color/link-in-text-block-style.json
@@ -5,6 +5,10 @@
     "impact": "serious",
     "messages": {
       "pass": "Links can be distinguished from surrounding text by visual styling",
+      "incomplete": {
+        "default": "Check if the link needs styling to distinguish it from nearby text",
+        "pseudoContent": "Check if the link's pseudo style are sufficient to distinguish it from the surrounding text"
+      },
       "fail": "The link has no styling (such as underline) to distinguish it from the surrounding text"
     }
   }

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -378,7 +378,12 @@ const ariaRoles = {
     type: 'widget',
     requiredContext: ['menu', 'menubar', 'group'],
     requiredAttrs: ['aria-checked'],
-    allowedAttrs: ['aria-expanded', 'aria-posinset', 'aria-readonly', 'aria-setsize'],
+    allowedAttrs: [
+      'aria-expanded',
+      'aria-posinset',
+      'aria-readonly',
+      'aria-setsize'
+    ],
     superclassRole: ['checkbox', 'menuitem'],
     accessibleNameRequired: true,
     nameFromContent: true,
@@ -388,7 +393,12 @@ const ariaRoles = {
     type: 'widget',
     requiredContext: ['menu', 'menubar', 'group'],
     requiredAttrs: ['aria-checked'],
-    allowedAttrs: ['aria-expanded', 'aria-posinset', 'aria-readonly', 'aria-setsize'],
+    allowedAttrs: [
+      'aria-expanded',
+      'aria-posinset',
+      'aria-readonly',
+      'aria-setsize'
+    ],
     superclassRole: ['menuitemcheckbox', 'radio'],
     accessibleNameRequired: true,
     nameFromContent: true,

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -625,7 +625,7 @@
       "pass": "Links can be distinguished from surrounding text by visual styling",
       "incomplete": {
         "default": "Check if the link needs styling to distinguish it from nearby text",
-        "pseudoContent": "Check if the link's pseudo style are sufficient to distinguish it from the surrounding text"
+        "pseudoContent": "Check if the link's pseudo style is sufficient to distinguish it from the surrounding text"
       },
       "fail": "The link has no styling (such as underline) to distinguish it from the surrounding text"
     },

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -623,6 +623,10 @@
     },
     "link-in-text-block-style": {
       "pass": "Links can be distinguished from surrounding text by visual styling",
+      "incomplete": {
+        "default": "Check if the link needs styling to distinguish it from nearby text",
+        "pseudoContent": "Check if the link's pseudo style are sufficient to distinguish it from the surrounding text"
+      },
       "fail": "The link has no styling (such as underline) to distinguish it from the surrounding text"
     },
     "link-in-text-block": {

--- a/test/integration/rules/link-in-text-block/link-in-text-block.html
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.html
@@ -149,3 +149,21 @@
     Link test</a
   >
 </p>
+
+<style>
+  #incomplete-pseudo-before {
+    text-decoration: none;
+    position: relative;
+  }
+  #incomplete-pseudo-before:before {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 1px;
+    background: purple;
+    bottom: 2px;
+  }
+</style>
+<p id="pseudo">
+  Lorem <a href="#" id="incomplete-pseudo-before">ipsum</a> dolor sit.
+</p>

--- a/test/integration/rules/link-in-text-block/link-in-text-block.json
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.json
@@ -14,5 +14,8 @@
     ["#pass-text-color"],
     ["#pass-same-colors"]
   ],
-  "incomplete": [["#incomplete-low-contrast-parent-has-gradient"]]
+  "incomplete": [
+    ["#incomplete-low-contrast-parent-has-gradient"],
+    ["#incomplete-pseudo-before"]
+  ]
 }


### PR DESCRIPTION
Links with content on a :before or :after pseudo-elements are reported as incomplete, as those may pseudo elements may or may not be used to indicate these are links.

Closes: #3993
