### PR TITLE
fix(aria-allowed-role): add meter to allowed roles for named img

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -358,7 +358,7 @@ const htmlElms = {
           'menuitem',
           'menuitemcheckbox',
           'menuitemradio',
-					'meter',
+	  'meter',
           'option',
           'progressbar',
           'radio',

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -358,6 +358,7 @@ const htmlElms = {
           'menuitem',
           'menuitemcheckbox',
           'menuitemradio',
+					'meter',
           'option',
           'progressbar',
           'radio',

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -246,7 +246,7 @@
 <div id="fail-dpub-4" role="doc-noteref">ok</div>
 <!-- images -->
 <div id="fail-dpub-5" role="doc-cover">ok</div>
-<img src="#" role="meter" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" alt="test">
+<img src="#" role="meter" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" alt="test" id="pass-img-valid-role-meter">
 <img role="doc-cover" aria-label="foo" id="pass-img-valid-role-aria-label" />
 <img role="menuitem" title="bar" id="pass-img-valid-role-title" />
 <div id="image-baz">hazaar</div>

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -246,6 +246,7 @@
 <div id="fail-dpub-4" role="doc-noteref">ok</div>
 <!-- images -->
 <div id="fail-dpub-5" role="doc-cover">ok</div>
+<img src="#" role="meter" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" alt="test">
 <img role="doc-cover" aria-label="foo" id="pass-img-valid-role-aria-label" />
 <img role="menuitem" title="bar" id="pass-img-valid-role-title" />
 <div id="image-baz">hazaar</div>

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.json
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.json
@@ -82,6 +82,7 @@
     ["#pass-img-valid-role-title"],
     ["#pass-img-valid-role-aria-labelledby"],
     ["#pass-img-valid-role-radio"],
+    ["#pass-img-valid-role-meter"],
     ["#pass-imgmap-1"],
     ["#pass-imgmap-2"],
     ["#pass-navnone-1"],


### PR DESCRIPTION
closes #4054

as stated in the PR title, this adds the meter element to be an allowed role for the img element when it is provided an accessible name. 