### PR TITLE
chore(import): fix memoize import color-contrast-evalulate

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -14,7 +14,7 @@ import {
   getTextShadowColors,
   flattenShadowColors
 } from '../../commons/color';
-import { memoize } from '../../core/utils';
+import memoize from '../../core/utils';
 
 export default function colorContrastEvaluate(node, options, virtualNode) {
   const {


### PR DESCRIPTION
The memoize is exported as a default module. This PR fixes the import on `color-contrast-evaluate`. Theres some other errors with the import in other files.