### PR TITLE
test: fix implicit test dependencies on local dev environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     }
   },
   "scripts": {
-    "start": "http-server -p 9876 --silent",
+    "start": "http-server -a \"\" -p 9876 --silent",
     "develop": "grunt dev --force",
     "api-docs": "jsdoc --configure .jsdoc.json",
     "build": "grunt",

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -7,6 +7,37 @@ describe('color.getBackgroundColor', function () {
   var origBodyBg;
   var origHtmlBg;
 
+  /**
+   * Assert that two Colors are equal.
+   * @param {axe.commons.color.Color[]} actual
+   * @param {axe.commons.color.Color[]} expected
+   */
+  function assertColorsEqual(actual, expected) {
+    assert.equal(actual.red, expected.red, 'red');
+    assert.equal(actual.green, expected.green, 'green');
+    assert.equal(actual.blue, expected.blue, 'blue');
+    assert.equal(actual.alpha, expected.alpha, 'alpha');
+  }
+
+  /**
+   * Assert that two Colors are close-to-equal.
+   * @param {axe.commons.color.Color[]} actual
+   * @param {axe.commons.color.Color[]} expected
+   * @param {number} threshold How much each RGB value may differ by
+   * @param {number} alphaThreshold How much the alpha channel may differ by
+   */
+  function assertColorsClose(
+    actual,
+    expected,
+    threshold = 0.5,
+    alphaThreshold = 0.1
+  ) {
+    assert.closeTo(actual.red, expected.red, threshold, 'red');
+    assert.closeTo(actual.green, expected.green, threshold, 'green');
+    assert.closeTo(actual.blue, expected.blue, threshold, 'blue');
+    assert.closeTo(actual.alpha, expected.alpha, alphaThreshold, 'alpha');
+  }
+
   before(function () {
     origBodyBg = document.body.style.background;
     origHtmlBg = document.documentElement.style.background;
@@ -31,10 +62,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(128, 0, 0, 1);
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -55,11 +83,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(64, 64, 0, 1);
-
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [target, pos]);
   });
 
@@ -75,10 +99,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(64, 64, 0, 1);
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [target, under]);
   });
 
@@ -101,11 +122,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(64, 64, 0, 1);
-
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [target, under]);
   });
 
@@ -120,10 +137,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(64, 64, 0, 1);
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [target, parent]);
   });
 
@@ -138,10 +152,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(64, 64, 0, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [target, parent]);
   });
 
