### PR TITLE
test: work around firefox 115 text-stroke-width regression

### DIFF
--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -56,7 +56,7 @@ describe('color.getForegroundColor', () => {
   describe('text-stroke', () => {
     it('ignores stroke when equal to 0', () => {
       const target = queryFixture(
-        '<div style="color: rgb(0 0 128); -webkit-text-stroke: 0 #CCC" id="target">Hello World</div>'
+        '<div style="color: rgb(0 0 128); font-size: 16px; -webkit-text-stroke: 0 #CCC" id="target">Hello World</div>'
       ).actualNode;
       const options = { textStrokeEmMin: 0 };
       const fgColor = getForegroundColor(target, null, null, options);
@@ -65,7 +65,7 @@ describe('color.getForegroundColor', () => {
 
     it('ignores stroke when less then the minimum', () => {
       const target = queryFixture(
-        '<div style="color: rgb(0 0 128); -webkit-text-stroke: 0.1em #CCC" id="target">Hello World</div>'
+        '<div style="color: rgb(0 0 128); font-size: 16px; -webkit-text-stroke: 0.1em #CCC" id="target">Hello World</div>'
       ).actualNode;
       const options = { textStrokeEmMin: 0.2 };
       const fgColor = getForegroundColor(target, null, null, options);
@@ -74,16 +74,16 @@ describe('color.getForegroundColor', () => {
 
     it('uses stroke color when thickness is equal to the minimum', () => {
       const target = queryFixture(
-        '<div style="color: #CCC; -webkit-text-stroke: 0.2em rgb(0 0 128);" id="target">Hello World</div>'
+        '<div style="color: #CCC; font-size: 16px; -webkit-text-stroke: 0.25em rgb(0 0 128);" id="target">Hello World</div>'
       ).actualNode;
-      const options = { textStrokeEmMin: 0.2 };
+      const options = { textStrokeEmMin: 0.25 };
       const fgColor = getForegroundColor(target, null, null, options);
       assertSameColor(fgColor, new Color(0, 0, 128));
     });
 
     it('blends the stroke color with `color`', () => {
       const target = queryFixture(
-        '<div style="color: rgb(0 0 55); -webkit-text-stroke: 0.2em rgb(0 0 255 / 50%);" id="target">Hello World</div>'
+        '<div style="color: rgb(0 0 55); font-size: 16px; -webkit-text-stroke: 0.2em rgb(0 0 255 / 50%);" id="target">Hello World</div>'
       ).actualNode;
       const options = { textStrokeEmMin: 0.1 };
       const fgColor = getForegroundColor(target, null, null, options);
@@ -129,6 +129,7 @@ describe('color.getForegroundColor', () => {
         `<div id="target" style="
           opacity: 0.5;
           color: transparent;
+          font-size: 16px;
           -webkit-text-stroke: 0.05em rgb(0 255 255 / 50%);
         ">Hello world</div>`
       ).actualNode;


### PR DESCRIPTION
This PR fixes a test failure against FirefoxNightly in our nightly CI build. Specifically, it works around a regression introduced in Firefox 115 tracked by https://bugzilla.mozilla.org/show_bug.cgi?id=1837692 where Firefox started clamping `-webkit-text-stroke-width` values to integer numbers of pixels. This broke test case `uses stroke color when thickness is equal to the minimum` in `get-foreground-color` because it involved verifying a test fixture that used a stroke width of `.2em` against a font-size of `16px` (ie, `3.2px`).

To address this, this PR pins that test case to use `16px` font-size and `.25em` stroke width, which resolves to an integer number of pixels.

To avoid the possibility of a similar issue being introduced in the future, I also updated all test cases in this file to pin font-size explicitly (to the currently-used value of `16px`) everywhere that stroke width is customized. @straker is separately investigating a more robust version of that fix to pin `font-size` (and probably some other "base" CSS) in our tests to a fixed value at a higher level than per-test, but that'll be addressed in a separate PR - this is just a minimal workaround to unblock our nightly test runs.
