### PR TITLE
perf(aggregate): add fast oneshot aggregate

### DIFF
--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -20,25 +20,30 @@ const criteriaMap = {
  */
 function aggregate(map, values, initial) {
   const valSize = values.length;
+
+  if (valSize === 1) {
+    return map[criteriaMap[values[0]]];
+  }
+
   const maxPoint = valSize / 2;
-  const tailEnd = valSize ? valSize - 1 : 0;
+  const tailEnd = valSize - 1;
   let mapIndex = initial ? criteriaMap[initial] : 0;
 
   if (mapIndex !== 3) {
     for (let i = 0; i < valSize; i++) {
       // double ended iterator max
-      if (i > maxPoint) {
-        break;
+      if(i > maxPoint) {
+        break
       }
       const head = criteriaMap[values[i]];
       const tail = criteriaMap[values[tailEnd - i]];
       const maxV = tail > head ? tail : head;
-
+    
       if (maxV > mapIndex) {
         mapIndex = maxV;
       }
-
-      if (mapIndex === map.length) {
+  
+      if (mapIndex === 3) {
         break;
       }
     }

--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -6,7 +6,7 @@ const criteriaMap = {
   cantTell: 2,
   serious: 2,
   critical: 3,
-  failed: 3,
+  failed: 3
 };
 
 /**
@@ -26,18 +26,18 @@ function aggregate(map, values, initial) {
   if (mapIndex !== 3) {
     for (let i = 0; i < valSize; i++) {
       // double ended iterator max
-      if(i > maxPoint) {
-        break
+      if (i > maxPoint) {
+        break;
       }
       const head = criteriaMap[values[i]];
       const tail = criteriaMap[values[valSize - i]];
       const maxV = tail > head ? tail : head;
-  
+
       if (maxV > mapIndex) {
         mapIndex = maxV;
       }
-  
-      if (maxV === 3) {
+
+      if (mapIndex === map.length) {
         break;
       }
     }

--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -1,11 +1,12 @@
 const criteriaMap = {
   minor: 0,
-  cantTell: 1,
+  inapplicable: 0,
   passed: 1,
-  moderate: 2,
-  serious: 3,
+  moderate: 1,
+  cantTell: 2,
+  serious: 2,
+  critical: 3,
   failed: 3,
-  critical: 3
 };
 
 /**

--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -21,6 +21,7 @@ const criteriaMap = {
 function aggregate(map, values, initial) {
   const valSize = values.length;
   const maxPoint = valSize / 2;
+  const tailEnd = valSize ? valSize - 1 : 0;
   let mapIndex = initial ? criteriaMap[initial] : 0;
 
   if (mapIndex !== 3) {
@@ -30,7 +31,7 @@ function aggregate(map, values, initial) {
         break;
       }
       const head = criteriaMap[values[i]];
-      const tail = criteriaMap[values[valSize - i]];
+      const tail = criteriaMap[values[tailEnd - i]];
       const maxV = tail > head ? tail : head;
 
       if (maxV > mapIndex) {

--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -28,18 +28,15 @@ function aggregate(map, values, initial) {
       if(i > maxPoint) {
         break
       }
-      const head = values[i];
-      const tail = values[valSize - i];
-      const h = criteriaMap[head];
-      const t = criteriaMap[tail];
-  
-      const maxV = t > h ? t : h;
+      const head = criteriaMap[values[i]];
+      const tail = criteriaMap[values[valSize - i]];
+      const maxV = tail > head ? tail : head;
   
       if (maxV > mapIndex) {
         mapIndex = maxV;
       }
   
-      if (mapIndex === 3) {
+      if (maxV === 3) {
         break;
       }
     }

--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -19,7 +19,7 @@ const criteriaMap = {
  */
 function aggregate(map, values, initial) {
   const valSize = values.length;
-  const maxPoint = valSize  / 2;
+  const maxPoint = valSize / 2;
   let mapIndex = initial ? criteriaMap[initial] : 0;
 
   if (mapIndex !== 3) {

--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -1,21 +1,51 @@
+const criteriaMap = {
+  minor: 0,
+  cantTell: 1,
+  passed: 1,
+  moderate: 2,
+  serious: 3,
+  failed: 3,
+  critical: 3
+};
+
 /**
  * From a list of values, find the one with the greatest weight according to
  * the supplied map
- * @param  {object} params Contains 3 properties:
+ * @param  {Array} params Contains 3 properties:
  * - map: a map indicating the order of values to run in
  *        example: ['small', 'medium', 'large']
- * - values: Array of values to take the highest from
- * - initial: optional starting value
+ * @param {Array} values of values to take the highest from
+ * @param {String} initial: optional starting value
  */
 function aggregate(map, values, initial) {
-  values = values.slice();
-  if (initial) {
-    values.push(initial);
+  const valSize = values.length;
+  const maxPoint = valSize  / 2;
+  let mapIndex = initial ? criteriaMap[initial] : 0;
+
+  if (mapIndex !== 3) {
+    for (let i = 0; i < valSize; i++) {
+      // double ended iterator max
+      if(i > maxPoint) {
+        break
+      }
+      const head = values[i];
+      const tail = values[i - valSize];
+      const h = criteriaMap[head];
+      const t = criteriaMap[tail];
+  
+      const maxV = t > h ? t : h;
+  
+      if (maxV > mapIndex) {
+        mapIndex = maxV;
+      }
+  
+      if (mapIndex === 3) {
+        break;
+      }
+    }
   }
 
-  var sorting = values.map(val => map.indexOf(val)).sort(); // Stupid NodeJS array.sort functor doesn't work!!
-
-  return map[sorting.pop()];
+  return map[mapIndex];
 }
 
 export default aggregate;

--- a/lib/core/utils/aggregate.js
+++ b/lib/core/utils/aggregate.js
@@ -29,7 +29,7 @@ function aggregate(map, values, initial) {
         break
       }
       const head = values[i];
-      const tail = values[i - valSize];
+      const tail = values[valSize - i];
       const h = criteriaMap[head];
       const t = criteriaMap[tail];
   


### PR DESCRIPTION
# Whats Changed

**Major** performance improvement for `aggregate` handling.

The aggregate util simply needs the map value at the last index. Iterating to get that value and breaking the loop as quick as possible to return brings huge performance boosts since prior the solution was cloning and iterating over the array multiple times. Expect to see performance increase around 1/3 - 1/4 baseline for a medium real world test case.

The logic for initial does not handle mapping to the array `map` param for the custom test cases.

TODO:

For the initial custom cases we need to convert the array to an object to map accordingly, we can do this when we notice the initial index of the array is not any of the predefined `criteriaMap` values. We could also look into removing the custom mapping since it does not seem to be used in the actual core beyond making the `aggregate` method a bit more dynamic.

-- Edit

~~Pr was done on phone, can look into the formatter later and the failing test. May have mapped one of the values incorrectly.~~