@@ -155,10 +166,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(102, 153, 51, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
   });
 
   it('should apply opacity from an ancestor not in the element stack', function () {
@@ -173,10 +181,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(102, 153, 51, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
   });
 
   it('should return null if containing parent has a background image and is non-opaque', function () {
@@ -195,16 +200,13 @@ describe('color.getBackgroundColor', function () {
     assert.equal(axe.commons.color.incompleteData.get('bgColor'), 'bgImage');
   });
 
-  it('should return white if transparency goes all the way up to document', function () {
+  it('should return body color if transparency goes all the way up to document', function () {
     fixture.innerHTML = '<div id="target" style="height: 10px; width: 30px;">';
     var target = fixture.querySelector('#target');
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target);
     var expected = new axe.commons.color.Color(255, 255, 255, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
   });
 
   it('should return null if there is a background image', function () {
@@ -272,10 +274,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(0, 128, 0, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [target]);
   });
 
@@ -324,9 +323,8 @@ describe('color.getBackgroundColor', function () {
       document.getElementById('target'),
       []
     );
-    assert.equal(Math.round(actual.blue), 255);
-    assert.equal(Math.round(actual.red), 255);
-    assert.equal(Math.round(actual.green), 255);
+    var expected = new axe.commons.color.Color(255, 255, 255);
+    assertColorsClose(actual, expected);
   });
 
   it('should return null if an absolutely positioned element partially obsures background', function () {
@@ -362,10 +360,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(243, 243, 243, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -384,10 +379,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(243, 243, 243, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -406,10 +398,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(243, 243, 243, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -428,10 +417,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(243, 243, 243, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -450,10 +436,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(243, 243, 243, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -472,10 +455,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(243, 243, 243, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -491,10 +471,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(255, 255, 255, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.notEqual(bgNodes, [parent]);
   });
 
@@ -508,10 +485,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(0, 0, 0, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
   });
 
   it('handles nested inline elements in the middle of a text', function () {
@@ -527,10 +501,8 @@ describe('color.getBackgroundColor', function () {
     var bgNodes = [];
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
-    assert.equal(actual.red, 0);
-    assert.equal(actual.green, 255);
-    assert.equal(actual.blue, 255);
-    assert.equal(actual.alpha, 1);
+    var expected = new axe.commons.color.Color(0, 255, 255, 1);
+    assertColorsEqual(actual, expected);
   });
 
   it('should return null for inline elements with position:absolute', function () {
@@ -560,10 +532,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(255, 255, 255, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.notEqual(bgNodes, [parent]);
   });
 
@@ -586,10 +555,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
     var expected = new axe.commons.color.Color(243, 243, 243, 1);
-    assert.equal(actual.red, expected.red);
-    assert.equal(actual.green, expected.green);
-    assert.equal(actual.blue, expected.blue);
-    assert.equal(actual.alpha, expected.alpha);
+    assertColorsEqual(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -609,10 +575,7 @@ describe('color.getBackgroundColor', function () {
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
 
     var expected = new axe.commons.color.Color(255, 255, 255, 1);
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -630,10 +593,7 @@ describe('color.getBackgroundColor', function () {
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
 
     var expected = new axe.commons.color.Color(255, 255, 255, 1);
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -655,10 +615,7 @@ describe('color.getBackgroundColor', function () {
 
     assert.deepEqual(bgNodes, [shifted]);
 
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
   });
 
   it('should return null when encountering background images during visual traversal', function () {
@@ -715,10 +672,7 @@ describe('color.getBackgroundColor', function () {
 
     var expected = new axe.commons.color.Color(0, 0, 0, 1);
 
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
   });
 
   it('returns negative z-index elements when body has a background', function () {
@@ -736,10 +690,7 @@ describe('color.getBackgroundColor', function () {
 
     var expected = new axe.commons.color.Color(0, 0, 0, 1);
 
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
   });
 
   it('should return null for negative z-index element when html and body have a background', function () {
@@ -768,11 +719,7 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(fixture, []);
     var expected = new axe.commons.color.Color(255, 255, 255, 1);
-
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
   });
 
   it('should return the body bgColor when content does not overlap', function () {
@@ -783,11 +730,8 @@ describe('color.getBackgroundColor', function () {
     axe.testUtils.flatTreeSetup(fixture);
     var target = fixture.querySelector('#target');
     var actual = axe.commons.color.getBackgroundColor(target, []);
-
-    assert.closeTo(actual.red, 255, 0);
-    assert.closeTo(actual.green, 255, 0);
-    assert.closeTo(actual.blue, 255, 0);
-    assert.closeTo(actual.alpha, 1, 0);
+    var expected = new axe.commons.color.Color(255, 255, 255, 1);
+    assertColorsEqual(actual, expected);
   });
 
   it('should return the html canvas inherited from body bgColor when element content does not overlap with body', function () {
@@ -801,17 +745,16 @@ describe('color.getBackgroundColor', function () {
     document.body.style.background = '#000';
     document.body.style.margin = 0;
 
-    axe.testUtils.flatTreeSetup(fixture);
-    var target = fixture.querySelector('#target');
-    var actual = axe.commons.color.getBackgroundColor(target, []);
-
-    assert.closeTo(actual.red, 0, 0);
-    assert.closeTo(actual.green, 0, 0);
-    assert.closeTo(actual.blue, 0, 0);
-    assert.closeTo(actual.alpha, 1, 0);
-
-    document.body.style.height = originalHeight;
-    document.body.style.margin = originalMargin;
+    try {
+      axe.testUtils.flatTreeSetup(fixture);
+      var target = fixture.querySelector('#target');
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      var expected = new axe.commons.color.Color(0, 0, 0, 1);
+      assertColorsEqual(actual, expected);
+    } finally {
+      document.body.style.height = originalHeight;
+      document.body.style.margin = originalMargin;
+    }
   });
 
   it('should return the html canvas bgColor when element content does not overlap with body', function () {
@@ -824,16 +767,15 @@ describe('color.getBackgroundColor', function () {
     document.body.style.background = '#0f0';
     document.documentElement.style.background = '#f00';
 
-    axe.testUtils.flatTreeSetup(fixture);
-    var target = fixture.querySelector('#target');
-    var actual = axe.commons.color.getBackgroundColor(target, []);
-
-    assert.closeTo(actual.red, 255, 0);
-    assert.closeTo(actual.green, 0, 0);
-    assert.closeTo(actual.blue, 0, 0);
-    assert.closeTo(actual.alpha, 1, 0);
-
-    document.body.style.height = originalHeight;
+    try {
+      axe.testUtils.flatTreeSetup(fixture);
+      var target = fixture.querySelector('#target');
+      var actual = axe.commons.color.getBackgroundColor(target, []);
+      var expected = new axe.commons.color.Color(255, 0, 0, 1);
+      assertColorsEqual(actual, expected);
+    } finally {
+      document.body.style.height = originalHeight;
+    }
   });
 
   it('should apply mix-blend-mode', function () {
@@ -870,10 +812,8 @@ describe('color.getBackgroundColor', function () {
       var target = shadow.querySelector('#shadowTarget');
       var actual = axe.commons.color.getBackgroundColor(target, []);
 
-      assert.closeTo(actual.red, 0, 0);
-      assert.closeTo(actual.green, 0, 0);
-      assert.closeTo(actual.blue, 0, 0);
-      assert.closeTo(actual.alpha, 1, 0);
+      var expected = new axe.commons.color.Color(0, 0, 0, 1);
+      assertColorsEqual(actual, expected);
     }
   );
 
@@ -890,11 +830,8 @@ describe('color.getBackgroundColor', function () {
 
       var target = shadow.querySelector('#shadowTarget');
       var actual = axe.commons.color.getBackgroundColor(target, [], false);
-
-      assert.equal(actual.red, 0);
-      assert.equal(actual.green, 0);
-      assert.equal(actual.blue, 0);
-      assert.equal(actual.alpha, 1);
+      var expected = new axe.commons.color.Color(0, 0, 0, 1);
+      assertColorsEqual(actual, expected);
     }
   );
 
@@ -911,11 +848,7 @@ describe('color.getBackgroundColor', function () {
       axe.testUtils.flatTreeSetup(fixture);
       var actual = axe.commons.color.getBackgroundColor(target, []);
       var expected = new axe.commons.color.Color(0, 0, 0, 1);
-
-      assert.equal(actual.red, expected.red);
-      assert.equal(actual.green, expected.green);
-      assert.equal(actual.blue, expected.blue);
-      assert.equal(actual.alpha, expected.alpha);
+      assertColorsEqual(actual, expected);
     }
   );
 
@@ -933,10 +866,8 @@ describe('color.getBackgroundColor', function () {
       var target = shadow.querySelector('#shadowTarget');
       axe.testUtils.flatTreeSetup(fixture);
       var actual = axe.commons.color.getBackgroundColor(target, []);
-      assert.equal(actual.red, 255);
-      assert.equal(actual.green, 255);
-      assert.equal(actual.blue, 255);
-      assert.equal(actual.alpha, 1);
+      var expected = new axe.commons.color.Color(255, 255, 255, 1);
+      assertColorsEqual(actual, expected);
     }
   );
 
@@ -954,10 +885,8 @@ describe('color.getBackgroundColor', function () {
       var elm2 = document.querySelector('#elm2');
       axe.testUtils.flatTreeSetup(fixture);
       var actual = axe.commons.color.getBackgroundColor(elm2, []);
-      assert.equal(actual.red, 0);
-      assert.equal(actual.blue, 0);
-      assert.equal(actual.green, 0);
-      assert.equal(actual.alpha, 1);
+      var expected = new axe.commons.color.Color(0, 0, 0, 1);
+      assertColorsEqual(actual, expected);
     }
   );
 
@@ -983,10 +912,8 @@ describe('color.getBackgroundColor', function () {
       var elm3 = shadow2.querySelector('#elm3');
       axe.testUtils.flatTreeSetup(fixture);
       var actual = axe.commons.color.getBackgroundColor(elm3, []);
-      assert.closeTo(actual.red, 128, 2);
-      assert.closeTo(actual.blue, 128, 2);
-      assert.closeTo(actual.green, 128, 2);
-      assert.closeTo(actual.alpha, 1, 0);
+      var expected = new axe.commons.color.Color(128, 128, 128, 1);
+      assertColorsClose(actual, expected, 2, 0);
     }
   );
 
@@ -1002,10 +929,8 @@ describe('color.getBackgroundColor', function () {
       axe.testUtils.flatTreeSetup(fixture);
       var target = shadow.querySelector('#shadowTarget');
       var actual = axe.commons.color.getBackgroundColor(target, []);
-      assert.equal(actual.red, 0);
-      assert.equal(actual.green, 0);
-      assert.equal(actual.blue, 0);
-      assert.equal(actual.alpha, 1);
+      var expected = new axe.commons.color.Color(0, 0, 0, 1);
+      assertColorsEqual(actual, expected);
     }
   );
 
@@ -1036,10 +961,8 @@ describe('color.getBackgroundColor', function () {
       axe.testUtils.flatTreeSetup(fixture);
       var linkElm = div.querySelector('a');
       var actual = axe.commons.color.getBackgroundColor(linkElm, []);
-      assert.equal(actual.red, 0);
-      assert.equal(actual.green, 0);
-      assert.equal(actual.blue, 0);
-      assert.equal(actual.alpha, 1);
+      var expected = new axe.commons.color.Color(0, 0, 0, 1);
+      assertColorsEqual(actual, expected);
     }
   );
 
@@ -1056,10 +979,7 @@ describe('color.getBackgroundColor', function () {
 
     // is 128 without the shadow
     var expected = new axe.commons.color.Color(145, 0, 0, 1);
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
     assert.deepEqual(bgNodes, [parent]);
   });
 
@@ -1072,11 +992,8 @@ describe('color.getBackgroundColor', function () {
     var bgNodes = [];
     axe.testUtils.flatTreeSetup(fixture);
     var actual = axe.commons.color.getBackgroundColor(target, bgNodes);
-
-    assert.equal(actual.red, 0);
-    assert.equal(actual.green, 0);
-    assert.equal(actual.blue, 0);
-    assert.equal(actual.alpha, 1);
+    var expected = new axe.commons.color.Color(0, 0, 0, 1);
+    assertColorsEqual(actual, expected);
   });
 
   it('ignores text-shadows thinner than shadowOutlineEmMax', function () {
@@ -1091,10 +1008,7 @@ describe('color.getBackgroundColor', function () {
 
     // is 128 without the shadow
     var expected = new axe.commons.color.Color(145, 0, 0, 1);
-    assert.closeTo(actual.red, expected.red, 0.5);
-    assert.closeTo(actual.green, expected.green, 0.5);
-    assert.closeTo(actual.blue, expected.blue, 0.5);
-    assert.closeTo(actual.alpha, expected.alpha, 0.1);
+    assertColorsClose(actual, expected);
   });
 
   describe('body and document', function () {
@@ -1108,11 +1022,7 @@ describe('color.getBackgroundColor', function () {
         []
       );
       var expected = new axe.commons.color.Color(255, 0, 0, 1);
-
-      assert.closeTo(actual.red, expected.red, 0.5);
-      assert.closeTo(actual.green, expected.green, 0.5);
-      assert.closeTo(actual.blue, expected.blue, 0.5);
-      assert.closeTo(actual.alpha, expected.alpha, 0.1);
+      assertColorsClose(actual, expected);
     });
 
     it('returns the body background even when the body is MUCH larger than the screen', function () {
@@ -1126,10 +1036,7 @@ describe('color.getBackgroundColor', function () {
       );
       var expected = new axe.commons.color.Color(255, 0, 0, 1);
 
-      assert.closeTo(actual.red, expected.red, 0.5);
-      assert.closeTo(actual.green, expected.green, 0.5);
-      assert.closeTo(actual.blue, expected.blue, 0.5);
-      assert.closeTo(actual.alpha, expected.alpha, 0.1);
+      assertColorsClose(actual, expected);
     });
 
     it('returns the html background', function () {
@@ -1145,10 +1052,7 @@ describe('color.getBackgroundColor', function () {
       document.body.removeAttribute('style');
       var expected = new axe.commons.color.Color(0, 255, 0, 1);
 
-      assert.closeTo(actual.red, expected.red, 0.5);
-      assert.closeTo(actual.green, expected.green, 0.5);
-      assert.closeTo(actual.blue, expected.blue, 0.5);
-      assert.closeTo(actual.alpha, expected.alpha, 0.1);
+      assertColorsClose(actual, expected);
     });
 
     it('returns the html background when body does not cover the element', function () {
@@ -1164,10 +1068,7 @@ describe('color.getBackgroundColor', function () {
       );
       var expected = new axe.commons.color.Color(0, 255, 0, 1);
 
-      assert.closeTo(actual.red, expected.red, 0.5);
-      assert.closeTo(actual.green, expected.green, 0.5);
-      assert.closeTo(actual.blue, expected.blue, 0.5);
-      assert.closeTo(actual.alpha, expected.alpha, 0.1);
+      assertColorsClose(actual, expected);
     });
 
     it('returns the body background when body does cover the element', function () {
@@ -1182,10 +1083,7 @@ describe('color.getBackgroundColor', function () {
       );
       var expected = new axe.commons.color.Color(0, 0, 255, 1);
 
-      assert.closeTo(actual.red, expected.red, 0.5);
-      assert.closeTo(actual.green, expected.green, 0.5);
-      assert.closeTo(actual.blue, expected.blue, 0.5);
-      assert.closeTo(actual.alpha, expected.alpha, 0.1);
+      assertColorsClose(actual, expected);
     });
 
     it('returns both the html and body background if the body has alpha', function () {
@@ -1200,10 +1098,7 @@ describe('color.getBackgroundColor', function () {
       );
       var expected = new axe.commons.color.Color(0, 128, 128, 1);
 
-      assert.closeTo(actual.red, expected.red, 0.5);
-      assert.closeTo(actual.green, expected.green, 0.5);
-      assert.closeTo(actual.blue, expected.blue, 0.5);
-      assert.closeTo(actual.alpha, expected.alpha, 0.1);
+      assertColorsClose(actual, expected);
     });
   });
 });

--- a/test/commons/color/get-background-color.js
+++ b/test/commons/color/get-background-color.js
@@ -43,12 +43,21 @@ describe('color.getBackgroundColor', function () {
     origHtmlBg = document.documentElement.style.background;
   });
 
-  afterEach(function () {
-    document.body.style.background = origBodyBg;
-    document.documentElement.style.background = origHtmlBg;
+  beforeEach(function () {
+    // This normalizes the default mocha behavior of setting a different background
+    // based on prefers-color-scheme settings.
+    document.body.style.background = '#fff';
+    document.documentElement.style.background = 'unset';
+  });
 
+  afterEach(function () {
     axe.commons.color.incompleteData.clear();
     axe._tree = undefined;
+  });
+
+  after(function () {
+    document.body.style.background = origBodyBg;
+    document.documentElement.style.background = origHtmlBg;
   });
 
   it('should return the blended color if it has no background set', function () {

--- a/test/commons/color/get-foreground-color.js
+++ b/test/commons/color/get-foreground-color.js
@@ -2,6 +2,8 @@ describe('color.getForegroundColor', () => {
   const { getForegroundColor, Color } = axe.commons.color;
   const { queryFixture, queryShadowFixture } = axe.testUtils;
 
+  var origBodyBg;
+
   function assertSameColor(actual, expected, margin = 0) {
     assert.closeTo(actual.red, expected.red, margin);
     assert.closeTo(actual.green, expected.green, margin);
@@ -10,9 +12,23 @@ describe('color.getForegroundColor', () => {
     assert.closeTo(actual.alpha, expected.alpha, margin / 255);
   }
 
+  before(() => {
+    origBodyBg = document.body.style.background;
+  });
+
+  beforeEach(() => {
+    // This normalizes the default mocha behavior of setting a different background
+    // based on prefers-color-scheme settings.
+    document.body.style.background = '#fff';
+  });
+
   afterEach(() => {
     axe.commons.color.incompleteData.clear();
     document.body.scrollTop = 0;
+  });
+
+  after(() => {
+    document.body.style.background = origBodyBg;
   });
 
   it('returns the CSS color property', () => {

--- a/test/commons/dom/get-visible-child-text-rects.js
+++ b/test/commons/dom/get-visible-child-text-rects.js
@@ -14,20 +14,20 @@ describe('dom.getVisibleChildTextRects', () => {
   }
 
   /**
-   * Asset that two DOMRect arrays are equal.
-   * @param {DOMRect[]} rectAs
-   * @param {DOMRect[]} rectBs
+   * Assert that two DOMRect arrays are equal.
+   * @param {DOMRect[]} actualRects
+   * @param {DOMRect[]} expectedRects
    */
-  function assertRectsEqual(rectAs, rectBs) {
-    assert.equal(rectAs.length, rectBs.length);
-    rectAs.forEach((rect, index) => {
-      const rectA = rectAs[index];
-      const rectB = rectBs[index];
+  function assertRectsEqual(actualRects, expectedRects) {
+    assert.equal(actualRects.length, expectedRects.length);
+    actualRects.forEach((rect, index) => {
+      const actual = actualRects[index];
+      const expected = expectedRects[index];
 
-      assert.approximately(rectA.left, rectB.left, 1);
-      assert.approximately(rectA.top, rectB.top, 1);
-      assert.approximately(rectA.width, rectB.width, 1);
-      assert.approximately(rectA.height, rectB.height, 1);
+      assert.approximately(actual.left, expected.left, 1, 'left');
+      assert.approximately(actual.top, expected.top, 1, 'top');
+      assert.approximately(actual.width, expected.width, 1, 'width');
+      assert.approximately(actual.height, expected.height, 1, 'height');
     });
   }
 

--- a/test/integration/full/dialog/dialog.html
+++ b/test/integration/full/dialog/dialog.html
@@ -22,12 +22,12 @@
   <body>
     <div id="target">
       <button id="root-button"></button>
-      <div style="background-color: #333">
+      <div style="background-color: #333; color: #000">
         <span id="root-color">Contrast failure</span>
       </div>
       <dialog>
         <button id="dialog-button"></button>
-        <div style="background-color: #333">
+        <div style="background-color: #333; color: #000">
           <span id="dialog-color">Contrast failure</span>
         </div>
       </dialog>


### PR DESCRIPTION
This PR fixes a few test failures I noticed when running `npm run test:unit` and `npm run test:integration` locally on my dev machine, which is running MacOS 13.4 with the system appearance preference set to dark mode. Before this PR, the integration tests wouldn't run and there were 11 bogus unit test failures on my local dev machine; after this PR, they are consistent with CI and pass.

The main issues this PR fixes are:
* `npm run start` used `http-server` without explicitly setting its `-a` argument, which means that it listens only on IPv4 localhost interfaces, not IPv6. This caused `npm run test:integration` to get stuck in `start-server-and-test`'s health check of the localhost server, which tried to connect on `::1` by default. Adding `-a ""` works around this. See https://github.com/http-party/http-server/issues/832 and https://github.com/http-party/http-server/pull/833/files for context.
* The CSS that we inherit from Mocha's `mocha.css` in our unit and integration tests uses a `prefers-color-scheme` media query to change the test page's background color according to system color scheme preference. However, many test cases in the `get-foreground-color` and `get-background-color` unit tests make assumptions about color blending that rely on the default light-scheme background color. This PR adds `before`/`after` hooks to those test files to normalize to the `#fff` background the tests assume. These hooks intentionally set the normalized color in `beforeEach` (to ensure each test case has an consistent starting state) and reset to the original color in `after` rather than `afterEach` (to limit the amount of unnecessary color flashing).
* The `dialog` integration test attempted to induce a color-contrast failure by overriding only `background-color`, but in dark mode, the new background color didn't actually cause a failure on its own. Updated that test to also override `color` to ensure the intended failure appears regardless of dark mode settings.

This PR also included a few refactorings that didn't turn out to be necessary to the fixes, but seemed nice enough and separate enough from the other changes to include. They are isolated to their own commits; feel free to review commit-by-commit to see them in isolation from the functional changes.

@straker and I originally explored an alternative for this that involved adding our own `/test/global-styles.css` that would override `mocha.css` and force a consistent background/text color across all tests all the time, ignoring prefers-color-scheme. I didn't end up going with this strategy because it conflicted too much with the test status messages that mocha includes on the page during `npm run test:debug` execution; in dark mode, it resulted in a lot of unreadable white-on-white text.

Closes: n/a
