### PR TITLE
fix(aria-allowed-attr): allow aria-required on role=slider

### DIFF
--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -631,11 +631,14 @@ const ariaRoles = {
     // Note: since the slider role has implicit
     // aria-orientation, aria-valuemax, aria-valuemin values it
     // is not required to be added by the user
+    // Note: aria-required is not in the 1.1 or 1.2 specs but is
+    // consistently supported in ATs
     allowedAttrs: [
       'aria-valuemax',
       'aria-valuemin',
       'aria-orientation',
       'aria-readonly',
+      'aria-required',
       'aria-valuetext'
     ],
     superclassRole: ['input', 'range'],

--- a/test/integration/rules/aria-allowed-attr/passes.html
+++ b/test/integration/rules/aria-allowed-attr/passes.html
@@ -1509,6 +1509,7 @@
   aria-owns="value"
   aria-relevant="value"
   aria-readonly="value"
+  aria-required="value"
 >
   ok
 </div>


### PR DESCRIPTION
Tested in VO/Safari, JAWS/Chrome, and NVDA/Firefox.

Closes: #4027
