### PR TITLE
Add doc-glossary to allowed roles for aside element

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -85,6 +85,7 @@ const htmlElms = {
       'doc-dedication',
       'doc-example',
       'doc-footnote',
+      'doc-glossary',
       'doc-pullquote',
       'doc-tip'
     ]


### PR DESCRIPTION
updates html-elms.js to add doc-glossary to the allowed roles list.  

Updates for aria-allowed-role.html/.json files are incoming.


Closes: #4082
