### PR TITLE
chore(rules): avoid passing unnecessary info into afters

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -537,9 +537,9 @@ Rule.prototype.after = function after(result, options) {
   var ruleID = this.id;
   afterChecks.forEach(check => {
     var beforeResults = findCheckResults(result.nodes, check.id);
-    var option = getCheckOption(check, ruleID, options);
+    var checkOption = getCheckOption(check, ruleID, options);
 
-    var afterResults = check.after(beforeResults, option);
+    var afterResults = check.after(beforeResults, checkOption.options);
 
     if (this.reviewOnFail) {
       afterResults.forEach(checkResult => {

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -1483,11 +1483,7 @@ describe('Rule', function () {
                 id: 'cats',
                 enabled: true,
                 after: function (results, options) {
-                  assert.deepEqual(options, {
-                    enabled: true,
-                    options: { dogs: true },
-                    absolutePaths: undefined
-                  });
+                  assert.deepEqual(options, { dogs: true });
                   success = true;
                   return results;
                 }


### PR DESCRIPTION
Fixes a 9 year old bug that effects nothing, since we don't have after methods that use options.