### PR TITLE
fix: avoid memory issues by doing better cleanup

### DIFF
--- a/build/tasks/esbuild.js
+++ b/build/tasks/esbuild.js
@@ -26,7 +26,10 @@ module.exports = function (grunt) {
             bundle: true
           })
             .then(done)
-            .catch(done);
+            .catch(e => {
+              grunt.fail.fatal(e);
+              done();
+            });
         });
       });
     }

--- a/lib/checks/navigation/region-evaluate.js
+++ b/lib/checks/navigation/region-evaluate.js
@@ -4,7 +4,6 @@ import * as standards from '../../commons/standards';
 import matches from '../../commons/matches';
 import cache from '../../core/base/cache';
 
-const landmarkRoles = standards.getAriaRolesByType('landmark');
 const implicitAriaLiveRoles = ['alert', 'log', 'status'];
 
 export default function regionEvaluate(node, options, virtualNode) {
@@ -92,6 +91,7 @@ function isRegion(virtualNode, options) {
   const node = virtualNode.actualNode;
   const role = getRole(virtualNode);
   const ariaLive = (node.getAttribute('aria-live') || '').toLowerCase().trim();
+  const landmarkRoles = standards.getAriaRolesByType('landmark');
 
   // Ignore content inside of aria-live
   if (

--- a/lib/commons/color/incomplete-data.js
+++ b/lib/commons/color/incomplete-data.js
@@ -1,9 +1,12 @@
+import cache from '../../core/base/cache';
+
+const cacheKey = 'color.incompleteData';
+
 /**
  * API for handling incomplete color data
  * @namespace axe.commons.color.incompleteData
  * @inner
  */
-let data = {};
 const incompleteData = {
   /**
    * Store incomplete data by key with a string value
@@ -17,6 +20,7 @@ const incompleteData = {
     if (typeof key !== 'string') {
       throw new Error('Incomplete data: key must be a string');
     }
+    const data = cache.get(cacheKey, () => ({}));
     if (reason) {
       data[key] = reason;
     }
@@ -31,7 +35,8 @@ const incompleteData = {
    * @return {String} String for reason we couldn't tell
    */
   get: function (key) {
-    return data[key];
+    const data = cache.get(cacheKey);
+    return data?.[key];
   },
   /**
    * Clear incomplete data on demand
@@ -40,7 +45,7 @@ const incompleteData = {
    * @instance
    */
   clear: function () {
-    data = {};
+    cache.set(cacheKey, {});
   }
 };
 

--- a/lib/commons/standards/implicit-html-roles.js
+++ b/lib/commons/standards/implicit-html-roles.js
@@ -10,13 +10,19 @@ import isRowHeader from '../table/is-row-header';
 import sanitize from '../text/sanitize';
 import isFocusable from '../dom/is-focusable';
 import { closest } from '../../core/utils';
+import cache from '../../core/base/cache';
 import getExplicitRole from '../aria/get-explicit-role';
 
-const sectioningElementSelector =
-  getElementsByContentType('sectioning')
-    .map(nodeName => `${nodeName}:not([role])`)
-    .join(', ') +
-  ' , main:not([role]), [role=article], [role=complementary], [role=main], [role=navigation], [role=region]';
+const getSectioningElementSelector = () => {
+  return cache.get('sectioningElementSelector', () => {
+    return (
+      getElementsByContentType('sectioning')
+        .map(nodeName => `${nodeName}:not([role])`)
+        .join(', ') +
+      ' , main:not([role]), [role=article], [role=complementary], [role=main], [role=navigation], [role=region]'
+    );
+  });
+};
 
 // sectioning elements only have an accessible name if the
 // aria-label, aria-labelledby, or title attribute has valid
@@ -64,7 +70,7 @@ const implicitHtmlRoles = {
   fieldset: 'group',
   figure: 'figure',
   footer: vNode => {
-    const sectioningElement = closest(vNode, sectioningElementSelector);
+    const sectioningElement = closest(vNode, getSectioningElementSelector());
 
     return !sectioningElement ? 'contentinfo' : null;
   },
@@ -78,7 +84,7 @@ const implicitHtmlRoles = {
   h5: 'heading',
   h6: 'heading',
   header: vNode => {
-    const sectioningElement = closest(vNode, sectioningElementSelector);
+    const sectioningElement = closest(vNode, getSectioningElementSelector());
 
     return !sectioningElement ? 'banner' : null;
   },

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -3,7 +3,6 @@ import { isXHTML, validInputTypes } from '../../utils';
 import { isFocusable, getTabbableElements } from '../../../commons/dom';
 import cache from '../cache';
 
-let isXHTMLGlobal;
 let nodeIndex = 0;
 
 class VirtualNode extends AbstractVirtualNode {
@@ -27,11 +26,7 @@ class VirtualNode extends AbstractVirtualNode {
 
     this._isHidden = null; // will be populated by axe.utils.isHidden
     this._cache = {};
-
-    if (typeof isXHTMLGlobal === 'undefined') {
-      isXHTMLGlobal = isXHTML(node.ownerDocument);
-    }
-    this._isXHTML = isXHTMLGlobal;
+    this._isXHTML = isXHTML(node.ownerDocument);
 
     // we will normalize the type prop for inputs by looking strictly
     // at the attribute and not what the browser resolves the type

--- a/lib/core/utils/frame-messenger/message-id.js
+++ b/lib/core/utils/frame-messenger/message-id.js
@@ -1,5 +1,6 @@
 import { v4 as createUuid } from '../uuid';
 
+// No cache, so that this can persist across axe.run calls
 const messageIds = [];
 
 export function createMessageId() {

--- a/lib/core/utils/frame-messenger/post-message.js
+++ b/lib/core/utils/frame-messenger/post-message.js
@@ -15,10 +15,6 @@ import { createMessageId } from './message-id';
  * @return {Boolean} true if the message was sent
  */
 export function postMessage(win, data, sendToParent, replyHandler) {
-  if (typeof replyHandler === 'function') {
-    storeReplyHandler(data.channelId, replyHandler, sendToParent);
-  }
-
   // Prevent messaging to an inappropriate window
   sendToParent ? assertIsParentWindow(win) : assertIsFrameWindow(win);
   if (data.message instanceof Error && !sendToParent) {
@@ -37,6 +33,9 @@ export function postMessage(win, data, sendToParent, replyHandler) {
     return false;
   }
 
+  if (typeof replyHandler === 'function') {
+    storeReplyHandler(data.channelId, replyHandler, sendToParent);
+  }
   // There is no way to know the origin of `win`, so we'll try them all.
   allowedOrigins.forEach(origin => {
     try {

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -237,7 +237,8 @@ function getElmId(elm) {
  * @return {String|Array<String>}	Base CSS selector for the node
  */
 function getBaseSelector(elm) {
-  const xhtml = isXHTML(elm.documentElement);
+  const xhtml = isXHTML(document);
+  console.log({ xhtml });
   return escapeSelector(xhtml ? elm.localName : elm.nodeName.toLowerCase());
 }
 

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -238,7 +238,6 @@ function getElmId(elm) {
  */
 function getBaseSelector(elm) {
   const xhtml = isXHTML(document);
-  console.log({ xhtml });
   return escapeSelector(xhtml ? elm.localName : elm.nodeName.toLowerCase());
 }
 

--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -5,7 +5,6 @@ import matchesSelector from './element-matches';
 import isXHTML from './is-xhtml';
 import getShadowSelector from './get-shadow-selector';
 
-let xhtml;
 const ignoredAttributes = [
   'class',
   'style',
@@ -238,9 +237,7 @@ function getElmId(elm) {
  * @return {String|Array<String>}	Base CSS selector for the node
  */
 function getBaseSelector(elm) {
-  if (typeof xhtml === 'undefined') {
-    xhtml = isXHTML(document);
-  }
+  const xhtml = isXHTML(elm.documentElement);
   return escapeSelector(xhtml ? elm.localName : elm.nodeName.toLowerCase());
 }
 

--- a/lib/core/utils/is-xhtml.js
+++ b/lib/core/utils/is-xhtml.js
@@ -1,3 +1,5 @@
+import memoize from './memoize';
+
 /**
  * Determines if a document node is XHTML
  * @method isXHTML
@@ -5,11 +7,11 @@
  * @param {Node} doc a document node
  * @return {Boolean}
  */
-function isXHTML(doc) {
-  if (!doc.createElement) {
+const isXHTML = memoize(doc => {
+  if (!doc?.createElement) {
     return false;
   }
   return doc.createElement('A').localName === 'A';
-}
+});
 
 export default isXHTML;

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -1,3 +1,4 @@
+import caches from '../base/cache';
 import { matchesExpression, convertSelector } from './matches';
 import { getNodesMatchingExpression } from './selector-cache';
 
@@ -19,17 +20,20 @@ function createLocalVariables(
   return retVal;
 }
 
-/**
- * Allocating new objects in createLocalVariables is quite expensive given
- * that matchExpressions is in the hot path.
- *
- * Keep track of previously allocated objects to avoid useless allocations
- * and garbage collection. This is intentionally shared between calls of
- * matchExpressions.
- */
-const recycledLocalVariables = [];
-
 function matchExpressions(domTree, expressions, filter) {
+  /**
+   * Allocating new objects in createLocalVariables is quite expensive given
+   * that matchExpressions is in the hot path.
+   *
+   * Keep track of previously allocated objects to avoid useless allocations
+   * and garbage collection. This is intentionally shared between calls of
+   * matchExpressions.
+   */
+  const recycledLocalVariables = caches.get(
+    'qsa.recycledLocalVariables',
+    () => []
+  );
+
   const stack = [];
   const vNodes = Array.isArray(domTree) ? domTree : [domTree];
   let currentLevel = createLocalVariables(

--- a/lib/core/utils/query-selector-all-filter.js
+++ b/lib/core/utils/query-selector-all-filter.js
@@ -1,4 +1,4 @@
-import caches from '../base/cache';
+import cache from '../base/cache';
 import { matchesExpression, convertSelector } from './matches';
 import { getNodesMatchingExpression } from './selector-cache';
 
@@ -29,7 +29,7 @@ function matchExpressions(domTree, expressions, filter) {
    * and garbage collection. This is intentionally shared between calls of
    * matchExpressions.
    */
-  const recycledLocalVariables = caches.get(
+  const recycledLocalVariables = cache.get(
     'qsa.recycledLocalVariables',
     () => []
   );

--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -358,7 +358,7 @@ const htmlElms = {
           'menuitem',
           'menuitemcheckbox',
           'menuitemradio',
-	  'meter',
+          'meter',
           'option',
           'progressbar',
           'radio',

--- a/test/checks/navigation/region.js
+++ b/test/checks/navigation/region.js
@@ -18,6 +18,7 @@ describe('region', function () {
   afterEach(function () {
     fixture.innerHTML = '';
     checkContext.reset();
+    axe.reset();
   });
 
   it('should return true when content is inside the region', function () {
@@ -25,6 +26,23 @@ describe('region', function () {
       '<div role="main"><a id="target" href="a.html#mainheader">Click Here</a><div><h1 id="mainheader" tabindex="0">Introduction</h1></div></div>'
     );
 
+    assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+  });
+
+  it('should return true when the region was removed from standards', () => {
+    axe.configure({
+      standards: {
+        ariaRoles: {
+          feed: {
+            type: 'landmark'
+          }
+        }
+      }
+    });
+    var checkArgs = checkSetup(
+      '<div role="feed" id="target">This is random content.</div>' +
+        '<div role="main"><h1 id="mainheader">Introduction</h1></div>'
+    );
     assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
   });
 

--- a/test/checks/navigation/region.js
+++ b/test/checks/navigation/region.js
@@ -29,7 +29,7 @@ describe('region', function () {
     assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
   });
 
-  it('should return true when the region was removed from standards', () => {
+  it('should return true when a region role is added to standards', () => {
     axe.configure({
       standards: {
         ariaRoles: {

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -246,7 +246,15 @@
 <div id="fail-dpub-4" role="doc-noteref">ok</div>
 <!-- images -->
 <div id="fail-dpub-5" role="doc-cover">ok</div>
-<img src="#" role="meter" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" alt="test" id="pass-img-valid-role-meter">
+<img
+  src="#"
+  role="meter"
+  aria-valuenow="0"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  alt="test"
+  id="pass-img-valid-role-meter"
+/>
 <img role="doc-cover" aria-label="foo" id="pass-img-valid-role-aria-label" />
 <img role="menuitem" title="bar" id="pass-img-valid-role-title" />
 <div id="image-baz">hazaar</div>


### PR DESCRIPTION
I went over the entire codebase looking for places where we're keeping variables we should clean up after a run. Probably the biggest one was in `querySelectorAllFilter`, which was indicated as a problem in the issue. I found a few other places where info was stored in file scope where it shouldn't have been. Those have been fixed. There shouldn't be any of those left now.

The issue indicated the biggest problem with in FrameMessenger's [channels](https://github.com/dequelabs/axe-core/blob/0e73be039eed78fda20e9bf28ee7f6f7c0d62fd8/lib/core/utils/frame-messenger/channel-store.js#L3). That's not something we can put into the cache though. FrameMessenger isn't necessarily tied to a run, so we can't clear channels after the run is closed. What I've tried to do instead is move things around a bit so we don't set listeners unnecessarily. I don't know if that solves the issue, but then I'm not sure if this is even an issue. Even if it persisted, I don't think `channels` should need to be all that big. 

An alternative could be that we put a timeout directly into FrameMessenger. If no response happens after a predetermined time, the handler is deleted and an error is thrown. That's a complicated change, so if we can avoid that I think I'd prefer that. We'll see if this does enough to solve the issue.

Closes: #4045
