### PR TITLE
chore: enable eslint:no-shadow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ module.exports = {
     'dot-notation': 2,
     'no-new-func': 0,
     'no-new-wrappers': 0,
+    'no-shadow': 2,
     'no-restricted-syntax': [
       'error',
       {

--- a/build/tasks/add-locale.js
+++ b/build/tasks/add-locale.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
         var commons = file.src[0];
 
         buildManual(grunt, options, commons, function (result) {
-          var out = {
+          var locale = {
             lang: options.lang,
             rules: result.rules.reduce(function (out, rule) {
               out[rule.id] = rule.metadata;
@@ -74,10 +74,10 @@ module.exports = function (grunt) {
             var oldMessages = grunt.file.readJSON(localeFile);
 
             // mergeMessages mutates out
-            mergeMessages(out, oldMessages);
+            mergeMessages(locale, oldMessages);
           }
 
-          grunt.file.write(file.dest, JSON.stringify(out, null, '  '));
+          grunt.file.write(file.dest, JSON.stringify(locale, null, '  '));
           console.log('created file at', file.dest);
         });
       });

--- a/doc/examples/chrome-debugging-protocol/axe-cdp.js
+++ b/doc/examples/chrome-debugging-protocol/axe-cdp.js
@@ -39,7 +39,7 @@ const example = async url => {
           // its value (`results.result.value` is undefined). By
           // `JSON.stringify()`ing it, we can `JSON.parse()` it later on
           // and return a valid results set.
-          .then(results => JSON.stringify(results))
+          .then(res => JSON.stringify(res))
           .then(resolve)
           .catch(reject);
       });

--- a/doc/examples/puppeteer/axe-puppeteer.js
+++ b/doc/examples/puppeteer/axe-puppeteer.js
@@ -9,11 +9,11 @@ const isValidURL = input => {
   return u.protocol && u.host;
 };
 
-// node axe-puppeteer.js <url>
-const url = process.argv[2];
-assert(isValidURL(url), 'Invalid URL');
+(async () => {
+  // node axe-puppeteer.js <url>
+  const url = process.argv[2];
+  assert(isValidURL(url), 'Invalid URL');
 
-const main = async url => {
   let browser;
   let results;
   try {
@@ -34,6 +34,8 @@ const main = async url => {
 
     // Get the results from `axe.run()`.
     results = await handle.jsonValue();
+    console.log(results);
+
     // Destroy the handle & return axe results.
     await handle.dispose();
   } catch (err) {
@@ -42,19 +44,9 @@ const main = async url => {
       await browser.close();
     }
 
-    // Re-throw
-    throw err;
+    console.error('Error running axe-core:', err.message);
+    process.exit(1);
   }
 
   await browser.close();
-  return results;
-};
-
-main(url)
-  .then(results => {
-    console.log(results);
-  })
-  .catch(err => {
-    console.error('Error running axe-core:', err.message);
-    process.exit(1);
-  });
+})();

--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -24,10 +24,10 @@ import { isVisibleToScreenReaders } from '../../commons/dom';
  * @memberof checks
  * @return {Mixed} True if aria-errormessage references an existing element that uses a supported technique. Undefined if it does not reference an existing element. False otherwise.
  */
-function ariaErrormessageEvaluate(node, options, virtualNode) {
+export default function ariaErrormessageEvaluate(node, options, virtualNode) {
   options = Array.isArray(options) ? options : [];
 
-  const attr = virtualNode.attr('aria-errormessage');
+  const errorMessage = virtualNode.attr('aria-errormessage');
   const hasAttr = virtualNode.hasAttr('aria-errormessage');
   const invaid = virtualNode.attr('aria-invalid');
   const hasInvallid = virtualNode.hasAttr('aria-invalid');
@@ -74,12 +74,10 @@ function ariaErrormessageEvaluate(node, options, virtualNode) {
   }
 
   // limit results to elements that actually have this attribute
-  if (options.indexOf(attr) === -1 && hasAttr) {
-    this.data(tokenList(attr));
-    return validateAttrValue.call(this, attr);
+  if (options.indexOf(errorMessage) === -1 && hasAttr) {
+    this.data(tokenList(errorMessage));
+    return validateAttrValue.call(this, errorMessage);
   }
 
   return true;
 }
-
-export default ariaErrormessageEvaluate;

--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -27,7 +27,7 @@ import { isVisibleToScreenReaders } from '../../commons/dom';
 export default function ariaErrormessageEvaluate(node, options, virtualNode) {
   options = Array.isArray(options) ? options : [];
 
-  const errorMessage = virtualNode.attr('aria-errormessage');
+  const errorMessageAttr = virtualNode.attr('aria-errormessage');
   const hasAttr = virtualNode.hasAttr('aria-errormessage');
   const invaid = virtualNode.attr('aria-invalid');
   const hasInvallid = virtualNode.hasAttr('aria-invalid');
@@ -74,9 +74,9 @@ export default function ariaErrormessageEvaluate(node, options, virtualNode) {
   }
 
   // limit results to elements that actually have this attribute
-  if (options.indexOf(errorMessage) === -1 && hasAttr) {
-    this.data(tokenList(errorMessage));
-    return validateAttrValue.call(this, errorMessage);
+  if (options.indexOf(errorMessageAttr) === -1 && hasAttr) {
+    this.data(tokenList(errorMessageAttr));
+    return validateAttrValue.call(this, errorMessageAttr);
   }
 
   return true;

--- a/lib/checks/aria/aria-required-children-evaluate.js
+++ b/lib/checks/aria/aria-required-children-evaluate.js
@@ -28,8 +28,8 @@ export default function ariaRequiredChildrenEvaluate(
 ) {
   const reviewEmpty =
     options && Array.isArray(options.reviewEmpty) ? options.reviewEmpty : [];
-  const role = getExplicitRole(virtualNode, { dpub: true });
-  const required = requiredOwned(role);
+  const explicitRole = getExplicitRole(virtualNode, { dpub: true });
+  const required = requiredOwned(explicitRole);
   if (required === null) {
     return true;
   }
@@ -51,12 +51,7 @@ export default function ariaRequiredChildrenEvaluate(
     return false;
   }
 
-  const missing = missingRequiredChildren(
-    virtualNode,
-    role,
-    required,
-    ownedRoles
-  );
+  const missing = missingRequiredChildren(virtualNode, required, ownedRoles);
   if (!missing) {
     return true;
   }
@@ -64,7 +59,7 @@ export default function ariaRequiredChildrenEvaluate(
   this.data(missing);
 
   // Only review empty nodes when a node is both empty and does not have an aria-owns relationship
-  if (reviewEmpty.includes(role) && !ownedElements.some(isContent)) {
+  if (reviewEmpty.includes(explicitRole) && !ownedElements.some(isContent)) {
     return undefined;
   }
 
@@ -117,7 +112,7 @@ function getOwnedRoles(virtualNode, required) {
 /**
  * Get missing children roles
  */
-function missingRequiredChildren(virtualNode, role, required, ownedRoles) {
+function missingRequiredChildren(virtualNode, required, ownedRoles) {
   for (let i = 0; i < ownedRoles.length; i++) {
     const { role } = ownedRoles[i];
 

--- a/lib/checks/lists/only-dlitems-evaluate.js
+++ b/lib/checks/lists/only-dlitems-evaluate.js
@@ -4,22 +4,22 @@ import { getRole, getExplicitRole } from '../../commons/aria';
 /**
  * @deprecated
  */
-function onlyDlitemsEvaluate(node, options, virtualNode) {
+export default function onlyDlitemsEvaluate(node, options, virtualNode) {
   const ALLOWED_ROLES = ['definition', 'term', 'list'];
   const base = {
     badNodes: [],
     hasNonEmptyTextNode: false
   };
 
-  const content = virtualNode.children.reduce((content, child) => {
+  const content = virtualNode.children.reduce((vNodes, child) => {
     const { actualNode } = child;
     if (
       actualNode.nodeName.toUpperCase() === 'DIV' &&
       getRole(actualNode) === null
     ) {
-      return content.concat(child.children);
+      return vNodes.concat(child.children);
     }
-    return content.concat(child);
+    return vNodes.concat(child);
   }, []);
 
   const result = content.reduce((out, childNode) => {
@@ -50,5 +50,3 @@ function onlyDlitemsEvaluate(node, options, virtualNode) {
 
   return !!result.badNodes.length || result.hasNonEmptyTextNode;
 }
-
-export default onlyDlitemsEvaluate;

--- a/lib/checks/tables/td-headers-attr-evaluate.js
+++ b/lib/checks/tables/td-headers-attr-evaluate.js
@@ -1,7 +1,7 @@
 import { tokenList } from '../../core/utils';
 import { isVisibleToScreenReaders } from '../../commons/dom';
 
-function tdHeadersAttrEvaluate(node) {
+export default function tdHeadersAttrEvaluate(node) {
   const cells = [];
   const reviewCells = [];
   const badCells = [];
@@ -14,12 +14,9 @@ function tdHeadersAttrEvaluate(node) {
     }
   }
 
-  const ids = cells.reduce((ids, cell) => {
-    if (cell.getAttribute('id')) {
-      ids.push(cell.getAttribute('id'));
-    }
-    return ids;
-  }, []);
+  const ids = cells
+    .filter(cell => cell.getAttribute('id'))
+    .map(cell => cell.getAttribute('id'));
 
   cells.forEach(cell => {
     let isSelf = false;
@@ -64,5 +61,3 @@ function tdHeadersAttrEvaluate(node) {
 
   return true;
 }
-
-export default tdHeadersAttrEvaluate;

--- a/lib/commons/color/stacking-context.js
+++ b/lib/commons/color/stacking-context.js
@@ -60,9 +60,9 @@ import flattenColors from './flatten-colors';
  * @return {Object}
  */
 export function getStackingContext(elm, elmStack) {
-  const vNode = getNodeFromTree(elm);
-  if (vNode._stackingContext) {
-    return vNode._stackingContext;
+  const virtualNode = getNodeFromTree(elm);
+  if (virtualNode._stackingContext) {
+    return virtualNode._stackingContext;
   }
 
   const stackingContext = [];
@@ -108,7 +108,7 @@ export function getStackingContext(elm, elmStack) {
     context.bgColor = bgColor;
   });
 
-  vNode._stackingContext = stackingContext;
+  virtualNode._stackingContext = stackingContext;
   return stackingContext;
 }
 

--- a/lib/commons/dom/create-grid.js
+++ b/lib/commons/dom/create-grid.js
@@ -381,7 +381,7 @@ function findScrollRegionParent(vNode, parentVNode) {
   // cache result of parent scroll region so we don't have to look up the entire
   // tree again for a child node
   checkedNodes.forEach(
-    vNode => (vNode._scrollRegionParent = scrollRegionParent)
+    virtualNode => (virtualNode._scrollRegionParent = scrollRegionParent)
   );
   return scrollRegionParent;
 }

--- a/lib/commons/matches/condition.js
+++ b/lib/commons/matches/condition.js
@@ -10,11 +10,9 @@
  * ```
  *
  * @param {any} argument
- * @param {Function|Null|undefined} condition
+ * @param {Function|Null|undefined} matcher
  * @returns {Boolean}
  */
-function condition(arg, condition) {
-  return !!condition(arg);
+export default function condition(arg, matcher) {
+  return !!matcher(arg);
 }
-
-export default condition;

--- a/lib/commons/math/split-rects.js
+++ b/lib/commons/math/split-rects.js
@@ -10,8 +10,8 @@
 export default function splitRects(outerRect, overlapRects) {
   let uniqueRects = [outerRect];
   for (const overlapRect of overlapRects) {
-    uniqueRects = uniqueRects.reduce((uniqueRects, inputRect) => {
-      return uniqueRects.concat(splitRect(inputRect, overlapRect));
+    uniqueRects = uniqueRects.reduce((rects, inputRect) => {
+      return rects.concat(splitRect(inputRect, overlapRect));
     }, []);
   }
   return uniqueRects;

--- a/lib/commons/table/get-scope.js
+++ b/lib/commons/table/get-scope.js
@@ -11,7 +11,7 @@ import { nodeLookup } from '../../core/utils';
  * @param {HTMLTableCellElement|AbstractVirtualNode} cell The table cell to test
  * @return {Boolean|String} Returns `false` if not a column header, or the scope of the column header element
  */
-function getScope(el) {
+export default function getScope(el) {
   const { vNode, domNode: cell } = nodeLookup(el);
 
   const scope = vNode.attr('scope');
@@ -32,29 +32,25 @@ function getScope(el) {
   } else if (!vNode.actualNode) {
     return 'auto';
   }
-  var tableGrid = toGrid(findUp(cell, 'table'));
-  var pos = getCellPosition(cell, tableGrid);
+  const tableGrid = toGrid(findUp(cell, 'table'));
+  const pos = getCellPosition(cell, tableGrid);
 
   // The element is in a row with all th elements, that makes it a column header
-  var headerRow = tableGrid[pos.y].reduce((headerRow, cell) => {
-    return headerRow && cell.nodeName.toUpperCase() === 'TH';
-  }, true);
+  const headerRow = tableGrid[pos.y].every(
+    node => node.nodeName.toUpperCase() === 'TH'
+  );
 
   if (headerRow) {
     return 'col';
   }
 
   // The element is in a column with all th elements, that makes it a row header
-  var headerCol = tableGrid
+  const headerCol = tableGrid
     .map(col => col[pos.x])
-    .reduce((headerCol, cell) => {
-      return headerCol && cell && cell.nodeName.toUpperCase() === 'TH';
-    }, true);
+    .every(node => node && node.nodeName.toUpperCase() === 'TH');
 
   if (headerCol) {
     return 'row';
   }
   return 'auto';
 }
-
-export default getScope;

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -18,7 +18,7 @@ import isIconLigature from '../text/is-icon-ligature';
  * @property {Bool} inLabelledByContext
  * @return {string}
  */
-function accessibleTextVirtual(virtualNode, context = {}) {
+export default function accessibleTextVirtual(virtualNode, context = {}) {
   context = prepareContext(virtualNode, context);
 
   // Step 2A, check visibility
@@ -42,7 +42,7 @@ function accessibleTextVirtual(virtualNode, context = {}) {
   ];
 
   // Find the first step that returns a non-empty string
-  const accName = computationSteps.reduce((accName, step) => {
+  const accessibleName = computationSteps.reduce((accName, step) => {
     if (context.startNode === virtualNode) {
       accName = sanitize(accName);
     }
@@ -55,9 +55,9 @@ function accessibleTextVirtual(virtualNode, context = {}) {
   }, '');
 
   if (context.debug) {
-    axe.log(accName || '{empty-value}', virtualNode.actualNode, context);
+    axe.log(accessibleName || '{empty-value}', virtualNode.actualNode, context);
   }
-  return accName;
+  return accessibleName;
 }
 
 /**
@@ -165,5 +165,3 @@ accessibleTextVirtual.alreadyProcessed = function alreadyProcessed(
   context.processed.push(virtualnode);
   return false;
 };
-
-export default accessibleTextVirtual;

--- a/lib/commons/text/is-icon-ligature.js
+++ b/lib/commons/text/is-icon-ligature.js
@@ -13,7 +13,7 @@ import cache from '../../core/base/cache';
  * @param {Number} differenceThreshold Percent of differences in pixel data or pixel width needed to determine if a font is a ligature font
  * @return {Boolean}
  */
-function isIconLigature(
+export default function isIconLigature(
   textVNode,
   differenceThreshold = 0.15,
   occurrenceThreshold = 3
@@ -191,8 +191,8 @@ function isIconLigature(
 
   // calculate the difference between the width of each character and the
   // combined with of all characters
-  const expectedWidth = nodeValue.split('').reduce((width, char) => {
-    return width + canvasContext.measureText(char).width;
+  const expectedWidth = nodeValue.split('').reduce((totalWidth, char) => {
+    return totalWidth + canvasContext.measureText(char).width;
   }, 0);
   const actualWidth = canvasContext.measureText(nodeValue).width;
 
@@ -209,5 +209,3 @@ function isIconLigature(
 
   return false;
 }
-
-export default isIconLigature;

--- a/lib/commons/text/native-text-alternative.js
+++ b/lib/commons/text/native-text-alternative.js
@@ -9,7 +9,7 @@ import nativeTextMethods from './native-text-methods';
  * @property {Bool} debug Enable logging for formControlValue
  * @return {String} Accessible text
  */
-function nativeTextAlternative(virtualNode, context = {}) {
+export default function nativeTextAlternative(virtualNode, context = {}) {
   const { actualNode } = virtualNode;
   if (
     virtualNode.props.nodeType !== 1 ||
@@ -20,14 +20,14 @@ function nativeTextAlternative(virtualNode, context = {}) {
 
   const textMethods = findTextMethods(virtualNode);
   // Find the first step that returns a non-empty string
-  const accName = textMethods.reduce((accName, step) => {
+  const accessibleName = textMethods.reduce((accName, step) => {
     return accName || step(virtualNode, context);
   }, '');
 
   if (context.debug) {
-    axe.log(accName || '{empty-value}', actualNode, context);
+    axe.log(accessibleName || '{empty-value}', actualNode, context);
   }
-  return accName;
+  return accessibleName;
 }
 
 /**
@@ -42,5 +42,3 @@ function findTextMethods(virtualNode) {
 
   return methods.map(methodName => nativeTextMethods[methodName]);
 }
-
-export default nativeTextAlternative;

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -15,162 +15,10 @@ import constants from '../constants';
 
 const dotRegex = /\{\{.+?\}\}/g;
 
-function getDefaultOrigin() {
-  // @see https://html.spec.whatwg.org/multipage/webappapis.html#dom-origin-dev
-  // window.origin does not exist in ie11
-  // prevent origin default "null" string on CDP `Page.setDocumentContent` https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDocumentContent
-  if (window.origin && window.origin !== 'null') {
-    return window.origin;
-  }
-  // window.location does not exist in node when we run the build
-  if (
-    window.location &&
-    window.location.origin &&
-    window.location.origin !== 'null'
-  ) {
-    return window.location.origin;
-  }
-}
-
-/*eslint no-unused-vars: 0*/
-function getDefaultConfiguration(audit) {
-  var config;
-  if (audit) {
-    config = clone(audit);
-    // Commons are configured into axe like everything else,
-    // however because things go funky if we have multiple commons objects
-    // we're not using the copy of that.
-    config.commons = audit.commons;
-  } else {
-    config = {};
-  }
-
-  config.reporter = config.reporter || null;
-  config.noHtml = config.noHtml || false;
-
-  if (!config.allowedOrigins) {
-    const defaultOrigin = getDefaultOrigin();
-    config.allowedOrigins = defaultOrigin ? [defaultOrigin] : [];
-  }
-
-  config.rules = config.rules || [];
-  config.checks = config.checks || [];
-  config.data = { checks: {}, rules: {}, ...config.data };
-  return config;
-}
-
-function unpackToObject(collection, audit, method) {
-  var i, l;
-  for (i = 0, l = collection.length; i < l; i++) {
-    audit[method](collection[i]);
-  }
-}
-
-/**
- * Merge two check locales (a, b), favoring `b`.
- *
- * Both locale `a` and the returned shape resemble:
- *
- *    {
- *      impact: string,
- *      messages: {
- *        pass: string | function,
- *        fail: string | function,
- *        incomplete: string | {
- *          [key: string]: string | function
- *        }
- *      }
- *    }
- *
- * Locale `b` follows the `axe.CheckLocale` shape and resembles:
- *
- *    {
- *      pass: string,
- *      fail: string,
- *      incomplete: string | { [key: string]: string }
- *    }
- */
-
-const mergeCheckLocale = (a, b) => {
-  let { pass, fail } = b;
-  // If the message(s) are Strings, they have not yet been run
-  // thru doT (which will return a Function).
-  if (typeof pass === 'string' && dotRegex.test(pass)) {
-    pass = doT.compile(pass);
-  }
-  if (typeof fail === 'string' && dotRegex.test(fail)) {
-    fail = doT.compile(fail);
-  }
-  return {
-    ...a,
-    messages: {
-      pass: pass || a.messages.pass,
-      fail: fail || a.messages.fail,
-      incomplete:
-        typeof a.messages.incomplete === 'object'
-          ? // TODO: for compleness-sake, we should be running
-            // incomplete messages thru doT as well. This was
-            // out-of-scope for runtime localization, but should
-            // eventually be addressed.
-            { ...a.messages.incomplete, ...b.incomplete }
-          : b.incomplete
-    }
-  };
-};
-
-/**
- * Merge two rule locales (a, b), favoring `b`.
- */
-
-const mergeRuleLocale = (a, b) => {
-  let { help, description } = b;
-  // If the message(s) are Strings, they have not yet been run
-  // thru doT (which will return a Function).
-  if (typeof help === 'string' && dotRegex.test(help)) {
-    help = doT.compile(help);
-  }
-  if (typeof description === 'string' && dotRegex.test(description)) {
-    description = doT.compile(description);
-  }
-  return {
-    ...a,
-    help: help || a.help,
-    description: description || a.description
-  };
-};
-
-/**
- * Merge two failure messages (a, b), favoring `b`.
- */
-
-const mergeFailureMessage = (a, b) => {
-  let { failureMessage } = b;
-  // If the message(s) are Strings, they have not yet been run
-  // thru doT (which will return a Function).
-  if (typeof failureMessage === 'string' && dotRegex.test(failureMessage)) {
-    failureMessage = doT.compile(failureMessage);
-  }
-  return {
-    ...a,
-    failureMessage: failureMessage || a.failureMessage
-  };
-};
-
-/**
- * Merge two incomplete fallback messages (a, b), favoring `b`.
- */
-
-const mergeFallbackMessage = (a, b) => {
-  if (typeof b === 'string' && dotRegex.test(b)) {
-    b = doT.compile(b);
-  }
-  return b || a;
-};
-
 /**
  * Constructor which holds configured rules and information about the document under test
  */
-class Audit {
+export default class Audit {
   constructor(audit) {
     // defaults
     this.lang = 'en';
@@ -439,11 +287,11 @@ class Audit {
     const preloaderQueue = queue();
     // defer preload if preload dependent rules exist
     if (runLaterRules.length) {
-      preloaderQueue.defer(resolve => {
+      preloaderQueue.defer(res => {
         // handle both success and fail of preload
         // and resolve, to allow to run all checks
         preload(options)
-          .then(assets => resolve(assets))
+          .then(assets => res(assets))
           .catch(err => {
             /**
              * Note:
@@ -451,7 +299,7 @@ class Audit {
              * -> instead we resolve as `undefined`
              */
             console.warn(`Couldn't load preload assets: `, err);
-            resolve(undefined);
+            res(undefined);
           });
       });
     }
@@ -672,6 +520,158 @@ class Audit {
   }
 }
 
+function getDefaultOrigin() {
+  // @see https://html.spec.whatwg.org/multipage/webappapis.html#dom-origin-dev
+  // window.origin does not exist in ie11
+  // prevent origin default "null" string on CDP `Page.setDocumentContent` https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDocumentContent
+  if (window.origin && window.origin !== 'null') {
+    return window.origin;
+  }
+  // window.location does not exist in node when we run the build
+  if (
+    window.location &&
+    window.location.origin &&
+    window.location.origin !== 'null'
+  ) {
+    return window.location.origin;
+  }
+}
+
+/*eslint no-unused-vars: 0*/
+function getDefaultConfiguration(audit) {
+  var config;
+  if (audit) {
+    config = clone(audit);
+    // Commons are configured into axe like everything else,
+    // however because things go funky if we have multiple commons objects
+    // we're not using the copy of that.
+    config.commons = audit.commons;
+  } else {
+    config = {};
+  }
+
+  config.reporter = config.reporter || null;
+  config.noHtml = config.noHtml || false;
+
+  if (!config.allowedOrigins) {
+    const defaultOrigin = getDefaultOrigin();
+    config.allowedOrigins = defaultOrigin ? [defaultOrigin] : [];
+  }
+
+  config.rules = config.rules || [];
+  config.checks = config.checks || [];
+  config.data = { checks: {}, rules: {}, ...config.data };
+  return config;
+}
+
+function unpackToObject(collection, audit, method) {
+  var i, l;
+  for (i = 0, l = collection.length; i < l; i++) {
+    audit[method](collection[i]);
+  }
+}
+
+/**
+ * Merge two check locales (a, b), favoring `b`.
+ *
+ * Both locale `a` and the returned shape resemble:
+ *
+ *    {
+ *      impact: string,
+ *      messages: {
+ *        pass: string | function,
+ *        fail: string | function,
+ *        incomplete: string | {
+ *          [key: string]: string | function
+ *        }
+ *      }
+ *    }
+ *
+ * Locale `b` follows the `axe.CheckLocale` shape and resembles:
+ *
+ *    {
+ *      pass: string,
+ *      fail: string,
+ *      incomplete: string | { [key: string]: string }
+ *    }
+ */
+
+const mergeCheckLocale = (a, b) => {
+  let { pass, fail } = b;
+  // If the message(s) are Strings, they have not yet been run
+  // thru doT (which will return a Function).
+  if (typeof pass === 'string' && dotRegex.test(pass)) {
+    pass = doT.compile(pass);
+  }
+  if (typeof fail === 'string' && dotRegex.test(fail)) {
+    fail = doT.compile(fail);
+  }
+  return {
+    ...a,
+    messages: {
+      pass: pass || a.messages.pass,
+      fail: fail || a.messages.fail,
+      incomplete:
+        typeof a.messages.incomplete === 'object'
+          ? // TODO: for compleness-sake, we should be running
+            // incomplete messages thru doT as well. This was
+            // out-of-scope for runtime localization, but should
+            // eventually be addressed.
+            { ...a.messages.incomplete, ...b.incomplete }
+          : b.incomplete
+    }
+  };
+};
+
+/**
+ * Merge two rule locales (a, b), favoring `b`.
+ */
+
+const mergeRuleLocale = (a, b) => {
+  let { help, description } = b;
+  // If the message(s) are Strings, they have not yet been run
+  // thru doT (which will return a Function).
+  if (typeof help === 'string' && dotRegex.test(help)) {
+    help = doT.compile(help);
+  }
+  if (typeof description === 'string' && dotRegex.test(description)) {
+    description = doT.compile(description);
+  }
+  return {
+    ...a,
+    help: help || a.help,
+    description: description || a.description
+  };
+};
+
+/**
+ * Merge two failure messages (a, b), favoring `b`.
+ */
+
+const mergeFailureMessage = (a, b) => {
+  let { failureMessage } = b;
+  // If the message(s) are Strings, they have not yet been run
+  // thru doT (which will return a Function).
+  if (typeof failureMessage === 'string' && dotRegex.test(failureMessage)) {
+    failureMessage = doT.compile(failureMessage);
+  }
+  return {
+    ...a,
+    failureMessage: failureMessage || a.failureMessage
+  };
+};
+
+/**
+ * Merge two incomplete fallback messages (a, b), favoring `b`.
+ */
+
+const mergeFallbackMessage = (a, b) => {
+  if (typeof b === 'string' && dotRegex.test(b)) {
+    b = doT.compile(b);
+  }
+  return b || a;
+};
+
 /**
  * Splits a given array of rules to two, with rules that can be run immediately and one's that are dependent on preloadedAssets
  * @method getRulesToRun
@@ -777,5 +777,3 @@ function getHelpUrl({ brand, application, lang }, ruleId, version) {
     (lang && lang !== 'en' ? '&lang=' + encodeURIComponent(lang) : '')
   );
 }
-
-export default Audit;

--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -537,9 +537,8 @@ function getDefaultOrigin() {
   }
 }
 
-/*eslint no-unused-vars: 0*/
 function getDefaultConfiguration(audit) {
-  var config;
+  let config;
   if (audit) {
     config = clone(audit);
     // Commons are configured into axe like everything else,
@@ -565,7 +564,7 @@ function getDefaultConfiguration(audit) {
 }
 
 function unpackToObject(collection, audit, method) {
-  var i, l;
+  let i, l;
   for (i = 0, l = collection.length; i < l; i++) {
     audit[method](collection[i]);
   }

--- a/lib/core/base/context/normalize-context.js
+++ b/lib/core/base/context/normalize-context.js
@@ -120,7 +120,7 @@ function assertLabelledFrameSelector(selector) {
   );
   assert(
     selector.fromFrames.every(
-      selector => !objectHasOwn(selector, 'fromFrames')
+      fromFrameSelector => !objectHasOwn(fromFrameSelector, 'fromFrames')
     ),
     'Invalid context; fromFrames selector must be appended, rather than nested'
   );
@@ -137,13 +137,15 @@ function assertLabelledShadowDomSelector(selector) {
   );
   assert(
     selector.fromShadowDom.every(
-      selector => !objectHasOwn(selector, 'fromFrames')
+      fromShadowDomSelector =>
+        !objectHasOwn(fromShadowDomSelector, 'fromFrames')
     ),
     'shadow selector must be inside fromFrame instead'
   );
   assert(
     selector.fromShadowDom.every(
-      selector => !objectHasOwn(selector, 'fromShadowDom')
+      fromShadowDomSelector =>
+        !objectHasOwn(fromShadowDomSelector, 'fromShadowDom')
     ),
     'fromShadowDom selector must be appended, rather than nested'
   );

--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -14,7 +14,7 @@ import { isVisibleToScreenReaders } from '../../commons/dom';
 import constants from '../constants';
 import log from '../log';
 
-function Rule(spec, parentAudit) {
+export default function Rule(spec, parentAudit) {
   this._audit = parentAudit;
 
   /**
@@ -286,7 +286,7 @@ Rule.prototype.run = function run(context, options = {}, resolve, reject) {
 
   // Defer the rule's execution to prevent "unresponsive script" warnings.
   // See https://github.com/dequelabs/axe-core/pull/1172 for discussion and details.
-  q.defer(resolve => setTimeout(resolve, 0));
+  q.defer(res => setTimeout(res, 0));
 
   if (options.performanceTimer) {
     this._logRulePerformance();
@@ -407,7 +407,7 @@ function getResult(results) {
     let hasResults = false;
     const result = {};
     results.forEach(r => {
-      const res = r.results.filter(result => result);
+      const res = r.results.filter(_result => _result);
       result[r.type] = res;
       if (res.length) {
         hasResults = true;
@@ -633,5 +633,3 @@ Rule.prototype.configure = function configure(spec) {
     this.impact = spec.impact;
   }
 };
-
-export default Rule;

--- a/lib/core/public/load.js
+++ b/lib/core/public/load.js
@@ -3,6 +3,15 @@ import cleanup from './cleanup';
 import runRules from './run-rules';
 import respondable from '../utils/respondable';
 
+/**
+ * Sets up Rules, Messages and default options for Checks, must be invoked before attempting analysis
+ * @param  {Object} audit The "audit specification" object
+ * @private
+ */
+export default function load(audit) {
+  axe._audit = new Audit(audit);
+}
+
 function runCommand(data, keepalive, callback) {
   var resolve = callback;
   var reject = function reject(err) {
@@ -23,10 +32,10 @@ function runCommand(data, keepalive, callback) {
       return runRules(
         context,
         options,
-        (results, cleanup) => {
+        (results, cleanupFn) => {
           resolve(results);
           // Cleanup AFTER resolve so that selectors can be generated
-          cleanup();
+          cleanupFn();
         },
         reject
       );
@@ -52,14 +61,3 @@ if (window.top !== window) {
     });
   });
 }
-
-/**
- * Sets up Rules, Messages and default options for Checks, must be invoked before attempting analysis
- * @param  {Object} audit The "audit specification" object
- * @private
- */
-function load(audit) {
-  axe._audit = new Audit(audit);
-}
-
-export default load;

--- a/lib/core/public/run-partial.js
+++ b/lib/core/public/run-partial.js
@@ -57,7 +57,7 @@ function serializeNode({ node, ...nodeResult }) {
     nodeResult[type] = nodeResult[type].map(
       ({ relatedNodes, ...checkResult }) => ({
         ...checkResult,
-        relatedNodes: relatedNodes.map(node => node.toJSON())
+        relatedNodes: relatedNodes.map(relatedNode => relatedNode.toJSON())
       })
     );
   }

--- a/lib/core/public/run-rules.js
+++ b/lib/core/public/run-rules.js
@@ -19,7 +19,7 @@ import log from '../log';
  * @param  {Function} resolve  Called when done running rules, receives ([results : Object], teardown : Function)
  * @param  {Function} reject   Called when execution failed, receives (err : Error)
  */
-function runRules(context, options, resolve, reject) {
+export default function runRules(context, options, resolve, reject) {
   try {
     context = new Context(context);
     axe._tree = context.flatTree;
@@ -52,8 +52,8 @@ function runRules(context, options, resolve, reject) {
 
       // Add wrapper object so that we may use the same "merge" function for results from inside and outside frames
       var results = mergeResults(
-        data.map(results => {
-          return { results };
+        data.map(res => {
+          return { results: res };
         })
       );
 
@@ -79,5 +79,3 @@ function runRules(context, options, resolve, reject) {
     reject(e);
   });
 }
-
-export default runRules;

--- a/lib/core/reporters/helpers/incomplete-fallback-msg.js
+++ b/lib/core/reporters/helpers/incomplete-fallback-msg.js
@@ -4,12 +4,12 @@
  * @return {String}
  */
 export default function incompleteFallbackMessage() {
-  let { incompleteFallbackMessage } = axe._audit.data;
-  if (typeof incompleteFallbackMessage === 'function') {
-    incompleteFallbackMessage = incompleteFallbackMessage();
+  let { incompleteFallbackMessage: message } = axe._audit.data;
+  if (typeof message === 'function') {
+    message = message();
   }
-  if (typeof incompleteFallbackMessage !== 'string') {
+  if (typeof message !== 'string') {
     return '';
   }
-  return incompleteFallbackMessage;
+  return message;
 }

--- a/lib/core/reporters/helpers/process-aggregate.js
+++ b/lib/core/reporters/helpers/process-aggregate.js
@@ -1,36 +1,6 @@
 import constants from '../../constants';
 
-function normalizeRelatedNodes(node, options) {
-  ['any', 'all', 'none'].forEach(type => {
-    if (!Array.isArray(node[type])) {
-      return;
-    }
-    node[type]
-      .filter(checkRes => Array.isArray(checkRes.relatedNodes))
-      .forEach(checkRes => {
-        checkRes.relatedNodes = checkRes.relatedNodes.map(relatedNode => {
-          var res = {
-            html: relatedNode?.source ?? 'Undefined'
-          };
-          if (options.elementRef && !relatedNode?.fromFrame) {
-            res.element = relatedNode?.element ?? null;
-          }
-          if (options.selectors !== false || relatedNode?.fromFrame) {
-            res.target = relatedNode?.selector ?? [':root'];
-          }
-          if (options.ancestry) {
-            res.ancestry = relatedNode?.ancestry ?? [':root'];
-          }
-          if (options.xpath) {
-            res.xpath = relatedNode?.xpath ?? ['/'];
-          }
-          return res;
-        });
-      });
-  });
-}
-
-var resultKeys = constants.resultGroups;
+const resultKeys = constants.resultGroups;
 
 /**
  * Configures the processing of axe results.
@@ -55,7 +25,7 @@ var resultKeys = constants.resultGroups;
  * @return {Object}
  *
  */
-function processAggregate(results, options) {
+export default function processAggregate(results, options) {
   var resultObject = axe.utils.aggregateResult(results);
 
   resultKeys.forEach(key => {
@@ -96,7 +66,7 @@ function processAggregate(results, options) {
         });
       }
 
-      resultKeys.forEach(key => delete ruleResult[key]);
+      resultKeys.forEach(k => delete ruleResult[k]);
       delete ruleResult.pageLevel;
       delete ruleResult.result;
 
@@ -107,4 +77,32 @@ function processAggregate(results, options) {
   return resultObject;
 }
 
-export default processAggregate;
+function normalizeRelatedNodes(node, options) {
+  ['any', 'all', 'none'].forEach(type => {
+    if (!Array.isArray(node[type])) {
+      return;
+    }
+    node[type]
+      .filter(checkRes => Array.isArray(checkRes.relatedNodes))
+      .forEach(checkRes => {
+        checkRes.relatedNodes = checkRes.relatedNodes.map(relatedNode => {
+          var res = {
+            html: relatedNode?.source ?? 'Undefined'
+          };
+          if (options.elementRef && !relatedNode?.fromFrame) {
+            res.element = relatedNode?.element ?? null;
+          }
+          if (options.selectors !== false || relatedNode?.fromFrame) {
+            res.target = relatedNode?.selector ?? [':root'];
+          }
+          if (options.ancestry) {
+            res.ancestry = relatedNode?.ancestry ?? [':root'];
+          }
+          if (options.xpath) {
+            res.xpath = relatedNode?.xpath ?? ['/'];
+          }
+          return res;
+        });
+      });
+  });
+}

--- a/lib/core/reporters/helpers/process-aggregate.js
+++ b/lib/core/reporters/helpers/process-aggregate.js
@@ -66,7 +66,7 @@ export default function processAggregate(results, options) {
         });
       }
 
-      resultKeys.forEach(k => delete ruleResult[k]);
+      resultKeys.forEach(resultKey => delete ruleResult[resultKey]);
       delete ruleResult.pageLevel;
       delete ruleResult.result;
 

--- a/lib/core/reporters/helpers/process-aggregate.js
+++ b/lib/core/reporters/helpers/process-aggregate.js
@@ -26,7 +26,7 @@ const resultKeys = constants.resultGroups;
  *
  */
 export default function processAggregate(results, options) {
-  var resultObject = axe.utils.aggregateResult(results);
+  const resultObject = axe.utils.aggregateResult(results);
 
   resultKeys.forEach(key => {
     if (options.resultTypes && !options.resultTypes.includes(key)) {
@@ -86,7 +86,7 @@ function normalizeRelatedNodes(node, options) {
       .filter(checkRes => Array.isArray(checkRes.relatedNodes))
       .forEach(checkRes => {
         checkRes.relatedNodes = checkRes.relatedNodes.map(relatedNode => {
-          var res = {
+          const res = {
             html: relatedNode?.source ?? 'Undefined'
           };
           if (options.elementRef && !relatedNode?.fromFrame) {

--- a/lib/core/utils/aggregate-result.js
+++ b/lib/core/utils/aggregate-result.js
@@ -3,8 +3,8 @@ import constants from '../constants';
 function copyToGroup(resultObject, subResult, group) {
   var resultCopy = Object.assign({}, subResult);
   resultCopy.nodes = (resultCopy[group] || []).concat();
-  constants.resultGroups.forEach(g => {
-    delete resultCopy[g];
+  constants.resultGroups.forEach(resultGroup => {
+    delete resultCopy[resultGroup];
   });
   resultObject[group].push(resultCopy);
 }

--- a/lib/core/utils/aggregate-result.js
+++ b/lib/core/utils/aggregate-result.js
@@ -3,8 +3,8 @@ import constants from '../constants';
 function copyToGroup(resultObject, subResult, group) {
   var resultCopy = Object.assign({}, subResult);
   resultCopy.nodes = (resultCopy[group] || []).concat();
-  constants.resultGroups.forEach(group => {
-    delete resultCopy[group];
+  constants.resultGroups.forEach(g => {
+    delete resultCopy[g];
   });
   resultObject[group].push(resultCopy);
 }

--- a/lib/core/utils/finalize-result.js
+++ b/lib/core/utils/finalize-result.js
@@ -8,7 +8,7 @@ import aggregateNodeResults from './aggregate-node-results';
 export default function finalizeRuleResult(ruleResult) {
   // we don't use getRule so that this code does not throw but returns
   // the results
-  const rule = axe._audit.rules.find(r => r.id === ruleResult.id);
+  const rule = axe._audit.rules.find(({ id }) => id === ruleResult.id);
   if (rule && rule.impact) {
     ruleResult.nodes.forEach(node => {
       ['any', 'all', 'none'].forEach(checkType => {

--- a/lib/core/utils/finalize-result.js
+++ b/lib/core/utils/finalize-result.js
@@ -5,10 +5,10 @@ import aggregateNodeResults from './aggregate-node-results';
  * @param ruleResult {object}
  * @return {object}
  */
-function finalizeRuleResult(ruleResult) {
+export default function finalizeRuleResult(ruleResult) {
   // we don't use getRule so that this code does not throw but returns
   // the results
-  const rule = axe._audit.rules.find(rule => rule.id === ruleResult.id);
+  const rule = axe._audit.rules.find(r => r.id === ruleResult.id);
   if (rule && rule.impact) {
     ruleResult.nodes.forEach(node => {
       ['any', 'all', 'none'].forEach(checkType => {
@@ -24,5 +24,3 @@ function finalizeRuleResult(ruleResult) {
 
   return ruleResult;
 }
-
-export default finalizeRuleResult;

--- a/lib/core/utils/get-flattened-tree.js
+++ b/lib/core/utils/get-flattened-tree.js
@@ -24,6 +24,36 @@ import { cacheNodeSelectors } from './selector-cache';
 let hasShadowRoot;
 
 /**
+ * Recursvely returns an array of the virtual DOM nodes at this level
+ * excluding comment nodes and the shadow DOM nodes <content> and <slot>
+ *
+ * @param {Node} [node=document.documentElement] optional node. NOTE: passing in anything other than body or the documentElement may result in incomplete results.
+ * @param {String} [shadowId] optional ID of the shadow DOM that is the closest shadow
+ *                           ancestor of the node
+ */
+export default function getFlattenedTree(
+  node = document.documentElement,
+  shadowId
+) {
+  hasShadowRoot = false;
+  const selectorMap = {};
+  cache.set('nodeMap', new WeakMap());
+  cache.set('selectorMap', selectorMap);
+
+  // specifically pass `null` to the parent to designate the top
+  // node of the tree. if parent === undefined then we know
+  // we are in a disconnected tree
+  const tree = flattenTree(node, shadowId, null);
+  tree[0]._selectorMap = selectorMap;
+
+  // allow rules and checks to know if there is a shadow root attached
+  // to the current tree
+  tree[0]._hasShadowRoot = hasShadowRoot;
+
+  return tree;
+}
+
+/**
  * find all the fallback content for a <slot> and return these as an array
  * this array will also include any #text nodes
  *
@@ -67,8 +97,8 @@ function createNode(node, parent, shadowId) {
 function flattenTree(node, shadowId, parent) {
   // using a closure here and therefore cannot easily refactor toreduce the statements
   var retVal, realArray, nodeName;
-  function reduceShadowDOM(res, child, parent) {
-    var replacements = flattenTree(child, shadowId, parent);
+  function reduceShadowDOM(res, child, parentVNode) {
+    var replacements = flattenTree(child, shadowId, parentVNode);
     if (replacements) {
       res = res.concat(replacements);
     }
@@ -145,32 +175,3 @@ function flattenTree(node, shadowId, parent) {
     }
   }
 }
-
-/**
- * Recursvely returns an array of the virtual DOM nodes at this level
- * excluding comment nodes and the shadow DOM nodes <content> and <slot>
- *
- * @param {Node} [node=document.documentElement] optional node. NOTE: passing in anything other than body or the documentElement may result in incomplete results.
- * @param {String} [shadowId] optional ID of the shadow DOM that is the closest shadow
- *                           ancestor of the node
- */
-function getFlattenedTree(node = document.documentElement, shadowId) {
-  hasShadowRoot = false;
-  const selectorMap = {};
-  cache.set('nodeMap', new WeakMap());
-  cache.set('selectorMap', selectorMap);
-
-  // specifically pass `null` to the parent to designate the top
-  // node of the tree. if parent === undefined then we know
-  // we are in a disconnected tree
-  const tree = flattenTree(node, shadowId, null);
-  tree[0]._selectorMap = selectorMap;
-
-  // allow rules and checks to know if there is a shadow root attached
-  // to the current tree
-  tree[0]._hasShadowRoot = hasShadowRoot;
-
-  return tree;
-}
-
-export default getFlattenedTree;

--- a/lib/core/utils/get-flattened-tree.js
+++ b/lib/core/utils/get-flattened-tree.js
@@ -98,7 +98,7 @@ function flattenTree(node, shadowId, parent) {
   // using a closure here and therefore cannot easily refactor toreduce the statements
   var retVal, realArray, nodeName;
   function reduceShadowDOM(res, child, parentVNode) {
-    var replacements = flattenTree(child, shadowId, parentVNode);
+    const replacements = flattenTree(child, shadowId, parentVNode);
     if (replacements) {
       res = res.concat(replacements);
     }

--- a/lib/core/utils/get-rule.js
+++ b/lib/core/utils/get-rule.js
@@ -5,7 +5,7 @@
  */
 export default function getRule(ruleId) {
   // TODO: es-modules_audit
-  const rule = axe._audit.rules.find(r => r.id === ruleId);
+  const rule = axe._audit.rules.find(({ id }) => id === ruleId);
 
   if (!rule) {
     throw new Error(`Cannot find rule by id: ${ruleId}`);

--- a/lib/core/utils/get-rule.js
+++ b/lib/core/utils/get-rule.js
@@ -5,7 +5,7 @@
  */
 export default function getRule(ruleId) {
   // TODO: es-modules_audit
-  var rule = axe._audit.rules.find(r => r.id === ruleId);
+  const rule = axe._audit.rules.find(r => r.id === ruleId);
 
   if (!rule) {
     throw new Error(`Cannot find rule by id: ${ruleId}`);

--- a/lib/core/utils/get-rule.js
+++ b/lib/core/utils/get-rule.js
@@ -3,9 +3,9 @@
  * @param {String} ruelId the rule id
  * @return {Rule}
  */
-function getRule(ruleId) {
+export default function getRule(ruleId) {
   // TODO: es-modules_audit
-  var rule = axe._audit.rules.find(rule => rule.id === ruleId);
+  var rule = axe._audit.rules.find(r => r.id === ruleId);
 
   if (!rule) {
     throw new Error(`Cannot find rule by id: ${ruleId}`);
@@ -13,5 +13,3 @@ function getRule(ruleId) {
 
   return rule;
 }
-
-export default getRule;

--- a/lib/core/utils/get-shadow-selector.js
+++ b/lib/core/utils/get-shadow-selector.js
@@ -4,7 +4,7 @@
  * @param {Object} optional options
  * @returns {String|Array<String>} Unique CSS selector for the node
  */
-function getShadowSelector(generateSelector, elm, options = {}) {
+export default function getShadowSelector(generateSelector, elm, options = {}) {
   if (!elm) {
     return '';
   }
@@ -25,7 +25,5 @@ function getShadowSelector(generateSelector, elm, options = {}) {
   }
 
   stack.unshift({ elm, doc });
-  return stack.map(({ elm, doc }) => generateSelector(elm, options, doc));
+  return stack.map(item => generateSelector(item.elm, options, item.doc));
 }
-
-export default getShadowSelector;

--- a/lib/core/utils/match-ancestry.js
+++ b/lib/core/utils/match-ancestry.js
@@ -1,20 +1,20 @@
 /**
  * Check if two ancestries are identical
  */
-function matchAncestry(ancestryA, ancestryB) {
+export default function matchAncestry(ancestryA, ancestryB) {
   if (ancestryA.length !== ancestryB.length) {
     return false;
   }
-  return ancestryA.every((selectorA, index) => {
-    const selectorB = ancestryB[index];
+  return ancestryA.every((selectorA, ancestorIndex) => {
+    const selectorB = ancestryB[ancestorIndex];
     if (!Array.isArray(selectorA)) {
       return selectorA === selectorB;
     }
     if (selectorA.length !== selectorB.length) {
       return false;
     }
-    return selectorA.every((str, index) => selectorB[index] === str);
+    return selectorA.every(
+      (str, selectorIndex) => selectorB[selectorIndex] === str
+    );
   });
 }
-
-export default matchAncestry;

--- a/lib/core/utils/matches.js
+++ b/lib/core/utils/matches.js
@@ -1,5 +1,19 @@
 import cssParser from './css-parser';
 
+/**
+ * matches implementation that operates on a VirtualNode
+ *
+ * @method matches
+ * @memberof axe.utils
+ * @param {VirtualNode} vNode VirtualNode to match
+ * @param {String} selector CSS selector string
+ * @return {Boolean}
+ */
+export default function matches(vNode, selector) {
+  const expressions = convertSelector(selector);
+  return expressions.some(expression => matchesExpression(vNode, expression));
+}
+
 function matchesTag(vNode, exp) {
   return (
     vNode.props.nodeType === 1 &&
@@ -232,11 +246,11 @@ function optimizedMatchesExpression(vNode, expressions, index, matchAnyParent) {
 
   const isArray = Array.isArray(expressions);
   const expression = isArray ? expressions[index] : expressions;
-  let matches = matchExpression(vNode, expression);
+  let machedExpression = matchExpression(vNode, expression);
 
-  while (!matches && matchAnyParent && vNode.parent) {
+  while (!machedExpression && matchAnyParent && vNode.parent) {
     vNode = vNode.parent;
-    matches = matchExpression(vNode, expression);
+    machedExpression = matchExpression(vNode, expression);
   }
 
   if (index > 0) {
@@ -247,8 +261,8 @@ function optimizedMatchesExpression(vNode, expressions, index, matchAnyParent) {
       );
     }
 
-    matches =
-      matches &&
+    machedExpression =
+      machedExpression &&
       optimizedMatchesExpression(
         vNode.parent,
         expressions,
@@ -257,7 +271,7 @@ function optimizedMatchesExpression(vNode, expressions, index, matchAnyParent) {
       );
   }
 
-  return matches;
+  return machedExpression;
 }
 
 /**
@@ -278,19 +292,3 @@ export function matchesExpression(vNode, expressions, matchAnyParent) {
     matchAnyParent
   );
 }
-
-/**
- * matches implementation that operates on a VirtualNode
- *
- * @method matches
- * @memberof axe.utils
- * @param {VirtualNode} vNode VirtualNode to match
- * @param {String} selector CSS selector string
- * @return {Boolean}
- */
-function matches(vNode, selector) {
-  const expressions = convertSelector(selector);
-  return expressions.some(expression => matchesExpression(vNode, expression));
-}
-
-export default matches;

--- a/lib/core/utils/preload.js
+++ b/lib/core/utils/preload.js
@@ -4,13 +4,82 @@ import uniqueArray from './unique-array';
 import constants from '../constants';
 
 /**
+ * Returns a Promise with results of all requested preload(able) assets. eg: ['cssom'].
+ *
+ * @param {Object} options run configuration options (or defaults) passed via axe.run
+ * @return {Object} Promise
+ */
+export default function preload(options) {
+  const preloadFunctionsMap = {
+    cssom: preloadCssom,
+    media: preloadMedia
+  };
+
+  if (!shouldPreload(options)) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const { assets, timeout } = getPreloadConfig(options);
+
+    /**
+     * Start `timeout` timer for preloading assets
+     * -> reject if allowed time expires.
+     */
+    const preloadTimeout = setTimeout(
+      () => reject(new Error(`Preload assets timed out.`)),
+      timeout
+    );
+
+    /**
+     * Fetch requested `assets`
+     */
+    Promise.all(
+      assets.map(asset =>
+        preloadFunctionsMap[asset](options).then(results => {
+          return {
+            [asset]: results
+          };
+        })
+      )
+    )
+      .then(results => {
+        /**
+         * Combine array of results into an object map
+         *
+         * From ->
+         *  [{cssom: [...], aom: [...]}]
+         * To ->
+         *  {
+         *    cssom: [...]
+         *    aom: [...]
+         *  }
+         */
+        const preloadAssets = results.reduce((out, result) => {
+          return {
+            ...out,
+            ...result
+          };
+        }, {});
+
+        clearTimeout(preloadTimeout);
+        resolve(preloadAssets);
+      })
+      .catch(err => {
+        clearTimeout(preloadTimeout);
+        reject(err);
+      });
+  });
+}
+
+/**
  * Validated the preload object
- * @param {Object | boolean} preload configuration object or boolean passed via the options parameter to axe.run
+ * @param {Object | boolean} preloadObj configuration object or boolean passed via the options parameter to axe.run
  * @return {boolean}
  * @private
  */
-function isValidPreloadObject(preload) {
-  return typeof preload === 'object' && Array.isArray(preload.assets);
+function isValidPreloadObject(preloadObj) {
+  return typeof preloadObj === 'object' && Array.isArray(preloadObj.assets);
 }
 
 /**
@@ -77,74 +146,3 @@ export function getPreloadConfig(options) {
   }
   return config;
 }
-
-/**
- * Returns a Promise with results of all requested preload(able) assets. eg: ['cssom'].
- *
- * @param {Object} options run configuration options (or defaults) passed via axe.run
- * @return {Object} Promise
- */
-function preload(options) {
-  const preloadFunctionsMap = {
-    cssom: preloadCssom,
-    media: preloadMedia
-  };
-
-  if (!shouldPreload(options)) {
-    return Promise.resolve();
-  }
-
-  return new Promise((resolve, reject) => {
-    const { assets, timeout } = getPreloadConfig(options);
-
-    /**
-     * Start `timeout` timer for preloading assets
-     * -> reject if allowed time expires.
-     */
-    const preloadTimeout = setTimeout(
-      () => reject(new Error(`Preload assets timed out.`)),
-      timeout
-    );
-
-    /**
-     * Fetch requested `assets`
-     */
-    Promise.all(
-      assets.map(asset =>
-        preloadFunctionsMap[asset](options).then(results => {
-          return {
-            [asset]: results
-          };
-        })
-      )
-    )
-      .then(results => {
-        /**
-         * Combine array of results into an object map
-         *
-         * From ->
-         * 	[{cssom: [...], aom: [...]}]
-         * To ->
-         * 	{
-         * 		cssom: [...]
-         * 	 	aom: [...]
-         * 	}
-         */
-        const preloadAssets = results.reduce((out, result) => {
-          return {
-            ...out,
-            ...result
-          };
-        }, {});
-
-        clearTimeout(preloadTimeout);
-        resolve(preloadAssets);
-      })
-      .catch(err => {
-        clearTimeout(preloadTimeout);
-        reject(err);
-      });
-  });
-}
-
-export default preload;

--- a/lib/core/utils/publish-metadata.js
+++ b/lib/core/utils/publish-metadata.js
@@ -5,6 +5,29 @@ import extendMetaData from './extend-meta-data';
 import incompleteFallbackMessage from '../reporters/helpers/incomplete-fallback-msg';
 
 /**
+ * Publish metadata from axe._audit.data
+ * @param  {RuleResult} result Result to publish to
+ * @private
+ */
+export default function publishMetaData(ruleResult) {
+  // TODO: es-modules_audit
+  const checksData = axe._audit.data.checks || {};
+  const rulesData = axe._audit.data.rules || {};
+  const rule = findBy(axe._audit.rules, 'id', ruleResult.id) || {};
+
+  ruleResult.tags = clone(rule.tags || []);
+
+  const shouldBeTrue = extender(checksData, true, rule);
+  const shouldBeFalse = extender(checksData, false, rule);
+  ruleResult.nodes.forEach(detail => {
+    detail.any.forEach(shouldBeTrue);
+    detail.all.forEach(shouldBeTrue);
+    detail.none.forEach(shouldBeFalse);
+  });
+  extendMetaData(ruleResult, clone(rulesData[ruleResult.id] || {}));
+}
+
+/**
  * Construct incomplete message from check.data
  * @param  {Object} checkData Check result with reason specified
  * @param  {Object} messages Source data object with message options
@@ -12,10 +35,10 @@ import incompleteFallbackMessage from '../reporters/helpers/incomplete-fallback-
  * @private
  */
 function getIncompleteReason(checkData, messages) {
-  function getDefaultMsg(messages) {
-    if (messages.incomplete && messages.incomplete.default) {
+  function getDefaultMsg(message) {
+    if (message.incomplete && message.incomplete.default) {
       // fall back to the default message if no reason specified
-      return messages.incomplete.default;
+      return message.incomplete.default;
     } else {
       return incompleteFallbackMessage();
     }
@@ -82,28 +105,3 @@ function extender(checksData, shouldBeTrue, rule) {
     extendMetaData(check, data);
   };
 }
-
-/**
- * Publish metadata from axe._audit.data
- * @param  {RuleResult} result Result to publish to
- * @private
- */
-function publishMetaData(ruleResult) {
-  // TODO: es-modules_audit
-  const checksData = axe._audit.data.checks || {};
-  const rulesData = axe._audit.data.rules || {};
-  const rule = findBy(axe._audit.rules, 'id', ruleResult.id) || {};
-
-  ruleResult.tags = clone(rule.tags || []);
-
-  const shouldBeTrue = extender(checksData, true, rule);
-  const shouldBeFalse = extender(checksData, false, rule);
-  ruleResult.nodes.forEach(detail => {
-    detail.any.forEach(shouldBeTrue);
-    detail.all.forEach(shouldBeTrue);
-    detail.none.forEach(shouldBeFalse);
-  });
-  extendMetaData(ruleResult, clone(rulesData[ruleResult.id] || {}));
-}
-
-export default publishMetaData;

--- a/lib/rules/landmark-unique-matches.js
+++ b/lib/rules/landmark-unique-matches.js
@@ -4,48 +4,45 @@ import { getRole } from '../commons/aria';
 import { getAriaRolesByType } from '../commons/standards';
 import { accessibleTextVirtual } from '../commons/text';
 
-function landmarkUniqueMatches(node, virtualNode) {
-  /*
-   * Since this is a best-practice rule, we are filtering elements as dictated by ARIA 1.1 Practices regardless of treatment by browser/AT combinations.
-   *
-   * Info: https://www.w3.org/TR/wai-aria-practices-1.1/#aria_landmark
-   */
-  var excludedParentsForHeaderFooterLandmarks = [
-    'article',
-    'aside',
-    'main',
-    'nav',
-    'section'
-  ].join(',');
-  function isHeaderFooterLandmark(headerFooterElement) {
-    return !closest(
-      headerFooterElement,
-      excludedParentsForHeaderFooterLandmarks
-    );
-  }
+/*
+ * Since this is a best-practice rule, we are filtering elements as dictated by ARIA 1.1 Practices regardless of treatment by browser/AT combinations.
+ *
+ * Info: https://www.w3.org/TR/wai-aria-practices-1.1/#aria_landmark
+ */
+const excludedParentsForHeaderFooterLandmarks = [
+  'article',
+  'aside',
+  'main',
+  'nav',
+  'section'
+].join(',');
 
-  function isLandmarkVirtual(virtualNode) {
-    var { actualNode } = virtualNode;
-    var landmarkRoles = getAriaRolesByType('landmark');
-    var role = getRole(actualNode);
-    if (!role) {
-      return false;
-    }
-
-    var nodeName = actualNode.nodeName.toUpperCase();
-    if (nodeName === 'HEADER' || nodeName === 'FOOTER') {
-      return isHeaderFooterLandmark(virtualNode);
-    }
-
-    if (nodeName === 'SECTION' || nodeName === 'FORM') {
-      var accessibleText = accessibleTextVirtual(virtualNode);
-      return !!accessibleText;
-    }
-
-    return landmarkRoles.indexOf(role) >= 0 || role === 'region';
-  }
-
-  return isLandmarkVirtual(virtualNode) && isVisibleToScreenReaders(node);
+export default function landmarkUniqueMatches(node, virtualNode) {
+  return (
+    isLandmarkVirtual(virtualNode) && isVisibleToScreenReaders(virtualNode)
+  );
 }
 
-export default landmarkUniqueMatches;
+function isLandmarkVirtual(vNode) {
+  const landmarkRoles = getAriaRolesByType('landmark');
+  const role = getRole(vNode);
+  if (!role) {
+    return false;
+  }
+
+  const { nodeName } = vNode.props;
+  if (nodeName === 'header' || nodeName === 'footer') {
+    return isHeaderFooterLandmark(vNode);
+  }
+
+  if (nodeName === 'section' || nodeName === 'form') {
+    const accessibleText = accessibleTextVirtual(vNode);
+    return !!accessibleText;
+  }
+
+  return landmarkRoles.indexOf(role) >= 0 || role === 'region';
+}
+
+function isHeaderFooterLandmark(headerFooterElement) {
+  return !closest(headerFooterElement, excludedParentsForHeaderFooterLandmarks);
+}

--- a/test/checks/color/link-in-text-block-style.js
+++ b/test/checks/color/link-in-text-block-style.js
@@ -1,67 +1,64 @@
-describe('link-in-text-block-style', function () {
-  'use strict';
+describe('link-in-text-block-style', () => {
+  const fixture = document.getElementById('fixture');
+  const shadowSupport = axe.testUtils.shadowSupport;
+  let styleElm;
 
-  var fixture = document.getElementById('fixture');
-  var shadowSupport = axe.testUtils.shadowSupport;
-  var styleElm;
-
-  var checkContext = axe.testUtils.MockCheckContext();
+  const checkContext = axe.testUtils.MockCheckContext();
 
   const { queryFixture } = axe.testUtils;
   const linkInBlockStyleCheck = axe.testUtils.getCheckEvaluate(
     'link-in-text-block-style'
   );
 
-  before(function () {
+  before(() => {
     styleElm = document.createElement('style');
     document.head.appendChild(styleElm);
   });
 
-  var defaultStyle = {
+  const defaultStyle = {
     color: 'black',
     textDecoration: 'none'
   };
 
-  beforeEach(function () {
+  beforeEach(() => {
     createStyleString('p', defaultStyle);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
     styleElm.innerHTML = '';
     checkContext.reset();
   });
 
-  after(function () {
+  after(() => {
     styleElm.parentNode.removeChild(styleElm);
   });
 
   function createStyleString(selector, outerStyle) {
     // Merge style with the default
-    var prop;
-    var styleObj = {};
-    for (prop in defaultStyle) {
+    const styleObj = {};
+    for (const prop in defaultStyle) {
       if (defaultStyle.hasOwnProperty(prop)) {
         styleObj[prop] = defaultStyle[prop];
       }
     }
-    for (prop in outerStyle) {
+    for (const prop in outerStyle) {
       if (outerStyle.hasOwnProperty(prop)) {
         styleObj[prop] = outerStyle[prop];
       }
     }
 
-    var cssLines = Object.keys(styleObj)
-      .map(function (prop) {
+    const cssLines = Object.keys(styleObj)
+      .map(prop => {
         // Make camelCase prop dash separated
-        var cssPropName = prop
+        const cssPropName = prop
           .trim()
           .split(/(?=[A-Z])/g)
-          .reduce(function (prop, propPiece) {
-            if (!prop) {
+          .reduce((name, propPiece) => {
+            if (!name) {
               return propPiece;
             } else {
-              return prop + '-' + propPiece.toLowerCase();
+              return name + '-' + propPiece.toLowerCase();
             }
           }, null);
 
@@ -76,8 +73,8 @@ describe('link-in-text-block-style', function () {
 
   function getLinkElm(linkStyle) {
     // Get a random id and build the style strings
-    var linkId = 'linkid-' + Math.floor(Math.random() * 100000);
-    var parId = 'parid-' + Math.floor(Math.random() * 100000);
+    const linkId = 'linkid-' + Math.floor(Math.random() * 100000);
+    const parId = 'parid-' + Math.floor(Math.random() * 100000);
 
     createStyleString('#' + linkId, linkStyle);
     createStyleString('#' + parId, {});
@@ -94,14 +91,14 @@ describe('link-in-text-block-style', function () {
     return document.getElementById(linkId);
   }
 
-  describe('link default state', function () {
-    beforeEach(function () {
+  describe('link default state', () => {
+    beforeEach(() => {
       createStyleString('a', {
         textDecoration: 'none'
       });
     });
 
-    it('passes the selected node and closest ancestral block element', function () {
+    it('passes the selected node and closest ancestral block element', () => {
       fixture.innerHTML =
         '<div> <span style="display:block; id="parent">' +
         '	<p style="display:inline"><a href="" id="link">' +
@@ -110,19 +107,19 @@ describe('link-in-text-block-style', function () {
         '</span> outside block </div>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var linkElm = document.getElementById('link');
+      const linkElm = document.getElementById('link');
 
       assert.isFalse(linkInBlockStyleCheck.call(checkContext, linkElm));
     });
 
     (shadowSupport.v1 ? it : xit)(
       'works with the block outside the shadow tree',
-      function () {
-        var parentElm = document.createElement('div');
-        var shadow = parentElm.attachShadow({ mode: 'open' });
+      () => {
+        const parentElm = document.createElement('div');
+        const shadow = parentElm.attachShadow({ mode: 'open' });
         shadow.innerHTML =
           '<a href="" style="text-decoration:underline;">Link</a>';
-        var linkElm = shadow.querySelector('a');
+        const linkElm = shadow.querySelector('a');
         fixture.appendChild(parentElm);
 
         axe.testUtils.flatTreeSetup(fixture);
@@ -133,33 +130,33 @@ describe('link-in-text-block-style', function () {
 
     (shadowSupport.v1 ? it : xit)(
       'works with the link inside the shadow tree slot',
-      function () {
-        var div = document.createElement('div');
+      () => {
+        const div = document.createElement('div');
         div.setAttribute('style', 'text-decoration:none;');
         div.innerHTML =
           '<a href="" style="text-decoration:underline;">Link</a>';
-        var shadow = div.attachShadow({ mode: 'open' });
+        const shadow = div.attachShadow({ mode: 'open' });
         shadow.innerHTML = '<p><slot></slot></p>';
         fixture.appendChild(div);
 
         axe.testUtils.flatTreeSetup(fixture);
-        var linkElm = div.querySelector('a');
+        const linkElm = div.querySelector('a');
 
         assert.isTrue(linkInBlockStyleCheck.call(checkContext, linkElm));
       }
     );
   });
 
-  describe('links distinguished through style', function () {
-    it('returns false if link style matches parent', function () {
-      var linkElm = getLinkElm({});
+  describe('links distinguished through style', () => {
+    it('returns false if link style matches parent', () => {
+      const linkElm = getLinkElm({});
       assert.isFalse(linkInBlockStyleCheck.call(checkContext, linkElm));
       assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
       assert.isNull(checkContext._data);
     });
 
-    it('returns true if link has underline', function () {
-      var linkElm = getLinkElm({
+    it('returns true if link has underline', () => {
+      const linkElm = getLinkElm({
         textDecoration: 'underline'
       });
       assert.isTrue(linkInBlockStyleCheck.call(checkContext, linkElm));
@@ -167,7 +164,7 @@ describe('link-in-text-block-style', function () {
       assert.isNull(checkContext._data);
     });
 
-    it('returns undefined when the link has a :before pseudo element', function () {
+    it('returns undefined when the link has a :before pseudo element', () => {
       const link = queryFixture(`
         <style>
           a:before { content: '🔗'; }
@@ -181,7 +178,7 @@ describe('link-in-text-block-style', function () {
       assert.equal(checkContext._relatedNodes[0], link.parentNode);
     });
 
-    it('returns undefined when the link has a :after pseudo element', function () {
+    it('returns undefined when the link has a :after pseudo element', () => {
       const link = queryFixture(`
         <style>
           a:after { content: ""; }
@@ -195,7 +192,7 @@ describe('link-in-text-block-style', function () {
       assert.equal(checkContext._relatedNodes[0], link.parentNode);
     });
 
-    it('does not return undefined when the pseudo element content is none', function () {
+    it('does not return undefined when the pseudo element content is none', () => {
       const link = queryFixture(`
         <style>
           a:after { content: none; position: absolute; }

--- a/test/checks/color/link-in-text-block.js
+++ b/test/checks/color/link-in-text-block.js
@@ -1,62 +1,59 @@
-describe('link-in-text-block', function () {
-  'use strict';
+describe('link-in-text-block', () => {
+  const fixture = document.getElementById('fixture');
+  const shadowSupport = axe.testUtils.shadowSupport;
+  let styleElm;
 
-  var fixture = document.getElementById('fixture');
-  var shadowSupport = axe.testUtils.shadowSupport;
-  var styleElm;
+  const checkContext = axe.testUtils.MockCheckContext();
 
-  var checkContext = axe.testUtils.MockCheckContext();
-
-  before(function () {
+  before(() => {
     styleElm = document.createElement('style');
     document.head.appendChild(styleElm);
   });
 
-  var defaultStyle = {
+  const defaultStyle = {
     color: '#000',
     textDecoration: 'none'
   };
 
-  beforeEach(function () {
+  beforeEach(() => {
     createStyleString('p', defaultStyle);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
     styleElm.innerHTML = '';
     checkContext.reset();
   });
 
-  after(function () {
+  after(() => {
     styleElm.parentNode.removeChild(styleElm);
   });
 
   function createStyleString(selector, outerStyle) {
     // Merge style with the default
-    var prop;
-    var styleObj = {};
-    for (prop in defaultStyle) {
+    const styleObj = {};
+    for (const prop in defaultStyle) {
       if (defaultStyle.hasOwnProperty(prop)) {
         styleObj[prop] = defaultStyle[prop];
       }
     }
-    for (prop in outerStyle) {
+    for (const prop in outerStyle) {
       if (outerStyle.hasOwnProperty(prop)) {
         styleObj[prop] = outerStyle[prop];
       }
     }
 
-    var cssLines = Object.keys(styleObj)
-      .map(function (prop) {
+    const cssLines = Object.keys(styleObj)
+      .map(prop => {
         // Make camelCase prop dash separated
-        var cssPropName = prop
+        const cssPropName = prop
           .trim()
           .split(/(?=[A-Z])/g)
-          .reduce(function (prop, propPiece) {
-            if (!prop) {
+          .reduce((name, propPiece) => {
+            if (!name) {
               return propPiece;
             } else {
-              return prop + '-' + propPiece.toLowerCase();
+              return name + '-' + propPiece.toLowerCase();
             }
           }, null);
 
@@ -71,8 +68,8 @@ describe('link-in-text-block', function () {
 
   function getLinkElm(linkStyle, paragraphStyle) {
     // Get a random id and build the style strings
-    var linkId = 'linkid-' + Math.floor(Math.random() * 100000);
-    var parId = 'parid-' + Math.floor(Math.random() * 100000);
+    const linkId = 'linkid-' + Math.floor(Math.random() * 100000);
+    const parId = 'parid-' + Math.floor(Math.random() * 100000);
 
     createStyleString('#' + linkId, linkStyle);
     createStyleString('#' + parId, paragraphStyle);
@@ -89,14 +86,14 @@ describe('link-in-text-block', function () {
     return document.getElementById(linkId);
   }
 
-  describe('link default state', function () {
-    beforeEach(function () {
+  describe('link default state', () => {
+    beforeEach(() => {
       createStyleString('a', {
         color: '#100' // insufficient contrast
       });
     });
 
-    it('passes the selected node and closest ancestral block element', function () {
+    it('passes the selected node and closest ancestral block element', () => {
       fixture.innerHTML =
         '<div> <span style="display:block; color: #010" id="parent">' +
         '	<p style="display:inline"><a href="" id="link">' +
@@ -105,7 +102,7 @@ describe('link-in-text-block', function () {
         '</span> outside block </div>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var linkElm = document.getElementById('link');
+      const linkElm = document.getElementById('link');
 
       assert.isFalse(
         axe.testUtils
@@ -117,16 +114,16 @@ describe('link-in-text-block', function () {
 
     (shadowSupport.v1 ? it : xit)(
       'works with the block outside the shadow tree',
-      function () {
-        var parentElm = document.createElement('div');
+      () => {
+        const parentElm = document.createElement('div');
         parentElm.setAttribute(
           'style',
           'color:#100; background-color:#FFFFFF;'
         );
-        var shadow = parentElm.attachShadow({ mode: 'open' });
+        const shadow = parentElm.attachShadow({ mode: 'open' });
         shadow.innerHTML =
           '<a href="" style="color:#000; background-color:#FFFFFF; text-decoration:none;">Link</a>';
-        var linkElm = shadow.querySelector('a');
+        const linkElm = shadow.querySelector('a');
         fixture.appendChild(parentElm);
 
         axe.testUtils.flatTreeSetup(fixture);
@@ -142,17 +139,17 @@ describe('link-in-text-block', function () {
 
     (shadowSupport.v1 ? it : xit)(
       'works with the link inside the shadow tree slot',
-      function () {
-        var div = document.createElement('div');
+      () => {
+        const div = document.createElement('div');
         div.setAttribute('style', 'color:#100; background-color:#FFFFFF;');
         div.innerHTML =
           '<a href="" style="color:#000;background-color:#FFFFFF;">Link</a>';
-        var shadow = div.attachShadow({ mode: 'open' });
+        const shadow = div.attachShadow({ mode: 'open' });
         shadow.innerHTML = '<p><slot></slot></p>';
         fixture.appendChild(div);
 
         axe.testUtils.flatTreeSetup(fixture);
-        var linkElm = div.querySelector('a');
+        const linkElm = div.querySelector('a');
 
         assert.isFalse(
           axe.testUtils
@@ -164,15 +161,15 @@ describe('link-in-text-block', function () {
     );
   });
 
-  describe('links distinguished through color', function () {
-    beforeEach(function () {
+  describe('links distinguished through color', () => {
+    beforeEach(() => {
       createStyleString('a:active, a:focus', {
         textDecoration: 'underline'
       });
     });
 
-    it('returns undefined if the background contrast can not be determined', function () {
-      var linkElm = getLinkElm(
+    it('returns undefined if the background contrast can not be determined', () => {
+      const linkElm = getLinkElm(
         {},
         {
           color: '#000010',
@@ -192,8 +189,8 @@ describe('link-in-text-block', function () {
       assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
     });
 
-    it('returns false with fgContrast key if nodes have insufficient foreground contrast and same background color', function () {
-      var linkElm = getLinkElm(
+    it('returns false with fgContrast key if nodes have insufficient foreground contrast and same background color', () => {
+      const linkElm = getLinkElm(
         {
           color: 'black'
         },
@@ -209,8 +206,8 @@ describe('link-in-text-block', function () {
       assert.equal(checkContext._data.messageKey, 'fgContrast');
     });
 
-    it('returns false with fgContrast key if nodes have insufficient foreground contrast and insufficient background color', function () {
-      var linkElm = getLinkElm(
+    it('returns false with fgContrast key if nodes have insufficient foreground contrast and insufficient background color', () => {
+      const linkElm = getLinkElm(
         {
           color: 'black',
           backgroundColor: 'white'
@@ -228,8 +225,8 @@ describe('link-in-text-block', function () {
       assert.equal(checkContext._data.messageKey, 'fgContrast');
     });
 
-    it('returns false with bgContrast key if nodes have same foreground color and insufficient background contrast', function () {
-      var linkElm = getLinkElm(
+    it('returns false with bgContrast key if nodes have same foreground color and insufficient background contrast', () => {
+      const linkElm = getLinkElm(
         {
           color: 'black',
           backgroundColor: 'white'
@@ -248,8 +245,8 @@ describe('link-in-text-block', function () {
       assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
     });
 
-    it('returns true if nodes have sufficient foreground contrast and insufficient background contrast', function () {
-      var linkElm = getLinkElm(
+    it('returns true if nodes have sufficient foreground contrast and insufficient background contrast', () => {
+      const linkElm = getLinkElm(
         {
           color: 'black',
           backgroundColor: 'white'
@@ -267,8 +264,8 @@ describe('link-in-text-block', function () {
       assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
     });
 
-    it('returns true if nodes have insufficient foreground contrast and sufficient background contrast', function () {
-      var linkElm = getLinkElm(
+    it('returns true if nodes have insufficient foreground contrast and sufficient background contrast', () => {
+      const linkElm = getLinkElm(
         {
           color: 'black',
           backgroundColor: 'white'
@@ -286,7 +283,7 @@ describe('link-in-text-block', function () {
       assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
     });
 
-    it('should return the proper values stored in data (fgContrast)', function () {
+    it('should return the proper values stored in data (fgContrast)', () => {
       fixture.innerHTML =
         '<div> <span style="display:block; color: #100" id="parent">' +
         ' <p style="display:inline"><a href="" id="link">' +
@@ -295,7 +292,7 @@ describe('link-in-text-block', function () {
         '</span> outside block </div>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var linkElm = document.getElementById('link');
+      const linkElm = document.getElementById('link');
 
       axe.testUtils
         .getCheckEvaluate('link-in-text-block')
@@ -310,8 +307,8 @@ describe('link-in-text-block', function () {
       });
     });
 
-    it('should return the proper values stored in data (bgContrast)', function () {
-      var linkElm = getLinkElm(
+    it('should return the proper values stored in data (bgContrast)', () => {
+      const linkElm = getLinkElm(
         {
           color: 'black',
           backgroundColor: 'white'
@@ -338,7 +335,7 @@ describe('link-in-text-block', function () {
 
     describe('options.allowSameColor', () => {
       it('when true, passes when link and text colors are identical', () => {
-        var linkElm = getLinkElm(
+        const linkElm = getLinkElm(
           {
             color: 'black'
           },
@@ -355,7 +352,7 @@ describe('link-in-text-block', function () {
       });
 
       it('when false, fails when link and text colors are identical', () => {
-        var linkElm = getLinkElm(
+        const linkElm = getLinkElm(
           {
             color: 'black'
           },

--- a/test/checks/shared/inline-style-property.js
+++ b/test/checks/shared/inline-style-property.js
@@ -1,35 +1,34 @@
-describe('inline-style-property tests', function () {
-  'use strict';
-  var fixture = document.getElementById('fixture');
-  var checkSetup = axe.testUtils.checkSetup;
+describe('inline-style-property tests', () => {
+  const fixture = document.getElementById('fixture');
+  const checkSetup = axe.testUtils.checkSetup;
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
   });
 
-  describe('important-letter-spacing check', function () {
-    var checkEvaluate = axe.testUtils.getCheckEvaluate(
+  describe('important-letter-spacing check', () => {
+    const checkEvaluate = axe.testUtils.getCheckEvaluate(
       'important-letter-spacing'
     );
-    var checkContext = axe.testUtils.MockCheckContext();
-    afterEach(function () {
+    const checkContext = axe.testUtils.MockCheckContext();
+    afterEach(() => {
       checkContext.reset();
     });
 
-    it('is true when the property is not set in the style attribute', function () {
-      var params = checkSetup(
+    it('is true when the property is not set in the style attribute', () => {
+      const params = checkSetup(
         '<p style="width: 60%" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
 
-    it('is false when letter-spacing is less than 0.12em and !important', function () {
-      var params = checkSetup(
+    it('is false when letter-spacing is less than 0.12em and !important', () => {
+      const params = checkSetup(
         '<p style="letter-spacing: 0.1em !important" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 0.1,
@@ -37,20 +36,20 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('is true when !important is not used', function () {
-      var params = checkSetup(
+    it('is true when !important is not used', () => {
+      const params = checkSetup(
         '<p style="letter-spacing: 0.1em" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
 
-    it('is true when letter-spacing is 0.15 times the font-size', function () {
-      var params = checkSetup(
+    it('is true when letter-spacing is 0.15 times the font-size', () => {
+      const params = checkSetup(
         '<p style="letter-spacing: 0.15em !important" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.deepEqual(checkContext._data, {
         value: 0.15,
@@ -58,16 +57,16 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('uses the highest priority value if multiple are set', function () {
-      var style = [
+    it('uses the highest priority value if multiple are set', () => {
+      const style = [
         'letter-spacing: 0.15em !important',
         'letter-spacing: 0.1em !important',
         'letter-spacing: 0.2em'
       ].join('; ');
-      var params = checkSetup(
+      const params = checkSetup(
         '<p style="' + style + '" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 0.1,
@@ -75,12 +74,12 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    describe('handles different font-sizes', function () {
-      it('is true when the font is 0.15 time the spacing', function () {
-        var params = checkSetup(
+    describe('handles different font-sizes', () => {
+      it('is true when the font is 0.15 time the spacing', () => {
+        const params = checkSetup(
           '<p style="font-size: 20px; letter-spacing: 3px !important" id="target">Hello world</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isTrue(result);
         assert.deepEqual(checkContext._data, {
           value: 0.15,
@@ -88,11 +87,11 @@ describe('inline-style-property tests', function () {
         });
       });
 
-      it('is false when the font is 0.10 times the spacing', function () {
-        var params = checkSetup(
+      it('is false when the font is 0.10 times the spacing', () => {
+        const params = checkSetup(
           '<p style="font-size: 30px; letter-spacing: 3px !important" id="target">Hello world</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isFalse(result);
         assert.deepEqual(checkContext._data, {
           value: 0.1,
@@ -101,12 +100,12 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    describe('with non-number values', function () {
-      it('is false when `normal` (which is 0) is used along with !important', function () {
-        var params = checkSetup(
+    describe('with non-number values', () => {
+      it('is false when `normal` (which is 0) is used along with !important', () => {
+        const params = checkSetup(
           '<p style="letter-spacing: normal !important" id="target">Hello world</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isFalse(result);
         assert.deepEqual(checkContext._data, {
           value: 0,
@@ -114,11 +113,11 @@ describe('inline-style-property tests', function () {
         });
       });
 
-      it('is false when `initial` (meaning `normal`) is used along with !important', function () {
-        var params = checkSetup(
+      it('is false when `initial` (meaning `normal`) is used along with !important', () => {
+        const params = checkSetup(
           '<p style="letter-spacing: initial !important" id="target">Hello world</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isFalse(result);
         assert.deepEqual(checkContext._data, {
           value: 0,
@@ -126,12 +125,12 @@ describe('inline-style-property tests', function () {
         });
       });
 
-      it('is true when `inherited` is used along with !important', function () {
-        var params = checkSetup(
+      it('is true when `inherited` is used along with !important', () => {
+        const params = checkSetup(
           '<p style="letter-spacing: 0.1em">' +
             '<span style="letter-spacing: inherit !important;" id="target">Hello world</span</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isTrue(result);
         assert.deepEqual(checkContext._data, {
           value: 'inherit',
@@ -139,12 +138,12 @@ describe('inline-style-property tests', function () {
         });
       });
 
-      it('is true when `unset` is used along with !important', function () {
-        var params = checkSetup(
+      it('is true when `unset` is used along with !important', () => {
+        const params = checkSetup(
           '<p style="letter-spacing: 0.1em">' +
             '<span style="letter-spacing: unset !important;" id="target">Hello world</span</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isTrue(result);
         assert.deepEqual(checkContext._data, {
           value: 'unset',
@@ -152,12 +151,12 @@ describe('inline-style-property tests', function () {
         });
       });
 
-      it('is true when `revert` is used along with !important', function () {
-        var params = checkSetup(
+      it('is true when `revert` is used along with !important', () => {
+        const params = checkSetup(
           '<p style="letter-spacing: 0.1em">' +
             '<span style="letter-spacing: revert !important;" id="target">Hello world</span</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isTrue(result);
         assert.deepEqual(checkContext._data, {
           value: 'revert',
@@ -165,12 +164,12 @@ describe('inline-style-property tests', function () {
         });
       });
 
-      it('is true when `revert-layer` is used along with !important', function () {
-        var params = checkSetup(
+      it('is true when `revert-layer` is used along with !important', () => {
+        const params = checkSetup(
           '<p style="letter-spacing: 0.1em">' +
             '<span style="letter-spacing: revert-layer !important;" id="target">Hello world</span</p>'
         );
-        var result = checkEvaluate.apply(checkContext, params);
+        const result = checkEvaluate.apply(checkContext, params);
         assert.isTrue(result);
         assert.deepEqual(checkContext._data, {
           value: 'revert-layer',
@@ -180,38 +179,38 @@ describe('inline-style-property tests', function () {
     });
   });
 
-  describe('important-word-spacing check', function () {
-    var checkEvaluate = axe.testUtils.getCheckEvaluate(
+  describe('important-word-spacing check', () => {
+    const checkEvaluate = axe.testUtils.getCheckEvaluate(
       'important-word-spacing'
     );
-    var checkContext = axe.testUtils.MockCheckContext();
-    afterEach(function () {
+    const checkContext = axe.testUtils.MockCheckContext();
+    afterEach(() => {
       checkContext.reset();
     });
 
-    it('is true when word-spacing is not set in the style attribute', function () {
-      var params = checkSetup(
+    it('is true when word-spacing is not set in the style attribute', () => {
+      const params = checkSetup(
         '<p style="width: 60%" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
 
-    it('is true when below 0.16em and not !important', function () {
-      var params = checkSetup(
+    it('is true when below 0.16em and not !important', () => {
+      const params = checkSetup(
         '<p style="word-spacing: 0.1em" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
 
-    it('is false when below 0.16em and !important', function () {
-      var params = checkSetup(
+    it('is false when below 0.16em and !important', () => {
+      const params = checkSetup(
         '<p style="word-spacing: 0.1em !important" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 0.1,
@@ -219,11 +218,11 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('is true when 0.16em and !important', function () {
-      var params = checkSetup(
+    it('is true when 0.16em and !important', () => {
+      const params = checkSetup(
         '<p style="word-spacing: 0.16em !important" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.deepEqual(checkContext._data, {
         value: 0.16,
@@ -232,40 +231,42 @@ describe('inline-style-property tests', function () {
     });
   });
 
-  describe('important-line-height check', function () {
-    var checkEvaluate = axe.testUtils.getCheckEvaluate('important-line-height');
-    var checkContext = axe.testUtils.MockCheckContext();
-    afterEach(function () {
+  describe('important-line-height check', () => {
+    const checkEvaluate = axe.testUtils.getCheckEvaluate(
+      'important-line-height'
+    );
+    const checkContext = axe.testUtils.MockCheckContext();
+    afterEach(() => {
       checkContext.reset();
     });
 
-    it('is true when line-height is not set in the style attribute', function () {
-      var params = checkSetup(
+    it('is true when line-height is not set in the style attribute', () => {
+      const params = checkSetup(
         '<p style="width: 60%" id="target">Hello world</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
 
-    it('is true when below 1.5em and not !important', function () {
-      var params = checkSetup(
+    it('is true when below 1.5em and not !important', () => {
+      const params = checkSetup(
         '<p style="line-height: 1.2em; max-width: 200px;" id="target">' +
           '	The toy brought back fond memories of being lost in the rain forest.' +
           '</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
 
-    it('is false when below 1.5em and !important', function () {
-      var params = checkSetup(
+    it('is false when below 1.5em and !important', () => {
+      const params = checkSetup(
         '<p style="line-height: 1.2em !important; max-width: 200px;" id="target">' +
           '	The toy brought back fond memories of being lost in the rain forest.' +
           '</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 1.2,
@@ -273,13 +274,13 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('is true when 1.5em and !important', function () {
-      var params = checkSetup(
+    it('is true when 1.5em and !important', () => {
+      const params = checkSetup(
         '<p style="line-height: 1.5em !important; max-width: 200px;" id="target">' +
           '	The toy brought back fond memories of being lost in the rain forest.' +
           '</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.deepEqual(checkContext._data, {
         value: 1.5,
@@ -287,13 +288,13 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('returns the 1em for `normal !important`', function () {
-      var params = checkSetup(
+    it('returns the 1em for `normal !important`', () => {
+      const params = checkSetup(
         '<p style="line-height: normal !important; max-width: 200px;" id="target">' +
           '	The toy brought back fond memories of being lost in the rain forest.' +
           '</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 1,
@@ -301,24 +302,24 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('is true for single line texts', function () {
-      var params = checkSetup(
+    it('is true for single line texts', () => {
+      const params = checkSetup(
         '<p style="line-height: 1.2em !important; max-width: 200px;" id="target">' +
           '	Short' +
           '</p>'
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
   });
 
-  describe('With options configured for font-size', function () {
-    var checkEvaluate = axe.testUtils.getCheckEvaluate(
+  describe('With options configured for font-size', () => {
+    const checkEvaluate = axe.testUtils.getCheckEvaluate(
       'important-letter-spacing'
     );
-    var checkContext = axe.testUtils.MockCheckContext();
-    var options = {
+    const checkContext = axe.testUtils.MockCheckContext();
+    const options = {
       cssProperty: 'font-size',
       minValue: 16,
       maxValue: 42,
@@ -326,16 +327,16 @@ describe('inline-style-property tests', function () {
       noImportant: false
     };
 
-    afterEach(function () {
+    afterEach(() => {
       checkContext.reset();
     });
 
-    it('is false when !important and below the minValue', function () {
-      var params = checkSetup(
+    it('is false when !important and below the minValue', () => {
+      const params = checkSetup(
         '<p style="font-size: 12px !important" id="target">Hello world</p>',
         options
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 12,
@@ -344,12 +345,12 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('is false when !important and above the maxValue', function () {
-      var params = checkSetup(
+    it('is false when !important and above the maxValue', () => {
+      const params = checkSetup(
         '<p style="font-size: 43px !important" id="target">Hello world</p>',
         options
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 43,
@@ -358,23 +359,23 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('is true when not !important', function () {
-      var params = checkSetup(
+    it('is true when not !important', () => {
+      const params = checkSetup(
         '<p style="font-size: 12px" id="target">Hello world</p>',
         options
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.isNull(checkContext._data);
     });
 
-    it('is false when not !important and {noImportant: true}', function () {
-      var opt = Object.assign({}, options, { noImportant: true });
-      var params = checkSetup(
+    it('is false when not !important and {noImportant: true}', () => {
+      const opt = Object.assign({}, options, { noImportant: true });
+      const params = checkSetup(
         '<p style="font-size: 12px" id="target">Hello world</p>',
         opt
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 12,
@@ -383,18 +384,18 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('returns the normal value when `normal` is used', function () {
+    it('returns the normal value when `normal` is used', () => {
       // Using line-height, since font-size cannot be normal
-      var options = {
+      const opts = {
         cssProperty: 'line-height',
         normalValue: 3,
         minValue: 5
       };
-      var params = checkSetup(
+      const params = checkSetup(
         '<p style="line-height: normal !important" id="target">Hello world</p>',
-        options
+        opts
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isFalse(result);
       assert.deepEqual(checkContext._data, {
         value: 3,
@@ -402,12 +403,12 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('is true when above the minValue', function () {
-      var params = checkSetup(
+    it('is true when above the minValue', () => {
+      const params = checkSetup(
         '<p style="font-size: 16px !important" id="target">Hello world</p>',
         options
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.deepEqual(checkContext._data, {
         value: 16,
@@ -416,13 +417,13 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('ignores minValue when not a number', function () {
-      var opt = Object.assign({}, options, { minValue: '16' });
-      var params = checkSetup(
+    it('ignores minValue when not a number', () => {
+      const opt = Object.assign({}, options, { minValue: '16' });
+      const params = checkSetup(
         '<p style="font-size: 12px !important" id="target">Hello world</p>',
         opt
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.deepEqual(checkContext._data, {
         value: 12,
@@ -430,13 +431,13 @@ describe('inline-style-property tests', function () {
       });
     });
 
-    it('ignores maxValue when not a number', function () {
-      var opt = Object.assign({}, options, { maxValue: '42' });
-      var params = checkSetup(
+    it('ignores maxValue when not a number', () => {
+      const opt = Object.assign({}, options, { maxValue: '42' });
+      const params = checkSetup(
         '<p style="font-size: 50px !important" id="target">Hello world</p>',
         opt
       );
-      var result = checkEvaluate.apply(checkContext, params);
+      const result = checkEvaluate.apply(checkContext, params);
       assert.isTrue(result);
       assert.deepEqual(checkContext._data, {
         value: 50,

--- a/test/commons/aria/validate-attr-value.js
+++ b/test/commons/aria/validate-attr-value.js
@@ -1,31 +1,29 @@
-describe('aria.validateAttrValue', function () {
-  'use strict';
+describe('aria.validateAttrValue', () => {
+  const fixture = document.getElementById('fixture');
+  const shadowSupport = axe.testUtils.shadowSupport;
+  let node;
 
-  var fixture = document.getElementById('fixture');
-  var shadowSupport = axe.testUtils.shadowSupport;
-  var node;
-
-  function setAttr(node, attrName, attrValue) {
-    node.setAttribute(attrName, attrValue);
+  function setAttr(elm, attrName, attrValue) {
+    elm.setAttribute(attrName, attrValue);
     axe.teardown();
-    return axe.setup(node);
+    return axe.setup(elm);
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     node = document.createElement('div');
   });
 
-  afterEach(function () {
+  afterEach(() => {
     axe.reset();
   });
 
-  it('should return true if there is no matching attribute (future-compat???)', function () {
+  it('should return true if there is no matching attribute (future-compat???)', () => {
     setAttr(node, 'unknown-attr', 'hello');
 
     assert.isTrue(axe.commons.aria.validateAttrValue(node, 'unknown-attr'));
   });
 
-  it('works on virtual nodes', function () {
+  it('works on virtual nodes', () => {
     axe.configure({
       standards: {
         ariaAttrs: {
@@ -37,14 +35,14 @@ describe('aria.validateAttrValue', function () {
         }
       }
     });
-    var vNode = axe.testUtils.queryFixture(
+    const vNode = axe.testUtils.queryFixture(
       '<div id="target" cats="valid"></div>'
     );
     assert.isTrue(axe.commons.aria.validateAttrValue(vNode, 'cats'));
   });
 
-  describe('allowEmpty', function () {
-    beforeEach(function () {
+  describe('allowEmpty', () => {
+    beforeEach(() => {
       axe.configure({
         standards: {
           ariaAttrs: {
@@ -82,7 +80,7 @@ describe('aria.validateAttrValue', function () {
       });
     });
 
-    it('returns true for empty attributes with allowEmpty:true', function () {
+    it('returns true for empty attributes with allowEmpty:true', () => {
       setAttr(node, 'cats', '');
       assert.isTrue(axe.commons.aria.validateAttrValue(node, 'cats'));
 
@@ -105,7 +103,7 @@ describe('aria.validateAttrValue', function () {
       assert.isTrue(axe.commons.aria.validateAttrValue(node, 'horses'));
     });
 
-    it('returns true for whitespace-only attributes with allowEmpty:true', function () {
+    it('returns true for whitespace-only attributes with allowEmpty:true', () => {
       setAttr(node, 'cats', '  \r\n\t  ');
       assert.isTrue(axe.commons.aria.validateAttrValue(node, 'cats'));
 
@@ -129,9 +127,9 @@ describe('aria.validateAttrValue', function () {
     });
   });
 
-  describe('schema defintions', function () {
-    describe('enumerated values', function () {
-      beforeEach(function () {
+  describe('schema defintions', () => {
+    describe('enumerated values', () => {
+      beforeEach(() => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -144,7 +142,7 @@ describe('aria.validateAttrValue', function () {
         });
       });
 
-      it('should validate against enumerated .values if present', function () {
+      it('should validate against enumerated .values if present', () => {
         setAttr(node, 'cats', 'valid');
 
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'cats'));
@@ -154,21 +152,21 @@ describe('aria.validateAttrValue', function () {
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'cats'));
       });
 
-      it('should be case-insensitive for enumerated values', function () {
+      it('should be case-insensitive for enumerated values', () => {
         setAttr(node, 'cats', 'vaLiD');
 
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'cats'));
       });
 
-      it('should reject empty strings', function () {
+      it('should reject empty strings', () => {
         setAttr(node, 'cats', '');
 
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'cats'));
       });
     });
 
-    describe('idref', function () {
-      beforeEach(function () {
+    describe('idref', () => {
+      beforeEach(() => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -180,7 +178,7 @@ describe('aria.validateAttrValue', function () {
         });
       });
 
-      it('should validate the referenced node exists', function () {
+      it('should validate the referenced node exists', () => {
         fixture.innerHTML = '<div id="target"></div>';
         setAttr(node, 'dogs', 'target');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'dogs'));
@@ -189,8 +187,8 @@ describe('aria.validateAttrValue', function () {
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'dogs'));
       });
 
-      it('should work in shadow DOM', function () {
-        var shadEl;
+      it('should work in shadow DOM', () => {
+        let shadEl;
 
         if (shadowSupport.v1) {
           // shadow DOM v1 - note: v0 is compatible with this code, so no need
@@ -209,14 +207,14 @@ describe('aria.validateAttrValue', function () {
         }
       });
 
-      it('returns false if empty without allowEmpty: true', function () {
+      it('returns false if empty without allowEmpty: true', () => {
         setAttr(node, 'dogs', '');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'dogs'));
       });
     });
 
-    describe('idrefs', function () {
-      beforeEach(function () {
+    describe('idrefs', () => {
+      beforeEach(() => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -228,46 +226,46 @@ describe('aria.validateAttrValue', function () {
         });
       });
 
-      it('should return false when a single referenced node is not found', function () {
+      it('should return false when a single referenced node is not found', () => {
         setAttr(node, 'goats', 'invalid');
         // target2 not found
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'goats'));
       });
 
-      it('should return false when no referenced element is found', function () {
+      it('should return false when no referenced element is found', () => {
         fixture.innerHTML = '<div id="target"></div>';
         setAttr(node, 'goats', 'target2 target3');
         // target2 not found
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'goats'));
       });
 
-      it('should return true when at least one referenced element is found', function () {
+      it('should return true when at least one referenced element is found', () => {
         fixture.innerHTML = '<div id="target"></div>';
         setAttr(node, 'goats', 'target target2');
         // target2 not found
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'goats'));
       });
 
-      it('should return true when all targets are found', function () {
+      it('should return true when all targets are found', () => {
         fixture.innerHTML = '<div id="target"></div><div id="target2"></div>';
         setAttr(node, 'goats', 'target target2');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'goats'));
       });
 
-      it('should not fail on weird whitespace', function () {
+      it('should not fail on weird whitespace', () => {
         fixture.innerHTML = '<div id="target"></div><div id="target2"></div>';
         setAttr(node, 'goats', ' \t \ttarget   \t   target2      ');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'goats'));
       });
 
-      it('returns false if empty without allowEmpty: true', function () {
+      it('returns false if empty without allowEmpty: true', () => {
         setAttr(node, 'goats', '');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'goats'));
       });
     });
 
-    describe('string', function () {
-      beforeEach(function () {
+    describe('string', () => {
+      beforeEach(() => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -279,19 +277,19 @@ describe('aria.validateAttrValue', function () {
         });
       });
 
-      it('returns true for non-empty strings', function () {
+      it('returns true for non-empty strings', () => {
         setAttr(node, 'cows', 'hi');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'cows'));
       });
 
-      it('returns false for non-empty strings without allowEmpty:true', function () {
+      it('returns false for non-empty strings without allowEmpty:true', () => {
         setAttr(node, 'cows', '');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'cows'));
       });
     });
 
-    describe('decimal', function () {
-      beforeEach(function () {
+    describe('decimal', () => {
+      beforeEach(() => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -303,7 +301,7 @@ describe('aria.validateAttrValue', function () {
         });
       });
 
-      it('should allow, but not require, a preceeding sign', function () {
+      it('should allow, but not require, a preceeding sign', () => {
         setAttr(node, 'sheep', '+1.12');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
 
@@ -314,7 +312,7 @@ describe('aria.validateAttrValue', function () {
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
 
-      it('should make the decimal separator optional', function () {
+      it('should make the decimal separator optional', () => {
         setAttr(node, 'sheep', '+1');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
 
@@ -325,7 +323,7 @@ describe('aria.validateAttrValue', function () {
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
 
-      it('should make the whole number optional', function () {
+      it('should make the whole number optional', () => {
         setAttr(node, 'sheep', '+.1');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
 
@@ -336,7 +334,7 @@ describe('aria.validateAttrValue', function () {
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
 
-      it('should make the right-side optional', function () {
+      it('should make the right-side optional', () => {
         setAttr(node, 'sheep', '+1.');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
 
@@ -347,7 +345,7 @@ describe('aria.validateAttrValue', function () {
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
 
-      it('should validate the entire string', function () {
+      it('should validate the entire string', () => {
         setAttr(node, 'sheep', ' +1.12 ');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'sheep'));
 
@@ -358,7 +356,7 @@ describe('aria.validateAttrValue', function () {
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
 
-      it('should only allow for numbers', function () {
+      it('should only allow for numbers', () => {
         setAttr(node, 'sheep', '+a.12');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'sheep'));
 
@@ -369,7 +367,7 @@ describe('aria.validateAttrValue', function () {
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
 
-      it('should require at least one number', function () {
+      it('should require at least one number', () => {
         setAttr(node, 'sheep', '+.');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'sheep'));
 
@@ -389,14 +387,14 @@ describe('aria.validateAttrValue', function () {
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
 
-      it('returns false for empty strings without allowEmpty:true', function () {
+      it('returns false for empty strings without allowEmpty:true', () => {
         setAttr(node, 'sheep', '');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'sheep'));
       });
     });
 
-    describe('int', function () {
-      beforeEach(function () {
+    describe('int', () => {
+      beforeEach(() => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -408,7 +406,7 @@ describe('aria.validateAttrValue', function () {
         });
       });
 
-      it('should only allow for numbers by an optional preceding sign', function () {
+      it('should only allow for numbers by an optional preceding sign', () => {
         setAttr(node, 'pigs', '+1234234');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'pigs'));
 
@@ -419,7 +417,7 @@ describe('aria.validateAttrValue', function () {
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'pigs'));
       });
 
-      it('should return true for value greater than or equal to minValue', function () {
+      it('should return true for value greater than or equal to minValue', () => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -441,12 +439,12 @@ describe('aria.validateAttrValue', function () {
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'pigs'));
       });
 
-      it('returns false for empty strings without allowEmpty:true', function () {
+      it('returns false for empty strings without allowEmpty:true', () => {
         setAttr(node, 'pigs', '');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'pigs'));
       });
 
-      it('should return false for value less than the minValue', function () {
+      it('should return false for value less than the minValue', () => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -463,8 +461,8 @@ describe('aria.validateAttrValue', function () {
       });
     });
 
-    describe('boolean', function () {
-      beforeEach(function () {
+    describe('boolean', () => {
+      beforeEach(() => {
         axe.configure({
           standards: {
             ariaAttrs: {
@@ -476,7 +474,7 @@ describe('aria.validateAttrValue', function () {
         });
       });
 
-      it('returns true for boolean value', function () {
+      it('returns true for boolean value', () => {
         setAttr(node, 'horses', 'true');
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'horses'));
 
@@ -484,13 +482,13 @@ describe('aria.validateAttrValue', function () {
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'horses'));
       });
 
-      it('should be case-insensitive', function () {
+      it('should be case-insensitive', () => {
         setAttr(node, 'horses', 'trUE');
 
         assert.isTrue(axe.commons.aria.validateAttrValue(node, 'horses'));
       });
 
-      it('returns false for non-boolean values', function () {
+      it('returns false for non-boolean values', () => {
         setAttr(node, 'horses', 'hi');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'horses'));
 
@@ -498,7 +496,7 @@ describe('aria.validateAttrValue', function () {
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'horses'));
       });
 
-      it('returns false for non-empty strings without allowEmpty:true', function () {
+      it('returns false for non-empty strings without allowEmpty:true', () => {
         setAttr(node, 'horses', '');
         assert.isFalse(axe.commons.aria.validateAttrValue(node, 'horses'));
       });
@@ -508,8 +506,8 @@ describe('aria.validateAttrValue', function () {
 
 function makeShadowTreeVAV(node) {
   'use strict';
-  var root = node.attachShadow({ mode: 'open' });
-  var div = document.createElement('div');
+  const root = node.attachShadow({ mode: 'open' });
+  const div = document.createElement('div');
   div.className = 'parent';
   root.appendChild(div);
   div.appendChild(createContentVAV());
@@ -517,7 +515,7 @@ function makeShadowTreeVAV(node) {
 
 function createContentVAV() {
   'use strict';
-  var group = document.createElement('div');
+  const group = document.createElement('div');
   group.innerHTML =
     '<label id="mylabel">Label</label>' +
     '<input id="myinput" aria-labelledby="mylabel" type="text" />' +

--- a/test/commons/color/element-is-distinct.js
+++ b/test/commons/color/element-is-distinct.js
@@ -1,50 +1,49 @@
-describe('color.elementIsDistinct', function () {
-  'use strict';
-  var styleElm, elementIsDistinct;
+describe('color.elementIsDistinct', () => {
+  let styleElm;
+  let elementIsDistinct;
 
-  var fixture = document.getElementById('fixture');
+  const fixture = document.getElementById('fixture');
 
-  before(function () {
+  before(() => {
     styleElm = document.createElement('style');
     document.head.appendChild(styleElm);
   });
 
-  var defaultStyle = {
+  const defaultStyle = {
     color: '#000',
     textDecoration: 'none'
   };
 
   function createStyleString(selector, outerStyle) {
     // Merge style with the default
-    var prop;
-    var styleObj = {};
-    for (prop in defaultStyle) {
+    const styleObj = {};
+    for (const prop in defaultStyle) {
       if (defaultStyle.hasOwnProperty(prop)) {
         styleObj[prop] = defaultStyle[prop];
       }
     }
-    for (prop in outerStyle) {
+    for (const prop in outerStyle) {
       if (outerStyle.hasOwnProperty(prop)) {
         styleObj[prop] = outerStyle[prop];
       }
     }
 
-    var cssLines = Object.keys(styleObj)
-      .map(function (prop) {
+    const cssLines = Object.keys(styleObj)
+      .map(prop => {
         // Make camelCase prop dash separated
-        var cssPropName = prop
+        const cssPropName = prop
           .trim()
           .split(/(?=[A-Z])/g)
-          .reduce(function (prop, propPiece) {
-            if (!prop) {
+          .reduce((name, propPiece) => {
+            if (!name) {
               return propPiece;
             } else {
-              return prop + '-' + propPiece.toLowerCase();
+              return name + '-' + propPiece.toLowerCase();
             }
           }, null);
 
         // Return indented line of style code
-        return '	' + cssPropName + ':' + styleObj[prop] + ';';
+        return '  ' + cssPropName + ':' + styleObj[prop] + ';';
       })
       .join('\n');
 
@@ -54,8 +53,8 @@ describe('color.elementIsDistinct', function () {
 
   function getLinkElm(linkStyle, paragraphStyle) {
     // Get a random id and build the style string
-    var linkId = 'linkid-' + Math.floor(Math.random() * 100000);
-    var parId = 'parid-' + Math.floor(Math.random() * 100000);
+    const linkId = 'linkid-' + Math.floor(Math.random() * 100000);
+    const parId = 'parid-' + Math.floor(Math.random() * 100000);
 
     createStyleString('#' + linkId, linkStyle);
     createStyleString('#' + parId, paragraphStyle);
@@ -74,92 +73,92 @@ describe('color.elementIsDistinct', function () {
     };
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     createStyleString('p', defaultStyle);
     elementIsDistinct = axe.commons.color.elementIsDistinct;
   });
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
     styleElm.innerHTML = '';
   });
 
-  after(function () {
+  after(() => {
     styleElm.parentNode.removeChild(styleElm);
   });
 
-  it('returns false without style adjustments', function () {
-    var elms = getLinkElm({});
-    var result = elementIsDistinct(elms.link, elms.par);
+  it('returns false without style adjustments', () => {
+    const elms = getLinkElm({});
+    const result = elementIsDistinct(elms.link, elms.par);
 
     assert.isFalse(result);
   });
 
-  it('returns true with background-image set', function () {
-    var elms = getLinkElm({
+  it('returns true with background-image set', () => {
+    const elms = getLinkElm({
       background: 'url(icon.png) no-repeat'
     });
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns true with border: dashed 1px black', function () {
-    var elms = getLinkElm({
+  it('returns true with border: dashed 1px black', () => {
+    const elms = getLinkElm({
       border: 'dashed 1px black'
     });
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns true with border-bottom: dashed 1px black', function () {
-    var elms = getLinkElm({
+  it('returns true with border-bottom: dashed 1px black', () => {
+    const elms = getLinkElm({
       borderBottom: 'dashed 1px black'
     });
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns false with border: solid 0px black', function () {
-    var elms = getLinkElm({
+  it('returns false with border: solid 0px black', () => {
+    const elms = getLinkElm({
       border: 'solid 0px black'
     });
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isFalse(result);
   });
 
-  it('returns false with border: none 1px black', function () {
-    var elms = getLinkElm({
+  it('returns false with border: none 1px black', () => {
+    const elms = getLinkElm({
       border: 'none 1px black'
     });
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isFalse(result);
   });
 
-  it('returns false with border: solid 1px transparent', function () {
-    var elms = getLinkElm({
+  it('returns false with border: solid 1px transparent', () => {
+    const elms = getLinkElm({
       border: 'solid 1px transparent'
     });
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isFalse(result);
   });
 
-  it('returns true with outline: solid 1px black', function () {
-    var elms = getLinkElm({
+  it('returns true with outline: solid 1px black', () => {
+    const elms = getLinkElm({
       outline: 'solid 1px black'
     });
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns true if font-weight is different', function () {
-    var elms = getLinkElm(
+  it('returns true if font-weight is different', () => {
+    const elms = getLinkElm(
       {
         fontWeight: 'bold'
       },
@@ -168,12 +167,12 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns false if font-weight is the same', function () {
-    var elms = getLinkElm(
+  it('returns false if font-weight is the same', () => {
+    const elms = getLinkElm(
       {
         fontWeight: 'bold'
       },
@@ -182,12 +181,12 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isFalse(result);
   });
 
-  it('compares font numbers and labels correctly', function () {
-    var elms = getLinkElm(
+  it('compares font numbers and labels correctly', () => {
+    const elms = getLinkElm(
       {
         fontWeight: 'bold'
       },
@@ -196,12 +195,12 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isFalse(result);
   });
 
-  it('returns true if text-decoration is different', function () {
-    var elms = getLinkElm(
+  it('returns true if text-decoration is different', () => {
+    const elms = getLinkElm(
       {
         textDecoration: 'underline'
       },
@@ -210,12 +209,12 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns false if text-decoration is the same', function () {
-    var elms = getLinkElm(
+  it('returns false if text-decoration is the same', () => {
+    const elms = getLinkElm(
       {
         textDecoration: 'underline'
       },
@@ -224,12 +223,12 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isFalse(result);
   });
 
-  it('returns true if font-size is different', function () {
-    var elms = getLinkElm(
+  it('returns true if font-size is different', () => {
+    const elms = getLinkElm(
       {
         fontSize: '14px'
       },
@@ -238,12 +237,12 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns true if font-family is different', function () {
-    var elms = getLinkElm(
+  it('returns true if font-family is different', () => {
+    const elms = getLinkElm(
       {
         fontFamily: 'Arial'
       },
@@ -252,12 +251,12 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isTrue(result);
   });
 
-  it('returns false if the first font-family is identical', function () {
-    var elms = getLinkElm(
+  it('returns false if the first font-family is identical', () => {
+    const elms = getLinkElm(
       {
         fontFamily: 'Arial-black, Arial'
       },
@@ -266,7 +265,7 @@ describe('color.elementIsDistinct', function () {
       }
     );
 
-    var result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.link, elms.par);
     assert.isFalse(result);
   });
 });

--- a/test/commons/matches/from-function.js
+++ b/test/commons/matches/from-function.js
@@ -1,47 +1,47 @@
-describe('matches.fromFunction', function () {
-  var fromFunction = axe.commons.matches.fromFunction;
+describe('matches.fromFunction', () => {
+  const fromFunction = axe.commons.matches.fromFunction;
   function noop() {}
 
-  it('throws an error when the matcher is a number', function () {
-    assert.throws(function () {
+  it('throws an error when the matcher is a number', () => {
+    assert.throws(() => {
       fromFunction(noop, 123);
     });
   });
 
-  it('throws an error when the matcher is a string', function () {
-    assert.throws(function () {
+  it('throws an error when the matcher is a string', () => {
+    assert.throws(() => {
       fromFunction(noop, 'foo');
     });
   });
 
-  it('throws an error when the matcher is an array', function () {
-    assert.throws(function () {
+  it('throws an error when the matcher is an array', () => {
+    assert.throws(() => {
       fromFunction(noop, ['foo']);
     });
   });
 
-  it('throws an error when the matcher is a RegExp', function () {
-    assert.throws(function () {
+  it('throws an error when the matcher is a RegExp', () => {
+    assert.throws(() => {
       fromFunction(noop, /foo/);
     });
   });
 
-  describe('with object matches', function () {
-    var keyMap = {};
+  describe('with object matches', () => {
+    let keyMap = {};
     function getValue(key) {
       return key;
     }
 
-    it('passes every object key to the getValue function once', function () {
-      var keys = ['foo', 'bar', 'baz'];
-      function getValue(key) {
-        var index = keys.indexOf(key);
+    it('passes every object key to the getValue function once', () => {
+      const keys = ['foo', 'bar', 'baz'];
+      function getValueOnce(key) {
+        const index = keys.indexOf(key);
         assert.notEqual(index, -1);
         keys.splice(index, 1);
         return key;
       }
 
-      fromFunction(getValue, {
+      fromFunction(getValueOnce, {
         foo: 'foo',
         bar: 'bar',
         baz: 'baz'
@@ -49,7 +49,7 @@ describe('matches.fromFunction', function () {
       assert.lengthOf(keys, 0);
     });
 
-    it('returns true if every value is matched', function () {
+    it('returns true if every value is matched', () => {
       keyMap = {
         foo: 'foo',
         bar: 'bar',
@@ -58,7 +58,7 @@ describe('matches.fromFunction', function () {
       assert.isTrue(fromFunction(getValue, keyMap));
     });
 
-    it('returns false if any value is not matched', function () {
+    it('returns false if any value is not matched', () => {
       keyMap = {
         foo: 'foo',
         bar: 'bar',
@@ -74,7 +74,7 @@ describe('matches.fromFunction', function () {
       );
     });
 
-    it('returns true if there are no keys', function () {
+    it('returns true if there are no keys', () => {
       assert.isTrue(fromFunction(getValue, {}));
     });
   });

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -1,23 +1,21 @@
-describe('text.accessibleTextVirtual', function () {
-  'use strict';
+describe('text.accessibleTextVirtual', () => {
+  const fixture = document.getElementById('fixture');
+  const shadowSupport = axe.testUtils.shadowSupport;
 
-  var fixture = document.getElementById('fixture');
-  var shadowSupport = axe.testUtils.shadowSupport;
-
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
     axe._tree = null;
   });
 
-  it('is called through accessibleText with a DOM node', function () {
-    var accessibleText = axe.commons.text.accessibleText;
+  it('is called through accessibleText with a DOM node', () => {
+    const accessibleText = axe.commons.text.accessibleText;
     fixture.innerHTML = '<label><input type="button"></label>';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = fixture.querySelector('input');
+    const target = fixture.querySelector('input');
     assert.equal(accessibleText(target), '');
   });
 
-  it('should match the first example from the ARIA spec', function () {
+  it('should match the first example from the ARIA spec', () => {
     fixture.innerHTML =
       '<ul role="menubar">' +
       ' <!-- Rule 2A: "File" label via aria-labelledby -->' +
@@ -33,14 +31,14 @@ describe('text.accessibleTextVirtual', function () {
       '</ul>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var rule2a = axe.utils.querySelectorAll(axe._tree, '#rule2a')[0];
-    var rule2c = axe.utils.querySelectorAll(axe._tree, '#rule2c')[0];
+    const rule2a = axe.utils.querySelectorAll(axe._tree, '#rule2a')[0];
+    const rule2c = axe.utils.querySelectorAll(axe._tree, '#rule2c')[0];
 
     assert.equal(axe.commons.text.accessibleTextVirtual(rule2a), 'File');
     assert.equal(axe.commons.text.accessibleTextVirtual(rule2c), 'New');
   });
 
-  it('should match the second example from the ARIA spec', function () {
+  it('should match the second example from the ARIA spec', () => {
     fixture.innerHTML =
       '<fieldset>' +
       '  <legend>Meeting alarms</legend>' +
@@ -58,8 +56,8 @@ describe('text.accessibleTextVirtual', function () {
       '</fieldset>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var rule2a = axe.utils.querySelectorAll(axe._tree, '#beep')[0];
-    var rule2b = axe.utils.querySelectorAll(axe._tree, '#flash')[0];
+    const rule2a = axe.utils.querySelectorAll(axe._tree, '#beep')[0];
+    const rule2b = axe.utils.querySelectorAll(axe._tree, '#flash')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(rule2a), 'Beep');
     // Chrome 72: "Flash the screen 3 times"
     // Firefox 62: "Flash the screen 3 times"
@@ -70,7 +68,7 @@ describe('text.accessibleTextVirtual', function () {
     );
   });
 
-  it('should use aria-labelledby if present', function () {
+  it('should use aria-labelledby if present', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'aria-labelledby="t1label" aria-label="ARIA Label" id="t1"> of <i>everything</i></div>' +
@@ -79,14 +77,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This is a label'
     );
   });
 
-  it('should use recusive aria-labelledby properly', function () {
+  it('should use recusive aria-labelledby properly', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'aria-labelledby="t1 t1label" aria-label="ARIA Label" id="t1"> of <i>everything</i></div>' +
@@ -95,14 +93,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'ARIA Label This is a label'
     );
   });
 
-  it('should include hidden text referred to with aria-labelledby', function () {
+  it('should include hidden text referred to with aria-labelledby', () => {
     fixture.innerHTML =
       '<div id="t1label" style="display:none">This is a ' +
       '<span style="visibility:hidden">hidden </span>' +
@@ -111,19 +109,19 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t1" aria-labelledby="t1label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This is a hidden secret'
     );
   });
 
-  it('should allow setting the initial includeHidden value', function () {
+  it('should allow setting the initial includeHidden value', () => {
     fixture.innerHTML =
       '<label id="lbl1" style="display:none;">hidden label</label>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#lbl1')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#lbl1')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target, {
         includeHidden: false
@@ -139,7 +137,7 @@ describe('text.accessibleTextVirtual', function () {
     );
   });
 
-  it('should use aria-label if present with no labelledby', function () {
+  it('should use aria-label if present with no labelledby', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'aria-label="ARIA Label" id="t1"> of <i>everything</i></div>' +
@@ -148,11 +146,11 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'ARIA Label');
   });
 
-  it('should use alt on imgs with no ARIA', function () {
+  it('should use alt on imgs with no ARIA', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'id="t1"> of <i>everything</i></div>' +
@@ -162,14 +160,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'Alt text goes here'
     );
   });
 
-  it('should use alt on image inputs with no ARIA', function () {
+  it('should use alt on image inputs with no ARIA', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'id="t1"> of <i>everything</i></div>' +
@@ -179,14 +177,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'Alt text goes here'
     );
   });
 
-  it('should use not use alt on text inputs with no ARIA', function () {
+  it('should use not use alt on text inputs with no ARIA', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'id="t1"> of <i>everything</i></div>' +
@@ -196,11 +194,11 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
   });
 
-  it('should use HTML label if no ARIA information', function () {
+  it('should use HTML label if no ARIA information', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'id="t1"> of <i>everything</i></div>' +
@@ -209,11 +207,11 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'HTML Label');
   });
 
-  it('should handle last ditch title attribute', function () {
+  it('should handle last ditch title attribute', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'aria-labelledby="t1label" aria-label="ARIA Label" id="t1"> of <i title="italics"></i></div>' +
@@ -222,14 +220,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This is This is a label of italics'
     );
   });
 
-  it('should handle totally empty elements', function () {
+  it('should handle totally empty elements', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'aria-labelledby="t1label" aria-label="ARIA Label" id="t1"> of <i></i></div>' +
@@ -238,14 +236,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This is This is a label of'
     );
   });
 
-  it('should handle author name-from roles properly', function () {
+  it('should handle author name-from roles properly', () => {
     fixture.innerHTML =
       '<div id="t2label" role="heading">This is ' +
       '  <input type="text" value="the value" ' +
@@ -256,7 +254,7 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
     // Chrome 86: This is This is a label of
     // Firefox 82: This is ARIA Label everything
     // Safari 14.0: This is This is a label of everything
@@ -266,32 +264,32 @@ describe('text.accessibleTextVirtual', function () {
     );
   });
 
-  it('should only show each node once when label is before input', function () {
+  it('should only show each node once when label is before input', () => {
     fixture.innerHTML =
       '<div id="target"><label for="tb1">My form input</label>' +
       '<input type="text" id="tb1"></div>';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'My form input'
     );
   });
 
-  it('should only show each node once when label follows input', function () {
+  it('should only show each node once when label follows input', () => {
     fixture.innerHTML =
       '<div id="target">' +
       '<input type="text" id="tb1"></div>' +
       '<label for="tb1">My form input</label>';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'My form input'
     );
   });
 
-  it('should handle nested inputs in normal context', function () {
+  it('should handle nested inputs in normal context', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="text" value="the value" ' +
       'aria-labelledby="t1label" aria-label="ARIA Label" id="t1"> of <i>everything</i></div>' +
@@ -300,14 +298,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2label')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This is This is a label of everything'
     );
   });
 
-  it('should use handle nested inputs properly in labelledby context', function () {
+  it('should use handle nested inputs properly in labelledby context', () => {
     // Chrome 72: This is This is a label of everything
     // Firefox 62: This is ARIA Label the value of everything
     // Safari 12.0: THis is This is a label of everything
@@ -319,14 +317,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This is ARIA Label of everything'
     );
   });
 
-  it('should use ignore hidden inputs', function () {
+  it('should use ignore hidden inputs', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input type="hidden" value="the value" ' +
       'Label" id="t1"> of <i>everything</i></div>' +
@@ -335,14 +333,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This is of everything'
     );
   });
 
-  it('should use handle inputs with no type as if they were text inputs', function () {
+  it('should use handle inputs with no type as if they were text inputs', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <input value="the value" ' +
       'aria-labelledby="t1label" id="t1"> of <i>everything</i></div>' +
@@ -351,7 +349,7 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
     // Chrome 70: "This is This is a label of everything"
     // Firefox 62: "This is the value of everything"
     // Safari 12.0: "This is This is a label of everything"
@@ -361,7 +359,7 @@ describe('text.accessibleTextVirtual', function () {
     );
   });
 
-  it('should use handle nested selects properly in labelledby context', function () {
+  it('should use handle nested selects properly in labelledby context', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <select multiple ' +
       'aria-labelledby="t1label" id="t1">' +
@@ -372,7 +370,7 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
     // Chrome 70: "This is This is a label of everything"
     // Firefox 62: "This is of everything"
     // Safari 12.0: "This is first third label of"
@@ -382,7 +380,7 @@ describe('text.accessibleTextVirtual', function () {
     );
   });
 
-  it('should use handle nested textareas properly in labelledby context', function () {
+  it('should use handle nested textareas properly in labelledby context', () => {
     fixture.innerHTML =
       '<div id="t2label">This is <textarea ' +
       'aria-labelledby="t1label" id="t1">the value</textarea> of <i>everything</i></div>' +
@@ -391,7 +389,7 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
     // Chrome 70: "This is This is a label of everything"
     // Firefox 62: "This is ARIA Label the value of everything"
     // Safari 12.0: "This is This is a label of everything"
@@ -401,7 +399,7 @@ describe('text.accessibleTextVirtual', function () {
     );
   });
 
-  it('should use handle ARIA labels properly in labelledby context', function () {
+  it('should use handle ARIA labels properly in labelledby context', () => {
     fixture.innerHTML =
       '<div id="t2label">This <span aria-label="not a span">span</span>' +
       ' is <input type="text" value="the value" ' +
@@ -411,14 +409,14 @@ describe('text.accessibleTextVirtual', function () {
       '<input type="text" id="t2" aria-labelledby="t2label">';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#t2')[0];
     assert.equal(
       axe.commons.text.accessibleTextVirtual(target),
       'This not a span is the value of everything'
     );
   });
 
-  it('should come up empty if input is labeled only by select options', function () {
+  it('should come up empty if input is labeled only by select options', () => {
     fixture.innerHTML =
       '<label for="target">' +
       '<select id="select">' +
@@ -428,14 +426,14 @@ describe('text.accessibleTextVirtual', function () {
       '</label>' +
       '<input id="target" type="text" />';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     // Chrome 70: ""
     // Firefox 62: "Chosen"
     // Safari 12.0: "Chosen"
     assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
   });
 
-  it("should be empty if input is labeled by labeled select (ref'd string labels have spotty support)", function () {
+  it("should be empty if input is labeled by labeled select (ref'd string labels have spotty support)", () => {
     fixture.innerHTML =
       '<label for="select">My Select</label>' +
       '<label for="target">' +
@@ -446,11 +444,11 @@ describe('text.accessibleTextVirtual', function () {
       '</label>' +
       '<input id="target" type="text" />';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
   });
 
-  it('should be empty for an empty label wrapping a select', function () {
+  it('should be empty for an empty label wrapping a select', () => {
     fixture.innerHTML =
       '<label>' +
       '<span class="label"></span>' +
@@ -463,11 +461,11 @@ describe('text.accessibleTextVirtual', function () {
       '</select>' +
       '</label>';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
   });
 
-  it('should not return select options if input is aria-labelled by a select', function () {
+  it('should not return select options if input is aria-labelled by a select', () => {
     fixture.innerHTML =
       '<label>' +
       '<select id="select">' +
@@ -477,132 +475,132 @@ describe('text.accessibleTextVirtual', function () {
       '</label>' +
       '<input aria-labelledby="select" type="text" id="target" />';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, '#target')[0];
     // Chrome 70: ""
     // Firefox 62: ""
     // Safari 12.0: "Chosen"
     assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
   });
 
-  it('shoud properly fall back to title', function () {
+  it('shoud properly fall back to title', () => {
     fixture.innerHTML = '<a href="#" role="presentation" title="Hello"></a>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('should give text even for role=presentation on anchors', function () {
+  it('should give text even for role=presentation on anchors', () => {
     fixture.innerHTML = '<a href="#" role="presentation">Hello</a>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('should give text even for role=presentation on buttons', function () {
+  it('should give text even for role=presentation on buttons', () => {
     fixture.innerHTML = '<button role="presentation">Hello</button>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('should give text even for role=presentation on summary', function () {
+  it('should give text even for role=presentation on summary', () => {
     fixture.innerHTML = '<summary role="presentation">Hello</summary>';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, 'summary')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'summary')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('shoud properly fall back to title', function () {
+  it('shoud properly fall back to title', () => {
     fixture.innerHTML = '<a href="#" role="none" title="Hello"></a>';
     axe.testUtils.flatTreeSetup(fixture);
-    var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('should give text even for role=none on anchors', function () {
+  it('should give text even for role=none on anchors', () => {
     fixture.innerHTML = '<a href="#" role="none">Hello</a>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('should give text even for role=none on buttons', function () {
+  it('should give text even for role=none on buttons', () => {
     fixture.innerHTML = '<button role="none">Hello</button>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('should give text even for role=none on summary', function () {
+  it('should give text even for role=none on summary', () => {
     fixture.innerHTML = '<summary role="none">Hello</summary>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'summary')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'summary')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
   });
 
-  it('should not add extra spaces around phrasing elements', function () {
+  it('should not add extra spaces around phrasing elements', () => {
     fixture.innerHTML = '<a href="#">Hello<span>World</span></a>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'HelloWorld');
   });
 
-  it('should add spaces around non-phrasing elements', function () {
+  it('should add spaces around non-phrasing elements', () => {
     fixture.innerHTML = '<a href="#">Hello<div>World</div></a>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello World');
   });
 
-  it('should not look at scripts', function () {
+  it('should not look at scripts', () => {
     fixture.innerHTML =
-      '<a href="#"><script> var ajiasdf = true; </script></a>';
+      '<a href="#"><script> const ajiasdf = true; </script></a>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
   });
 
-  it('should use <label> for input buttons', function () {
+  it('should use <label> for input buttons', () => {
     fixture.innerHTML = '<label><input type="button"></label>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
   });
 
-  it('should not stop when attributes contain whitespace', function () {
+  it('should not stop when attributes contain whitespace', () => {
     fixture.innerHTML =
       '<button aria-label=" " aria-labelledby=" ">Hello World</button>';
     axe.testUtils.flatTreeSetup(fixture);
 
-    var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+    const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
     assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello World');
   });
 
   (!!document.fonts ? it : xit)(
     'should allow ignoring icon ligatures',
-    function (done) {
-      var materialFont = new FontFace(
+    done => {
+      const materialFont = new FontFace(
         'Material Icons',
         'url(https://fonts.gstatic.com/s/materialicons/v48/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2)'
       );
-      materialFont.load().then(function () {
+      materialFont.load().then(() => {
         document.fonts.add(materialFont);
 
         fixture.innerHTML =
           '<button id="target">Hello World<span style="font-family: \'Material Icons\'">delete</span></button>';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
         try {
           assert.equal(
             axe.commons.text.accessibleTextVirtual(target, {
@@ -620,13 +618,13 @@ describe('text.accessibleTextVirtual', function () {
 
   (shadowSupport.v1 ? it : xit)(
     'should only find aria-labelledby element in the same context ',
-    function () {
+    () => {
       fixture.innerHTML =
         '<div id="t2label">This is <input type="text" value="the value" ' +
         'aria-labelledby="t1label" aria-label="ARIA Label" id="t1"> of <i>everything</i></div>' +
         '<div id="shadow"></div>';
 
-      var shadow = document
+      const shadow = document
         .getElementById('shadow')
         .attachShadow({ mode: 'open' });
       shadow.innerHTML =
@@ -635,7 +633,7 @@ describe('text.accessibleTextVirtual', function () {
         '<input type="text" id="t2" aria-labelledby="t2label">';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'ARIA Label'
@@ -645,16 +643,16 @@ describe('text.accessibleTextVirtual', function () {
 
   (shadowSupport.v1 ? it : xit)(
     'should find attributes within a shadow tree',
-    function () {
+    () => {
       fixture.innerHTML = '<div id="shadow"></div>';
 
-      var shadow = document
+      const shadow = document
         .getElementById('shadow')
         .attachShadow({ mode: 'open' });
       shadow.innerHTML = '<input type="text" id="t1" title="I will be king">';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'I will be king'
@@ -664,17 +662,17 @@ describe('text.accessibleTextVirtual', function () {
 
   (shadowSupport.v1 ? it : xit)(
     'should find attributes within a slot on the shadow tree',
-    function () {
+    () => {
       fixture.innerHTML =
         '<div id="shadow"><input type="text" id="t1" title="you will be queen"></div>';
 
-      var shadow = document
+      const shadow = document
         .getElementById('shadow')
         .attachShadow({ mode: 'open' });
       shadow.innerHTML = '<slot></slot>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'you will be queen'
@@ -684,10 +682,10 @@ describe('text.accessibleTextVirtual', function () {
 
   (shadowSupport.v1 ? it : xit)(
     'should find fallback content for shadow DOM',
-    function () {
+    () => {
       fixture.innerHTML = '<div id="shadow"></div>';
 
-      var shadow = document
+      const shadow = document
         .getElementById('shadow')
         .attachShadow({ mode: 'open' });
       shadow.innerHTML =
@@ -695,7 +693,7 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="t1"><slot>Fallback content heroes</slot></label>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Fallback content heroes'
@@ -703,110 +701,110 @@ describe('text.accessibleTextVirtual', function () {
     }
   );
 
-  describe('figure', function () {
-    it('should check aria-labelledby', function () {
+  describe('figure', () => {
+    it('should check aria-labelledby', () => {
       fixture.innerHTML =
         '<div id="t1">Hello</div>' +
         '<figure aria-labelledby="t1">Not part of a11yName <figcaption>Fail</figcaption></figure>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should check aria-label', function () {
+    it('should check aria-label', () => {
       fixture.innerHTML =
         '<figure aria-label="Hello">Not part of a11yName <figcaption>Fail</figcaption></figure>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should check the figures figcaption', function () {
+    it('should check the figures figcaption', () => {
       fixture.innerHTML =
         '<figure>Not part of a11yName <figcaption>Hello</figcaption></figure>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should check title on figure', function () {
+    it('should check title on figure', () => {
       fixture.innerHTML =
         '<figure title="Hello">Not part of a11yName <figcaption></figcaption></figure>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should fall back to innerText of figure', function () {
+    it('should fall back to innerText of figure', () => {
       fixture.innerHTML = '<figure>Hello<figcaption></figcaption></figure>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
     (shadowSupport.v1 ? it : xit)(
       'should check within the composed (shadow) tree',
-      function () {
-        var node = document.createElement('div');
+      () => {
+        const node = document.createElement('div');
         node.innerHTML = 'Hello';
-        var shadowRoot = node.attachShadow({ mode: 'open' });
+        const shadowRoot = node.attachShadow({ mode: 'open' });
         shadowRoot.innerHTML =
           '<figure>Not part of a11yName <figcaption><slot></slot></figcaption></figure>';
         fixture.appendChild(node);
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'figure')[0];
         assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
       }
     );
   });
 
-  describe('img', function () {
-    it('should work with aria-labelledby attribute', function () {
+  describe('img', () => {
+    it('should work with aria-labelledby attribute', () => {
       fixture.innerHTML =
         '<div id="t1">Hello</div><div id="t2">World</div>' +
         '<img aria-labelledby="t1 t2">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should work with aria-label attribute', function () {
+    it('should work with aria-label attribute', () => {
       fixture.innerHTML = '<img aria-label="Hello World">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should work with alt attribute', function () {
+    it('should work with alt attribute', () => {
       fixture.innerHTML = '<img alt="Hello World">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should work with title attribute', function () {
+    it('should work with title attribute', () => {
       fixture.innerHTML = '<img title="Hello World">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'img')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
@@ -814,65 +812,65 @@ describe('text.accessibleTextVirtual', function () {
     });
   });
 
-  describe('input buttons', function () {
-    it('should find value for input type=button', function () {
+  describe('input buttons', () => {
+    it('should find value for input type=button', () => {
       fixture.innerHTML = '<input type="button" value="Hello">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should find value for input type=reset', function () {
+    it('should find value for input type=reset', () => {
       fixture.innerHTML = '<input type="reset" value="Hello">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should find value for input type=submit', function () {
+    it('should find value for input type=submit', () => {
       fixture.innerHTML = '<input type="submit" value="Hello">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should provide a default value for input type="submit"', function () {
+    it('should provide a default value for input type="submit"', () => {
       fixture.innerHTML = '<input type="submit">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         target.actualNode.value || 'Submit'
       );
     });
 
-    it('should provide a default value for input type="reset"', function () {
+    it('should provide a default value for input type="reset"', () => {
       fixture.innerHTML = '<input type="reset">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
-      var defaultText = axe.commons.text.accessibleTextVirtual(target);
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const defaultText = axe.commons.text.accessibleTextVirtual(target);
       assert.isString(defaultText);
       assert.equal(defaultText, target.actualNode.value || 'Reset');
     });
 
-    it('should find title for input type=button', function () {
+    it('should find title for input type=button', () => {
       fixture.innerHTML = '<input type="button" title="Hello">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Hello');
     });
 
-    it('should find title for input type=reset', function () {
+    it('should find title for input type=reset', () => {
       fixture.innerHTML = '<input type="reset" title="Hello">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       // IE does not use title; but will use default value instead
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
@@ -880,11 +878,11 @@ describe('text.accessibleTextVirtual', function () {
       );
     });
 
-    it('should find title for input type=submit', function () {
+    it('should find title for input type=submit', () => {
       fixture.innerHTML = '<input type="submit" title="Hello">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       // Again, default value takes precedence over title
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
@@ -893,73 +891,73 @@ describe('text.accessibleTextVirtual', function () {
     });
   });
 
-  describe('tables', function () {
-    it('should work with aria-labelledby', function () {
+  describe('tables', () => {
+    it('should work with aria-labelledby', () => {
       fixture.innerHTML =
         '<div id="t1">Hello</div><div id="t2">World</div>' +
         '<table aria-labelledby="t1 t2"></table>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should work with aria-label', function () {
+    it('should work with aria-label', () => {
       fixture.innerHTML = '<table aria-label="Hello World"></table>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should work with the caption element', function () {
+    it('should work with the caption element', () => {
       fixture.innerHTML =
         '<table><caption>Hello World</caption><tr><td>Stuff</td></tr></table>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should work with the title attribute', function () {
+    it('should work with the title attribute', () => {
       fixture.innerHTML = '<table title="Hello World"></table>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should work with the summary attribute', function () {
+    it('should work with the summary attribute', () => {
       fixture.innerHTML = '<table summary="Hello World"></table>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should prefer summary attribute over title attribute', function () {
+    it('should prefer summary attribute over title attribute', () => {
       // Chrome 70: "Hello world"
       // Firefox 62: "Hello world"
       // Safari 12.0: "FAIL"
       fixture.innerHTML = '<table summary="Hello World" title="FAIL"></table>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'table')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
@@ -967,12 +965,12 @@ describe('text.accessibleTextVirtual', function () {
     });
   });
 
-  describe('text inputs', function () {
-    var types = ['text', 'password', 'search', 'tel', 'email', 'url', null];
+  describe('text inputs', () => {
+    const types = ['text', 'password', 'search', 'tel', 'email', 'url', null];
 
-    it('should find aria-labelledby', function () {
+    it('should find aria-labelledby', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML =
           '<div id="t1">Hello</div><div id="t2">World</div>' +
           '<input' +
@@ -980,7 +978,7 @@ describe('text.accessibleTextVirtual', function () {
           ' aria-labelledby="t1 t2">';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(
           axe.commons.text.accessibleTextVirtual(target),
           'Hello World',
@@ -989,13 +987,13 @@ describe('text.accessibleTextVirtual', function () {
       });
     });
 
-    it('should find aria-label', function () {
+    it('should find aria-label', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML = '<input' + t + ' aria-label="Hello World">';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(
           axe.commons.text.accessibleTextVirtual(target),
           'Hello World',
@@ -1004,14 +1002,14 @@ describe('text.accessibleTextVirtual', function () {
       });
     });
 
-    it('should find an implicit label', function () {
+    it('should find an implicit label', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML =
           '<label for="t1">Hello World' + '<input' + t + '></label>';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(
           axe.commons.text.accessibleTextVirtual(target),
           'Hello World',
@@ -1020,14 +1018,14 @@ describe('text.accessibleTextVirtual', function () {
       });
     });
 
-    it('should find an explicit label', function () {
+    it('should find an explicit label', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML =
           '<label for="t1">Hello World</label>' + '<input' + t + ' id="t1">';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(
           axe.commons.text.accessibleTextVirtual(target),
           'Hello World',
@@ -1036,14 +1034,14 @@ describe('text.accessibleTextVirtual', function () {
       });
     });
 
-    it('should find implicit labels with id that does not match to a label', function () {
+    it('should find implicit labels with id that does not match to a label', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML =
           '<label for="t1">Hello World' + '<input' + t + ' id="foo"></label>';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(
           axe.commons.text.accessibleTextVirtual(target),
           'Hello World',
@@ -1052,13 +1050,13 @@ describe('text.accessibleTextVirtual', function () {
       });
     });
 
-    it('should find a placeholder attribute', function () {
+    it('should find a placeholder attribute', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML = '<input' + t + ' placeholder="Hello World">';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(
           axe.commons.text.accessibleTextVirtual(target),
           'Hello World',
@@ -1067,13 +1065,13 @@ describe('text.accessibleTextVirtual', function () {
       });
     });
 
-    it('should find a title attribute', function () {
+    it('should find a title attribute', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML = '<input' + t + ' title="Hello World">';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(
           axe.commons.text.accessibleTextVirtual(target),
           'Hello World',
@@ -1082,210 +1080,210 @@ describe('text.accessibleTextVirtual', function () {
       });
     });
 
-    it('should otherwise be empty string', function () {
+    it('should otherwise be empty string', () => {
       types.forEach(function (type) {
-        var t = type ? ' type="' + type + '"' : '';
+        const t = type ? ' type="' + type + '"' : '';
         fixture.innerHTML = '<input' + t + '>';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+        const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
         assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
       });
     });
   });
 
-  describe('textarea', function () {
-    it('should find aria-labelledby', function () {
+  describe('textarea', () => {
+    it('should find aria-labelledby', () => {
       fixture.innerHTML =
         '<div id="t1">Hello</div><div id="t2">World</div>' +
         '<textarea aria-labelledby="t1 t2"></textarea>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find aria-label', function () {
+    it('should find aria-label', () => {
       fixture.innerHTML = '<textarea aria-label="Hello World"></textarea>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find an implicit label', function () {
+    it('should find an implicit label', () => {
       fixture.innerHTML =
         '<label for="t1">Hello World' + '<textarea></textarea></label>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find an explicit label', function () {
+    it('should find an explicit label', () => {
       fixture.innerHTML =
         '<label for="t1">Hello World</label>' + '<textarea id="t1"></textarea>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find a placeholder attribute', function () {
+    it('should find a placeholder attribute', () => {
       fixture.innerHTML = '<textarea placeholder="Hello World"></textarea>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find a title attribute', function () {
+    it('should find a title attribute', () => {
       fixture.innerHTML = '<textarea title="Hello World"></textarea>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should otherwise be empty string', function () {
+    it('should otherwise be empty string', () => {
       fixture.innerHTML = '<textarea></textarea>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'textarea')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
     });
   });
 
-  describe('image inputs', function () {
-    it('should find aria-labelledby', function () {
+  describe('image inputs', () => {
+    it('should find aria-labelledby', () => {
       fixture.innerHTML =
         '<div id="t1">Hello</div><div id="t2">World</div>' +
         '<input type="image" aria-labelledby="t1 t2">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find aria-label', function () {
+    it('should find aria-label', () => {
       fixture.innerHTML = '<input type="image" aria-label="Hello World">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find an alt attribute', function () {
+    it('should find an alt attribute', () => {
       fixture.innerHTML = '<input type="image" alt="Hello World">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find a title attribute', function () {
+    it('should find a title attribute', () => {
       fixture.innerHTML = '<input type="image" title="Hello World">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should otherwise be "Submit" string', function () {
+    it('should otherwise be "Submit" string', () => {
       fixture.innerHTML = '<input type="image">';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'input')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), 'Submit');
     });
   });
 
-  describe('a', function () {
-    it('should find aria-labelledby', function () {
+  describe('a', () => {
+    it('should find aria-labelledby', () => {
       fixture.innerHTML =
         '<div id="t1">Hello</div><div id="t2">World</div>' +
         '<a aria-labelledby="t1 t2"></a>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find aria-label', function () {
+    it('should find aria-label', () => {
       fixture.innerHTML = '<a aria-label="Hello World"></a>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should check subtree', function () {
+    it('should check subtree', () => {
       fixture.innerHTML = '<a><span>Hello<span> World</span></span></a>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find a title attribute', function () {
+    it('should find a title attribute', () => {
       fixture.innerHTML = '<a title="Hello World"></a>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should otherwise be empty string', function () {
+    it('should otherwise be empty string', () => {
       fixture.innerHTML = '<a></a>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
     });
 
-    it('should use text from a table with a single cell and role=presentation', function () {
+    it('should use text from a table with a single cell and role=presentation', () => {
       fixture.innerHTML =
         '<a href="example.html">' +
         '<table role="presentation">' +
@@ -1298,7 +1296,7 @@ describe('text.accessibleTextVirtual', function () {
         '</a>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'a')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Descriptive Link Text'
@@ -1306,65 +1304,65 @@ describe('text.accessibleTextVirtual', function () {
     });
   });
 
-  describe('button', function () {
-    it('should find aria-labelledby', function () {
+  describe('button', () => {
+    it('should find aria-labelledby', () => {
       fixture.innerHTML =
         '<div id="t1">Hello</div><div id="t2">World</div>' +
         '<button aria-labelledby="t1 t2"></button>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find aria-label', function () {
+    it('should find aria-label', () => {
       fixture.innerHTML = '<button aria-label="Hello World"></button>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should check subtree', function () {
+    it('should check subtree', () => {
       fixture.innerHTML =
         '<button><span>Hello<span> World</span></span></button>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should find a title attribute', function () {
+    it('should find a title attribute', () => {
       fixture.innerHTML = '<button title="Hello World"></button>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
       assert.equal(
         axe.commons.text.accessibleTextVirtual(target),
         'Hello World'
       );
     });
 
-    it('should otherwise be empty string', function () {
+    it('should otherwise be empty string', () => {
       fixture.innerHTML = '<button></button>';
       axe.testUtils.flatTreeSetup(fixture);
 
-      var target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
+      const target = axe.utils.querySelectorAll(axe._tree, 'button')[0];
       assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
     });
   });
 
-  describe('text level semantics', function () {
-    var tags = [
+  describe('text level semantics', () => {
+    const tags = [
       'em',
       'strong',
       'small',
@@ -1393,67 +1391,67 @@ describe('text.accessibleTextVirtual', function () {
       'wbr'
     ];
 
-    it('should find aria-labelledby', function () {
+    it('should find aria-labelledby', () => {
       tags.forEach(function (tag) {
         fixture.innerHTML = '<div id="t1">Hello</div><div id="t2">World</div>';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var elm = document.createElement(tag);
+        const elm = document.createElement(tag);
         elm.setAttribute('aria-labelledby', 't1 t2');
         elm.style.display = 'inline'; // Firefox hides some of these elements because reasons...
         fixture.appendChild(elm);
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.getNodeFromTree(elm);
-        var result = axe.commons.text.accessibleTextVirtual(target);
+        const target = axe.utils.getNodeFromTree(elm);
+        const result = axe.commons.text.accessibleTextVirtual(target);
         assert.equal(result, 'Hello World', tag);
       });
     });
 
-    it('should find aria-label', function () {
+    it('should find aria-label', () => {
       tags.forEach(function (tag) {
-        var elm = document.createElement(tag);
+        const elm = document.createElement(tag);
         elm.setAttribute('aria-label', 'Hello World');
         elm.style.display = 'inline'; // Firefox hack, see above
         fixture.appendChild(elm);
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.getNodeFromTree(elm);
-        var result = axe.commons.text.accessibleTextVirtual(target);
+        const target = axe.utils.getNodeFromTree(elm);
+        const result = axe.commons.text.accessibleTextVirtual(target);
         assert.equal(result, 'Hello World', tag);
       });
     });
 
-    it('should find a title attribute', function () {
+    it('should find a title attribute', () => {
       tags.forEach(function (tag) {
-        var elm = document.createElement(tag);
+        const elm = document.createElement(tag);
         elm.setAttribute('title', 'Hello World');
         elm.style.display = 'inline'; // Firefox hack, see above
         fixture.appendChild(elm);
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.getNodeFromTree(elm);
-        var result = axe.commons.text.accessibleTextVirtual(target);
+        const target = axe.utils.getNodeFromTree(elm);
+        const result = axe.commons.text.accessibleTextVirtual(target);
         assert.equal(result, 'Hello World', tag);
       });
     });
 
-    it('should otherwise be empty string', function () {
+    it('should otherwise be empty string', () => {
       tags.forEach(function (tag) {
         fixture.innerHTML = '<' + tag + '></' + tag + '>';
         axe.testUtils.flatTreeSetup(fixture);
 
-        var target = axe.utils.querySelectorAll(axe._tree, tag)[0];
+        const target = axe.utils.querySelectorAll(axe._tree, tag)[0];
         assert.equal(axe.commons.text.accessibleTextVirtual(target), '');
       });
     });
 
-    it('inserts a space before img alt text', function () {
-      var accessibleText = axe.commons.text.accessibleText;
+    it('inserts a space before img alt text', () => {
+      const accessibleText = axe.commons.text.accessibleText;
       fixture.innerHTML =
         '<a id="test" href="../images/index.html">Images tool test page<img id="img18" aria-label="aria-label text" alt="logo" src="../images/Accessibility.jpg" width="50" height="50"></a>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(
         accessibleText(target),
         'Images tool test page aria-label text'
@@ -1461,87 +1459,86 @@ describe('text.accessibleTextVirtual', function () {
     });
   });
 
-  describe('text.accessibleText acceptance tests', function () {
+  describe('text.accessibleText acceptance tests', () => {
     'use strict';
     // Tests borrowed from the AccName 1.1 testing docs
     // https://www.w3.org/wiki/AccName_1.1_Testable_Statements#Name_test_case_539
 
-    var ariaValuetext = xit; // Not acc supported
-    var pseudoText = xit; // Not acc supported
+    const ariaValuetext = xit; // Not acc supported
+    const pseudoText = xit; // Not acc supported
 
-    var fixture = document.getElementById('fixture');
-    var accessibleText = axe.commons.text.accessibleText;
-    var _unsupported;
+    const accessibleText = axe.commons.text.accessibleText;
+    let _unsupported;
 
-    before(function () {
+    before(() => {
       _unsupported = axe.commons.text.unsupported.accessibleNameFromFieldValue;
       axe.commons.text.unsupported.accessibleNameFromFieldValue = [];
     });
-    after(function () {
+    after(() => {
       axe.commons.text.unsupported.accessibleNameFromFieldValue = _unsupported;
     });
 
-    afterEach(function () {
+    afterEach(() => {
       fixture.innerHTML = '';
       axe._tree = null;
     });
 
-    it('passes test 1', function () {
+    it('passes test 1', () => {
       fixture.innerHTML = '<input type="button" aria-label="Rich" id="test">';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Rich');
     });
 
-    it('passes test 2', function () {
+    it('passes test 2', () => {
       fixture.innerHTML =
         '<div id="ID1">Rich\'s button</div>' +
         '<input type="button" aria-labelledby="ID1" id="test">';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), "Rich's button");
     });
 
-    it('passes test 3', function () {
+    it('passes test 3', () => {
       fixture.innerHTML =
         '<div id="ID1">Rich\'s button</div>' +
         '<input type="button" aria-label="bar" aria-labelledby="ID1" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), "Rich's button");
     });
 
-    it('passes test 4', function () {
+    it('passes test 4', () => {
       fixture.innerHTML = '<input type="reset" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Reset');
     });
 
-    it('passes test 5', function () {
+    it('passes test 5', () => {
       fixture.innerHTML = '<input type="button" id="test" value="foo"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 6', function () {
+    it('passes test 6', () => {
       fixture.innerHTML =
         '<input src="baz.html" type="image" id="test" alt="foo"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 7', function () {
+    it('passes test 7', () => {
       fixture.innerHTML =
         '<label for="test">States:</label>' + '<input type="text" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'States:');
     });
 
-    it('passes test 8', function () {
+    it('passes test 8', () => {
       fixture.innerHTML =
         '<label for="test">' +
         'foo' +
@@ -1549,11 +1546,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="text" id="test" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo David');
     });
 
-    it('passes test 9', function () {
+    it('passes test 9', () => {
       fixture.innerHTML =
         '<label for="test">' +
         'crazy' +
@@ -1564,11 +1561,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label> ' +
         '<input type="text" id="test" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    ariaValuetext('passes test 10', function () {
+    ariaValuetext('passes test 10', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -1577,11 +1574,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="text" id="test" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy Monday');
     });
 
-    it('passes test 11', function () {
+    it('passes test 11', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -1590,19 +1587,19 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="text" id="test" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy 4');
     });
 
-    it('passes test 12', function () {
+    it('passes test 12', () => {
       fixture.innerHTML =
         '<input type="text" id="test" title="crazy" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    pseudoText('passes test 13', function () {
+    pseudoText('passes test 13', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:before { content:"fancy "; }' +
@@ -1610,11 +1607,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fruit</label>' +
         '<input type="text" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 14', function () {
+    pseudoText('passes test 14', () => {
       fixture.innerHTML =
         '<style type="text/css">' +
         '  [data-after]:after { content: attr(data-after); }' +
@@ -1622,338 +1619,338 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test" data-after="test content"></label>' +
         '<input type="text" id="test">';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'test content');
     });
 
-    it('passes test 15', function () {
+    it('passes test 15', () => {
       fixture.innerHTML = '<img id="test" src="foo.jpg" aria-label="1"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), '1');
     });
 
-    it('passes test 16', function () {
+    it('passes test 16', () => {
       fixture.innerHTML =
         '<img id="test" src="foo.jpg" aria-label="1" alt="a" title="t"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), '1');
     });
 
     // To the best of my knowledge, this test is incorrect
     // Chrome and Firefox seem to return "peanuts", so does axe-core.
-    xit('passes test 17', function () {
+    xit('passes test 17', () => {
       fixture.innerHTML =
         '<input type="text" value="peanuts" id="test">' +
         '<img aria-labelledby="test" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), '');
     });
 
-    it('passes test 18', function () {
+    it('passes test 18', () => {
       fixture.innerHTML =
         '<img id="test" aria-labelledby="test" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), '');
     });
 
     // To the best of my knowledge, this test is incorrect
     // Chrome and Firefox seem to return "peanuts", so does axe-core.
-    xit('passes test 19', function () {
+    xit('passes test 19', () => {
       fixture.innerHTML =
         '<input type="text" value="peanuts" id="test">' +
         '<img aria-labelledby="test" aria-label="1" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), '');
     });
 
-    it('passes test 20', function () {
+    it('passes test 20', () => {
       fixture.innerHTML =
         '<img id="test" aria-labelledby="test" aria-label="1" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), '1');
     });
 
-    it('passes test 21', function () {
+    it('passes test 21', () => {
       fixture.innerHTML =
         '<input type="text" value="peanuts" id="ID1">' +
         '<input type="text" value="popcorn" id="ID2">' +
         '<input type="text" value="apple jacks" id="ID3">' +
         '<img aria-labelledby="ID1 ID2 ID3" id="test" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'peanuts popcorn apple jacks');
     });
 
-    it('passes test 22', function () {
+    it('passes test 22', () => {
       fixture.innerHTML =
         '<input type="text" value="peanuts" id="ID1">' +
         '<img id="test" aria-label="l" aria-labelledby="test ID1" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'l peanuts');
     });
 
-    it('passes test 23', function () {
+    it('passes test 23', () => {
       fixture.innerHTML =
         '<input type="text" value="peanuts" id="ID1">' +
         '<input type="text" value="popcorn" id="ID2">' +
         '<img id="test" aria-label="l" aria-labelledby="test ID1 ID2" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'l peanuts popcorn');
     });
 
-    it('passes test 24', function () {
+    it('passes test 24', () => {
       fixture.innerHTML =
         '<input type="text" value="peanuts" id="ID1">' +
         '<input type="text" value="popcorn" id="ID2">' +
         '<input type="text" value="apple jacks" id="ID3">' +
         '<img id="test" aria-label="l" aria-labelledby="test ID1 ID2 ID3" alt= "a" title="t" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'l peanuts popcorn apple jacks');
     });
 
-    it('passes test 25', function () {
+    it('passes test 25', () => {
       fixture.innerHTML =
         '<input type="text" value="peanuts" id="ID1">' +
         '<input type="text" value="popcorn" id="ID2">' +
         '<input type="text" value="apple jacks" id="ID3">' +
         '<img id="test" aria-label="" aria-labelledby="test ID1 ID2 ID3" alt="" title="t" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 't peanuts popcorn apple jacks');
     });
 
-    it('passes test 26', function () {
+    it('passes test 26', () => {
       fixture.innerHTML =
         '<div id="test" aria-labelledby="ID1">foo</div>' +
         '<span id="ID1">bar</span>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'bar');
     });
 
-    it('passes test 27', function () {
+    it('passes test 27', () => {
       fixture.innerHTML = '<div id="test" aria-label="Tag">foo</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Tag');
     });
 
-    it('passes test 28', function () {
+    it('passes test 28', () => {
       fixture.innerHTML =
         '<div id="test" aria-labelledby="ID1" aria-label="Tag">foo</div>' +
         '<span id="ID1">bar</span>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'bar');
     });
 
-    it('passes test 29', function () {
+    it('passes test 29', () => {
       fixture.innerHTML =
         '<div id="test" aria-labelledby="ID0 ID1" aria-label="Tag">foo</div>' +
         '<span id="ID0">bar</span>' +
         '<span id="ID1">baz</span>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'bar baz');
     });
 
     // Should only pass in strict mode
-    it('passes test 30', function () {
+    it('passes test 30', () => {
       fixture.innerHTML = '<div id="test">Div with text</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target, { strict: true }), '');
     });
 
-    it('passes test 31', function () {
+    it('passes test 31', () => {
       fixture.innerHTML = '<div id="test" role="button">foo</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 32', function () {
+    it('passes test 32', () => {
       fixture.innerHTML =
         '<div id="test" role="button" title="Tag" style="outline:medium solid black; width:2em; height:1em;">' +
         '</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Tag');
     });
 
-    it('passes test 33', function () {
+    it('passes test 33', () => {
       fixture.innerHTML =
         '<div id="ID1">foo</div>' +
         '<a id="test" href="test.html" aria-labelledby="ID1">bar</a>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 34', function () {
+    it('passes test 34', () => {
       fixture.innerHTML =
         '<a id="test" href="test.html" aria-label="Tag">ABC</a>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Tag');
     });
 
-    it('passes test 35', function () {
+    it('passes test 35', () => {
       fixture.innerHTML =
         '<a href="test.html" id="test" aria-labelledby="ID1" aria-label="Tag">foo</a>' +
         '<p id="ID1">bar</p>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'bar');
     });
 
-    it('passes test 36', function () {
+    it('passes test 36', () => {
       fixture.innerHTML =
         '<a href="test.html" id="test" aria-labelledby="test ID1" aria-label="Tag"></a>' +
         '<p id="ID1">foo</p>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Tag foo');
     });
 
-    it('passes test 37', function () {
+    it('passes test 37', () => {
       fixture.innerHTML = '<a href="test.html" id="test">ABC</a>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'ABC');
     });
 
-    it('passes test 38', function () {
+    it('passes test 38', () => {
       fixture.innerHTML = '<a href="test.html" id="test" title="Tag"></a>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Tag');
     });
 
-    it('passes test 39', function () {
+    it('passes test 39', () => {
       fixture.innerHTML =
         '<input id="test" type="text" aria-labelledby="ID1 ID2 ID3">' +
         '<p id="ID1">foo</p>' +
         '<p id="ID2">bar</p>' +
         '<p id="ID3">baz</p>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    it('passes test 40', function () {
+    it('passes test 40', () => {
       fixture.innerHTML =
         '<input id="test" type="text" aria-label="bar" aria-labelledby="ID1 test">' +
         '<div id="ID1">foo</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar');
     });
 
-    it('passes test 41', function () {
+    it('passes test 41', () => {
       fixture.innerHTML =
         '<input id="test" type="text"/>' + '<label for="test">foo</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 42', function () {
+    it('passes test 42', () => {
       fixture.innerHTML =
         '<input type="password" id="test">' + '<label for="test">foo</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 43', function () {
+    it('passes test 43', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test">' +
         '<label for="test">foo</label></body>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 44', function () {
+    it('passes test 44', () => {
       fixture.innerHTML =
         '<input type="radio" id="test">' + '<label for="test">foo</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 45', function () {
+    it('passes test 45', () => {
       fixture.innerHTML =
         '<input type="file" id="test">' + '<label for="test">foo</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 46', function () {
+    it('passes test 46', () => {
       fixture.innerHTML =
         '<input type="image" id="test">' + '<label for="test">foo</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 47', function () {
+    it('passes test 47', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test">' +
         '<label for="test">foo<input type="text" value="bar">baz</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    it('passes test 48', function () {
+    it('passes test 48', () => {
       fixture.innerHTML =
         '<input type="text" id="test">' +
         '<label for="test">foo<input type="text" value="bar">baz</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    it('passes test 49', function () {
+    it('passes test 49', () => {
       fixture.innerHTML =
         '<input type="password" id="test">' +
         '<label for="test">foo<input type="text" value="bar">baz</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    it('passes test 50', function () {
+    it('passes test 50', () => {
       fixture.innerHTML =
         '<input type="radio" id="test">' +
         '<label for="test">foo<input type="text" value="bar">baz</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    it('passes test 51', function () {
+    it('passes test 51', () => {
       fixture.innerHTML =
         '<input type="file" id="test">' +
         '<label for="test">foo <input type="text" value="bar"> baz</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    pseudoText('passes test 52', function () {
+    pseudoText('passes test 52', () => {
       fixture.innerHTML =
         '<style type="text/css">' +
         '  label:before { content: "foo"; }' +
@@ -1963,11 +1960,11 @@ describe('text.accessibleTextVirtual', function () {
         '  <label for="test" title="bar"><input id="test" type="text" name="test" title="buz"></label> ' +
         '</form>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    pseudoText('passes test 53', function () {
+    pseudoText('passes test 53', () => {
       fixture.innerHTML =
         '<style type="text/css">' +
         '  label:before { content: "foo"; }' +
@@ -1977,11 +1974,11 @@ describe('text.accessibleTextVirtual', function () {
         '  <label for="test" title="bar"><input id="test" type="password" name="test" title="buz"></label> ' +
         '</form>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo bar baz');
     });
 
-    pseudoText('passes test 54', function () {
+    pseudoText('passes test 54', () => {
       fixture.innerHTML =
         '<style type="text/css">' +
         '  label:before { content: "foo"; }' +
@@ -1991,11 +1988,11 @@ describe('text.accessibleTextVirtual', function () {
         '  <label for="test"><input id="test" type="checkbox" name="test" title=" bar "></label>' +
         '</form>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo baz');
     });
 
-    pseudoText('passes test 55', function () {
+    pseudoText('passes test 55', () => {
       fixture.innerHTML =
         '<style type="text/css">' +
         '  label:before { content: "foo"; }' +
@@ -2005,11 +2002,11 @@ describe('text.accessibleTextVirtual', function () {
         '  <label for="test"><input id="test" type="radio" name="test" title=" bar "></label> ' +
         '</form>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo baz');
     });
 
-    pseudoText('passes test 56', function () {
+    pseudoText('passes test 56', () => {
       fixture.innerHTML =
         '<style type="text/css">' +
         '  label:before { content: "foo"; }' +
@@ -2019,11 +2016,11 @@ describe('text.accessibleTextVirtual', function () {
         '  <label for="test"><input id="test" type="file" name="test" title="bar"></label>' +
         '</form>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo baz');
     });
 
-    pseudoText('passes test 57', function () {
+    pseudoText('passes test 57', () => {
       fixture.innerHTML =
         '<style type="text/css">' +
         '  label:before { content: "foo"; }' +
@@ -2033,54 +2030,54 @@ describe('text.accessibleTextVirtual', function () {
         '  <label for="test"><input id="test" type="image" src="foo.jpg" name="test" title="bar"></label>' +
         '</form>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo baz');
     });
 
-    it('passes test 58', function () {
+    it('passes test 58', () => {
       fixture.innerHTML =
         '<label for="test">States:</label>' +
         '<input type="password" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'States:');
     });
 
-    it('passes test 59', function () {
+    it('passes test 59', () => {
       fixture.innerHTML =
         '<label for="test">States:</label>' +
         '<input type="checkbox" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'States:');
     });
 
-    it('passes test 60', function () {
+    it('passes test 60', () => {
       fixture.innerHTML =
         '<label for="test">States:</label>' + '<input type="radio" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'States:');
     });
 
-    it('passes test 61', function () {
+    it('passes test 61', () => {
       fixture.innerHTML =
         '<label for="test">File:</label>' + '<input type="file" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'File:');
     });
 
-    it('passes test 62', function () {
+    it('passes test 62', () => {
       fixture.innerHTML =
         '<label for="test">States:</label>' +
         '<input type="image" id="test" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'States:');
     });
 
-    it('passes test 63', function () {
+    it('passes test 63', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  foo' +
@@ -2088,11 +2085,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="password" id="test" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo David');
     });
 
-    it('passes test 64', function () {
+    it('passes test 64', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  foo' +
@@ -2100,11 +2097,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="checkbox" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo David');
     });
 
-    it('passes test 65', function () {
+    it('passes test 65', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  foo' +
@@ -2112,11 +2109,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="radio" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo David');
     });
 
-    it('passes test 66', function () {
+    it('passes test 66', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  foo' +
@@ -2124,11 +2121,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="file" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo David');
     });
 
-    it('passes test 67', function () {
+    it('passes test 67', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  foo' +
@@ -2136,11 +2133,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="image" id="test" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo David');
     });
 
-    it('passes test 68', function () {
+    it('passes test 68', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2151,11 +2148,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label> ' +
         '<input type="password" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 69', function () {
+    it('passes test 69', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2166,11 +2163,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label> ' +
         '<input type="checkbox" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 70', function () {
+    it('passes test 70', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2181,11 +2178,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label> ' +
         '<input type="radio" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 71', function () {
+    it('passes test 71', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2196,11 +2193,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label> ' +
         '<input type="file" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 72', function () {
+    it('passes test 72', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2211,11 +2208,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label> ' +
         '<input type="image" id="test" src="foo.jpg"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    ariaValuetext('passes test 73', function () {
+    ariaValuetext('passes test 73', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2224,11 +2221,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="password" value="baz" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy Monday');
     });
 
-    ariaValuetext('passes test 74', function () {
+    ariaValuetext('passes test 74', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2237,11 +2234,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="checkbox" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy Monday');
     });
 
-    ariaValuetext('passes test 75', function () {
+    ariaValuetext('passes test 75', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2250,11 +2247,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="radio" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy Monday');
     });
 
-    ariaValuetext('passes test 76', function () {
+    ariaValuetext('passes test 76', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2263,11 +2260,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="file" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy Monday');
     });
 
-    ariaValuetext('passes test 77', function () {
+    ariaValuetext('passes test 77', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2276,11 +2273,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="image" src="foo.jpg" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy Monday');
     });
 
-    it('passes test 78', function () {
+    it('passes test 78', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2289,11 +2286,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="password" id="test" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy 4');
     });
 
-    it('passes test 79', function () {
+    it('passes test 79', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2302,11 +2299,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="checkbox" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy 4');
     });
 
-    it('passes test 80', function () {
+    it('passes test 80', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2315,11 +2312,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="radio" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy 4');
     });
 
-    it('passes test 81', function () {
+    it('passes test 81', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2328,11 +2325,11 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="file" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy 4');
     });
 
-    it('passes test 82', function () {
+    it('passes test 82', () => {
       fixture.innerHTML =
         '<label for="test">' +
         '  crazy' +
@@ -2341,48 +2338,48 @@ describe('text.accessibleTextVirtual', function () {
         '</label>' +
         '<input type="image" src="foo.jpg" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy 4');
     });
 
-    it('passes test 83', function () {
+    it('passes test 83', () => {
       fixture.innerHTML =
         '<input type="password" id="test" title="crazy" value="baz"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 84', function () {
+    it('passes test 84', () => {
       fixture.innerHTML = '<input type="checkbox" id="test" title="crazy"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 85', function () {
+    it('passes test 85', () => {
       fixture.innerHTML = '<input type="radio" id="test" title="crazy"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 86', function () {
+    it('passes test 86', () => {
       fixture.innerHTML = '<input type="file" id="test" title="crazy"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    it('passes test 87', function () {
+    it('passes test 87', () => {
       fixture.innerHTML =
         '<input type="image" src="foo.jpg" id="test" title="crazy"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'crazy');
     });
 
-    pseudoText('passes test 88', function () {
+    pseudoText('passes test 88', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:before { content:"fancy "; }' +
@@ -2390,11 +2387,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fruit</label>' +
         '<input type="password" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 89', function () {
+    pseudoText('passes test 89', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:before { content:"fancy "; }' +
@@ -2402,11 +2399,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fruit</label>' +
         '<input type="checkbox" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 90', function () {
+    pseudoText('passes test 90', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:before { content:"fancy "; }' +
@@ -2414,11 +2411,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fruit</label>' +
         '<input type="radio" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 91', function () {
+    pseudoText('passes test 91', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:before { content:"fancy "; }' +
@@ -2426,11 +2423,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fruit</label>' +
         '<input type="file" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 92', function () {
+    pseudoText('passes test 92', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:before { content:"fancy "; }' +
@@ -2438,11 +2435,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fruit</label>' +
         '<input type="image" src="foo.jpg" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 93', function () {
+    pseudoText('passes test 93', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:after { content:" fruit"; }' +
@@ -2450,11 +2447,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fancy</label>' +
         '<input type="password" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 94', function () {
+    pseudoText('passes test 94', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:after { content:" fruit"; }' +
@@ -2462,11 +2459,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fancy</label>' +
         '<input type="checkbox" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 95', function () {
+    pseudoText('passes test 95', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:after { content:" fruit"; }' +
@@ -2474,11 +2471,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fancy</label>' +
         '<input type="radio" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 96', function () {
+    pseudoText('passes test 96', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:after { content:" fruit"; }' +
@@ -2486,11 +2483,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fancy</label>' +
         '<input type="file" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    pseudoText('passes test 97', function () {
+    pseudoText('passes test 97', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:after { content:" fruit"; }' +
@@ -2498,11 +2495,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">fancy</label>' +
         '<input type="image" src="foo.jpg" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'fancy fruit');
     });
 
-    it('passes test 98', function () {
+    it('passes test 98', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2517,14 +2514,14 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       // Chrome 72: "Flash the screen 1 times"
       // Safari 12.0: "Flash the screen 1 times"
       // Firefox 62: "Flash the screen 1 times"
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 99', function () {
+    it('passes test 99', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2536,11 +2533,11 @@ describe('text.accessibleTextVirtual', function () {
         '    times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen times.');
     });
 
-    it('passes test 100', function () {
+    it('passes test 100', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2552,38 +2549,38 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 101', function () {
+    it('passes test 101', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test" />' +
         '<label for="test">foo <input role="slider" type="range" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz   	' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 102', function () {
+    it('passes test 102', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test" />' +
         '<label for="test">foo <input role="spinbutton" type="number" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 103', function () {
+    it('passes test 103', () => {
       fixture.innerHTML = '<input type="checkbox" id="test" title="foo" />';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 104', function () {
+    it('passes test 104', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2598,11 +2595,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 105', function () {
+    it('passes test 105', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2614,11 +2611,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen times.');
     });
 
-    it('passes test 106', function () {
+    it('passes test 106', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2630,46 +2627,46 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 107', function () {
+    it('passes test 107', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">foo <input role="slider" type="range" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 108', function () {
+    it('passes test 108', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">foo <input role="spinbutton" type="number" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 109', function () {
+    it('passes test 109', () => {
       fixture.innerHTML = '<input type="file" id="test" title="foo" />';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 110', function () {
+    it('passes test 110', () => {
       fixture.innerHTML =
         '<input type="image" src="test.png" id="test" title="foo" />';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 111', function () {
+    it('passes test 111', () => {
       fixture.innerHTML =
         '<input type="password" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2684,11 +2681,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 112', function () {
+    it('passes test 112', () => {
       fixture.innerHTML =
         '<input type="password" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2700,11 +2697,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen times.');
     });
 
-    it('passes test 113', function () {
+    it('passes test 113', () => {
       fixture.innerHTML =
         '<input type="password" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2716,38 +2713,38 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 114', function () {
+    it('passes test 114', () => {
       fixture.innerHTML =
         '<input type="password" id="test" />' +
         '<label for="test">foo <input role="slider" type="range" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 115', function () {
+    it('passes test 115', () => {
       fixture.innerHTML =
         '<input type="password" id="test" />' +
         '<label for="test">foo <input role="spinbutton" type="number" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 116', function () {
+    it('passes test 116', () => {
       fixture.innerHTML = '<input type="password" id="test" title="foo" />';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 117', function () {
+    it('passes test 117', () => {
       fixture.innerHTML =
         '<input type="radio" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2762,11 +2759,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 118', function () {
+    it('passes test 118', () => {
       fixture.innerHTML =
         '<input type="radio" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2778,11 +2775,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen times.');
     });
 
-    it('passes test 119', function () {
+    it('passes test 119', () => {
       fixture.innerHTML =
         '<input type="radio" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2794,44 +2791,44 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       // Chrome 72: "Flash the screen 1 times"
       // Firefox 62: "Flash the screen 1 times"
       // Safari 12.0: "Flash the screen 1 times"
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 120', function () {
+    it('passes test 120', () => {
       fixture.innerHTML =
         '<input type="radio" id="test" />' +
         '<label for="test">foo <input role="slider" type="range" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       // Chrome 70: Foo 5 baz
       // Firefox 62: Foo 5 baz
       // Safari 12.0: Foo 5 baz
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 121', function () {
+    it('passes test 121', () => {
       fixture.innerHTML =
         '<input type="radio" id="test" />' +
         '<label for="test">foo <input role="spinbutton"  type="number" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 122', function () {
+    it('passes test 122', () => {
       fixture.innerHTML = '<input type="radio" id="test" title="foo" />';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
-    it('passes test 123', function () {
+    it('passes test 123', () => {
       fixture.innerHTML =
         '<input type="text" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2846,14 +2843,14 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       // Chrome 72: "Flash the screen 1 times."
       // Firefox 62: "Flash the screen 1 times."
       // Safari 12.0: "Flash the screen 1 times."
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 124', function () {
+    it('passes test 124', () => {
       fixture.innerHTML =
         '<input type="text" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2865,11 +2862,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen times.');
     });
 
-    it('passes test 125', function () {
+    it('passes test 125', () => {
       fixture.innerHTML =
         '<input type="text" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -2881,43 +2878,43 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       // Chrome 72: Flash the screen 1 times
       // Firefox 62: Flash the screen 1 times
       // Safari 12.0: Flash the screen 1 times
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 126', function () {
+    it('passes test 126', () => {
       fixture.innerHTML =
         '<input type="text" id="test" />' +
         '<label for="test">foo <input role="slider" type="range" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 127', function () {
+    it('passes test 127', () => {
       fixture.innerHTML =
         '<input type="text" id="test" />' +
         '<label for="test">foo <input role="spinbutton" type="number" value="5" min="1" max="10" aria-valuenow="5" aria-valuemin="1" aria-valuemax="10"> baz' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo 5 baz');
     });
 
-    it('passes test 128', function () {
+    it('passes test 128', () => {
       fixture.innerHTML = '<input type="text" id="test" title="foo" />';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'foo');
     });
 
     // Skip from 128 - 138 as those are name description cases
 
-    it('passes test 139', function () {
+    it('passes test 139', () => {
       fixture.innerHTML =
         '<style>' +
         '  .hidden { display: none; }' +
@@ -2943,7 +2940,7 @@ describe('text.accessibleTextVirtual', function () {
         '</div>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       // Chrome 72: "My name is Eli the weird. (QED) Where are my marbles?"
       // Safari 12.0: "My name is Eli the weird. (QED) Where are my marbles?"
       // Firefox 62: "Hello, My name is Eli the weird. (QED)"
@@ -2953,7 +2950,7 @@ describe('text.accessibleTextVirtual', function () {
       );
     });
 
-    it('passes test 140', function () {
+    it('passes test 140', () => {
       fixture.innerHTML =
         '<style>' +
         '  .hidden { display: none; }' +
@@ -2980,7 +2977,7 @@ describe('text.accessibleTextVirtual', function () {
         '</div>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(
         accessibleText(target),
         'My name is Eli the weird. (QED) Where are my marbles?'
@@ -2989,7 +2986,7 @@ describe('text.accessibleTextVirtual', function () {
 
     // Disabling this, axe has a buggy implicitName computation
     //  shouldn't be a big deal
-    xit('passes test 141', function () {
+    xit('passes test 141', () => {
       fixture.innerHTML =
         '<style>' +
         '  .hidden { display: none; }' +
@@ -3016,14 +3013,14 @@ describe('text.accessibleTextVirtual', function () {
         '</label>';
 
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(
         accessibleText(target),
         'My name is Eli the weird. (QED) Where are my marbles?'
       );
     });
 
-    it('passes test 143', function () {
+    it('passes test 143', () => {
       fixture.innerHTML =
         '  <style>' +
         '    .hidden { display: none; }' +
@@ -3059,29 +3056,29 @@ describe('text.accessibleTextVirtual', function () {
         '    </div>' +
         '  </div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Important stuff');
     });
 
-    it('passes test 144', function () {
+    it('passes test 144', () => {
       fixture.innerHTML =
         '<input id="test" role="combobox" type="text" title="Choose your language" value="English">';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Choose your language');
     });
 
-    it('passes test 145', function () {
+    it('passes test 145', () => {
       fixture.innerHTML =
         '<div id="test" role="combobox" tabindex="0" title="Choose your language.">' +
         '  <span> English </span>' +
         '</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Choose your language.');
     });
 
-    it('passes test 147', function () {
+    it('passes test 147', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -3093,11 +3090,11 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    pseudoText('passes test 148', function () {
+    pseudoText('passes test 148', () => {
       fixture.innerHTML =
         '<input type="checkbox" id="test" />' +
         '<label for="test">Flash the screen ' +
@@ -3105,38 +3102,38 @@ describe('text.accessibleTextVirtual', function () {
         '  times.' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 149', function () {
+    it('passes test 149', () => {
       fixture.innerHTML =
         '<label for="test">a test</label>' +
         '<label>This <input type="checkbox" id="test" /> is</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'a test This is');
     });
 
-    it('passes test 150', function () {
+    it('passes test 150', () => {
       fixture.innerHTML =
         '<label>This <input type="checkbox" id="test" /> is</label>' +
         '<label for="test">a test</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'This is a test');
     });
 
-    it('passes test 151', function () {
+    it('passes test 151', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">W<i>h<b>a</b></i>t<br>is<div>your<div>name<b>?</b></div></div></label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'What is your name?');
     });
 
-    pseudoText('passes test 152', function () {
+    pseudoText('passes test 152', () => {
       fixture.innerHTML =
         '<style>' +
         '  label:before { content: "This"; display: block; }' +
@@ -3145,11 +3142,11 @@ describe('text.accessibleTextVirtual', function () {
         '<label for="test">is a test</label>' +
         '<input type="text" id="test"/>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'This is a test.');
     });
 
-    it('passes test 153', function () {
+    it('passes test 153', () => {
       fixture.innerHTML =
         '<style>' +
         '  .hidden { display: none; }' +
@@ -3163,11 +3160,11 @@ describe('text.accessibleTextVirtual', function () {
         '  <span aria-hidden="false" class="hidden">9</span><span>10</span>' +
         '</label>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), '2 4 6 8 10');
     });
 
-    it('passes test 154', function () {
+    it('passes test 154', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">Flash <span aria-owns="id1">the screen</span> times.</label>' +
@@ -3184,11 +3181,11 @@ describe('text.accessibleTextVirtual', function () {
         '  </ul>' +
         '</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 2 times.');
     });
 
-    it('passes test 155', function () {
+    it('passes test 155', () => {
       fixture.innerHTML =
         '<input type="file" id="test" />' +
         '<label for="test">Flash <span aria-owns="id1">the screen</span> times.</label>' +
@@ -3203,11 +3200,11 @@ describe('text.accessibleTextVirtual', function () {
         '  </div>' +
         '</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Flash the screen 1 times.');
     });
 
-    it('passes test 156', function () {
+    it('passes test 156', () => {
       fixture.innerHTML =
         '<style>' +
         '  .hidden { display: none; }' +
@@ -3222,27 +3219,27 @@ describe('text.accessibleTextVirtual', function () {
         '  <span class="hidden"><i><b>and don\'t you forget it.</b></i></span>' +
         '</div>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'My name is Eli the weird. (QED)');
     });
 
-    it('passes test 158', function () {
+    it('passes test 158', () => {
       fixture.innerHTML =
         '<a id="test" href="#" aria-label="California"' +
         ' title="San Francisco">United States</a>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'California');
     });
 
-    it('passes test 159', function () {
+    it('passes test 159', () => {
       fixture.innerHTML =
         '<h2 id="test">' +
         'Country of origin:' +
         '<input role="combobox" type="text" title="Choose your country." value="United States">' +
         '</h2>';
       axe.testUtils.flatTreeSetup(fixture);
-      var target = fixture.querySelector('#test');
+      const target = fixture.querySelector('#test');
       assert.equal(accessibleText(target), 'Country of origin: United States');
     });
 
@@ -3261,10 +3258,10 @@ describe('text.accessibleTextVirtual', function () {
 		).join(' +\n      ') + ';'
 
 		return `
-		it('passes test ${index + 1}', function () {
+		it('passes test ${index + 1}', () => {
 			fixture.innerHTML = ${strings}
 			axe.testUtils.flatTreeSetup(fixture);
-			var target = fixture.querySelector('#${id}');
+			const target = fixture.querySelector('#${id}');
 			assert.equal(accessibleText(target), '${expected}');
 		});`
 	}*/

--- a/test/commons/text/form-control-value.js
+++ b/test/commons/text/form-control-value.js
@@ -1,13 +1,13 @@
-describe('text.formControlValue', function () {
-  var formControlValue = axe.commons.text.formControlValue;
-  var queryFixture = axe.testUtils.queryFixture;
-  var fixtureSetup = axe.testUtils.fixtureSetup;
-  var injectIntoFixture = axe.testUtils.injectIntoFixture;
-  var fixture = document.querySelector('#fixture');
+describe('text.formControlValue', () => {
+  const formControlValue = axe.commons.text.formControlValue;
+  const queryFixture = axe.testUtils.queryFixture;
+  const fixtureSetup = axe.testUtils.fixtureSetup;
+  const injectIntoFixture = axe.testUtils.injectIntoFixture;
+  const fixture = document.querySelector('#fixture');
 
   function getNodeType(node) {
     // Note: Inconsistent response for `node.type` across browsers, hence resolving and sanitizing using getAttribute
-    var nodeType = node.hasAttribute('type')
+    let nodeType = node.hasAttribute('type')
       ? axe.commons.text.sanitize(node.getAttribute('type')).toLowerCase()
       : 'text';
     nodeType = axe.utils.validInputTypes().includes(nodeType)
@@ -16,37 +16,37 @@ describe('text.formControlValue', function () {
     return nodeType;
   }
 
-  it('returns the first truthy result from text.formControlValueMethods', function () {
-    var target = queryFixture(
+  it('returns the first truthy result from text.formControlValueMethods', () => {
+    const target = queryFixture(
       '<div id="target" role="textbox" value="foo">bar</div>'
     );
-    var fixture = axe.utils.querySelectorAll(axe._tree, '#fixture')[0];
-    assert.equal(formControlValue(target, { startNode: fixture }), 'bar');
+    const vNode = axe.utils.querySelectorAll(axe._tree, '#fixture')[0];
+    assert.equal(formControlValue(target, { startNode: vNode }), 'bar');
   });
 
-  it('returns `` when the node equals context.startNode', function () {
-    var target = queryFixture('<input id="target" value="foo" />');
+  it('returns `` when the node equals context.startNode', () => {
+    const target = queryFixture('<input id="target" value="foo" />');
     assert.equal(formControlValue(target, { startNode: target }), '');
   });
 
-  it('returns `` when accessibleNameFromFieldValue says the role is unsupported', function () {
-    var target = queryFixture(
+  it('returns `` when accessibleNameFromFieldValue says the role is unsupported', () => {
+    const target = queryFixture(
       '<input id="target" value="foo" role="combobox"/>'
     );
     assert.equal(formControlValue(target), '');
   });
 
-  describe('nativeTextboxValue', function () {
-    var nativeTextboxValue =
+  describe('nativeTextboxValue', () => {
+    const nativeTextboxValue =
       axe.commons.text.formControlValueMethods.nativeTextboxValue;
 
-    it('returns the value of textarea elements', function () {
-      var target = queryFixture('<textarea>foo</textarea>', 'textarea');
+    it('returns the value of textarea elements', () => {
+      const target = queryFixture('<textarea>foo</textarea>', 'textarea');
       assert.equal(nativeTextboxValue(target), 'foo');
     });
 
-    it('returns the value of text field input elements', function () {
-      var formData = {
+    it('returns the value of text field input elements', () => {
+      const formData = {
         text: 'foo',
         date: '2018-12-12',
         'datetime-local': '2018-12-12T12:34',
@@ -74,9 +74,9 @@ describe('text.formControlValue', function () {
       axe.utils
         .querySelectorAll(axe._tree[0], '#fixture input')
         .forEach(function (target) {
-          var expected = formData[getNodeType(target.actualNode)];
+          const expected = formData[getNodeType(target.actualNode)];
           assert.isDefined(expected);
-          var actual = nativeTextboxValue(target);
+          const actual = nativeTextboxValue(target);
           assert.equal(
             actual,
             expected,
@@ -85,7 +85,7 @@ describe('text.formControlValue', function () {
         });
     });
 
-    it('returns `` for non-text input elements', function () {
+    it('returns `` for non-text input elements', () => {
       fixtureSetup(
         '<input type="button" value="foo">' +
           '<input type="checkbox" value="foo">' +
@@ -116,17 +116,17 @@ describe('text.formControlValue', function () {
         });
     });
 
-    it('returns the value of DOM nodes', function () {
+    it('returns the value of DOM nodes', () => {
       fixture.innerHTML = '<input value="foo">';
       axe.utils.getFlattenedTree(fixture);
       assert.equal(nativeTextboxValue(fixture.querySelector('input')), 'foo');
     });
 
-    it('returns `` for other elements', function () {
+    it('returns `` for other elements', () => {
       // some random elements:
       ['div', 'span', 'h1', 'output', 'summary', 'style', 'template'].forEach(
         function (nodeName) {
-          var target = document.createElement(nodeName);
+          const target = document.createElement(nodeName);
           target.value = 'foo'; // That shouldn't do anything
           fixture.appendChild(target);
           axe.utils.getFlattenedTree(fixture);
@@ -136,12 +136,12 @@ describe('text.formControlValue', function () {
     });
   });
 
-  describe('nativeSelectValue', function () {
-    var nativeSelectValue =
+  describe('nativeSelectValue', () => {
+    const nativeSelectValue =
       axe.commons.text.formControlValueMethods.nativeSelectValue;
 
-    it('returns the selected option text', function () {
-      var target = queryFixture(
+    it('returns the selected option text', () => {
+      const target = queryFixture(
         '<select id="target">' +
           '  <option>foo</option>' +
           '  <option value="bar" selected>baz</option>' +
@@ -150,7 +150,7 @@ describe('text.formControlValue', function () {
       assert.equal(nativeSelectValue(target), 'baz');
     });
 
-    it('returns the selected option text after selection', function () {
+    it('returns the selected option text after selection', () => {
       injectIntoFixture(
         '<select id="target">' +
           '  <option value="foo" selected>foo</option>' +
@@ -158,14 +158,14 @@ describe('text.formControlValue', function () {
           '</select>'
       );
       fixture.querySelector('#target').value = 'bar';
-      var rootNode = axe.setup(fixture);
-      var target = axe.utils.querySelectorAll(rootNode, '#target')[0];
+      const rootNode = axe.setup(fixture);
+      const target = axe.utils.querySelectorAll(rootNode, '#target')[0];
       assert.equal(nativeSelectValue(target), 'baz');
     });
 
-    it('returns multiple options, space seperated', function () {
+    it('returns multiple options, space seperated', () => {
       // Can't apply multiple "selected" props without setting "multiple"
-      var target = queryFixture(
+      const target = queryFixture(
         '<select id="target" multiple>' +
           '  <option>oof</option>' +
           '  <option selected>foo</option>' +
@@ -178,8 +178,8 @@ describe('text.formControlValue', function () {
       assert.equal(nativeSelectValue(target), 'foo bar baz');
     });
 
-    it('returns options from within optgroup elements', function () {
-      var target = queryFixture(
+    it('returns options from within optgroup elements', () => {
+      const target = queryFixture(
         '<select id="target" multiple>' +
           '  <option>oof</option>' +
           '  <option selected>foo</option>' +
@@ -196,9 +196,9 @@ describe('text.formControlValue', function () {
       assert.equal(nativeSelectValue(target), 'foo bar baz');
     });
 
-    it('returns the first option when there are no selected options', function () {
+    it('returns the first option when there are no selected options', () => {
       // Browser automatically selectes the first option
-      var target = queryFixture(
+      const target = queryFixture(
         '<select id="target">' +
           '  <option>foo</option>' +
           '  <option>baz</option>' +
@@ -207,11 +207,11 @@ describe('text.formControlValue', function () {
       assert.equal(nativeSelectValue(target), 'foo');
     });
 
-    it('returns `` for other elements', function () {
+    it('returns `` for other elements', () => {
       // some random elements:
       ['div', 'span', 'h1', 'output', 'summary', 'style', 'template'].forEach(
         function (nodeName) {
-          var target = document.createElement(nodeName);
+          const target = document.createElement(nodeName);
           target.value = 'foo'; // That shouldn't do anything
           fixture.appendChild(target);
           axe.utils.getFlattenedTree(fixture);
@@ -221,22 +221,22 @@ describe('text.formControlValue', function () {
     });
   });
 
-  describe('ariaTextboxValue', function () {
-    var ariaTextboxValue =
+  describe('ariaTextboxValue', () => {
+    const ariaTextboxValue =
       axe.commons.text.formControlValueMethods.ariaTextboxValue;
 
-    it('returns the text of role=textbox elements', function () {
-      var target = queryFixture('<div id="target" role="textbox">foo</div>');
+    it('returns the text of role=textbox elements', () => {
+      const target = queryFixture('<div id="target" role="textbox">foo</div>');
       assert.equal(ariaTextboxValue(target), 'foo');
     });
 
-    it('returns `` for elements without role=textbox', function () {
-      var target = queryFixture('<div id="target" role="combobox">foo</div>');
+    it('returns `` for elements without role=textbox', () => {
+      const target = queryFixture('<div id="target" role="combobox">foo</div>');
       assert.equal(ariaTextboxValue(target), '');
     });
 
-    it('ignores text hidden with CSS', function () {
-      var target = queryFixture(
+    it('ignores text hidden with CSS', () => {
+      const target = queryFixture(
         '<div id="target" role="textbox">' +
           '<span>foo</span>' +
           '<span style="display: none;">bar</span>' +
@@ -246,8 +246,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaTextboxValue(target), 'foo');
     });
 
-    it('ignores elements with hidden content', function () {
-      var target = queryFixture(
+    it('ignores elements with hidden content', () => {
+      const target = queryFixture(
         '<div id="target" role="textbox">' +
           '<span>span</span>' +
           '<style>style</style>' +
@@ -260,8 +260,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaTextboxValue(target), 'spanh1');
     });
 
-    it('does not return HTML or comments', function () {
-      var target = queryFixture(
+    it('does not return HTML or comments', () => {
+      const target = queryFixture(
         '<div id="target" role="textbox">' +
           '<i>foo</i>' +
           '<!-- comment -->' +
@@ -270,8 +270,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaTextboxValue(target), 'foo');
     });
 
-    it('returns the entire text content if the textbox is hidden', function () {
-      var target = queryFixture(
+    it('returns the entire text content if the textbox is hidden', () => {
+      const target = queryFixture(
         '<div id="target" role="textbox" style="display:none">' +
           // Yes, this is how it works in browsers :-(
           '<style>[role=texbox] { display: none }</style>' +
@@ -281,12 +281,12 @@ describe('text.formControlValue', function () {
     });
   });
 
-  describe('ariaListboxValue', function () {
-    var ariaListboxValue =
+  describe('ariaListboxValue', () => {
+    const ariaListboxValue =
       axe.commons.text.formControlValueMethods.ariaListboxValue;
 
-    it('returns the selected option when the element is a listbox', function () {
-      var target = queryFixture(
+    it('returns the selected option when the element is a listbox', () => {
+      const target = queryFixture(
         '<div id="target" role="listbox">' +
           '  <div role="option">foo</div>' +
           '  <div role="option" aria-selected="true">bar</div>' +
@@ -296,8 +296,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaListboxValue(target), 'bar');
     });
 
-    it('returns `` when the element is not a listbox', function () {
-      var target = queryFixture(
+    it('returns `` when the element is not a listbox', () => {
+      const target = queryFixture(
         '<div id="target" role="combobox">' +
           '  <div role="option">foo</div>' +
           '  <div role="option" aria-selected="true">bar</div>' +
@@ -307,8 +307,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    it('returns `` when there is no selected option', function () {
-      var target = queryFixture(
+    it('returns `` when there is no selected option', () => {
+      const target = queryFixture(
         '<div id="target" role="listbox">' +
           '  <div role="option">foo</div>' +
           '  <div role="option">bar</div>' +
@@ -318,8 +318,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    it('returns `` when aria-selected is not true option', function () {
-      var target = queryFixture(
+    it('returns `` when aria-selected is not true option', () => {
+      const target = queryFixture(
         '<div id="target" role="listbox">' +
           '  <div role="option" aria-selected="false">foo</div>' +
           '  <div role="option" aria-selected="TRUE">bar</div>' +
@@ -330,8 +330,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    it('returns selected options from aria-owned', function () {
-      var target = queryFixture(
+    it('returns selected options from aria-owned', () => {
+      const target = queryFixture(
         '<div id="target" role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
           '<div role="option" id="opt1">foo</div>' +
           '<div role="option" id="opt2" aria-selected="true">bar</div>' +
@@ -340,8 +340,8 @@ describe('text.formControlValue', function () {
       assert.equal(ariaListboxValue(target), 'bar');
     });
 
-    it('ignores aria-selected for elements that are not options', function () {
-      var target = queryFixture(
+    it('ignores aria-selected for elements that are not options', () => {
+      const target = queryFixture(
         '<div id="target" role="listbox" aria-owns="opt1 opt2 opt3"></div>' +
           '<div id="opt1">foo</div>' +
           '<div id="opt2" aria-selected="true">bar</div>' +
@@ -350,9 +350,9 @@ describe('text.formControlValue', function () {
       assert.equal(ariaListboxValue(target), '');
     });
 
-    describe('with multiple aria-selected', function () {
-      it('returns the first selected option from children', function () {
-        var target = queryFixture(
+    describe('with multiple aria-selected', () => {
+      it('returns the first selected option from children', () => {
+        const target = queryFixture(
           '<div id="target" role="listbox">' +
             '  <div role="option">foo</div>' +
             '  <div role="option" aria-selected="true">bar</div>' +
@@ -362,8 +362,8 @@ describe('text.formControlValue', function () {
         assert.equal(ariaListboxValue(target), 'bar');
       });
 
-      it('returns the first selected option in aria-owned (as opposed to in the DOM order)', function () {
-        var target = queryFixture(
+      it('returns the first selected option in aria-owned (as opposed to in the DOM order)', () => {
+        const target = queryFixture(
           '<div id="target" role="listbox" aria-owns="opt3 opt2 opt1"></div>' +
             '<div role="option" id="opt1" aria-selected="true">foo</div>' +
             '<div role="option" id="opt2" aria-selected="true">bar</div>' +
@@ -372,8 +372,8 @@ describe('text.formControlValue', function () {
         assert.equal(ariaListboxValue(target), 'bar');
       });
 
-      it('returns the a selected child before a selected aria-owned element', function () {
-        var target = queryFixture(
+      it('returns the a selected child before a selected aria-owned element', () => {
+        const target = queryFixture(
           '<div id="target" role="listbox" aria-owns="opt2 opt3">' +
             '  <div role="option" aria-selected="true">foo</div>' +
             '</div>' +
@@ -383,9 +383,9 @@ describe('text.formControlValue', function () {
         assert.equal(ariaListboxValue(target), 'foo');
       });
 
-      it('ignores aria-multiselectable=true', function () {
+      it('ignores aria-multiselectable=true', () => {
         // aria-multiselectable doesn't add additional content to the accessible name
-        var target = queryFixture(
+        const target = queryFixture(
           '<div id="target" role="listbox" aria-owns="opt2 opt3" aria-multiselectable="true">' +
             '  <div role="option" aria-selected="true">foo</div>' +
             '</div>' +
@@ -397,41 +397,41 @@ describe('text.formControlValue', function () {
     });
   });
 
-  describe('ariaComboboxValue', function () {
-    var ariaComboboxValue =
+  describe('ariaComboboxValue', () => {
+    const ariaComboboxValue =
       axe.commons.text.formControlValueMethods.ariaComboboxValue;
 
-    var comboboxContent =
+    const comboboxContent =
       '<div role="textbox" id="text">nope</div>' +
       '<div role="listbox" id="list">' +
       '  <div role="option">foo</div>' +
       '  <div role="option" aria-selected="true">bar</div>' +
       '</div>';
 
-    it('returns the text of role=combobox elements', function () {
-      var target = queryFixture(
+    it('returns the text of role=combobox elements', () => {
+      const target = queryFixture(
         '<div id="target" role="combobox">' + comboboxContent + '</div>'
       );
       assert.equal(ariaComboboxValue(target), 'bar');
     });
 
-    it('returns `` for elements without role=combobox', function () {
-      var target = queryFixture(
+    it('returns `` for elements without role=combobox', () => {
+      const target = queryFixture(
         '<div role="combobox">' + comboboxContent + '</div>',
         '[role=listbox]'
       );
       assert.equal(ariaComboboxValue(target), '');
     });
 
-    it('passes child listbox to `ariaListboxValue` and returns its result', function () {
-      var target = queryFixture(
+    it('passes child listbox to `ariaListboxValue` and returns its result', () => {
+      const target = queryFixture(
         '<div id="target" role="combobox">' + comboboxContent + '</div>'
       );
       assert.equal(ariaComboboxValue(target), 'bar');
     });
 
-    it('passes aria-owned listbox to `ariaListboxValue` and returns its result', function () {
-      var target = queryFixture(
+    it('passes aria-owned listbox to `ariaListboxValue` and returns its result', () => {
+      const target = queryFixture(
         '<div id="target" role="combobox" aria-owns="text list"></div>' +
           comboboxContent
       );
@@ -439,20 +439,20 @@ describe('text.formControlValue', function () {
     });
   });
 
-  describe('ariaRangeValue', function () {
-    var rangeRoles = ['progressbar', 'scrollbar', 'slider', 'spinbutton'];
-    var ariaRangeValue =
+  describe('ariaRangeValue', () => {
+    const rangeRoles = ['progressbar', 'scrollbar', 'slider', 'spinbutton'];
+    const ariaRangeValue =
       axe.commons.text.formControlValueMethods.ariaRangeValue;
 
-    it('returns `` for roles that are not ranges', function () {
-      var target = queryFixture('<div id="target" role="textbox">foo</div>');
+    it('returns `` for roles that are not ranges', () => {
+      const target = queryFixture('<div id="target" role="textbox">foo</div>');
       assert.equal(ariaRangeValue(target), '');
     });
 
     rangeRoles.forEach(function (role) {
-      describe('with ' + role, function () {
-        it('returns the result of aria-valuenow', function () {
-          var target = queryFixture(
+      describe('with ' + role, () => {
+        it('returns the result of aria-valuenow', () => {
+          const target = queryFixture(
             '<div id="target" role="' +
               role +
               '" aria-valuenow="+123">foo</div>'
@@ -460,15 +460,15 @@ describe('text.formControlValue', function () {
           assert.equal(ariaRangeValue(target), '123');
         });
 
-        it('returns `0` if aria-valuenow is not a number', function () {
-          var target = queryFixture(
+        it('returns `0` if aria-valuenow is not a number', () => {
+          const target = queryFixture(
             '<div id="target" role="' + role + '" aria-valuenow="abc">foo</div>'
           );
           assert.equal(ariaRangeValue(target), '0');
         });
 
-        it('returns decimal numbers', function () {
-          var target = queryFixture(
+        it('returns decimal numbers', () => {
+          const target = queryFixture(
             '<div id="target" role="' +
               role +
               '" aria-valuenow="1.5678">foo</div>'
@@ -476,8 +476,8 @@ describe('text.formControlValue', function () {
           assert.equal(ariaRangeValue(target), '1.5678');
         });
 
-        it('returns negative numbers', function () {
-          var target = queryFixture(
+        it('returns negative numbers', () => {
+          const target = queryFixture(
             '<div id="target" role="' +
               role +
               '" aria-valuenow="-1.0">foo</div>'

--- a/test/commons/text/native-text-methods.js
+++ b/test/commons/text/native-text-methods.js
@@ -1,104 +1,100 @@
-describe('text.nativeTextMethods', function () {
-  var text = axe.commons.text;
-  var nativeTextMethods = text.nativeTextMethods;
-  var fixtureSetup = axe.testUtils.fixtureSetup;
+describe('text.nativeTextMethods', () => {
+  const text = axe.commons.text;
+  const nativeTextMethods = text.nativeTextMethods;
+  const fixtureSetup = axe.testUtils.fixtureSetup;
 
-  describe('valueText', function () {
-    var valueText = nativeTextMethods.valueText;
-    it('returns the value of actualNode', function () {
+  describe('valueText', () => {
+    const valueText = nativeTextMethods.valueText;
+    it('returns the value of actualNode', () => {
       fixtureSetup('<input value="foo" />');
-      var input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
+      const input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
       assert.equal(valueText(input), 'foo');
     });
 
-    it('returns `` when there is no value', function () {
+    it('returns `` when there is no value', () => {
       fixtureSetup('<input />');
-      var input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
+      const input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
       assert.equal(valueText(input), '');
     });
   });
 
-  describe('buttonDefaultText', function () {
-    var buttonDefaultText = nativeTextMethods.buttonDefaultText;
-    it('returns the default button text', function () {
+  describe('buttonDefaultText', () => {
+    const buttonDefaultText = nativeTextMethods.buttonDefaultText;
+    it('returns the default button text', () => {
       fixtureSetup(
         '<input type="submit" />' +
           '<input type="image" />' +
           '<input type="reset" />' +
           '<input type="button" />'
       );
-      var inputs = axe.utils.querySelectorAll(axe._tree[0], 'input');
+      const inputs = axe.utils.querySelectorAll(axe._tree[0], 'input');
       assert.equal(buttonDefaultText(inputs[0]), 'Submit');
       assert.equal(buttonDefaultText(inputs[1]), 'Submit');
       assert.equal(buttonDefaultText(inputs[2]), 'Reset');
       assert.equal(buttonDefaultText(inputs[3]), '');
     });
 
-    it('returns `` when the element is not a button', function () {
+    it('returns `` when the element is not a button', () => {
       fixtureSetup('<input type="text">');
-      var input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
+      const input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
       assert.equal(buttonDefaultText(input), '');
     });
   });
 
-  describe('altText', function () {
-    var altText = nativeTextMethods.altText;
-    it('returns the alt attribute of actualNode', function () {
+  describe('altText', () => {
+    const altText = nativeTextMethods.altText;
+    it('returns the alt attribute of actualNode', () => {
       fixtureSetup('<img alt="foo" />');
-      var img = axe.utils.querySelectorAll(axe._tree[0], 'img')[0];
+      const img = axe.utils.querySelectorAll(axe._tree[0], 'img')[0];
       assert.equal(altText(img), 'foo');
     });
 
-    it('returns `` when there is no alt', function () {
+    it('returns `` when there is no alt', () => {
       fixtureSetup('<img />');
-      var img = axe.utils.querySelectorAll(axe._tree[0], 'img')[0];
+      const img = axe.utils.querySelectorAll(axe._tree[0], 'img')[0];
       assert.equal(altText(img), '');
     });
   });
 
-  describe('figureText', function () {
-    var figureText = nativeTextMethods.figureText;
-    it('returns the figcaption text', function () {
+  describe('figureText', () => {
+    it('returns the figcaption text', () => {
+      const figureText = nativeTextMethods.figureText;
       fixtureSetup(
         '<figure>' +
           '  <figcaption>My caption</figcaption>' +
           '  some content' +
           '</figure>'
       );
-      var figure = axe.utils.querySelectorAll(axe._tree[0], 'figure')[0];
+      const figure = axe.utils.querySelectorAll(axe._tree[0], 'figure')[0];
       assert.equal(figureText(figure), 'My caption');
     });
 
-    it('returns `` when there is no figcaption', function () {
-      var figureText = nativeTextMethods.figureText;
-      it('returns the figcaption text', function () {
-        fixtureSetup('<figure>' + '  some content' + '</figure>');
-        var figure = axe.utils.querySelectorAll(axe._tree[0], 'figure')[0];
-        assert.equal(figureText(figure), '');
-      });
+    it('returns `` when there is no figcaption', () => {
+      const figureText = nativeTextMethods.figureText;
+      fixtureSetup('<figure>' + '  some content' + '</figure>');
+      const figure = axe.utils.querySelectorAll(axe._tree[0], 'figure')[0];
+      assert.equal(figureText(figure), '');
     });
 
-    it('returns `` when if the figcaption is nested in another figure', function () {
-      var figureText = nativeTextMethods.figureText;
-      it('returns the figcaption text', function () {
-        fixtureSetup(
-          '<figure id="fig1">' +
-            '  <figure>' +
-            '    <figcaption>No caption</figcaption>' +
-            '    some content' +
-            '  </figure>' +
-            '  some other content' +
-            '</figure>'
-        );
-        var figure = axe.utils.querySelectorAll(axe._tree[0], '#fig1')[0];
-        assert.equal(figureText(figure), '');
-      });
+    it('returns `` when if the figcaption is nested in another figure', () => {
+      const figureText = nativeTextMethods.figureText;
+      fixtureSetup(
+        '<figure id="fig1">' +
+          '  <figure>' +
+          '    <figcaption>No caption</figcaption>' +
+          '    some content' +
+          '  </figure>' +
+          '  some other content' +
+          '</figure>'
+      );
+      const figure = axe.utils.querySelectorAll(axe._tree[0], '#fig1')[0];
+      assert.equal(figureText(figure), '');
     });
   });
 
-  describe('tableCaptionText', function () {
-    var tableCaptionText = nativeTextMethods.tableCaptionText;
-    it('returns the table caption text', function () {
+  describe('tableCaptionText', () => {
+    const tableCaptionText = nativeTextMethods.tableCaptionText;
+    it('returns the table caption text', () => {
       fixtureSetup(
         '<table>' +
           '  <caption>My caption</caption>' +
@@ -106,22 +102,22 @@ describe('text.nativeTextMethods', function () {
           '  <tr><td>data</td></tr>' +
           '</table>'
       );
-      var table = axe.utils.querySelectorAll(axe._tree[0], 'table')[0];
+      const table = axe.utils.querySelectorAll(axe._tree[0], 'table')[0];
       assert.equal(tableCaptionText(table), 'My caption');
     });
 
-    it('returns `` when there is no caption', function () {
+    it('returns `` when there is no caption', () => {
       fixtureSetup(
         '<table>' +
           '  <tr><th>heading</th></tr>' +
           '  <tr><td>data</td></tr>' +
           '</table>'
       );
-      var table = axe.utils.querySelectorAll(axe._tree[0], 'table')[0];
+      const table = axe.utils.querySelectorAll(axe._tree[0], 'table')[0];
       assert.equal(tableCaptionText(table), '');
     });
 
-    it('returns `` when if the caption is nested in another table', function () {
+    it('returns `` when if the caption is nested in another table', () => {
       fixtureSetup(
         '<table id="tbl1">' +
           '  <tr><td>' +
@@ -133,71 +129,67 @@ describe('text.nativeTextMethods', function () {
           '  </th></tr>' +
           '</table>'
       );
-      var table = axe.utils.querySelectorAll(axe._tree[0], '#tbl1')[0];
+      const table = axe.utils.querySelectorAll(axe._tree[0], '#tbl1')[0];
       assert.equal(tableCaptionText(table), '');
     });
   });
 
-  describe('fieldsetLegendText', function () {
-    var fieldsetLegendText = nativeTextMethods.fieldsetLegendText;
-    it('returns the legend text', function () {
+  describe('fieldsetLegendText', () => {
+    it('returns the legend text', () => {
+      const fieldsetLegendText = nativeTextMethods.fieldsetLegendText;
       fixtureSetup(
         '<fieldset>' +
           '  <legend>My legend</legend>' +
           '  some content' +
           '</fieldset>'
       );
-      var fieldset = axe.utils.querySelectorAll(axe._tree[0], 'fieldset')[0];
+      const fieldset = axe.utils.querySelectorAll(axe._tree[0], 'fieldset')[0];
       assert.equal(fieldsetLegendText(fieldset), 'My legend');
     });
 
-    it('returns `` when there is no legend', function () {
-      var fieldsetLegendText = nativeTextMethods.fieldsetLegendText;
-      it('returns the legend text', function () {
-        fixtureSetup('<fieldset>' + '  some content' + '</fieldset>');
-        var fieldset = axe.utils.querySelectorAll(axe._tree[0], 'fieldset')[0];
-        assert.equal(fieldsetLegendText(fieldset), '');
-      });
+    it('returns `` when there is no legend', () => {
+      const fieldsetLegendText = nativeTextMethods.fieldsetLegendText;
+      fixtureSetup('<fieldset>' + '  some content' + '</fieldset>');
+      const fieldset = axe.utils.querySelectorAll(axe._tree[0], 'fieldset')[0];
+      assert.equal(fieldsetLegendText(fieldset), '');
     });
 
-    it('returns `` when if the legend is nested in another fieldset', function () {
-      var fieldsetLegendText = nativeTextMethods.fieldsetLegendText;
-      it('returns the legend text', function () {
-        fixtureSetup(
-          '<fieldset id="fig1">' +
-            '  <fieldset>' +
-            '    <legend>No legend</legend>' +
-            '    some content' +
-            '  </fieldset>' +
-            '  some other content' +
-            '</fieldset>'
-        );
-        var fieldset = axe.utils.querySelectorAll(axe._tree[0], '#fig1')[0];
-        assert.equal(fieldsetLegendText(fieldset), '');
-      });
+    it('returns `` when if the legend is nested in another fieldset', () => {
+      const fieldsetLegendText = nativeTextMethods.fieldsetLegendText;
+      fixtureSetup(
+        '<fieldset id="fig1">' +
+          '  <fieldset>' +
+          '    <legend>No legend</legend>' +
+          '    some content' +
+          '  </fieldset>' +
+          '  some other content' +
+          '</fieldset>'
+      );
+      const fieldset = axe.utils.querySelectorAll(axe._tree[0], '#fig1')[0];
+      assert.equal(fieldsetLegendText(fieldset), '');
     });
   });
 
-  describe('svgTitleText', function () {
-    var svgTitleText = nativeTextMethods.svgTitleText;
-    it('returns the title text', function () {
+  describe('svgTitleText', () => {
+    const svgTitleText = nativeTextMethods.svgTitleText;
+    it('returns the title text', () => {
       fixtureSetup(
         '<svg>' + '  <title>My title</title>' + '  some content' + '</svg>'
       );
-      var svg = axe.utils.querySelectorAll(axe._tree[0], 'svg')[0];
+      const svg = axe.utils.querySelectorAll(axe._tree[0], 'svg')[0];
       assert.equal(svgTitleText(svg), 'My title');
     });
 
-    it('returns `` when there is no title', function () {
-      it('returns the title text', function () {
+    it('returns `` when there is no title', () => {
+      it('returns the title text', () => {
         fixtureSetup('<svg>' + '  some content' + '</svg>');
-        var svg = axe.utils.querySelectorAll(axe._tree[0], 'svg')[0];
+        const svg = axe.utils.querySelectorAll(axe._tree[0], 'svg')[0];
         assert.equal(svgTitleText(svg), '');
       });
     });
 
-    it('returns `` when if the title is nested in another svg', function () {
-      it('returns the title text', function () {
+    it('returns `` when if the title is nested in another svg', () => {
+      it('returns the title text', () => {
         fixtureSetup(
           '<svg id="fig1">' +
             '  <svg>' +
@@ -207,30 +199,30 @@ describe('text.nativeTextMethods', function () {
             '  some other content' +
             '</svg>'
         );
-        var svg = axe.utils.querySelectorAll(axe._tree[0], '#fig1')[0];
+        const svg = axe.utils.querySelectorAll(axe._tree[0], '#fig1')[0];
         assert.equal(svgTitleText(svg), '');
       });
     });
   });
 
-  describe('singleSpace', function () {
-    var singleSpace = nativeTextMethods.singleSpace;
-    it('returns a single space', function () {
+  describe('singleSpace', () => {
+    const singleSpace = nativeTextMethods.singleSpace;
+    it('returns a single space', () => {
       assert.equal(singleSpace(), ' ');
     });
   });
 
-  describe('placeholderText', function () {
-    var placeholderText = nativeTextMethods.placeholderText;
-    it('returns the placeholder attribute of actualNode', function () {
+  describe('placeholderText', () => {
+    const placeholderText = nativeTextMethods.placeholderText;
+    it('returns the placeholder attribute of actualNode', () => {
       fixtureSetup('<input placeholder="foo" />');
-      var input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
+      const input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
       assert.equal(placeholderText(input), 'foo');
     });
 
-    it('returns `` when there is no placeholder', function () {
+    it('returns `` when there is no placeholder', () => {
       fixtureSetup('<input />');
-      var input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
+      const input = axe.utils.querySelectorAll(axe._tree[0], 'input')[0];
       assert.equal(placeholderText(input), '');
     });
   });

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -1,44 +1,41 @@
-/* global Promise */
-describe('Audit', function () {
-  'use strict';
-
-  var Audit = axe._thisWillBeDeletedDoNotUse.base.Audit;
-  var Rule = axe._thisWillBeDeletedDoNotUse.base.Rule;
-  var ver = axe.version.substring(0, axe.version.lastIndexOf('.'));
-  var a, getFlattenedTree;
-  var isNotCalled = function (err) {
+describe('Audit', () => {
+  const Audit = axe._thisWillBeDeletedDoNotUse.base.Audit;
+  const Rule = axe._thisWillBeDeletedDoNotUse.base.Rule;
+  const ver = axe.version.substring(0, axe.version.lastIndexOf('.'));
+  let a, getFlattenedTree;
+  const isNotCalled = function (err) {
     throw err || new Error('Reject should not be called');
   };
-  var noop = function () {};
+  const noop = () => {};
 
-  var mockChecks = [
+  const mockChecks = [
     {
       id: 'positive1-check1',
-      evaluate: function () {
+      evaluate: () => {
         return true;
       }
     },
     {
       id: 'positive2-check1',
-      evaluate: function () {
+      evaluate: () => {
         return true;
       }
     },
     {
       id: 'negative1-check1',
-      evaluate: function () {
+      evaluate: () => {
         return true;
       }
     },
     {
       id: 'positive3-check1',
-      evaluate: function () {
+      evaluate: () => {
         return true;
       }
     }
   ];
 
-  var mockRules = [
+  const mockRules = [
     {
       id: 'positive1',
       selector: 'input',
@@ -69,12 +66,12 @@ describe('Audit', function () {
     }
   ];
 
-  var fixture = document.getElementById('fixture');
+  const fixture = document.getElementById('fixture');
 
-  var origAuditRun;
-  var origAxeUtilsPreload;
+  let origAuditRun;
+  let origAxeUtilsPreload;
 
-  beforeEach(function () {
+  beforeEach(() => {
     a = new Audit();
     mockRules.forEach(function (r) {
       a.addRule(r);
@@ -85,32 +82,32 @@ describe('Audit', function () {
     origAuditRun = a.run;
   });
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
     axe._tree = undefined;
     axe._selectCache = undefined;
     a.run = origAuditRun;
   });
 
-  it('should be a function', function () {
+  it('should be a function', () => {
     assert.isFunction(Audit);
   });
 
-  describe('defaults', function () {
-    it('should set noHtml', function () {
-      var audit = new Audit();
+  describe('defaults', () => {
+    it('should set noHtml', () => {
+      const audit = new Audit();
       assert.isFalse(audit.noHtml);
     });
 
-    it('should set allowedOrigins', function () {
-      var audit = new Audit();
+    it('should set allowedOrigins', () => {
+      const audit = new Audit();
       assert.deepEqual(audit.allowedOrigins, [window.location.origin]);
     });
   });
 
-  describe('Audit#_constructHelpUrls', function () {
-    it('should create default help URLS', function () {
-      var audit = new Audit();
+  describe('Audit#_constructHelpUrls', () => {
+    it('should create default help URLS', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -126,8 +123,8 @@ describe('Audit', function () {
           '/target?application=axeAPI'
       });
     });
-    it('should use changed branding', function () {
-      var audit = new Audit();
+    it('should use changed branding', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -144,8 +141,8 @@ describe('Audit', function () {
           '/target?application=axeAPI'
       });
     });
-    it('should use changed application', function () {
-      var audit = new Audit();
+    it('should use changed application', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -163,8 +160,8 @@ describe('Audit', function () {
       });
     });
 
-    it('does not override helpUrls of different products', function () {
-      var audit = new Audit();
+    it('does not override helpUrls of different products', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target1',
         matches: 'function () {return "hello";}',
@@ -207,9 +204,9 @@ describe('Audit', function () {
           '/target2?application=axeAPI'
       );
     });
-    it('understands prerelease type version numbers', function () {
-      var tempVersion = axe.version;
-      var audit = new Audit();
+    it('understands prerelease type version numbers', () => {
+      const tempVersion = axe.version;
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -226,9 +223,9 @@ describe('Audit', function () {
       );
     });
 
-    it('matches major release versions', function () {
-      var tempVersion = axe.version;
-      var audit = new Audit();
+    it('matches major release versions', () => {
+      const tempVersion = axe.version;
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -244,8 +241,8 @@ describe('Audit', function () {
         'https://dequeuniversity.com/rules/axe/1.0/target?application=axeAPI'
       );
     });
-    it('sets the lang query if locale has been set', function () {
-      var audit = new Audit();
+    it('sets the lang query if locale has been set', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -266,9 +263,9 @@ describe('Audit', function () {
     });
   });
 
-  describe('Audit#setBranding', function () {
-    it('should change the brand', function () {
-      var audit = new Audit();
+  describe('Audit#setBranding', () => {
+    it('should change the brand', () => {
+      const audit = new Audit();
       assert.equal(audit.brand, 'axe');
       assert.equal(audit.application, 'axeAPI');
       audit.setBranding({
@@ -277,8 +274,8 @@ describe('Audit', function () {
       assert.equal(audit.brand, 'thing');
       assert.equal(audit.application, 'axeAPI');
     });
-    it('should change the application', function () {
-      var audit = new Audit();
+    it('should change the application', () => {
+      const audit = new Audit();
       assert.equal(audit.brand, 'axe');
       assert.equal(audit.application, 'axeAPI');
       audit.setBranding({
@@ -287,16 +284,16 @@ describe('Audit', function () {
       assert.equal(audit.brand, 'axe');
       assert.equal(audit.application, 'thing');
     });
-    it('should change the application when passed a string', function () {
-      var audit = new Audit();
+    it('should change the application when passed a string', () => {
+      const audit = new Audit();
       assert.equal(audit.brand, 'axe');
       assert.equal(audit.application, 'axeAPI');
       audit.setBranding('thing');
       assert.equal(audit.brand, 'axe');
       assert.equal(audit.application, 'thing');
     });
-    it('should call _constructHelpUrls', function () {
-      var audit = new Audit();
+    it('should call _constructHelpUrls', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -314,8 +311,8 @@ describe('Audit', function () {
           '/target?application=thing'
       });
     });
-    it('should call _constructHelpUrls even when nothing changed', function () {
-      var audit = new Audit();
+    it('should call _constructHelpUrls even when nothing changed', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -331,8 +328,8 @@ describe('Audit', function () {
           '/target?application=axeAPI'
       });
     });
-    it('should not replace custom set branding', function () {
-      var audit = new Audit();
+    it('should not replace custom set branding', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -357,9 +354,9 @@ describe('Audit', function () {
     });
   });
 
-  describe('Audit#addRule', function () {
-    it('should override existing rule', function () {
-      var audit = new Audit();
+  describe('Audit#addRule', () => {
+    it('should override existing rule', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         matches: 'function () {return "hello";}',
@@ -378,8 +375,8 @@ describe('Audit', function () {
       assert.equal(audit.rules[0].selector, 'fred');
       assert.equal(audit.rules[0].matches(), 'hello');
     });
-    it('should otherwise push new rule', function () {
-      var audit = new Audit();
+    it('should otherwise push new rule', () => {
+      const audit = new Audit();
       audit.addRule({
         id: 'target',
         selector: 'bob'
@@ -399,9 +396,9 @@ describe('Audit', function () {
     });
   });
 
-  describe('Audit#resetRulesAndChecks', function () {
-    it('should override newly created check', function () {
-      var audit = new Audit();
+  describe('Audit#resetRulesAndChecks', () => {
+    it('should override newly created check', () => {
+      const audit = new Audit();
       assert.equal(audit.checks.target, undefined);
       audit.addCheck({
         id: 'target',
@@ -412,8 +409,8 @@ describe('Audit', function () {
       audit.resetRulesAndChecks();
       assert.equal(audit.checks.target, undefined);
     });
-    it('should reset locale', function () {
-      var audit = new Audit();
+    it('should reset locale', () => {
+      const audit = new Audit();
       assert.equal(audit.lang, 'en');
       audit.applyLocale({
         lang: 'de'
@@ -422,8 +419,8 @@ describe('Audit', function () {
       audit.resetRulesAndChecks();
       assert.equal(audit.lang, 'en');
     });
-    it('should reset brand', function () {
-      var audit = new Audit();
+    it('should reset brand', () => {
+      const audit = new Audit();
       assert.equal(audit.brand, 'axe');
       audit.setBranding({
         brand: 'test'
@@ -432,8 +429,8 @@ describe('Audit', function () {
       audit.resetRulesAndChecks();
       assert.equal(audit.brand, 'axe');
     });
-    it('should reset brand application', function () {
-      var audit = new Audit();
+    it('should reset brand application', () => {
+      const audit = new Audit();
       assert.equal(audit.application, 'axeAPI');
       audit.setBranding({
         application: 'test'
@@ -442,7 +439,7 @@ describe('Audit', function () {
       audit.resetRulesAndChecks();
       assert.equal(audit.application, 'axeAPI');
     });
-    it('should reset brand tagExlcude', function () {
+    it('should reset brand tagExlcude', () => {
       axe._load({});
       assert.deepEqual(axe._audit.tagExclude, ['experimental']);
       axe.configure({
@@ -452,24 +449,24 @@ describe('Audit', function () {
       assert.deepEqual(axe._audit.tagExclude, ['experimental']);
     });
 
-    it('should reset noHtml', function () {
-      var audit = new Audit();
+    it('should reset noHtml', () => {
+      const audit = new Audit();
       audit.noHtml = true;
       audit.resetRulesAndChecks();
       assert.isFalse(audit.noHtml);
     });
 
-    it('should reset allowedOrigins', function () {
-      var audit = new Audit();
+    it('should reset allowedOrigins', () => {
+      const audit = new Audit();
       audit.allowedOrigins = ['hello'];
       audit.resetRulesAndChecks();
       assert.deepEqual(audit.allowedOrigins, [window.location.origin]);
     });
   });
 
-  describe('Audit#addCheck', function () {
-    it('should create a new check', function () {
-      var audit = new Audit();
+  describe('Audit#addCheck', () => {
+    it('should create a new check', () => {
+      const audit = new Audit();
       assert.equal(audit.checks.target, undefined);
       audit.addCheck({
         id: 'target',
@@ -478,8 +475,8 @@ describe('Audit', function () {
       assert.ok(audit.checks.target);
       assert.deepEqual(audit.checks.target.options, { value: 'jane' });
     });
-    it('should configure the metadata, if passed', function () {
-      var audit = new Audit();
+    it('should configure the metadata, if passed', () => {
+      const audit = new Audit();
       assert.equal(audit.checks.target, undefined);
       audit.addCheck({
         id: 'target',
@@ -488,9 +485,9 @@ describe('Audit', function () {
       assert.ok(audit.checks.target);
       assert.equal(audit.data.checks.target.guy, 'bob');
     });
-    it('should reconfigure existing check', function () {
-      var audit = new Audit();
-      var myTest = function () {};
+    it('should reconfigure existing check', () => {
+      const audit = new Audit();
+      const myTest = () => {};
       audit.addCheck({
         id: 'target',
         evaluate: myTest,
@@ -507,9 +504,9 @@ describe('Audit', function () {
       assert.equal(audit.checks.target.evaluate, myTest);
       assert.deepEqual(audit.checks.target.options, { value: 'fred' });
     });
-    it('should not turn messages into a function', function () {
-      var audit = new Audit();
-      var spec = {
+    it('should not turn messages into a function', () => {
+      const audit = new Audit();
+      const spec = {
         id: 'target',
         evaluate: 'function () { return "blah";}',
         metadata: {
@@ -525,9 +522,9 @@ describe('Audit', function () {
       assert.equal(audit.data.checks.target.messages.fail, 'it failed');
     });
 
-    it('should turn function strings into a function', function () {
-      var audit = new Audit();
-      var spec = {
+    it('should turn function strings into a function', () => {
+      const audit = new Audit();
+      const spec = {
         id: 'target',
         evaluate: 'function () { return "blah";}',
         metadata: {
@@ -544,9 +541,9 @@ describe('Audit', function () {
     });
   });
 
-  describe('Audit#setAllowedOrigins', function () {
-    it('should set allowedOrigins', function () {
-      var audit = new Audit();
+  describe('Audit#setAllowedOrigins', () => {
+    it('should set allowedOrigins', () => {
+      const audit = new Audit();
       audit.setAllowedOrigins([
         'https://deque.com',
         'https://dequeuniversity.com'
@@ -557,8 +554,8 @@ describe('Audit', function () {
       ]);
     });
 
-    it('should normalize <same_origin>', function () {
-      var audit = new Audit();
+    it('should normalize <same_origin>', () => {
+      const audit = new Audit();
       audit.setAllowedOrigins(['<same_origin>', 'https://deque.com']);
       assert.deepEqual(audit.allowedOrigins, [
         window.location.origin,
@@ -566,8 +563,8 @@ describe('Audit', function () {
       ]);
     });
 
-    it('should normalize <unsafe_all_origins>', function () {
-      var audit = new Audit();
+    it('should normalize <unsafe_all_origins>', () => {
+      const audit = new Audit();
       audit.setAllowedOrigins([
         'https://deque.com',
         '<unsafe_all_origins>',
@@ -577,8 +574,8 @@ describe('Audit', function () {
     });
   });
 
-  describe('Audit#run', function () {
-    it('should run all the rules', function (done) {
+  describe('Audit#run', () => {
+    it('should run all the rules', done => {
       fixture.innerHTML =
         '<input aria-label="monkeys" type="text">' +
         '<div id="monkeys">bananas</div>' +
@@ -589,7 +586,7 @@ describe('Audit', function () {
         { include: [axe.utils.getFlattenedTree(fixture)[0]] },
         {},
         function (results) {
-          var expected = [
+          const expected = [
             {
               id: 'positive1',
               result: 'inapplicable',
@@ -620,7 +617,7 @@ describe('Audit', function () {
             }
           ];
 
-          var out = results[0].nodes[0].node.source;
+          const out = results[0].nodes[0].node.source;
           results.forEach(function (res) {
             // attribute order is a pain in the lower back in IE, so we're not
             // comparing nodes. Check.run and Rule.run do this.
@@ -638,7 +635,7 @@ describe('Audit', function () {
       );
     });
 
-    it('should not run rules disabled by the options', function (done) {
+    it('should not run rules disabled by the options', done => {
       a.run(
         { include: [axe.utils.getFlattenedTree()[0]] },
         {
@@ -656,16 +653,16 @@ describe('Audit', function () {
       );
     });
 
-    it('should ensure audit.run recieves preload options', function (done) {
+    it('should ensure audit.run recieves preload options', done => {
       fixture.innerHTML = '<input aria-label="yo" type="text">';
 
-      var audit = new Audit();
+      const audit = new Audit();
       audit.addRule({
         id: 'preload1',
         selector: '*'
       });
       audit.run = function (context, options, resolve, reject) {
-        var randomRule = this.rules[0];
+        const randomRule = this.rules[0];
         randomRule.run(
           context,
           options,
@@ -677,7 +674,7 @@ describe('Audit', function () {
         );
       };
 
-      var preloadOptions = {
+      const preloadOptions = {
         preload: {
           assets: ['cssom']
         }
@@ -693,7 +690,7 @@ describe('Audit', function () {
           assert.lengthOf(res, 1);
           assert.property(res[0], 'OPTIONS_PASSED');
 
-          var optionsPassed = res[0].OPTIONS_PASSED;
+          const optionsPassed = res[0].OPTIONS_PASSED;
           assert.property(optionsPassed, 'preload');
           assert.deepEqual(optionsPassed.preload, preloadOptions);
 
@@ -706,7 +703,7 @@ describe('Audit', function () {
       );
     });
 
-    it.skip('should run rules (that do not need preload) and preload assets simultaneously', function (done) {
+    it.skip('should run rules (that do not need preload) and preload assets simultaneously', done => {
       /**
        * Note:
        * overriding and resolving both check and preload with a delay,
@@ -715,11 +712,11 @@ describe('Audit', function () {
 
       fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
 
-      var runStartTime = new Date();
-      var preloadInvokedTime = new Date();
-      var noPreloadCheckedInvokedTime = new Date();
-      var noPreloadRuleCheckEvaluateInvoked = false;
-      var preloadOverrideInvoked = false;
+      const runStartTime = new Date();
+      const preloadInvokedTime = new Date();
+      const noPreloadCheckedInvokedTime = new Date();
+      const noPreloadRuleCheckEvaluateInvoked = false;
+      const preloadOverrideInvoked = false;
 
       // override preload method
       axe.utils.preload = function (options) {
@@ -727,13 +724,13 @@ describe('Audit', function () {
         preloadOverrideInvoked = true;
 
         return new Promise(function (res, rej) {
-          setTimeout(function () {
+          setTimeout(() => {
             res(true);
           }, 2000);
         });
       };
 
-      var audit = new Audit();
+      const audit = new Audit();
       // add a rule and check that does not need preload
       audit.addRule({
         id: 'no-preload',
@@ -746,8 +743,8 @@ describe('Audit', function () {
         evaluate: function (node, options, vNode, context) {
           noPreloadCheckedInvokedTime = new Date();
           noPreloadRuleCheckEvaluateInvoked = true;
-          var ready = this.async();
-          setTimeout(function () {
+          const ready = this.async();
+          setTimeout(() => {
             ready(true);
           }, 1000);
         }
@@ -760,13 +757,13 @@ describe('Audit', function () {
         preload: true
       });
 
-      var preloadOptions = {
+      const preloadOptions = {
         preload: {
           assets: ['cssom']
         }
       };
 
-      var allowedDiff = 50;
+      const allowedDiff = 50;
 
       audit.run(
         { include: [axe.utils.getFlattenedTree(fixture)[0]] },
@@ -797,13 +794,13 @@ describe('Audit', function () {
       );
     });
 
-    it.skip('should pass assets from preload to rule check that needs assets as context', function (done) {
+    it.skip('should pass assets from preload to rule check that needs assets as context', done => {
       fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
 
-      var yesPreloadRuleCheckEvaluateInvoked = false;
-      var preloadOverrideInvoked = false;
+      const yesPreloadRuleCheckEvaluateInvoked = false;
+      const preloadOverrideInvoked = false;
 
-      var preloadData = {
+      const preloadData = {
         data: 'you got it!'
       };
       // override preload method
@@ -814,7 +811,7 @@ describe('Audit', function () {
         });
       };
 
-      var audit = new Audit();
+      const audit = new Audit();
       // add a rule and check that does not need preload
       audit.addRule({
         id: 'no-preload',
@@ -837,7 +834,7 @@ describe('Audit', function () {
         }
       });
 
-      var preloadOptions = {
+      const preloadOptions = {
         preload: {
           assets: ['cssom']
         }
@@ -855,10 +852,10 @@ describe('Audit', function () {
           assert.isTrue(preloadOverrideInvoked);
 
           // assert preload data that was passed to check
-          var ruleResult = results.filter(function (r) {
+          const ruleResult = results.filter(function (r) {
             return (r.id = 'yes-preload' && r.nodes.length > 0);
           })[0];
-          var checkResult = ruleResult.nodes[0].any[0];
+          const checkResult = ruleResult.nodes[0].any[0];
           assert.isDefined(checkResult.data);
           assert.property(checkResult.data, 'cssom');
           assert.deepEqual(checkResult.data.cssom, preloadData);
@@ -871,12 +868,12 @@ describe('Audit', function () {
       );
     });
 
-    it.skip('should continue to run rules and return result when preload is rejected', function (done) {
+    it.skip('should continue to run rules and return result when preload is rejected', done => {
       fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
 
-      var preloadOverrideInvoked = false;
-      var preloadNeededCheckInvoked = false;
-      var rejectionMsg =
+      const preloadOverrideInvoked = false;
+      const preloadNeededCheckInvoked = false;
+      const rejectionMsg =
         'Boom! Things went terribly wrong! (But this was intended in this test)';
 
       // override preload method
@@ -885,7 +882,7 @@ describe('Audit', function () {
         return Promise.reject(rejectionMsg);
       };
 
-      var audit = new Audit();
+      const audit = new Audit();
       // add a rule and check that does not need preload
       audit.addRule({
         id: 'no-preload',
@@ -908,7 +905,7 @@ describe('Audit', function () {
         }
       });
 
-      var preloadOptions = {
+      const preloadOptions = {
         preload: {
           assets: ['cssom']
         }
@@ -929,10 +926,10 @@ describe('Audit', function () {
           // assert that because preload failed
           // cssom was not populated on context of repective check
           assert.isTrue(preloadNeededCheckInvoked);
-          var ruleResult = results.filter(function (r) {
+          const ruleResult = results.filter(function (r) {
             return (r.id = 'yes-preload' && r.nodes.length > 0);
           })[0];
-          var checkResult = ruleResult.nodes[0].any[0];
+          const checkResult = ruleResult.nodes[0].any[0];
           assert.isDefined(checkResult.data);
           assert.notProperty(checkResult.data, 'cssom');
           // done
@@ -942,14 +939,14 @@ describe('Audit', function () {
       );
     });
 
-    it('should continue to run rules and return result when axios time(s)out and rejects preload', function (done) {
+    it('should continue to run rules and return result when axios time(s)out and rejects preload', done => {
       fixture.innerHTML = '<div id="div1"></div><div id="div2"></div>';
 
       // there is no stubbing here,
       // the actual axios call is invoked, and timedout immediately as timeout is set to 0.1
 
-      var preloadNeededCheckInvoked = false;
-      var audit = new Audit();
+      let preloadNeededCheckInvoked = false;
+      const audit = new Audit();
       // add a rule and check that does not need preload
       audit.addRule({
         id: 'no-preload',
@@ -972,7 +969,7 @@ describe('Audit', function () {
         }
       });
 
-      var preloadOptions = {
+      const preloadOptions = {
         preload: {
           assets: ['cssom'],
           timeout: 0.1
@@ -991,10 +988,10 @@ describe('Audit', function () {
           // assert that because preload failed
           // cssom was not populated on context of repective check
           assert.isTrue(preloadNeededCheckInvoked);
-          var ruleResult = results.filter(function (r) {
+          const ruleResult = results.filter(function (r) {
             return (r.id = 'yes-preload' && r.nodes.length > 0);
           })[0];
-          var checkResult = ruleResult.nodes[0].any[0];
+          const checkResult = ruleResult.nodes[0].any[0];
           assert.isDefined(checkResult.data);
           assert.notProperty(checkResult.data, 'cssom');
           // done
@@ -1004,16 +1001,16 @@ describe('Audit', function () {
       );
     });
 
-    it.skip('should assign an empty array to axe._selectCache', function (done) {
-      var saved = axe.utils.ruleShouldRun;
-      axe.utils.ruleShouldRun = function () {
+    it.skip('should assign an empty array to axe._selectCache', done => {
+      const saved = axe.utils.ruleShouldRun;
+      axe.utils.ruleShouldRun = () => {
         assert.equal(axe._selectCache.length, 0);
         return false;
       };
       a.run(
         { include: [axe.utils.getFlattenedTree()[0]] },
         {},
-        function () {
+        () => {
           axe.utils.ruleShouldRun = saved;
           done();
         },
@@ -1021,13 +1018,13 @@ describe('Audit', function () {
       );
     });
 
-    it('should clear axe._selectCache', function (done) {
+    it('should clear axe._selectCache', done => {
       a.run(
         { include: [axe.utils.getFlattenedTree()[0]] },
         {
           rules: {}
         },
-        function () {
+        () => {
           assert.isTrue(typeof axe._selectCache === 'undefined');
           done();
         },
@@ -1035,10 +1032,10 @@ describe('Audit', function () {
       );
     });
 
-    it('should not run rules disabled by the configuration', function (done) {
-      var a = new Audit();
-      var success = true;
-      a.rules.push(
+    it('should not run rules disabled by the configuration', done => {
+      const audit = new Audit();
+      const success = true;
+      audit.rules.push(
         new Rule({
           id: 'positive1',
           selector: '*',
@@ -1046,17 +1043,17 @@ describe('Audit', function () {
           any: [
             {
               id: 'positive1-check1',
-              evaluate: function () {
+              evaluate: () => {
                 success = false;
               }
             }
           ]
         })
       );
-      a.run(
+      audit.run(
         { include: [axe.utils.getFlattenedTree()[0]] },
         {},
-        function () {
+        () => {
           assert.ok(success);
           done();
         },
@@ -1064,11 +1061,11 @@ describe('Audit', function () {
       );
     });
 
-    it("should call the rule's run function", function (done) {
-      var targetRule = mockRules[mockRules.length - 1],
-        rule = axe.utils.findBy(a.rules, 'id', targetRule.id),
-        called = false,
-        orig;
+    it("should call the rule's run function", done => {
+      const targetRule = mockRules[mockRules.length - 1];
+      const rule = axe.utils.findBy(a.rules, 'id', targetRule.id);
+      let called = false;
+      let orig;
 
       fixture.innerHTML = '<a href="#">link</a>';
       orig = rule.run;
@@ -1079,7 +1076,7 @@ describe('Audit', function () {
       a.run(
         { include: [axe.utils.getFlattenedTree()[0]] },
         {},
-        function () {
+        () => {
           assert.isTrue(called);
           rule.run = orig;
           done();
@@ -1088,12 +1085,12 @@ describe('Audit', function () {
       );
     });
 
-    it('should pass the option to the run function', function (done) {
-      var targetRule = mockRules[mockRules.length - 1],
-        rule = axe.utils.findBy(a.rules, 'id', targetRule.id),
-        passed = false,
-        orig,
-        options;
+    it('should pass the option to the run function', done => {
+      const targetRule = mockRules[mockRules.length - 1];
+      const rule = axe.utils.findBy(a.rules, 'id', targetRule.id);
+      let passed = false;
+      let orig;
+      let options;
 
       fixture.innerHTML = '<a href="#">link</a>';
       orig = rule.run;
@@ -1107,7 +1104,7 @@ describe('Audit', function () {
       a.run(
         { include: [axe.utils.getFlattenedTree()[0]] },
         options,
-        function () {
+        () => {
           assert.ok(passed);
           rule.run = orig;
           done();
@@ -1116,14 +1113,14 @@ describe('Audit', function () {
       );
     });
 
-    it('should skip pageLevel rules if context is not set to entire page', function () {
-      var audit = new Audit();
+    it('should skip pageLevel rules if context is not set to entire page', () => {
+      const audit = new Audit();
 
       audit.rules.push(
         new Rule({
           pageLevel: true,
           enabled: true,
-          evaluate: function () {
+          evaluate: () => {
             assert.ok(false, 'Should not run');
           }
         })
@@ -1142,8 +1139,8 @@ describe('Audit', function () {
       );
     });
 
-    it('catches errors and passes them as a cantTell result', function (done) {
-      var err = new Error('Launch the super sheep!');
+    it('catches errors and passes them as a cantTell result', done => {
+      const err = new Error('Launch the super sheep!');
       a.addRule({
         id: 'throw1',
         selector: '*',
@@ -1155,7 +1152,7 @@ describe('Audit', function () {
       });
       a.addCheck({
         id: 'throw1-check1',
-        evaluate: function () {
+        evaluate: () => {
           throw err;
         }
       });
@@ -1181,7 +1178,7 @@ describe('Audit', function () {
       );
     });
 
-    it('should not halt if errors occur', function (done) {
+    it('should not halt if errors occur', done => {
       a.addRule({
         id: 'throw1',
         selector: '*',
@@ -1193,7 +1190,7 @@ describe('Audit', function () {
       });
       a.addCheck({
         id: 'throw1-check1',
-        evaluate: function () {
+        evaluate: () => {
           throw new Error('Launch the super sheep!');
         }
       });
@@ -1205,22 +1202,22 @@ describe('Audit', function () {
             values: ['throw1', 'positive1']
           }
         },
-        function () {
+        () => {
           done();
         },
         isNotCalled
       );
     });
 
-    it('should run audit.normalizeOptions to ensure valid input', function () {
+    it('should run audit.normalizeOptions to ensure valid input', () => {
       fixture.innerHTML =
         '<input type="text" aria-label="monkeys">' +
         '<div id="monkeys">bananas</div>' +
         '<input aria-labelledby="monkeys" type="text">' +
         '<blink>FAIL ME</blink>';
-      var checked = 'options not validated';
+      let checked = 'options not validated';
 
-      a.normalizeOptions = function () {
+      a.normalizeOptions = () => {
         checked = 'options validated';
       };
 
@@ -1233,7 +1230,7 @@ describe('Audit', function () {
       assert.equal(checked, 'options validated');
     });
 
-    it('should halt if an error occurs when debug is set', function (done) {
+    it('should halt if an error occurs when debug is set', done => {
       a.addRule({
         id: 'throw1',
         selector: '*',
@@ -1245,7 +1242,7 @@ describe('Audit', function () {
       });
       a.addCheck({
         id: 'throw1-check1',
-        evaluate: function () {
+        evaluate: () => {
           throw new Error('Launch the super sheep!');
         }
       });
@@ -1271,13 +1268,13 @@ describe('Audit', function () {
     });
   });
 
-  describe('Audit#after', function () {
-    it('should run Rule#after on any rule whose result is passed in', function () {
+  describe('Audit#after', () => {
+    it('should run Rule#after on any rule whose result is passed in', () => {
       /*eslint no-unused-vars:0*/
-      var audit = new Audit();
-      var success = false;
-      var options = [{ id: 'hehe', enabled: true, monkeys: 'bananas' }];
-      var results = [
+      const audit = new Audit();
+      let success = false;
+      const options = [{ id: 'hehe', enabled: true, monkeys: 'bananas' }];
+      const results = [
         {
           id: 'hehe',
           monkeys: 'bananas'
@@ -1301,17 +1298,17 @@ describe('Audit', function () {
     });
   });
 
-  describe('Audit#normalizeOptions', function () {
-    var axeLog;
-    beforeEach(function () {
+  describe('Audit#normalizeOptions', () => {
+    let axeLog;
+    beforeEach(() => {
       axeLog = axe.log;
     });
-    afterEach(function () {
+    afterEach(() => {
       axe.log = axeLog;
     });
 
-    it('returns the options object when it is valid', function () {
-      var opt = {
+    it('returns the options object when it is valid', () => {
+      const opt = {
         runOnly: {
           type: 'rule',
           values: ['positive1', 'positive2']
@@ -1323,20 +1320,20 @@ describe('Audit', function () {
       assert(a.normalizeOptions(opt), opt);
     });
 
-    it('allows `value` as alternative to `values`', function () {
-      var opt = {
+    it('allows `value` as alternative to `values`', () => {
+      const opt = {
         runOnly: {
           type: 'rule',
           value: ['positive1', 'positive2']
         }
       };
-      var out = a.normalizeOptions(opt);
+      const out = a.normalizeOptions(opt);
       assert.deepEqual(out.runOnly.values, ['positive1', 'positive2']);
       assert.isUndefined(out.runOnly.value);
     });
 
-    it('allows type: rules as an alternative to type: rule', function () {
-      var opt = {
+    it('allows type: rules as an alternative to type: rule', () => {
+      const opt = {
         runOnly: {
           type: 'rules',
           values: ['positive1', 'positive2']
@@ -1345,8 +1342,8 @@ describe('Audit', function () {
       assert(a.normalizeOptions(opt).runOnly.type, 'rule');
     });
 
-    it('allows type: tags as an alternative to type: tag', function () {
-      var opt = {
+    it('allows type: tags as an alternative to type: tag', () => {
+      const opt = {
         runOnly: {
           type: 'tags',
           values: ['positive']
@@ -1355,8 +1352,8 @@ describe('Audit', function () {
       assert(a.normalizeOptions(opt).runOnly.type, 'tag');
     });
 
-    it('allows type: undefined as an alternative to type: tag', function () {
-      var opt = {
+    it('allows type: undefined as an alternative to type: tag', () => {
+      const opt = {
         runOnly: {
           values: ['positive']
         }
@@ -1364,44 +1361,44 @@ describe('Audit', function () {
       assert(a.normalizeOptions(opt).runOnly.type, 'tag');
     });
 
-    it('allows runOnly as an array as an alternative to type: tag', function () {
-      var opt = { runOnly: ['positive', 'negative'] };
-      var out = a.normalizeOptions(opt);
+    it('allows runOnly as an array as an alternative to type: tag', () => {
+      const opt = { runOnly: ['positive', 'negative'] };
+      const out = a.normalizeOptions(opt);
       assert(out.runOnly.type, 'tag');
       assert.deepEqual(out.runOnly.values, ['positive', 'negative']);
     });
 
-    it('allows runOnly as an array as an alternative to type: rule', function () {
-      var opt = { runOnly: ['positive1', 'negative1'] };
-      var out = a.normalizeOptions(opt);
+    it('allows runOnly as an array as an alternative to type: rule', () => {
+      const opt = { runOnly: ['positive1', 'negative1'] };
+      const out = a.normalizeOptions(opt);
       assert(out.runOnly.type, 'rule');
       assert.deepEqual(out.runOnly.values, ['positive1', 'negative1']);
     });
 
-    it('allows runOnly as a string as an alternative to an array', function () {
-      var opt = { runOnly: 'positive1' };
-      var out = a.normalizeOptions(opt);
+    it('allows runOnly as a string as an alternative to an array', () => {
+      const opt = { runOnly: 'positive1' };
+      const out = a.normalizeOptions(opt);
       assert(out.runOnly.type, 'rule');
       assert.deepEqual(out.runOnly.values, ['positive1']);
     });
 
-    it('throws an error if runOnly contains both rules and tags', function () {
-      assert.throws(function () {
+    it('throws an error if runOnly contains both rules and tags', () => {
+      assert.throws(() => {
         a.normalizeOptions({
           runOnly: ['positive', 'negative1']
         });
       });
     });
 
-    it('defaults runOnly to type: tag', function () {
-      var opt = { runOnly: ['fakeTag'] };
-      var out = a.normalizeOptions(opt);
+    it('defaults runOnly to type: tag', () => {
+      const opt = { runOnly: ['fakeTag'] };
+      const out = a.normalizeOptions(opt);
       assert(out.runOnly.type, 'tag');
       assert.deepEqual(out.runOnly.values, ['fakeTag']);
     });
 
-    it('throws an error runOnly.values not an array', function () {
-      assert.throws(function () {
+    it('throws an error runOnly.values not an array', () => {
+      assert.throws(() => {
         a.normalizeOptions({
           runOnly: {
             type: 'rule',
@@ -1411,8 +1408,8 @@ describe('Audit', function () {
       });
     });
 
-    it('throws an error runOnly.values an empty', function () {
-      assert.throws(function () {
+    it('throws an error runOnly.values an empty', () => {
+      assert.throws(() => {
         a.normalizeOptions({
           runOnly: {
             type: 'rule',
@@ -1422,8 +1419,8 @@ describe('Audit', function () {
       });
     });
 
-    it('throws an error runOnly.type is unknown', function () {
-      assert.throws(function () {
+    it('throws an error runOnly.type is unknown', () => {
+      assert.throws(() => {
         a.normalizeOptions({
           runOnly: {
             type: 'something-else',
@@ -1433,8 +1430,8 @@ describe('Audit', function () {
       });
     });
 
-    it('throws an error when option.runOnly has an unknown rule', function () {
-      assert.throws(function () {
+    it('throws an error when option.runOnly has an unknown rule', () => {
+      assert.throws(() => {
         a.normalizeOptions({
           runOnly: {
             type: 'rule',
@@ -1444,8 +1441,8 @@ describe('Audit', function () {
       });
     });
 
-    it("doesn't throw an error when option.runOnly has an unknown tag", function () {
-      assert.doesNotThrow(function () {
+    it("doesn't throw an error when option.runOnly has an unknown tag", () => {
+      assert.doesNotThrow(() => {
         a.normalizeOptions({
           runOnly: {
             type: 'tags',
@@ -1455,8 +1452,8 @@ describe('Audit', function () {
       });
     });
 
-    it('throws an error when option.rules has an unknown rule', function () {
-      assert.throws(function () {
+    it('throws an error when option.rules has an unknown rule', () => {
+      assert.throws(() => {
         a.normalizeOptions({
           rules: {
             fakeRule: { enabled: false }
@@ -1465,8 +1462,8 @@ describe('Audit', function () {
       });
     });
 
-    it('logs an issue when a tag is unknown', function () {
-      var message = '';
+    it('logs an issue when a tag is unknown', () => {
+      let message = '';
       axe.log = function (m) {
         message = m;
       };
@@ -1479,8 +1476,8 @@ describe('Audit', function () {
       assert.include(message, 'Could not find tags');
     });
 
-    it('logs no issues for unknown WCAG level tags', function () {
-      var message = '';
+    it('logs no issues for unknown WCAG level tags', () => {
+      let message = '';
       axe.log = function (m) {
         message = m;
       };
@@ -1493,8 +1490,8 @@ describe('Audit', function () {
       assert.isEmpty(message);
     });
 
-    it('logs an issue when a tag is unknown, together with a wcag level tag', function () {
-      var message = '';
+    it('logs an issue when a tag is unknown, together with a wcag level tag', () => {
+      let message = '';
       axe.log = function (m) {
         message = m;
       };

--- a/test/core/base/check.js
+++ b/test/core/base/check.js
@@ -1,114 +1,112 @@
-describe('Check', function () {
-  'use strict';
-
-  var Check = axe._thisWillBeDeletedDoNotUse.base.Check;
-  var CheckResult = axe._thisWillBeDeletedDoNotUse.base.CheckResult;
-  var metadataFunctionMap =
+describe('Check', () => {
+  const Check = axe._thisWillBeDeletedDoNotUse.base.Check;
+  const CheckResult = axe._thisWillBeDeletedDoNotUse.base.CheckResult;
+  const metadataFunctionMap =
     axe._thisWillBeDeletedDoNotUse.base.metadataFunctionMap;
-  var noop = function () {};
+  const noop = () => {};
 
-  var fixture = document.getElementById('fixture');
+  const fixture = document.getElementById('fixture');
 
   afterEach(function () {
     fixture.innerHTML = '';
   });
 
-  it('should be a function', function () {
+  it('should be a function', () => {
     assert.isFunction(Check);
   });
 
-  describe('prototype', function () {
-    describe('enabled', function () {
-      it('should be true by default', function () {
-        var check = new Check({});
+  describe('prototype', () => {
+    describe('enabled', () => {
+      it('should be true by default', () => {
+        const check = new Check({});
         assert.isTrue(check.enabled);
       });
-      it('should be set to whatever is passed in', function () {
-        var check = new Check({ enabled: false });
+      it('should be set to whatever is passed in', () => {
+        const check = new Check({ enabled: false });
         assert.isFalse(check.enabled);
       });
     });
 
-    describe('configure', function () {
-      it('should accept one parameter', function () {
+    describe('configure', () => {
+      it('should accept one parameter', () => {
         assert.lengthOf(new Check({}).configure, 1);
       });
-      it('should override options', function () {
+      it('should override options', () => {
         Check.prototype.test = function () {
           return this.options;
         };
-        var check = new Check({
+        const check = new Check({
           options: ['foo']
         });
         check.configure({ options: { value: 'fong' } });
         assert.deepEqual({ value: 'fong' }, check.test());
         delete Check.prototype.test;
       });
-      it('should override evaluate', function () {
+      it('should override evaluate', () => {
         Check.prototype.test = function () {
           return this.evaluate();
         };
-        var check = new Check({
+        const check = new Check({
           evaluate: 'function () { return "foo"; }'
         });
         check.configure({ evaluate: 'function () { return "fong"; }' });
         assert.equal('fong', check.test());
         delete Check.prototype.test;
       });
-      it('should override after', function () {
+      it('should override after', () => {
         Check.prototype.test = function () {
           return this.after();
         };
-        var check = new Check({
+        const check = new Check({
           after: 'function () { return "foo"; }'
         });
         check.configure({ after: 'function () { return "fong"; }' });
         assert.equal('fong', check.test());
         delete Check.prototype.test;
       });
-      it('should override evaluate as a function', function () {
+      it('should override evaluate as a function', () => {
         Check.prototype.test = function () {
           return this.evaluate();
         };
-        var check = new Check({
-          evaluate: function () {
+        const check = new Check({
+          evaluate() {
             return 'foo';
           }
         });
         check.configure({
-          evaluate: function () {
+          evaluate() {
             return 'fong';
           }
         });
         assert.equal('fong', check.test());
         delete Check.prototype.test;
       });
-      it('should override after as a function', function () {
+      it('should override after as a function', () => {
         Check.prototype.test = function () {
           return this.after();
         };
-        var check = new Check({
-          after: function () {
+        const check = new Check({
+          after() {
             return 'foo';
           }
         });
         check.configure({
-          after: function () {
+          after() {
             return 'fong';
           }
         });
         assert.equal('fong', check.test());
         delete Check.prototype.test;
       });
-      it('should override evaluate as ID', function () {
-        metadataFunctionMap['custom-evaluate'] = function () {
+      it('should override evaluate as ID', () => {
+        metadataFunctionMap['custom-evaluate'] = () => {
           return 'fong';
         };
 
         Check.prototype.test = function () {
           return this.evaluate();
         };
-        var check = new Check({
+        const check = new Check({
           evaluate: 'function () { return "foo"; }'
         });
         check.configure({ evaluate: 'custom-evaluate' });
@@ -116,15 +114,15 @@ describe('Check', function () {
         delete Check.prototype.test;
         delete metadataFunctionMap['custom-evaluate'];
       });
-      it('should override after as ID', function () {
-        metadataFunctionMap['custom-after'] = function () {
+      it('should override after as ID', () => {
+        metadataFunctionMap['custom-after'] = () => {
           return 'fong';
         };
 
         Check.prototype.test = function () {
           return this.after();
         };
-        var check = new Check({
+        const check = new Check({
           after: 'function () { return "foo"; }'
         });
         check.configure({ after: 'custom-after' });
@@ -132,9 +130,9 @@ describe('Check', function () {
         delete Check.prototype.test;
         delete metadataFunctionMap['custom-after'];
       });
-      it('should error if evaluate does not match an ID', function () {
+      it('should error if evaluate does not match an ID', () => {
         function fn() {
-          var check = new Check({});
+          const check = new Check({});
           check.configure({ evaluate: 'does-not-exist' });
         }
 
@@ -143,9 +141,9 @@ describe('Check', function () {
           'Function ID does not exist in the metadata-function-map: does-not-exist'
         );
       });
-      it('should error if after does not match an ID', function () {
+      it('should error if after does not match an ID', () => {
         function fn() {
-          var check = new Check({});
+          const check = new Check({});
           check.configure({ after: 'does-not-exist' });
         }
 
@@ -154,79 +152,79 @@ describe('Check', function () {
           'Function ID does not exist in the metadata-function-map: does-not-exist'
         );
       });
-      it('should override enabled', function () {
+      it('should override enabled', () => {
         Check.prototype.test = function () {
           return this.enabled;
         };
-        var check = new Check({
+        const check = new Check({
           enabled: true
         });
         check.configure({ enabled: false });
         assert.equal(false, check.test());
         delete Check.prototype.test;
       });
-      it('should NOT override id', function () {
+      it('should NOT override id', () => {
         Check.prototype.test = function () {
           return this.id;
         };
-        var check = new Check({
+        const check = new Check({
           id: 'fong'
         });
         check.configure({ id: 'foo' });
         assert.equal('fong', check.test());
         delete Check.prototype.test;
       });
-      it('should NOT override any random property', function () {
+      it('should NOT override any random property', () => {
         Check.prototype.test = function () {
           return this.random;
         };
-        var check = new Check({});
+        const check = new Check({});
         check.configure({ random: 'foo' });
         assert.equal(undefined, check.test());
         delete Check.prototype.test;
       });
     });
 
-    describe('run', function () {
-      it('should accept 5 parameters', function () {
+    describe('run', () => {
+      it('should accept 5 parameters', () => {
         assert.lengthOf(new Check({}).run, 5);
       });
 
-      it('should pass the node through', function (done) {
+      it('should pass the node through', done => {
         new Check({
-          evaluate: function (node) {
+          evaluate(node) {
             assert.equal(node, fixture);
             done();
           }
         }).run(axe.utils.getFlattenedTree(fixture)[0], {}, {}, noop);
       });
 
-      it('should pass the options through', function (done) {
-        var expected = { monkeys: 'bananas' };
+      it('should pass the options through', done => {
+        const expected = { monkeys: 'bananas' };
 
         new Check({
           options: expected,
-          evaluate: function (node, options) {
+          evaluate(node, options) {
             assert.deepEqual(options, expected);
             done();
           }
         }).run(fixture, {}, {}, noop);
       });
 
-      it('should pass the options through modified by the ones passed into the call', function (done) {
-        var configured = { monkeys: 'bananas' },
+      it('should pass the options through modified by the ones passed into the call', done => {
+        const configured = { monkeys: 'bananas' },
           expected = { monkeys: 'bananas', dogs: 'cats' };
 
         new Check({
           options: configured,
-          evaluate: function (node, options) {
+          evaluate(node, options) {
             assert.deepEqual(options, expected);
             done();
           }
         }).run(fixture, { options: expected }, {}, noop);
       });
 
-      it('should normalize non-object options for internal checks', function (done) {
+      it('should normalize non-object options for internal checks', done => {
         metadataFunctionMap['custom-check'] = function (node, options) {
           assert.deepEqual(options, { value: 'foo' });
           done();
@@ -237,24 +235,24 @@ describe('Check', function () {
         delete metadataFunctionMap['custom-check'];
       });
 
-      it('should not normalize non-object options for external checks', function (done) {
+      it('should not normalize non-object options for external checks', done => {
         new Check({
-          evaluate: function (node, options) {
+          evaluate(node, options) {
             assert.deepEqual(options, 'foo');
             done();
           }
         }).run(fixture, { options: 'foo' }, {}, noop);
       });
 
-      it('should pass the context through to check evaluate call', function (done) {
-        var configured = {
+      it('should pass the context through to check evaluate call', done => {
+        const configured = {
           cssom: 'yay',
           source: 'this is page source',
           aom: undefined
         };
         new Check({
           options: configured,
-          evaluate: function (node, options, virtualNode, context) {
+          evaluate(node, options, virtualNode, context) {
             assert.property(context, 'cssom');
             assert.deepEqual(context, configured);
             done();
@@ -262,33 +260,33 @@ describe('Check', function () {
         }).run(fixture, {}, configured, noop);
       });
 
-      it('should pass the virtual node through', function (done) {
-        var tree = axe.utils.getFlattenedTree(fixture);
+      it('should pass the virtual node through', done => {
+        const tree = axe.utils.getFlattenedTree(fixture);
         new Check({
-          evaluate: function (node, options, virtualNode) {
+          evaluate(node, options, virtualNode) {
             assert.equal(virtualNode, tree[0]);
             done();
           }
         }).run(tree[0]);
       });
 
-      it.skip('should bind context to `bindCheckResult`', function (done) {
-        var orig = axe.utils.checkHelper,
-          cb = function () {
+      it.skip('should bind context to `bindCheckResult`', done => {
+        const orig = axe.utils.checkHelper,
+          cb = () => {
             return true;
           },
           options = {},
           context = {},
           result = { monkeys: 'bananas' };
 
-        axe.utils.checkHelper = function (checkResult, options, callback) {
+        axe.utils.checkHelper = function (checkResult, opts, callback) {
           assert.instanceOf(checkResult, window.CheckResult);
           assert.equal(callback, cb);
           return result;
         };
 
         new Check({
-          evaluate: function () {
+          evaluate() {
             assert.deepEqual(result, this);
             axe.utils.checkHelper = orig;
             done();
@@ -296,11 +294,11 @@ describe('Check', function () {
         }).run(fixture, options, context, cb);
       });
 
-      it('should allow for asynchronous checks', function (done) {
-        var data = { monkeys: 'bananas' };
+      it('should allow for asynchronous checks', done => {
+        const data = { monkeys: 'bananas' };
         new Check({
-          evaluate: function () {
-            var ready = this.async();
+          evaluate() {
+            const ready = this.async();
             setTimeout(function () {
               ready(data);
             }, 10);
@@ -312,9 +310,9 @@ describe('Check', function () {
         });
       });
 
-      it('should pass `null` as the parameter if not enabled', function (done) {
+      it('should pass `null` as the parameter if not enabled', done => {
         new Check({
-          evaluate: function () {},
+          evaluate() {},
           enabled: false
         }).run(fixture, {}, {}, function (data) {
           assert.isNull(data);
@@ -322,9 +320,9 @@ describe('Check', function () {
         });
       });
 
-      it('should pass `null` as the parameter if options disable', function (done) {
+      it('should pass `null` as the parameter if options disable', done => {
         new Check({
-          evaluate: function () {}
+          evaluate() {}
         }).run(
           fixture,
           {
@@ -338,9 +336,9 @@ describe('Check', function () {
         );
       });
 
-      it('passes a result to the resolve argument', function (done) {
+      it('passes a result to the resolve argument', done => {
         new Check({
-          evaluate: function () {
+          evaluate() {
             return true;
           }
         }).run(fixture, {}, {}, function (data) {
@@ -350,9 +348,9 @@ describe('Check', function () {
         });
       });
 
-      it('should pass errors to the reject argument', function (done) {
+      it('should pass errors to the reject argument', done => {
         new Check({
-          evaluate: function () {
+          evaluate() {
             throw new Error('Grenade!');
           }
         }).run(fixture, {}, {}, noop, function (err) {
@@ -363,43 +361,43 @@ describe('Check', function () {
       });
     });
 
-    describe('runSync', function () {
-      it('should accept 3 parameters', function () {
+    describe('runSync', () => {
+      it('should accept 3 parameters', () => {
         assert.lengthOf(new Check({}).runSync, 3);
       });
 
-      it('should pass the node through', function () {
+      it('should pass the node through', () => {
         new Check({
-          evaluate: function (node) {
+          evaluate(node) {
             assert.equal(node, fixture);
           }
         }).runSync(axe.utils.getFlattenedTree(fixture)[0], {}, {});
       });
 
-      it('should pass the options through', function () {
-        var expected = { monkeys: 'bananas' };
+      it('should pass the options through', () => {
+        const expected = { monkeys: 'bananas' };
 
         new Check({
           options: expected,
-          evaluate: function (node, options) {
+          evaluate(node, options) {
             assert.deepEqual(options, expected);
           }
         }).runSync(fixture, {}, {});
       });
 
-      it('should pass the options through modified by the ones passed into the call', function () {
-        var configured = { monkeys: 'bananas' },
+      it('should pass the options through modified by the ones passed into the call', () => {
+        const configured = { monkeys: 'bananas' },
           expected = { monkeys: 'bananas', dogs: 'cats' };
 
         new Check({
           options: configured,
-          evaluate: function (node, options) {
+          evaluate(node, options) {
             assert.deepEqual(options, expected);
           }
         }).runSync(fixture, { options: expected }, {});
       });
 
-      it('should normalize non-object options for internal checks', function (done) {
+      it('should normalize non-object options for internal checks', done => {
         metadataFunctionMap['custom-check'] = function (node, options) {
           assert.deepEqual(options, { value: 'foo' });
           done();
@@ -410,46 +408,46 @@ describe('Check', function () {
         delete metadataFunctionMap['custom-check'];
       });
 
-      it('should not normalize non-object options for external checks', function (done) {
+      it('should not normalize non-object options for external checks', done => {
         new Check({
-          evaluate: function (node, options) {
+          evaluate(node, options) {
             assert.deepEqual(options, 'foo');
             done();
           }
         }).runSync(fixture, { options: 'foo' }, {});
       });
 
-      it('should pass the context through to check evaluate call', function () {
-        var configured = {
+      it('should pass the context through to check evaluate call', () => {
+        const configured = {
           cssom: 'yay',
           source: 'this is page source',
           aom: undefined
         };
         new Check({
           options: configured,
-          evaluate: function (node, options, virtualNode, context) {
+          evaluate(node, options, virtualNode, context) {
             assert.property(context, 'cssom');
             assert.deepEqual(context, configured);
           }
         }).runSync(fixture, {}, configured);
       });
 
-      it('should pass the virtual node through', function () {
-        var tree = axe.utils.getFlattenedTree(fixture);
+      it('should pass the virtual node through', () => {
+        const tree = axe.utils.getFlattenedTree(fixture);
         new Check({
-          evaluate: function (node, options, virtualNode) {
+          evaluate(node, options, virtualNode) {
             assert.equal(virtualNode, tree[0]);
           }
         }).runSync(tree[0]);
       });
 
-      it('should throw error for asynchronous checks', function () {
-        var data = { monkeys: 'bananas' };
+      it('should throw error for asynchronous checks', () => {
+        const data = { monkeys: 'bananas' };
 
         try {
           new Check({
-            evaluate: function () {
-              var ready = this.async();
+            evaluate() {
+              const ready = this.async();
               setTimeout(function () {
                 ready(data);
               }, 10);
@@ -464,18 +462,18 @@ describe('Check', function () {
         }
       });
 
-      it('should pass `null` as the parameter if not enabled', function () {
-        var data = new Check({
-          evaluate: function () {},
+      it('should pass `null` as the parameter if not enabled', () => {
+        const data = new Check({
+          evaluate() {},
           enabled: false
         }).runSync(fixture, {}, {});
 
         assert.isNull(data);
       });
 
-      it('should pass `null` as the parameter if options disable', function () {
-        var data = new Check({
-          evaluate: function () {}
+      it('should pass `null` as the parameter if options disable', () => {
+        const data = new Check({
+          evaluate() {}
         }).runSync(
           fixture,
           {
@@ -486,9 +484,9 @@ describe('Check', function () {
         assert.isNull(data);
       });
 
-      it('passes a result to the resolve argument', function () {
-        var data = new Check({
-          evaluate: function () {
+      it('passes a result to the resolve argument', () => {
+        const data = new Check({
+          evaluate() {
             return true;
           }
         }).runSync(fixture, {}, {});
@@ -496,10 +494,10 @@ describe('Check', function () {
         assert.isTrue(data.result);
       });
 
-      it('should throw errors', function () {
+      it('should throw errors', () => {
         try {
           new Check({
-            evaluate: function () {
+            evaluate() {
               throw new Error('Grenade!');
             }
           }).runSync(fixture, {}, {});
@@ -510,8 +508,8 @@ describe('Check', function () {
       });
     });
 
-    describe('getOptions', function () {
-      var check;
+    describe('getOptions', () => {
+      let check;
       beforeEach(function () {
         check = new Check({
           options: {
@@ -520,57 +518,57 @@ describe('Check', function () {
         });
       });
 
-      it('should return default check options', function () {
+      it('should return default check options', () => {
         assert.deepEqual(check.getOptions(), { foo: 'bar' });
       });
 
-      it('should merge options with Check defaults', function () {
-        var options = check.getOptions({ hello: 'world' });
+      it('should merge options with Check defaults', () => {
+        const options = check.getOptions({ hello: 'world' });
         assert.deepEqual(options, { foo: 'bar', hello: 'world' });
       });
 
-      it('should override defaults', function () {
-        var options = check.getOptions({ foo: 'world' });
+      it('should override defaults', () => {
+        const options = check.getOptions({ foo: 'world' });
         assert.deepEqual(options, { foo: 'world' });
       });
 
-      it('should normalize passed in options', function () {
-        var options = check.getOptions('world');
+      it('should normalize passed in options', () => {
+        const options = check.getOptions('world');
         assert.deepEqual(options, { foo: 'bar', value: 'world' });
       });
     });
   });
 
-  describe('spec object', function () {
-    describe('.id', function () {
-      it('should be set', function () {
-        var spec = {
+  describe('spec object', () => {
+    describe('.id', () => {
+      it('should be set', () => {
+        const spec = {
           id: 'monkeys'
         };
         assert.equal(new Check(spec).id, spec.id);
       });
 
-      it('should have no default', function () {
-        var spec = {};
+      it('should have no default', () => {
+        const spec = {};
         assert.equal(new Check(spec).id, spec.id);
       });
     });
 
-    describe('.after', function () {
-      it('should be set', function () {
-        var spec = {
-          after: function () {}
+    describe('.after', () => {
+      it('should be set', () => {
+        const spec = {
+          after() {}
         };
         assert.equal(new Check(spec).after, spec.after);
       });
 
-      it('should have no default', function () {
-        var spec = {};
+      it('should have no default', () => {
+        const spec = {};
         assert.equal(new Check(spec).after, spec.after);
       });
 
-      it('should be able to take a string and turn it into a function', function () {
-        var spec = {
+      it('should be able to take a string and turn it into a function', () => {
+        const spec = {
           after: 'function () {return "blah";}'
         };
         assert.equal(typeof new Check(spec).after, 'function');
@@ -578,45 +576,45 @@ describe('Check', function () {
       });
     });
 
-    describe('.options', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.options', () => {
+      it('should be set', () => {
+        const spec = {
           options: { value: ['monkeys', 'bananas'] }
         };
         assert.equal(new Check(spec).options, spec.options);
       });
 
-      it('should have no default', function () {
-        var spec = {};
+      it('should have no default', () => {
+        const spec = {};
         assert.equal(new Check(spec).options, spec.options);
       });
 
-      it('should normalize non-object options for internal checks', function () {
-        var spec = {
+      it('should normalize non-object options for internal checks', () => {
+        const spec = {
           options: 'foo'
         };
         assert.deepEqual(new Check(spec).options, { value: 'foo' });
       });
 
-      it('should not normalize non-object options for external checks', function () {
-        var spec = {
+      it('should not normalize non-object options for external checks', () => {
+        const spec = {
           options: 'foo',
-          evaluate: function () {}
+          evaluate() {}
         };
         assert.deepEqual(new Check(spec).options, 'foo');
       });
     });
 
-    describe('.evaluate', function () {
-      it('should be set', function () {
-        var spec = {
-          evaluate: function () {}
+    describe('.evaluate', () => {
+      it('should be set', () => {
+        const spec = {
+          evaluate() {}
         };
         assert.equal(typeof new Check(spec).evaluate, 'function');
         assert.equal(new Check(spec).evaluate, spec.evaluate);
       });
-      it('should turn a string into a function', function () {
-        var spec = {
+      it('should turn a string into a function', () => {
+        const spec = {
           evaluate: 'function () { return "blah";}'
         };
         assert.equal(typeof new Check(spec).evaluate, 'function');

--- a/test/core/base/rule.js
+++ b/test/core/base/rule.js
@@ -1,43 +1,41 @@
-describe('Rule', function () {
-  'use strict';
-
-  var Rule = axe._thisWillBeDeletedDoNotUse.base.Rule;
-  var Check = axe._thisWillBeDeletedDoNotUse.base.Check;
-  var metadataFunctionMap =
+describe('Rule', () => {
+  const Rule = axe._thisWillBeDeletedDoNotUse.base.Rule;
+  const Check = axe._thisWillBeDeletedDoNotUse.base.Check;
+  const metadataFunctionMap =
     axe._thisWillBeDeletedDoNotUse.base.metadataFunctionMap;
-  var fixture = document.getElementById('fixture');
-  var noop = function () {};
-  var isNotCalled = function (err) {
+  const fixture = document.getElementById('fixture');
+  const noop = () => {};
+  const isNotCalled = function (err) {
     throw err || new Error('Reject should not be called');
   };
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
   });
 
-  it('should be a function', function () {
+  it('should be a function', () => {
     assert.isFunction(Rule);
   });
 
-  it('should accept two parameters', function () {
+  it('should accept two parameters', () => {
     assert.lengthOf(Rule, 2);
   });
 
-  describe('prototype', function () {
-    describe('gather', function () {
-      it('should gather nodes which match the selector', function () {
-        var node = document.createElement('div');
+  describe('prototype', () => {
+    describe('gather', () => {
+      it('should gather nodes which match the selector', () => {
+        const node = document.createElement('div');
         node.id = 'monkeys';
         fixture.appendChild(node);
 
-        var rule = new Rule({
-            selector: '#monkeys'
-          }),
-          nodes = rule.gather({
-            include: [axe.utils.getFlattenedTree(fixture)[0]],
-            exclude: [],
-            frames: []
-          });
+        const rule = new Rule({
+          selector: '#monkeys'
+        });
+        let nodes = rule.gather({
+          include: [axe.utils.getFlattenedTree(fixture)[0]],
+          exclude: [],
+          frames: []
+        });
 
         assert.lengthOf(nodes, 1);
         assert.equal(nodes[0].actualNode, node);
@@ -52,33 +50,33 @@ describe('Rule', function () {
         assert.lengthOf(nodes, 0);
       });
 
-      it('should return a real array', function () {
-        var rule = new Rule({
-            selector: 'div'
-          }),
-          result = rule.gather({
-            include: [axe.utils.getFlattenedTree(fixture)[0]],
-            exclude: [],
-            frames: []
-          });
+      it('should return a real array', () => {
+        const rule = new Rule({
+          selector: 'div'
+        });
+        const result = rule.gather({
+          include: [axe.utils.getFlattenedTree(fixture)[0]],
+          exclude: [],
+          frames: []
+        });
 
         assert.isArray(result);
       });
 
-      it('should take a context parameter', function () {
-        var node = document.createElement('div');
+      it('should take a context parameter', () => {
+        const node = document.createElement('div');
         fixture.appendChild(node);
 
-        var rule = new Rule({
-            selector: 'div'
-          }),
-          nodes = rule.gather({
-            include: [
-              axe.utils.getFlattenedTree(
-                document.getElementById('fixture').firstChild
-              )[0]
-            ]
-          });
+        const rule = new Rule({
+          selector: 'div'
+        });
+        const nodes = rule.gather({
+          include: [
+            axe.utils.getFlattenedTree(
+              document.getElementById('fixture').firstChild
+            )[0]
+          ]
+        });
 
         assert.deepEqual(
           nodes.map(function (n) {
@@ -88,9 +86,9 @@ describe('Rule', function () {
         );
       });
 
-      it('should default to all nodes if selector is not specified', function () {
-        var nodes = [fixture],
-          node = document.createElement('div');
+      it('should default to all nodes if selector is not specified', () => {
+        const nodes = [fixture];
+        let node = document.createElement('div');
 
         fixture.appendChild(node);
         nodes.push(node);
@@ -100,7 +98,7 @@ describe('Rule', function () {
         fixture.appendChild(node);
         nodes.push(node);
 
-        var rule = new Rule({}),
+        const rule = new Rule({}),
           result = rule.gather({
             include: [
               axe.utils.getFlattenedTree(document.getElementById('fixture'))[0]
@@ -115,11 +113,11 @@ describe('Rule', function () {
           nodes
         );
       });
-      it('should exclude hidden elements', function () {
+      it('should exclude hidden elements', () => {
         fixture.innerHTML =
           '<div style="display: none"><span>HEHEHE</span></div>';
 
-        var rule = new Rule({}),
+        const rule = new Rule({}),
           result = rule.gather({
             include: [
               axe.utils.getFlattenedTree(
@@ -130,19 +128,19 @@ describe('Rule', function () {
 
         assert.lengthOf(result, 0);
       });
-      it('should include hidden elements if excludeHidden is false', function () {
+      it('should include hidden elements if excludeHidden is false', () => {
         fixture.innerHTML = '<div style="display: none"></div>';
 
-        var rule = new Rule({
-            excludeHidden: false
-          }),
-          result = rule.gather({
-            include: [
-              axe.utils.getFlattenedTree(
-                document.getElementById('fixture').firstChild
-              )[0]
-            ]
-          });
+        const rule = new Rule({
+          excludeHidden: false
+        });
+        const result = rule.gather({
+          include: [
+            axe.utils.getFlattenedTree(
+              document.getElementById('fixture').firstChild
+            )[0]
+          ]
+        });
 
         assert.deepEqual(
           result.map(function (n) {
@@ -153,29 +151,29 @@ describe('Rule', function () {
       });
     });
 
-    describe('run', function () {
-      it('should be a function', function () {
+    describe('run', () => {
+      it('should be a function', () => {
         assert.isFunction(Rule.prototype.run);
       });
 
-      it('should run #matches', function (done) {
-        var div = document.createElement('div');
+      it('should run #matches', done => {
+        const div = document.createElement('div');
         fixture.appendChild(div);
-        var success = false,
-          rule = new Rule({
-            matches: function (node) {
-              assert.equal(node, div);
-              success = true;
-              return [];
-            }
-          });
+        let success = false;
+        const rule = new Rule({
+          matches: function (node) {
+            assert.equal(node, div);
+            success = true;
+            return [];
+          }
+        });
 
         rule.run(
           {
             include: [axe.utils.getFlattenedTree(div)[0]]
           },
           {},
-          function () {
+          () => {
             assert.isTrue(success);
             done();
           },
@@ -183,10 +181,10 @@ describe('Rule', function () {
         );
       });
 
-      it('should pass a virtualNode to #matches', function (done) {
-        var div = document.createElement('div');
+      it('should pass a virtualNode to #matches', done => {
+        const div = document.createElement('div');
         fixture.appendChild(div);
-        var success = false,
+        let success = false,
           rule = new Rule({
             matches: function (node, virtualNode) {
               assert.equal(virtualNode.actualNode, div);
@@ -200,7 +198,7 @@ describe('Rule', function () {
             include: [axe.utils.getFlattenedTree(div)[0]]
           },
           {},
-          function () {
+          () => {
             assert.isTrue(success);
             done();
           },
@@ -208,10 +206,10 @@ describe('Rule', function () {
         );
       });
 
-      it('should pass a context to #matches', function (done) {
-        var div = document.createElement('div');
+      it('should pass a context to #matches', done => {
+        const div = document.createElement('div');
         fixture.appendChild(div);
-        var success = false,
+        let success = false,
           rule = new Rule({
             matches: function (node, virtualNode, context) {
               assert.isDefined(context);
@@ -227,7 +225,7 @@ describe('Rule', function () {
             include: [axe.utils.getFlattenedTree(div)[0]]
           },
           {},
-          function () {
+          () => {
             assert.isTrue(success);
             done();
           },
@@ -235,13 +233,13 @@ describe('Rule', function () {
         );
       });
 
-      it('should handle an error in #matches', function (done) {
-        var div = document.createElement('div');
+      it('should handle an error in #matches', done => {
+        const div = document.createElement('div');
         div.setAttribute('style', '#fff');
         fixture.appendChild(div);
-        var success = false,
+        let success = false,
           rule = new Rule({
-            matches: function () {
+            matches: () => {
               throw new Error('this is an error');
             }
           });
@@ -252,17 +250,17 @@ describe('Rule', function () {
           },
           {},
           isNotCalled,
-          function () {
+          () => {
             assert.isFalse(success);
             done();
           }
         );
       });
 
-      it('should execute Check#run on its child checks - any', function (done) {
+      it('should execute Check#run on its child checks - any', done => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var success = false;
-        var rule = new Rule(
+        let success = false;
+        const rule = new Rule(
           {
             any: ['cats']
           },
@@ -283,7 +281,7 @@ describe('Rule', function () {
             include: [axe.utils.getFlattenedTree(fixture)[0]]
           },
           {},
-          function () {
+          () => {
             assert.isTrue(success);
             done();
           },
@@ -291,10 +289,10 @@ describe('Rule', function () {
         );
       });
 
-      it('should execute Check#run on its child checks - all', function (done) {
+      it('should execute Check#run on its child checks - all', done => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var success = false;
-        var rule = new Rule(
+        let success = false;
+        const rule = new Rule(
           {
             all: ['cats']
           },
@@ -315,7 +313,7 @@ describe('Rule', function () {
             include: [axe.utils.getFlattenedTree(fixture)[0]]
           },
           {},
-          function () {
+          () => {
             assert.isTrue(success);
             done();
           },
@@ -323,10 +321,10 @@ describe('Rule', function () {
         );
       });
 
-      it('should execute Check#run on its child checks - none', function (done) {
+      it('should execute Check#run on its child checks - none', done => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var success = false;
-        var rule = new Rule(
+        let success = false;
+        const rule = new Rule(
           {
             none: ['cats']
           },
@@ -348,7 +346,7 @@ describe('Rule', function () {
             include: [axe.utils.getFlattenedTree(fixture)[0]]
           },
           {},
-          function () {
+          () => {
             assert.isTrue(success);
             done();
           },
@@ -356,9 +354,9 @@ describe('Rule', function () {
         );
       });
 
-      it('should pass the matching option to check.run', function (done) {
+      it('should pass the matching option to check.run', done => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var options = {
+        const options = {
           checks: {
             cats: {
               enabled: 'bananas',
@@ -366,7 +364,7 @@ describe('Rule', function () {
             }
           }
         };
-        var rule = new Rule(
+        const rule = new Rule(
           {
             none: ['cats']
           },
@@ -374,9 +372,9 @@ describe('Rule', function () {
             checks: {
               cats: {
                 id: 'cats',
-                run: function (node, options, context, resolve) {
-                  assert.equal(options.enabled, 'bananas');
-                  assert.equal(options.options, 'minkeys');
+                run: function (node, opts, context, resolve) {
+                  assert.equal(opts.enabled, 'bananas');
+                  assert.equal(opts.options, 'minkeys');
                   resolve(true);
                 }
               }
@@ -388,16 +386,16 @@ describe('Rule', function () {
             include: [axe.utils.getFlattenedTree(document)[0]]
           },
           options,
-          function () {
+          () => {
             done();
           },
           isNotCalled
         );
       });
 
-      it('should pass the matching option to check.run defined on the rule over global', function (done) {
+      it('should pass the matching option to check.run defined on the rule over global', done => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var options = {
+        const options = {
           rules: {
             cats: {
               checks: {
@@ -416,7 +414,7 @@ describe('Rule', function () {
           }
         };
 
-        var rule = new Rule(
+        const rule = new Rule(
           {
             id: 'cats',
             any: [
@@ -429,9 +427,9 @@ describe('Rule', function () {
             checks: {
               cats: {
                 id: 'cats',
-                run: function (node, options, context, resolve) {
-                  assert.equal(options.enabled, 'apples');
-                  assert.equal(options.options, 'apes');
+                run: function (node, opts, context, resolve) {
+                  assert.equal(opts.enabled, 'apples');
+                  assert.equal(opts.options, 'apes');
                   resolve(true);
                 }
               }
@@ -443,15 +441,15 @@ describe('Rule', function () {
             include: [axe.utils.getFlattenedTree(document)[0]]
           },
           options,
-          function () {
+          () => {
             done();
           },
           isNotCalled
         );
       });
 
-      it('should filter out null results', function () {
-        var rule = new Rule(
+      it('should filter out null results', () => {
+        const rule = new Rule(
           {
             selector: '#fixture',
             any: ['cats']
@@ -460,7 +458,7 @@ describe('Rule', function () {
             checks: {
               cats: {
                 id: 'cats',
-                run: function () {}
+                run: () => {}
               }
             }
           }
@@ -477,25 +475,25 @@ describe('Rule', function () {
         );
       });
 
-      describe.skip('DqElement', function () {
-        var origDqElement;
-        var isDqElementCalled;
+      describe.skip('DqElement', () => {
+        let origDqElement;
+        let isDqElementCalled;
 
-        beforeEach(function () {
+        beforeEach(() => {
           isDqElementCalled = false;
           origDqElement = axe.utils.DqElement;
-          axe.utils.DqElement = function () {
+          axe.utils.DqElement = () => {
             isDqElementCalled = true;
           };
           fixture.innerHTML = '<blink>Hi</blink>';
         });
 
-        afterEach(function () {
+        afterEach(() => {
           axe.utils.DqElement = origDqElement;
         });
 
-        it('is created for matching nodes', function (done) {
-          var rule = new Rule(
+        it('is created for matching nodes', done => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -504,10 +502,10 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: true,
-                  evaluate: function () {
+                  evaluate: () => {
                     return true;
                   },
-                  matches: function () {
+                  matches: () => {
                     return true;
                   }
                 })
@@ -519,7 +517,7 @@ describe('Rule', function () {
               include: [axe.utils.getFlattenedTree(fixture)[0]]
             },
             {},
-            function () {
+            () => {
               assert.isTrue(isDqElementCalled);
               done();
             },
@@ -527,8 +525,8 @@ describe('Rule', function () {
           );
         });
 
-        it('is not created for disabled checks', function (done) {
-          var rule = new Rule(
+        it('is not created for disabled checks', done => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -537,8 +535,8 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: false,
-                  evaluate: function () {},
-                  matches: function () {
+                  evaluate: () => {},
+                  matches: () => {
                     return true;
                   }
                 })
@@ -550,7 +548,7 @@ describe('Rule', function () {
               include: [axe.utils.getFlattenedTree(fixture)[0]]
             },
             {},
-            function () {
+            () => {
               assert.isFalse(isDqElementCalled);
               done();
             },
@@ -558,8 +556,8 @@ describe('Rule', function () {
           );
         });
 
-        it('is created for matching nodes', function (done) {
-          var rule = new Rule(
+        it('is created for matching nodes', done => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -568,7 +566,7 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: true,
-                  evaluate: function () {
+                  evaluate: () => {
                     return true;
                   }
                 })
@@ -580,7 +578,7 @@ describe('Rule', function () {
               include: [axe.utils.getFlattenedTree(fixture)[0]]
             },
             {},
-            function () {
+            () => {
               assert.isTrue(isDqElementCalled);
               done();
             },
@@ -588,8 +586,8 @@ describe('Rule', function () {
           );
         });
 
-        it('is not created for disabled checks', function (done) {
-          var rule = new Rule(
+        it('is not created for disabled checks', done => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -598,7 +596,7 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: false,
-                  evaluate: function () {}
+                  evaluate: () => {}
                 })
               }
             }
@@ -608,7 +606,7 @@ describe('Rule', function () {
               include: [axe.utils.getFlattenedTree(fixture)[0]]
             },
             {},
-            function () {
+            () => {
               assert.isFalse(isDqElementCalled);
               done();
             },
@@ -617,16 +615,16 @@ describe('Rule', function () {
         });
       });
 
-      it('should pass thrown errors to the reject param', function (done) {
+      it('should pass thrown errors to the reject param', done => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var rule = new Rule(
+        const rule = new Rule(
           {
             none: ['cats']
           },
           {
             checks: {
               cats: {
-                run: function () {
+                run: () => {
                   throw new Error('Holy hand grenade');
                 }
               }
@@ -648,9 +646,9 @@ describe('Rule', function () {
         );
       });
 
-      it('should pass reject calls to the reject param', function (done) {
+      it('should pass reject calls to the reject param', done => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var rule = new Rule(
+        const rule = new Rule(
           {
             none: ['cats']
           },
@@ -679,8 +677,8 @@ describe('Rule', function () {
         );
       });
 
-      it('should mark checks as incomplete if reviewOnFail is set to true', function (done) {
-        var rule = new Rule(
+      it('should mark checks as incomplete if reviewOnFail is set to true', done => {
+        const rule = new Rule(
           {
             reviewOnFail: true,
             all: ['cats'],
@@ -691,13 +689,13 @@ describe('Rule', function () {
             checks: {
               cats: new Check({
                 id: 'cats',
-                evaluate: function () {
+                evaluate: () => {
                   return false;
                 }
               }),
               dogs: new Check({
                 id: 'dogs',
-                evaluate: function () {
+                evaluate: () => {
                   return true;
                 }
               })
@@ -720,21 +718,21 @@ describe('Rule', function () {
         );
       });
 
-      describe('NODE rule', function () {
-        it('should create a RuleResult', function () {
-          var orig = window.RuleResult;
-          var success = false;
+      describe('NODE rule', () => {
+        it('should create a RuleResult', () => {
+          const orig = window.RuleResult;
+          let success = false;
           window.RuleResult = function (r) {
             this.nodes = [];
             assert.equal(rule, r);
             success = true;
           };
 
-          var rule = new Rule(
+          const rule = new Rule(
             {
               any: [
                 {
-                  evaluate: function () {},
+                  evaluate: () => {},
                   id: 'cats'
                 }
               ]
@@ -762,14 +760,14 @@ describe('Rule', function () {
 
           window.RuleResult = orig;
         });
-        it('should execute rule callback', function () {
-          var success = false;
+        it('should execute rule callback', () => {
+          let success = false;
 
-          var rule = new Rule(
+          const rule = new Rule(
             {
               any: [
                 {
-                  evaluate: function () {},
+                  evaluate: () => {},
                   id: 'cats'
                 }
               ]
@@ -790,7 +788,7 @@ describe('Rule', function () {
               include: [axe.utils.getFlattenedTree(document)[0]]
             },
             {},
-            function () {
+            () => {
               success = true;
             },
             isNotCalled
@@ -800,22 +798,22 @@ describe('Rule', function () {
       });
     });
 
-    describe('runSync', function () {
-      it('should be a function', function () {
+    describe('runSync', () => {
+      it('should be a function', () => {
         assert.isFunction(Rule.prototype.runSync);
       });
 
-      it('should run #matches', function () {
-        var div = document.createElement('div');
+      it('should run #matches', () => {
+        const div = document.createElement('div');
         fixture.appendChild(div);
-        var success = false,
-          rule = new Rule({
-            matches: function (node) {
-              assert.equal(node, div);
-              success = true;
-              return [];
-            }
-          });
+        let success = false;
+        const rule = new Rule({
+          matches: function (node) {
+            assert.equal(node, div);
+            success = true;
+            return [];
+          }
+        });
 
         try {
           rule.runSync(
@@ -830,17 +828,17 @@ describe('Rule', function () {
         }
       });
 
-      it('should pass a virtualNode to #matches', function () {
-        var div = document.createElement('div');
+      it('should pass a virtualNode to #matches', () => {
+        const div = document.createElement('div');
         fixture.appendChild(div);
-        var success = false,
-          rule = new Rule({
-            matches: function (node, virtualNode) {
-              assert.equal(virtualNode.actualNode, div);
-              success = true;
-              return [];
-            }
-          });
+        let success = false;
+        const rule = new Rule({
+          matches: function (node, virtualNode) {
+            assert.equal(virtualNode.actualNode, div);
+            success = true;
+            return [];
+          }
+        });
 
         try {
           rule.runSync(
@@ -855,19 +853,19 @@ describe('Rule', function () {
         }
       });
 
-      it('should pass a context to #matches', function () {
-        var div = document.createElement('div');
+      it('should pass a context to #matches', () => {
+        const div = document.createElement('div');
         fixture.appendChild(div);
-        var success = false,
-          rule = new Rule({
-            matches: function (node, virtualNode, context) {
-              assert.isDefined(context);
-              assert.hasAnyKeys(context, ['cssom', 'include', 'exclude']);
-              assert.lengthOf(context.include, 1);
-              success = true;
-              return [];
-            }
-          });
+        let success = false;
+        const rule = new Rule({
+          matches: function (node, virtualNode, context) {
+            assert.isDefined(context);
+            assert.hasAnyKeys(context, ['cssom', 'include', 'exclude']);
+            assert.lengthOf(context.include, 1);
+            success = true;
+            return [];
+          }
+        });
 
         try {
           rule.runSync(
@@ -882,13 +880,13 @@ describe('Rule', function () {
         }
       });
 
-      it('should handle an error in #matches', function () {
-        var div = document.createElement('div');
+      it('should handle an error in #matches', () => {
+        const div = document.createElement('div');
         div.setAttribute('style', '#fff');
         fixture.appendChild(div);
-        var success = false;
-        var rule = new Rule({
-          matches: function () {
+        let success = false;
+        const rule = new Rule({
+          matches: () => {
             throw new Error('this is an error');
           }
         });
@@ -906,17 +904,17 @@ describe('Rule', function () {
         }
       });
 
-      it('should execute Check#runSync on its child checks - any', function () {
+      it('should execute Check#runSync on its child checks - any', () => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var success = false;
-        var rule = new Rule(
+        let success = false;
+        const rule = new Rule(
           {
             any: ['cats']
           },
           {
             checks: {
               cats: {
-                runSync: function () {
+                runSync: () => {
                   success = true;
                 }
               }
@@ -937,17 +935,17 @@ describe('Rule', function () {
         }
       });
 
-      it('should execute Check#runSync on its child checks - all', function () {
+      it('should execute Check#runSync on its child checks - all', () => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var success = false;
-        var rule = new Rule(
+        let success = false;
+        const rule = new Rule(
           {
             all: ['cats']
           },
           {
             checks: {
               cats: {
-                runSync: function () {
+                runSync: () => {
                   success = true;
                 }
               }
@@ -968,17 +966,17 @@ describe('Rule', function () {
         }
       });
 
-      it('should execute Check#run on its child checks - none', function () {
+      it('should execute Check#run on its child checks - none', () => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var success = false;
-        var rule = new Rule(
+        let success = false;
+        const rule = new Rule(
           {
             none: ['cats']
           },
           {
             checks: {
               cats: {
-                runSync: function () {
+                runSync: () => {
                   success = true;
                 }
               }
@@ -1000,9 +998,9 @@ describe('Rule', function () {
         }
       });
 
-      it('should pass the matching option to check.runSync', function () {
+      it('should pass the matching option to check.runSync', () => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var options = {
+        const options = {
           checks: {
             cats: {
               enabled: 'bananas',
@@ -1010,7 +1008,7 @@ describe('Rule', function () {
             }
           }
         };
-        var rule = new Rule(
+        const rule = new Rule(
           {
             none: ['cats']
           },
@@ -1018,9 +1016,9 @@ describe('Rule', function () {
             checks: {
               cats: {
                 id: 'cats',
-                runSync: function (node, options) {
-                  assert.equal(options.enabled, 'bananas');
-                  assert.equal(options.options, 'minkeys');
+                runSync: function (node, opts) {
+                  assert.equal(opts.enabled, 'bananas');
+                  assert.equal(opts.options, 'minkeys');
                 }
               }
             }
@@ -1039,9 +1037,9 @@ describe('Rule', function () {
         }
       });
 
-      it('should pass the matching option to check.runSync defined on the rule over global', function () {
+      it('should pass the matching option to check.runSync defined on the rule over global', () => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var options = {
+        const options = {
           rules: {
             cats: {
               checks: {
@@ -1060,7 +1058,7 @@ describe('Rule', function () {
           }
         };
 
-        var rule = new Rule(
+        const rule = new Rule(
           {
             id: 'cats',
             any: [
@@ -1073,9 +1071,9 @@ describe('Rule', function () {
             checks: {
               cats: {
                 id: 'cats',
-                runSync: function (node, options) {
-                  assert.equal(options.enabled, 'apples');
-                  assert.equal(options.options, 'apes');
+                runSync: function (node, opts) {
+                  assert.equal(opts.enabled, 'apples');
+                  assert.equal(opts.options, 'apes');
                 }
               }
             }
@@ -1094,8 +1092,8 @@ describe('Rule', function () {
         }
       });
 
-      it('should filter out null results', function () {
-        var rule = new Rule(
+      it('should filter out null results', () => {
+        const rule = new Rule(
           {
             selector: '#fixture',
             any: ['cats']
@@ -1104,14 +1102,14 @@ describe('Rule', function () {
             checks: {
               cats: {
                 id: 'cats',
-                runSync: function () {}
+                runSync: () => {}
               }
             }
           }
         );
 
         try {
-          var r = rule.runSync(
+          const r = rule.runSync(
             {
               include: [axe.utils.getFlattenedTree(document)[0]]
             },
@@ -1123,25 +1121,25 @@ describe('Rule', function () {
         }
       });
 
-      describe.skip('DqElement', function () {
-        var origDqElement;
-        var isDqElementCalled;
+      describe.skip('DqElement', () => {
+        let origDqElement;
+        let isDqElementCalled;
 
-        beforeEach(function () {
+        beforeEach(() => {
           isDqElementCalled = false;
           origDqElement = axe.utils.DqElement;
-          axe.utils.DqElement = function () {
+          axe.utils.DqElement = () => {
             isDqElementCalled = true;
           };
           fixture.innerHTML = '<blink>Hi</blink>';
         });
 
-        afterEach(function () {
+        afterEach(() => {
           axe.utils.DqElement = origDqElement;
         });
 
-        it('is created for matching nodes', function () {
-          var rule = new Rule(
+        it('is created for matching nodes', () => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -1150,10 +1148,10 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: true,
-                  evaluate: function () {
+                  evaluate: () => {
                     return true;
                   },
-                  matches: function () {
+                  matches: () => {
                     return true;
                   }
                 })
@@ -1174,8 +1172,8 @@ describe('Rule', function () {
           }
         });
 
-        it('is not created for disabled checks', function () {
-          var rule = new Rule(
+        it('is not created for disabled checks', () => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -1184,8 +1182,8 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: false,
-                  evaluate: function () {},
-                  matches: function () {
+                  evaluate: () => {},
+                  matches: () => {
                     return true;
                   }
                 })
@@ -1206,8 +1204,8 @@ describe('Rule', function () {
           }
         });
 
-        it('is created for matching nodes', function () {
-          var rule = new Rule(
+        it('is created for matching nodes', () => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -1216,7 +1214,7 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: true,
-                  evaluate: function () {
+                  evaluate: () => {
                     return true;
                   }
                 })
@@ -1237,8 +1235,8 @@ describe('Rule', function () {
           }
         });
 
-        it('is not created for disabled checks', function () {
-          var rule = new Rule(
+        it('is not created for disabled checks', () => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -1247,7 +1245,7 @@ describe('Rule', function () {
                 cats: new Check({
                   id: 'cats',
                   enabled: false,
-                  evaluate: function () {}
+                  evaluate: () => {}
                 })
               }
             }
@@ -1257,15 +1255,15 @@ describe('Rule', function () {
               include: [axe.utils.getFlattenedTree(fixture)[0]]
             },
             {},
-            function () {
+            () => {
               assert.isFalse(isDqElementCalled);
             },
             isNotCalled
           );
         });
 
-        it('should not be called when there is no actualNode', function () {
-          var rule = new Rule(
+        it('should not be called when there is no actualNode', () => {
+          const rule = new Rule(
             {
               all: ['cats']
             },
@@ -1273,13 +1271,13 @@ describe('Rule', function () {
               checks: {
                 cats: new Check({
                   id: 'cats',
-                  evaluate: function () {}
+                  evaluate: () => {}
                 })
               }
             }
           );
           rule.excludeHidden = false; // so we don't call utils.isHidden
-          var vNode = {
+          const vNode = {
             shadowId: undefined,
             children: [],
             parent: undefined,
@@ -1295,7 +1293,7 @@ describe('Rule', function () {
               id: null,
               type: 'text'
             },
-            hasClass: function () {
+            hasClass: () => {
               return false;
             },
             attr: function (attrName) {
@@ -1310,7 +1308,7 @@ describe('Rule', function () {
               include: [vNode]
             },
             {},
-            function () {
+            () => {
               assert.isFalse(isDqElementCalled);
             },
             isNotCalled
@@ -1318,16 +1316,16 @@ describe('Rule', function () {
         });
       });
 
-      it('should pass thrown errors to the reject param', function () {
+      it('should pass thrown errors to the reject param', () => {
         fixture.innerHTML = '<blink>Hi</blink>';
-        var rule = new Rule(
+        const rule = new Rule(
           {
             none: ['cats']
           },
           {
             checks: {
               cats: {
-                runSync: function () {
+                runSync: () => {
                   throw new Error('Holy hand grenade');
                 }
               }
@@ -1348,8 +1346,8 @@ describe('Rule', function () {
         }
       });
 
-      it('should mark checks as incomplete if reviewOnFail is set to true', function () {
-        var rule = new Rule(
+      it('should mark checks as incomplete if reviewOnFail is set to true', () => {
+        const rule = new Rule(
           {
             reviewOnFail: true,
             all: ['cats'],
@@ -1360,13 +1358,13 @@ describe('Rule', function () {
             checks: {
               cats: new Check({
                 id: 'cats',
-                evaluate: function () {
+                evaluate: () => {
                   return false;
                 }
               }),
               dogs: new Check({
                 id: 'dogs',
-                evaluate: function () {
+                evaluate: () => {
                   return true;
                 }
               })
@@ -1374,7 +1372,7 @@ describe('Rule', function () {
           }
         );
 
-        var results = rule.runSync(
+        const results = rule.runSync(
           {
             include: [axe.utils.getFlattenedTree(fixture)[0]]
           },
@@ -1386,21 +1384,21 @@ describe('Rule', function () {
         assert.isUndefined(results.nodes[0].none[0].result);
       });
 
-      describe.skip('NODE rule', function () {
-        it('should create a RuleResult', function () {
-          var orig = window.RuleResult;
-          var success = false;
+      describe.skip('NODE rule', () => {
+        it('should create a RuleResult', () => {
+          const orig = window.RuleResult;
+          let success = false;
           window.RuleResult = function (r) {
             this.nodes = [];
             assert.equal(rule, r);
             success = true;
           };
 
-          var rule = new Rule(
+          const rule = new Rule(
             {
               any: [
                 {
-                  evaluate: function () {},
+                  evaluate: () => {},
                   id: 'cats'
                 }
               ]
@@ -1408,7 +1406,7 @@ describe('Rule', function () {
             {
               checks: {
                 cats: {
-                  runSync: function () {}
+                  runSync: () => {}
                 }
               }
             }
@@ -1429,14 +1427,14 @@ describe('Rule', function () {
           window.RuleResult = orig;
         });
 
-        it('should execute rule callback', function () {
-          var success = false;
+        it('should execute rule callback', () => {
+          let success = false;
 
-          var rule = new Rule(
+          const rule = new Rule(
             {
               any: [
                 {
-                  evaluate: function () {},
+                  evaluate: () => {},
                   id: 'cats'
                 }
               ]
@@ -1444,7 +1442,7 @@ describe('Rule', function () {
             {
               checks: {
                 cats: {
-                  runSync: function () {
+                  runSync: () => {
                     success = true;
                   }
                 }
@@ -1468,11 +1466,11 @@ describe('Rule', function () {
       });
     });
 
-    describe('after', function () {
-      it('should execute Check#after with options', function () {
-        var success = false;
+    describe('after', () => {
+      it('should execute Check#after with options', () => {
+        let success = false;
 
-        var rule = new Rule(
+        const rule = new Rule(
           {
             id: 'cats',
             any: ['cats']
@@ -1514,10 +1512,10 @@ describe('Rule', function () {
         assert.isTrue(success);
       });
 
-      it('should add the check node to the check result', function () {
-        var success = false;
+      it('should add the check node to the check result', () => {
+        let success = false;
 
-        var rule = new Rule(
+        const rule = new Rule(
           {
             id: 'cats',
             any: ['cats']
@@ -1560,8 +1558,8 @@ describe('Rule', function () {
         assert.isTrue(success);
       });
 
-      it('should filter removed checks', function () {
-        var rule = new Rule(
+      it('should filter removed checks', () => {
+        const rule = new Rule(
           {
             id: 'cats',
             any: ['cats']
@@ -1578,7 +1576,7 @@ describe('Rule', function () {
           }
         );
 
-        var result = rule.after(
+        const result = rule.after(
           {
             id: 'cats',
             nodes: [
@@ -1612,10 +1610,10 @@ describe('Rule', function () {
         assert.isTrue(result.nodes[0].all[0].result);
       });
 
-      it('should combine all checks for pageLevel rules', function () {
-        var rule = new Rule({});
+      it('should combine all checks for pageLevel rules', () => {
+        const rule = new Rule({});
 
-        var result = rule.after(
+        const result = rule.after(
           {
             id: 'cats',
             pageLevel: true,
@@ -1659,9 +1657,9 @@ describe('Rule', function () {
       });
     });
 
-    describe('after', function () {
-      it('should mark checks as incomplete if reviewOnFail is set to true for all', function () {
-        var rule = new Rule(
+    describe('after', () => {
+      it('should mark checks as incomplete if reviewOnFail is set to true for all', () => {
+        const rule = new Rule(
           {
             id: 'cats',
             reviewOnFail: true,
@@ -1683,7 +1681,7 @@ describe('Rule', function () {
           }
         );
 
-        var result = rule.after(
+        const result = rule.after(
           {
             id: 'cats',
             nodes: [
@@ -1707,8 +1705,8 @@ describe('Rule', function () {
         assert.isUndefined(result.nodes[0].all[0].result);
       });
 
-      it('should mark checks as incomplete if reviewOnFail is set to true for any', function () {
-        var rule = new Rule(
+      it('should mark checks as incomplete if reviewOnFail is set to true for any', () => {
+        const rule = new Rule(
           {
             id: 'cats',
             reviewOnFail: true,
@@ -1730,7 +1728,7 @@ describe('Rule', function () {
           }
         );
 
-        var result = rule.after(
+        const result = rule.after(
           {
             id: 'cats',
             nodes: [
@@ -1754,8 +1752,8 @@ describe('Rule', function () {
         assert.isEmpty(result.nodes[0].all);
       });
 
-      it('should mark checks as incomplete if reviewOnFail is set to true for none', function () {
-        var rule = new Rule(
+      it('should mark checks as incomplete if reviewOnFail is set to true for none', () => {
+        const rule = new Rule(
           {
             id: 'cats',
             reviewOnFail: true,
@@ -1777,7 +1775,7 @@ describe('Rule', function () {
           }
         );
 
-        var result = rule.after(
+        const result = rule.after(
           {
             id: 'cats',
             nodes: [
@@ -1803,143 +1801,143 @@ describe('Rule', function () {
     });
   });
 
-  describe('spec object', function () {
-    describe('.selector', function () {
-      it('should be set', function () {
-        var spec = {
+  describe('spec object', () => {
+    describe('.selector', () => {
+      it('should be set', () => {
+        const spec = {
           selector: '#monkeys'
         };
         assert.equal(new Rule(spec).selector, spec.selector);
       });
 
-      it('should default to *', function () {
-        var spec = {};
+      it('should default to *', () => {
+        const spec = {};
         assert.equal(new Rule(spec).selector, '*');
       });
     });
 
-    describe('.enabled', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.enabled', () => {
+      it('should be set', () => {
+        const spec = {
           enabled: false
         };
         assert.equal(new Rule(spec).enabled, spec.enabled);
       });
 
-      it('should default to true', function () {
-        var spec = {};
+      it('should default to true', () => {
+        const spec = {};
         assert.isTrue(new Rule(spec).enabled);
       });
 
-      it('should default to true if given a bad value', function () {
-        var spec = {
+      it('should default to true if given a bad value', () => {
+        const spec = {
           enabled: 'monkeys'
         };
         assert.isTrue(new Rule(spec).enabled);
       });
     });
 
-    describe('.excludeHidden', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.excludeHidden', () => {
+      it('should be set', () => {
+        const spec = {
           excludeHidden: false
         };
         assert.equal(new Rule(spec).excludeHidden, spec.excludeHidden);
       });
 
-      it('should default to true', function () {
-        var spec = {};
+      it('should default to true', () => {
+        const spec = {};
         assert.isTrue(new Rule(spec).excludeHidden);
       });
 
-      it('should default to true if given a bad value', function () {
-        var spec = {
+      it('should default to true if given a bad value', () => {
+        const spec = {
           excludeHidden: 'monkeys'
         };
         assert.isTrue(new Rule(spec).excludeHidden);
       });
     });
 
-    describe('.pageLevel', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.pageLevel', () => {
+      it('should be set', () => {
+        const spec = {
           pageLevel: false
         };
         assert.equal(new Rule(spec).pageLevel, spec.pageLevel);
       });
 
-      it('should default to false', function () {
-        var spec = {};
+      it('should default to false', () => {
+        const spec = {};
         assert.isFalse(new Rule(spec).pageLevel);
       });
 
-      it('should default to false if given a bad value', function () {
-        var spec = {
+      it('should default to false if given a bad value', () => {
+        const spec = {
           pageLevel: 'monkeys'
         };
         assert.isFalse(new Rule(spec).pageLevel);
       });
     });
 
-    describe('.reviewOnFail', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.reviewOnFail', () => {
+      it('should be set', () => {
+        const spec = {
           reviewOnFail: true
         };
         assert.equal(new Rule(spec).reviewOnFail, spec.reviewOnFail);
       });
 
-      it('should default to false', function () {
-        var spec = {};
+      it('should default to false', () => {
+        const spec = {};
         assert.isFalse(new Rule(spec).reviewOnFail);
       });
 
-      it('should default to false if given a bad value', function () {
-        var spec = {
+      it('should default to false if given a bad value', () => {
+        const spec = {
           reviewOnFail: 'monkeys'
         };
         assert.isFalse(new Rule(spec).reviewOnFail);
       });
     });
 
-    describe('.id', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.id', () => {
+      it('should be set', () => {
+        const spec = {
           id: 'monkeys'
         };
         assert.equal(new Rule(spec).id, spec.id);
       });
 
-      it('should have no default', function () {
-        var spec = {};
+      it('should have no default', () => {
+        const spec = {};
         assert.equal(new Rule(spec).id, spec.id);
       });
     });
 
-    describe('.impact', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.impact', () => {
+      it('should be set', () => {
+        const spec = {
           impact: 'critical'
         };
         assert.equal(new Rule(spec).impact, spec.impact);
       });
 
-      it('should have no default', function () {
-        var spec = {};
+      it('should have no default', () => {
+        const spec = {};
         assert.isUndefined(new Rule(spec).impact);
       });
 
-      it('throws if impact is invalid', function () {
-        assert.throws(function () {
+      it('throws if impact is invalid', () => {
+        assert.throws(() => {
           // eslint-disable-next-line no-new
           new Rule({ impact: 'hello' });
         });
       });
     });
 
-    describe('.any', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.any', () => {
+      it('should be set', () => {
+        const spec = {
           any: [
             {
               name: 'monkeys'
@@ -1956,9 +1954,9 @@ describe('Rule', function () {
       });
     });
 
-    describe('.all', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.all', () => {
+      it('should be set', () => {
+        const spec = {
           all: [
             {
               name: 'monkeys'
@@ -1975,9 +1973,9 @@ describe('Rule', function () {
       });
     });
 
-    describe('.none', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.none', () => {
+      it('should be set', () => {
+        const spec = {
           none: [
             {
               name: 'monkeys'
@@ -1994,162 +1992,162 @@ describe('Rule', function () {
       });
     });
 
-    describe('.matches', function () {
-      it('should be set', function () {
-        var spec = {
-          matches: function () {}
+    describe('.matches', () => {
+      it('should be set', () => {
+        const spec = {
+          matches: () => {}
         };
         assert.equal(new Rule(spec).matches, spec.matches);
       });
 
-      it('should default to prototype', function () {
-        var spec = {};
+      it('should default to prototype', () => {
+        const spec = {};
         assert.equal(new Rule(spec).matches, Rule.prototype.matches);
       });
 
-      it('should turn a string into a function', function () {
-        var spec = {
+      it('should turn a string into a function', () => {
+        const spec = {
           matches: 'function() {return "blah";}'
         };
         assert.equal(new Rule(spec).matches(), 'blah');
       });
     });
 
-    describe('.tags', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.tags', () => {
+      it('should be set', () => {
+        const spec = {
           tags: ['foo', 'bar']
         };
         assert.deepEqual(new Rule(spec).tags, spec.tags);
       });
 
-      it('should default to empty array', function () {
-        var spec = {};
+      it('should default to empty array', () => {
+        const spec = {};
         assert.deepEqual(new Rule(spec).tags, []);
       });
     });
 
-    describe('.actIds', function () {
-      it('should be set', function () {
-        var spec = {
+    describe('.actIds', () => {
+      it('should be set', () => {
+        const spec = {
           actIds: ['abc123', 'xyz789']
         };
         assert.deepEqual(new Rule(spec).actIds, spec.actIds);
       });
 
-      it('should default to undefined', function () {
-        var spec = {};
+      it('should default to undefined', () => {
+        const spec = {};
         assert.isUndefined(new Rule(spec).actIds);
       });
     });
   });
 
-  describe('configure', function () {
-    beforeEach(function () {
+  describe('configure', () => {
+    beforeEach(() => {
       Rule.prototype._get = function (attr) {
         return this[attr];
       };
     });
-    afterEach(function () {
+    afterEach(() => {
       delete Rule.prototype._get;
     });
-    it('should be a function that takes one argument', function () {
+    it('should be a function that takes one argument', () => {
       assert.isFunction(Rule.prototype.configure);
       assert.lengthOf(new Rule({}).configure, 1);
     });
-    it('should NOT override the id', function () {
-      var rule = new Rule({ id: 'foo' });
+    it('should NOT override the id', () => {
+      const rule = new Rule({ id: 'foo' });
 
       assert.equal(rule._get('id'), 'foo');
       rule.configure({ id: 'fong' });
       assert.equal(rule._get('id'), 'foo');
     });
-    it('should NOT override a random property', function () {
-      var rule = new Rule({ id: 'foo' });
+    it('should NOT override a random property', () => {
+      const rule = new Rule({ id: 'foo' });
 
       rule.configure({ fong: 'fong' });
       assert.equal(rule._get('fong'), undefined);
     });
-    it('should override the selector', function () {
-      var rule = new Rule({ selector: 'foo' });
+    it('should override the selector', () => {
+      const rule = new Rule({ selector: 'foo' });
 
       assert.equal(rule._get('selector'), 'foo');
       rule.configure({ selector: 'fong' });
       assert.equal(rule._get('selector'), 'fong');
     });
-    it('should override excludeHidden', function () {
-      var rule = new Rule({ excludeHidden: false });
+    it('should override excludeHidden', () => {
+      const rule = new Rule({ excludeHidden: false });
 
       assert.equal(rule._get('excludeHidden'), false);
       rule.configure({ excludeHidden: true });
       assert.equal(rule._get('excludeHidden'), true);
     });
-    it('should override enabled', function () {
-      var rule = new Rule({ enabled: false });
+    it('should override enabled', () => {
+      const rule = new Rule({ enabled: false });
 
       assert.equal(rule._get('enabled'), false);
       rule.configure({ enabled: true });
       assert.equal(rule._get('enabled'), true);
     });
-    it('should override pageLevel', function () {
-      var rule = new Rule({ pageLevel: false });
+    it('should override pageLevel', () => {
+      const rule = new Rule({ pageLevel: false });
 
       assert.equal(rule._get('pageLevel'), false);
       rule.configure({ pageLevel: true });
       assert.equal(rule._get('pageLevel'), true);
     });
-    it('should override reviewOnFail', function () {
-      var rule = new Rule({ reviewOnFail: false });
+    it('should override reviewOnFail', () => {
+      const rule = new Rule({ reviewOnFail: false });
 
       assert.equal(rule._get('reviewOnFail'), false);
       rule.configure({ reviewOnFail: true });
       assert.equal(rule._get('reviewOnFail'), true);
     });
-    it('should override any', function () {
-      var rule = new Rule({ any: ['one', 'two'] });
+    it('should override any', () => {
+      const rule = new Rule({ any: ['one', 'two'] });
 
       assert.deepEqual(rule._get('any'), ['one', 'two']);
       rule.configure({ any: [] });
       assert.deepEqual(rule._get('any'), []);
     });
-    it('should override all', function () {
-      var rule = new Rule({ all: ['one', 'two'] });
+    it('should override all', () => {
+      const rule = new Rule({ all: ['one', 'two'] });
 
       assert.deepEqual(rule._get('all'), ['one', 'two']);
       rule.configure({ all: [] });
       assert.deepEqual(rule._get('all'), []);
     });
-    it('should override none', function () {
-      var rule = new Rule({ none: ['none', 'two'] });
+    it('should override none', () => {
+      const rule = new Rule({ none: ['none', 'two'] });
 
       assert.deepEqual(rule._get('none'), ['none', 'two']);
       rule.configure({ none: [] });
       assert.deepEqual(rule._get('none'), []);
     });
-    it('should override tags', function () {
-      var rule = new Rule({ tags: ['tags', 'two'] });
+    it('should override tags', () => {
+      const rule = new Rule({ tags: ['tags', 'two'] });
 
       assert.deepEqual(rule._get('tags'), ['tags', 'two']);
       rule.configure({ tags: [] });
       assert.deepEqual(rule._get('tags'), []);
     });
-    it('should override matches (doT.js function)', function () {
-      var rule = new Rule({ matches: 'function () {return "matches";}' });
+    it('should override matches (doT.js function)', () => {
+      const rule = new Rule({ matches: 'function () {return "matches";}' });
 
       assert.equal(rule._get('matches')(), 'matches');
       rule.configure({ matches: 'function () {return "does not match";}' });
       assert.equal(rule._get('matches')(), 'does not match');
     });
-    it('should override matches (metadata function name)', function () {
+    it('should override matches (metadata function name)', () => {
       axe._load({});
-      metadataFunctionMap['custom-matches'] = function () {
+      metadataFunctionMap['custom-matches'] = () => {
         return 'custom-matches';
       };
-      metadataFunctionMap['other-matches'] = function () {
+      metadataFunctionMap['other-matches'] = () => {
         return 'other-matches';
       };
 
-      var rule = new Rule({ matches: 'custom-matches' });
+      const rule = new Rule({ matches: 'custom-matches' });
 
       assert.equal(rule._get('matches')(), 'custom-matches');
       rule.configure({ matches: 'other-matches' });
@@ -2158,9 +2156,9 @@ describe('Rule', function () {
       delete metadataFunctionMap['custom-matches'];
       delete metadataFunctionMap['other-matches'];
     });
-    it('should error if matches does not match an ID', function () {
+    it('should error if matches does not match an ID', () => {
       function fn() {
-        var rule = new Rule({});
+        const rule = new Rule({});
         rule.configure({ matches: 'does-not-exist' });
       }
 
@@ -2169,17 +2167,17 @@ describe('Rule', function () {
         'Function ID does not exist in the metadata-function-map: does-not-exist'
       );
     });
-    it('should override impact', function () {
-      var rule = new Rule({ impact: 'minor' });
+    it('should override impact', () => {
+      const rule = new Rule({ impact: 'minor' });
 
       assert.equal(rule._get('impact'), 'minor');
       rule.configure({ impact: 'serious' });
       assert.equal(rule._get('impact'), 'serious');
     });
-    it('should throw if impact impact', function () {
-      var rule = new Rule({ impact: 'minor' });
+    it('should throw if impact impact', () => {
+      const rule = new Rule({ impact: 'minor' });
 
-      assert.throws(function () {
+      assert.throws(() => {
         rule.configure({ impact: 'hello' });
       });
     });

--- a/test/core/base/virtual-node/virtual-node.js
+++ b/test/core/base/virtual-node/virtual-node.js
@@ -1,25 +1,23 @@
-describe('VirtualNode', function () {
-  'use strict';
+describe('VirtualNode', () => {
+  const VirtualNode = axe.VirtualNode;
+  let node;
 
-  var VirtualNode = axe.VirtualNode;
-  var node;
-
-  beforeEach(function () {
+  beforeEach(() => {
     node = document.createElement('div');
   });
 
-  it('should be a function', function () {
+  it('should be a function', () => {
     assert.isFunction(VirtualNode);
   });
 
-  it('should accept three parameters', function () {
+  it('should accept three parameters', () => {
     assert.lengthOf(VirtualNode, 3);
   });
 
-  describe('prototype', function () {
-    it('should have public properties', function () {
-      var parent = {};
-      var vNode = new VirtualNode(node, parent, 'foo');
+  describe('prototype', () => {
+    it('should have public properties', () => {
+      const parent = {};
+      const vNode = new VirtualNode(node, parent, 'foo');
 
       assert.equal(vNode.shadowId, 'foo');
       assert.typeOf(vNode.children, 'array');
@@ -27,10 +25,10 @@ describe('VirtualNode', function () {
       assert.equal(vNode.parent, parent);
     });
 
-    it('should abstract Node properties', function () {
+    it('should abstract Node properties', () => {
       node = document.createElement('input');
       node.id = 'monkeys';
-      var vNode = new VirtualNode(node);
+      const vNode = new VirtualNode(node);
 
       assert.isDefined(vNode.props);
       assert.equal(vNode.props.nodeType, 1);
@@ -39,9 +37,9 @@ describe('VirtualNode', function () {
       assert.equal(vNode.props.type, 'text');
     });
 
-    it('should reflect selected property', function () {
+    it('should reflect selected property', () => {
       node = document.createElement('option');
-      var vNode = new VirtualNode(node);
+      let vNode = new VirtualNode(node);
       assert.equal(vNode.props.selected, false);
 
       node.selected = true;
@@ -49,125 +47,125 @@ describe('VirtualNode', function () {
       assert.equal(vNode.props.selected, true);
     });
 
-    it('should lowercase type', function () {
-      var node = document.createElement('input');
+    it('should lowercase type', () => {
+      node = document.createElement('input');
       node.setAttribute('type', 'COLOR');
-      var vNode = new VirtualNode(node);
+      const vNode = new VirtualNode(node);
 
       assert.equal(vNode.props.type, 'color');
     });
 
-    it('should default type to text', function () {
-      var node = document.createElement('input');
-      var vNode = new VirtualNode(node);
+    it('should default type to text', () => {
+      node = document.createElement('input');
+      const vNode = new VirtualNode(node);
 
       assert.equal(vNode.props.type, 'text');
     });
 
-    it('should default type to text if type is invalid', function () {
-      var node = document.createElement('input');
+    it('should default type to text if type is invalid', () => {
+      node = document.createElement('input');
       node.setAttribute('type', 'woohoo');
-      var vNode = new VirtualNode(node);
+      const vNode = new VirtualNode(node);
 
       assert.equal(vNode.props.type, 'text');
     });
 
-    it('should lowercase nodeName', function () {
-      var node = {
+    it('should lowercase nodeName', () => {
+      node = {
         nodeName: 'FOOBAR'
       };
-      var vNode = new VirtualNode(node);
+      const vNode = new VirtualNode(node);
 
       assert.equal(vNode.props.nodeName, 'foobar');
     });
 
-    describe('attr', function () {
-      it('should return the value of the given attribute', function () {
+    describe('attr', () => {
+      it('should return the value of the given attribute', () => {
         node.setAttribute('data-foo', 'bar');
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
 
         assert.equal(vNode.attr('data-foo'), 'bar');
       });
 
-      it('should return null for text nodes', function () {
+      it('should return null for text nodes', () => {
         node.textContent = 'hello';
-        var vNode = new VirtualNode(node.firstChild);
+        const vNode = new VirtualNode(node.firstChild);
 
         assert.isNull(vNode.attr('data-foo'));
       });
 
-      it('should return null if getAttribute is not a function', function () {
-        var node = {
+      it('should return null if getAttribute is not a function', () => {
+        node = {
           nodeName: 'DIV',
           getAttribute: null
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
 
         assert.isNull(vNode.attr('data-foo'));
       });
     });
 
-    describe('hasAttr', function () {
-      it('should return true if the element has the attribute', function () {
+    describe('hasAttr', () => {
+      it('should return true if the element has the attribute', () => {
         node.setAttribute('foo', 'bar');
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
 
         assert.isTrue(vNode.hasAttr('foo'));
       });
 
-      it('should return false if the element does not have the attribute', function () {
-        var vNode = new VirtualNode(node);
+      it('should return false if the element does not have the attribute', () => {
+        const vNode = new VirtualNode(node);
 
         assert.isFalse(vNode.hasAttr('foo'));
       });
 
-      it('should return false for text nodes', function () {
+      it('should return false for text nodes', () => {
         node.textContent = 'hello';
-        var vNode = new VirtualNode(node.firstChild);
+        const vNode = new VirtualNode(node.firstChild);
 
         assert.isFalse(vNode.hasAttr('foo'));
       });
 
-      it('should return false if hasAttribute is not a function', function () {
-        var node = {
+      it('should return false if hasAttribute is not a function', () => {
+        node = {
           nodeName: 'DIV',
           hasAttribute: null
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
 
         assert.isFalse(vNode.hasAttr('foo'));
       });
     });
 
-    describe('attrNames', function () {
-      it('should return a list of attribute names', function () {
+    describe('attrNames', () => {
+      it('should return a list of attribute names', () => {
         node.setAttribute('foo', 'bar');
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
 
         assert.deepEqual(vNode.attrNames, ['foo']);
       });
 
-      it('should work with clobbered attributes', function () {
-        var node = document.createElement('form');
+      it('should work with clobbered attributes', () => {
+        node = document.createElement('form');
         node.setAttribute('id', '123');
         node.innerHTML = '<select name="attributes"></select>';
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
 
         assert.deepEqual(vNode.attrNames, ['id']);
       });
 
-      it('should return an empty array if there are no attributes', function () {
-        var vNode = new VirtualNode(node);
+      it('should return an empty array if there are no attributes', () => {
+        const vNode = new VirtualNode(node);
         assert.deepEqual(vNode.attrNames, []);
       });
     });
 
-    describe('nodeIndex', function () {
-      it('increments nodeIndex when a parent is passed', function () {
-        var vHtml = new VirtualNode({ nodeName: 'html' });
-        var vHead = new VirtualNode({ nodeName: 'head' }, vHtml);
-        var vTitle = new VirtualNode({ nodeName: 'title' }, vHead);
-        var vBody = new VirtualNode({ nodeName: 'body' }, vHtml);
+    describe('nodeIndex', () => {
+      it('increments nodeIndex when a parent is passed', () => {
+        const vHtml = new VirtualNode({ nodeName: 'html' });
+        const vHead = new VirtualNode({ nodeName: 'head' }, vHtml);
+        const vTitle = new VirtualNode({ nodeName: 'title' }, vHead);
+        const vBody = new VirtualNode({ nodeName: 'body' }, vHtml);
 
         assert.equal(vHtml.nodeIndex, 0);
         assert.equal(vHead.nodeIndex, 1);
@@ -175,9 +173,9 @@ describe('VirtualNode', function () {
         assert.equal(vBody.nodeIndex, 3);
       });
 
-      it('resets nodeIndex when no parent is passed', function () {
-        var vHtml = new VirtualNode({ nodeName: 'html' });
-        var vHead = new VirtualNode({ nodeName: 'head' }, vHtml);
+      it('resets nodeIndex when no parent is passed', () => {
+        let vHtml = new VirtualNode({ nodeName: 'html' });
+        let vHead = new VirtualNode({ nodeName: 'head' }, vHtml);
         assert.equal(vHtml.nodeIndex, 0);
         assert.equal(vHead.nodeIndex, 1);
 
@@ -189,12 +187,12 @@ describe('VirtualNode', function () {
     });
 
     describe('checkbox properties', () => {
-      it('should reflect the checked property', function () {
+      it('should reflect the checked property', () => {
         const div = document.createElement('div');
         const vDiv = new VirtualNode(div);
         assert.isUndefined(vDiv.props.checked);
 
-        const node = document.createElement('input');
+        node = document.createElement('input');
         node.setAttribute('type', 'checkbox');
         const vUnchecked = new VirtualNode(node);
         assert.isFalse(vUnchecked.props.checked);
@@ -209,7 +207,7 @@ describe('VirtualNode', function () {
         const vDiv = new VirtualNode(div);
         assert.isUndefined(vDiv.props.indeterminate);
 
-        const node = document.createElement('input');
+        node = document.createElement('input');
         node.setAttribute('type', 'checkbox');
         const vUnchecked = new VirtualNode(node);
         assert.isFalse(vUnchecked.props.indeterminate);
@@ -220,42 +218,42 @@ describe('VirtualNode', function () {
       });
     });
 
-    describe.skip('isFocusable', function () {
-      var commons;
+    describe.skip('isFocusable', () => {
+      let commons;
 
-      beforeEach(function () {
+      beforeEach(() => {
         commons = axe.commons = axe.commons;
       });
 
-      afterEach(function () {
+      afterEach(() => {
         axe.commons = commons;
       });
 
-      it('should call dom.isFocusable', function () {
-        var called = false;
+      it('should call dom.isFocusable', () => {
+        let called = false;
         axe.commons = {
           dom: {
-            isFocusable: function () {
+            isFocusable: () => {
               called = true;
             }
           }
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.isFocusable;
 
         assert.isTrue(called);
       });
 
-      it('should only call dom.isFocusable once', function () {
-        var count = 0;
+      it('should only call dom.isFocusable once', () => {
+        let count = 0;
         axe.commons = {
           dom: {
-            isFocusable: function () {
+            isFocusable: () => {
               count++;
             }
           }
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.isFocusable;
         vNode.isFocusable;
         vNode.isFocusable;
@@ -263,42 +261,42 @@ describe('VirtualNode', function () {
       });
     });
 
-    describe.skip('tabbableElements', function () {
-      var commons;
+    describe.skip('tabbableElements', () => {
+      let commons;
 
-      beforeEach(function () {
+      beforeEach(() => {
         commons = axe.commons = axe.commons;
       });
 
-      afterEach(function () {
+      afterEach(() => {
         axe.commons = commons;
       });
 
-      it('should call dom.getTabbableElements', function () {
-        var called = false;
+      it('should call dom.getTabbableElements', () => {
+        let called = false;
         axe.commons = {
           dom: {
-            getTabbableElements: function () {
+            getTabbableElements: () => {
               called = true;
             }
           }
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.tabbableElements;
 
         assert.isTrue(called);
       });
 
-      it('should only call dom.getTabbableElements once', function () {
-        var count = 0;
+      it('should only call dom.getTabbableElements once', () => {
+        let count = 0;
         axe.commons = {
           dom: {
-            getTabbableElements: function () {
+            getTabbableElements: () => {
               count++;
             }
           }
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.tabbableElements;
         vNode.tabbableElements;
         vNode.tabbableElements;
@@ -306,46 +304,46 @@ describe('VirtualNode', function () {
       });
     });
 
-    describe('getComputedStylePropertyValue', function () {
-      var computedStyle;
+    describe('getComputedStylePropertyValue', () => {
+      let computedStyle;
 
-      beforeEach(function () {
+      beforeEach(() => {
         computedStyle = window.getComputedStyle;
       });
 
-      afterEach(function () {
+      afterEach(() => {
         window.getComputedStyle = computedStyle;
       });
 
-      it('should call window.getComputedStyle and return the property', function () {
-        var called = false;
-        window.getComputedStyle = function () {
+      it('should call window.getComputedStyle and return the property', () => {
+        let called = false;
+        window.getComputedStyle = () => {
           called = true;
           return {
-            getPropertyValue: function () {
+            getPropertyValue: () => {
               return 'result';
             }
           };
         };
-        var vNode = new VirtualNode(node);
-        var result = vNode.getComputedStylePropertyValue('prop');
+        const vNode = new VirtualNode(node);
+        const result = vNode.getComputedStylePropertyValue('prop');
 
         assert.isTrue(called);
         assert.equal(result, 'result');
       });
 
-      it('should only call window.getComputedStyle and getPropertyValue once', function () {
-        var computedCount = 0;
-        var propertyCount = 0;
-        window.getComputedStyle = function () {
+      it('should only call window.getComputedStyle and getPropertyValue once', () => {
+        let computedCount = 0;
+        let propertyCount = 0;
+        window.getComputedStyle = () => {
           computedCount++;
           return {
-            getPropertyValue: function () {
+            getPropertyValue: () => {
               propertyCount++;
             }
           };
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.getComputedStylePropertyValue('prop');
         vNode.getComputedStylePropertyValue('prop');
         vNode.getComputedStylePropertyValue('prop');
@@ -354,60 +352,60 @@ describe('VirtualNode', function () {
       });
     });
 
-    describe('clientRects', function () {
-      it('should call node.getClientRects', function () {
-        var called = false;
-        node.getClientRects = function () {
+    describe('clientRects', () => {
+      it('should call node.getClientRects', () => {
+        let called = false;
+        node.getClientRects = () => {
           called = true;
           return [];
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.clientRects;
 
         assert.isTrue(called);
       });
 
-      it('should only call node.getClientRects once', function () {
-        var count = 0;
-        node.getClientRects = function () {
+      it('should only call node.getClientRects once', () => {
+        let count = 0;
+        node.getClientRects = () => {
           count++;
           return [];
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.clientRects;
         vNode.clientRects;
         vNode.clientRects;
         assert.equal(count, 1);
       });
 
-      it('should filter out 0 width rects', function () {
-        node.getClientRects = function () {
+      it('should filter out 0 width rects', () => {
+        node.getClientRects = () => {
           return [{ width: 10 }, { width: 0 }, { width: 20 }];
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
 
         assert.deepEqual(vNode.clientRects, [{ width: 10 }, { width: 20 }]);
       });
     });
 
-    describe('boundingClientRect', function () {
-      it('should call node.getBoundingClientRect', function () {
-        var called = false;
-        node.getBoundingClientRect = function () {
+    describe('boundingClientRect', () => {
+      it('should call node.getBoundingClientRect', () => {
+        let called = false;
+        node.getBoundingClientRect = () => {
           called = true;
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.boundingClientRect;
 
         assert.isTrue(called);
       });
 
-      it('should only call node.getBoundingClientRect once', function () {
-        var count = 0;
-        node.getBoundingClientRect = function () {
+      it('should only call node.getBoundingClientRect once', () => {
+        let count = 0;
+        node.getBoundingClientRect = () => {
           count++;
         };
-        var vNode = new VirtualNode(node);
+        const vNode = new VirtualNode(node);
         vNode.boundingClientRect;
         vNode.boundingClientRect;
         vNode.boundingClientRect;

--- a/test/core/public/plugins.js
+++ b/test/core/public/plugins.js
@@ -1,10 +1,8 @@
-describe('plugins', function () {
-  'use strict';
-
+describe('plugins', () => {
   function createFrames(callback) {
-    var frame,
-      num = 2,
-      loaded = 0;
+    let frame;
+    const num = 2;
+    let loaded = 0;
 
     function onLoad() {
       loaded++;
@@ -26,29 +24,29 @@ describe('plugins', function () {
     fixture.appendChild(frame);
   }
 
-  var fixture = document.getElementById('fixture');
+  const fixture = document.getElementById('fixture');
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
     axe._audit = null;
   });
 
-  beforeEach(function () {
+  beforeEach(() => {
     axe._load({
       rules: []
     });
   });
 
-  it('Should have registerPlugin function', function () {
+  it('Should have registerPlugin function', () => {
     assert.ok(axe.registerPlugin);
     assert.equal(typeof axe.registerPlugin, 'function');
   });
 
-  it('should have an empty set of plugins', function () {
+  it('should have an empty set of plugins', () => {
     assert.deepEqual({}, axe.plugins);
   });
 
-  it('should add a plugin to the plugins list and a command to the audit commands', function () {
+  it('should add a plugin to the plugins list and a command to the audit commands', () => {
     axe.registerPlugin({
       id: 'my-plugin',
       run: 'run',
@@ -63,9 +61,9 @@ describe('plugins', function () {
     assert.equal(axe.plugins['my-plugin']._run, 'run');
     assert.equal(axe._audit.commands['my-command'], 'callback');
   });
-  describe('Plugin class', function () {
-    it('should call the run function of the registered plugin, when run is called', function () {
-      var called = false;
+  describe('Plugin class', () => {
+    it('should call the run function of the registered plugin, when run is called', () => {
+      let called = false;
       axe.registerPlugin({
         id: 'my-plugin',
         run: function (id, action, options) {
@@ -89,13 +87,13 @@ describe('plugins', function () {
       );
     });
   });
-  describe('Plugin.protoype.run', function () {
-    afterEach(function () {
+  describe('Plugin.protoype.run', () => {
+    afterEach(() => {
       fixture.innerHTML = '';
       axe._audit = null;
       axe.plugins = {};
     });
-    beforeEach(function () {
+    beforeEach(() => {
       axe._load({
         rules: []
       });
@@ -124,12 +122,12 @@ describe('plugins', function () {
       });
       axe.plugins.multi.add({
         id: 'hideall',
-        cleanup: function (done) {
+        cleanup: done => {
           done();
         },
         run: function (options, callback) {
-          var frames;
-          var q = axe.utils.queue();
+          let frames;
+          const q = axe.utils.queue();
 
           frames = axe.utils.toArray(
             document.querySelectorAll('iframe, frame')
@@ -150,13 +148,13 @@ describe('plugins', function () {
             });
           });
 
-          q.defer(function (done) {
+          q.defer(done => {
             // implementation
             done('ola!');
           });
           q.then(function (data) {
             // done with all the frames
-            var results = [];
+            let results = [];
             data.forEach(function (datum) {
               if (datum) {
                 results = results.concat(datum);
@@ -167,15 +165,15 @@ describe('plugins', function () {
         }
       });
     });
-    it('should work without frames', function (done) {
+    it('should work without frames', done => {
       axe.plugins.multi.run('hideall', 'run', {}, function (results) {
         assert.deepEqual(results, ['ola!']);
         done();
       });
     });
-    it('should work with frames', function (done) {
-      createFrames(function () {
-        setTimeout(function () {
+    it('should work with frames', done => {
+      createFrames(() => {
+        setTimeout(() => {
           axe.plugins.multi.run('hideall', 'run', {}, function (results) {
             assert.deepEqual(results, ['ola!', 'ola!', 'ola!', 'ola!', 'ola!']);
             done();
@@ -183,13 +181,13 @@ describe('plugins', function () {
         }, 500);
       });
     });
-    it("should call the implementation's cleanup function", function (done) {
-      var called = false;
-      axe.plugins.multi.cleanup = function (done) {
+    it("should call the implementation's cleanup function", done => {
+      let called = false;
+      axe.plugins.multi.cleanup = doneFn => {
         called = true;
-        done();
+        doneFn();
       };
-      axe.plugins.multi.cleanup(function () {
+      axe.plugins.multi.cleanup(() => {
         assert.ok(called);
         done();
       });

--- a/test/core/utils/get-shadow-selector.js
+++ b/test/core/utils/get-shadow-selector.js
@@ -1,77 +1,74 @@
-describe('axe.utils.getShadowSelector', function () {
-  var fixture = document.getElementById('fixture');
-  var shadowTest = axe.testUtils.shadowSupport.v1 ? it : xit;
-  var getShadowSelector = axe.utils.getShadowSelector;
+describe('axe.utils.getShadowSelector', () => {
+  const fixture = document.getElementById('fixture');
+  const shadowTest = axe.testUtils.shadowSupport.v1 ? it : xit;
+  const getShadowSelector = axe.utils.getShadowSelector;
 
   function generator(node) {
     return node.nodeName.toLowerCase();
   }
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
   });
 
-  it('returns generated output for light DOM nodes', function () {
-    var h1 = document.createElement('h1');
+  it('returns generated output for light DOM nodes', () => {
+    const h1 = document.createElement('h1');
     fixture.appendChild(h1);
 
-    var selector = getShadowSelector(generator, h1);
+    const selector = getShadowSelector(generator, h1);
     assert.equal(selector, 'h1');
   });
 
-  it('passes node and options to generator', function () {
-    var called = false;
-    var node = document.createElement('h1');
-    var options = { hello: 'world' };
-    function generator(arg1, arg2) {
+  it('passes node and options to generator', () => {
+    let called = false;
+    const node = document.createElement('h1');
+    const options = { hello: 'world' };
+    function generatorFn(arg1, arg2) {
       called = true;
       assert.equal(arg1, node);
       assert.equal(arg2, options);
     }
 
-    getShadowSelector(generator, node, options);
+    getShadowSelector(generatorFn, node, options);
     assert.isTrue(called);
   });
 
-  it('passes am empty object if no options are provided', function () {
-    var called = false;
-    var node = document.createElement('h1');
-    function generator(_, arg2) {
+  it('passes am empty object if no options are provided', () => {
+    let called = false;
+    const node = document.createElement('h1');
+    function generatorFn(_, arg2) {
       called = true;
       assert.deepEqual(arg2, {});
     }
 
-    getShadowSelector(generator, node);
+    getShadowSelector(generatorFn, node);
     assert.isTrue(called);
   });
 
-  shadowTest('returns the output of the generator for light DOM', function () {
+  shadowTest('returns the output of the generator for light DOM', () => {
     fixture.innerHTML = '<div><h1>Hello world</h1></div>';
-    var div = fixture.querySelector('div');
-    var h1 = fixture.querySelector('h1');
-    var shadowHost = div.attachShadow({ mode: 'open' });
+    const div = fixture.querySelector('div');
+    const h1 = fixture.querySelector('h1');
+    const shadowHost = div.attachShadow({ mode: 'open' });
     shadowHost.innerHTML = '<span><slot /></span>';
 
     assert.equal(getShadowSelector(generator, h1), 'h1');
   });
 
-  shadowTest(
-    'returns an array of outputs for each shadow tree host',
-    function () {
-      var node = document.createElement('section');
-      fixture.appendChild(node);
+  shadowTest('returns an array of outputs for each shadow tree host', () => {
+    const node = document.createElement('section');
+    fixture.appendChild(node);
 
-      var shadowRoot1 = node.attachShadow({ mode: 'open' });
-      shadowRoot1.innerHTML = '<div><article><slot /></article</div>';
+    const shadowRoot1 = node.attachShadow({ mode: 'open' });
+    shadowRoot1.innerHTML = '<div><article><slot /></article</div>';
 
-      var shadowRoot2 = shadowRoot1
-        .querySelector('article')
-        .attachShadow({ mode: 'open' });
-      shadowRoot2.innerHTML = '<h1>Hello world</h1>';
+    const shadowRoot2 = shadowRoot1
+      .querySelector('article')
+      .attachShadow({ mode: 'open' });
+    shadowRoot2.innerHTML = '<h1>Hello world</h1>';
 
-      var target = shadowRoot2.querySelector('h1');
-      var sel = getShadowSelector(generator, target);
-      assert.deepEqual(sel, ['section', 'article', 'h1']);
-    }
-  );
+    const target = shadowRoot2.querySelector('h1');
+    const sel = getShadowSelector(generator, target);
+    assert.deepEqual(sel, ['section', 'article', 'h1']);
+  });
 });

--- a/test/core/utils/parse-sameorigin-stylesheet.js
+++ b/test/core/utils/parse-sameorigin-stylesheet.js
@@ -1,8 +1,6 @@
-describe('axe.utils.parseSameOriginStylesheet', function () {
-  'use strict';
-
-  var stylesForPage;
-  var styleSheets = {
+describe('axe.utils.parseSameOriginStylesheet', () => {
+  let stylesForPage;
+  const styleSheets = {
     emptyStyleTag: {
       id: 'emptyStyleTag',
       text: ''
@@ -16,43 +14,43 @@ describe('axe.utils.parseSameOriginStylesheet', function () {
       text: '.inline-css { font-weight:normal; }'
     }
   };
-  var dynamicDoc;
-  var convertDataToStylesheet;
+  let dynamicDoc;
+  let convertDataToStylesheet;
 
-  beforeEach(function () {
+  beforeEach(() => {
     dynamicDoc = document.implementation.createHTMLDocument(
       'Dynamic document for testing axe.utils.parseSameOriginStylesheet'
     );
     convertDataToStylesheet = axe.utils.getStyleSheetFactory(dynamicDoc);
   });
 
-  afterEach(function (done) {
+  afterEach(done => {
     dynamicDoc = undefined;
     convertDataToStylesheet = undefined;
-    axe.testUtils.removeStyleSheets(stylesForPage).then(function () {
+    axe.testUtils.removeStyleSheets(stylesForPage).then(() => {
       done();
       stylesForPage = undefined;
     });
   });
 
-  it('returns empty results when given sheet has no cssRules', function (done) {
+  it('returns empty results when given sheet has no cssRules', done => {
     // add style that has no styles
     stylesForPage = [styleSheets.emptyStyleTag];
 
-    axe.testUtils.addStyleSheets(stylesForPage).then(function () {
+    axe.testUtils.addStyleSheets(stylesForPage).then(() => {
       // get recently added sheet
-      var sheet = Array.from(document.styleSheets).filter(function (sheet) {
-        return sheet.ownerNode.id === styleSheets.emptyStyleTag.id;
+      const sheet = Array.from(document.styleSheets).filter(styleSheet => {
+        return styleSheet.ownerNode.id === styleSheets.emptyStyleTag.id;
       })[0];
       // parse sheet
-      var options = {
+      const options = {
         rootNode: document,
         shadowId: undefined,
         convertDataToStylesheet: convertDataToStylesheet
       };
-      var priority = [1, 0];
-      var importedUrls = [];
-      var isCrossOriginRequest = false;
+      const priority = [1, 0];
+      const importedUrls = [];
+      const isCrossOriginRequest = false;
       axe.utils
         .parseSameOriginStylesheet(
           sheet,
@@ -73,24 +71,24 @@ describe('axe.utils.parseSameOriginStylesheet', function () {
     });
   });
 
-  it('returns @import rule specified in the stylesheet', function (done) {
+  it('returns @import rule specified in the stylesheet', done => {
     // add style that has @import style
     stylesForPage = [styleSheets.styleTagWithOneImport];
 
-    axe.testUtils.addStyleSheets(stylesForPage).then(function () {
+    axe.testUtils.addStyleSheets(stylesForPage).then(() => {
       // get recently added sheet
-      var sheet = Array.from(document.styleSheets).filter(function (sheet) {
-        return sheet.ownerNode.id === styleSheets.styleTagWithOneImport.id;
+      const sheet = Array.from(document.styleSheets).filter(styleSheet => {
+        return styleSheet.ownerNode.id === styleSheets.styleTagWithOneImport.id;
       })[0];
       // parse sheet
-      var options = {
+      const options = {
         rootNode: document,
         shadowId: undefined,
         convertDataToStylesheet: convertDataToStylesheet
       };
-      var priority = [1, 0];
-      var importedUrls = [];
-      var isCrossOriginRequest = false;
+      const priority = [1, 0];
+      const importedUrls = [];
+      const isCrossOriginRequest = false;
       axe.utils
         .parseSameOriginStylesheet(
           sheet,
@@ -102,7 +100,7 @@ describe('axe.utils.parseSameOriginStylesheet', function () {
         .then(function (data) {
           assert.isDefined(data);
 
-          var parsedImportData = data[0];
+          const parsedImportData = data[0];
           assert.isDefined(parsedImportData.sheet);
           assert.equal(parsedImportData.isCrossOrigin, isCrossOriginRequest);
           // as @import is a style with in @imported sheet, an additional priority is appended.
@@ -119,24 +117,24 @@ describe('axe.utils.parseSameOriginStylesheet', function () {
     });
   });
 
-  it('returns inline style specified in the stylesheet', function (done) {
+  it('returns inline style specified in the stylesheet', done => {
     // add style that has @import style
     stylesForPage = [styleSheets.inlineStyle];
 
-    axe.testUtils.addStyleSheets(stylesForPage).then(function () {
+    axe.testUtils.addStyleSheets(stylesForPage).then(() => {
       // get recently added sheet
-      var sheet = Array.from(document.styleSheets).filter(function (sheet) {
-        return sheet.ownerNode.id === styleSheets.inlineStyle.id;
+      const sheet = Array.from(document.styleSheets).filter(styleSheet => {
+        return styleSheet.ownerNode.id === styleSheets.inlineStyle.id;
       })[0];
       // parse sheet
-      var options = {
+      const options = {
         rootNode: document,
         shadowId: undefined,
         convertDataToStylesheet: convertDataToStylesheet
       };
-      var priority = [1, 0];
-      var importedUrls = [];
-      var isCrossOriginRequest = false;
+      const priority = [1, 0];
+      const importedUrls = [];
+      const isCrossOriginRequest = false;
       axe.utils
         .parseSameOriginStylesheet(
           sheet,

--- a/test/core/utils/selector-cache.js
+++ b/test/core/utils/selector-cache.js
@@ -1,54 +1,54 @@
-describe('utils.selector-cache', function () {
-  var fixture = document.querySelector('#fixture');
-  var cacheNodeSelectors =
+describe('utils.selector-cache', () => {
+  const fixture = document.querySelector('#fixture');
+  const cacheNodeSelectors =
     axe._thisWillBeDeletedDoNotUse.utils.cacheNodeSelectors;
-  var getNodesMatchingExpression =
+  const getNodesMatchingExpression =
     axe._thisWillBeDeletedDoNotUse.utils.getNodesMatchingExpression;
-  var convertSelector = axe.utils.convertSelector;
-  var shadowSupported = axe.testUtils.shadowSupport.v1;
+  const convertSelector = axe.utils.convertSelector;
+  const shadowSupported = axe.testUtils.shadowSupport.v1;
 
-  var vNode;
-  beforeEach(function () {
+  let vNode;
+  beforeEach(() => {
     fixture.innerHTML = '<div id="target" class="foo" aria-label="bar"></div>';
     vNode = new axe.VirtualNode(fixture.firstChild);
   });
 
-  describe('cacheNodeSelectors', function () {
-    it('should add the node to the global selector', function () {
-      var map = {};
+  describe('cacheNodeSelectors', () => {
+    it('should add the node to the global selector', () => {
+      const map = {};
       cacheNodeSelectors(vNode, map);
       assert.deepEqual(map['*'], [vNode]);
     });
 
-    it('should add the node to the nodeName', function () {
-      var map = {};
+    it('should add the node to the nodeName', () => {
+      const map = {};
       cacheNodeSelectors(vNode, map);
       assert.deepEqual(map.div, [vNode]);
     });
 
-    it('should add the node to all attribute selectors', function () {
-      var map = {};
+    it('should add the node to all attribute selectors', () => {
+      const map = {};
       cacheNodeSelectors(vNode, map);
       assert.deepEqual(map['[id]'], [vNode]);
       assert.deepEqual(map['[class]'], [vNode]);
       assert.deepEqual(map['[aria-label]'], [vNode]);
     });
 
-    it('should add the node to the id map', function () {
-      var map = {};
+    it('should add the node to the id map', () => {
+      const map = {};
       cacheNodeSelectors(vNode, map);
       assert.deepEqual(map[' [idsMap]'].target, [vNode]);
     });
 
-    it('should not add the node to selectors it does not match', function () {
-      var map = {};
+    it('should not add the node to selectors it does not match', () => {
+      const map = {};
       cacheNodeSelectors(vNode, map);
       assert.isUndefined(map['[for]']);
       assert.isUndefined(map.h1);
     });
 
-    it('should ignore non-element nodes', function () {
-      var map = {};
+    it('should ignore non-element nodes', () => {
+      const map = {};
       fixture.innerHTML = 'Hello';
       vNode = new axe.VirtualNode(fixture.firstChild);
       cacheNodeSelectors(vNode, map);
@@ -56,7 +56,7 @@ describe('utils.selector-cache', function () {
       assert.lengthOf(Object.keys(map), 0);
     });
 
-    describe('with javascripty attribute selectors', function () {
+    describe('with javascripty attribute selectors', () => {
       const terms = [
         'prototype',
         'constructor',
@@ -67,9 +67,9 @@ describe('utils.selector-cache', function () {
         'toString'
       ];
       for (const term of terms) {
-        it(`works with ${term}`, function () {
+        it(`works with ${term}`, () => {
           fixture.innerHTML = `<div id="${term}" class="${term}" aria-label="${term}"></div>`;
-          const vNode = new axe.VirtualNode(fixture.firstChild);
+          vNode = new axe.VirtualNode(fixture.firstChild);
           const map = {};
           cacheNodeSelectors(vNode, map);
           assert.deepEqual(map['[id]'], [vNode]);
@@ -80,18 +80,18 @@ describe('utils.selector-cache', function () {
     });
   });
 
-  describe('getNodesMatchingExpression', function () {
-    var tree;
-    var spanVNode;
-    var headingVNode;
+  describe('getNodesMatchingExpression', () => {
+    let tree;
+    let spanVNode;
+    let headingVNode;
 
     function createTree() {
-      for (var i = 0; i < fixture.children.length; i++) {
-        var child = fixture.children[i];
-        var isShadow = child.hasAttribute('data-shadow');
-        var html = child.innerHTML;
+      for (let i = 0; i < fixture.children.length; i++) {
+        const child = fixture.children[i];
+        const isShadow = child.hasAttribute('data-shadow');
+        const html = child.innerHTML;
         if (isShadow) {
-          var shadowRoot = child.attachShadow({ mode: 'open' });
+          const shadowRoot = child.attachShadow({ mode: 'open' });
           shadowRoot.innerHTML = html;
           child.innerHTML = '';
         }
@@ -100,7 +100,7 @@ describe('utils.selector-cache', function () {
       return axe.utils.getFlattenedTree(fixture);
     }
 
-    beforeEach(function () {
+    beforeEach(() => {
       fixture.firstChild.innerHTML =
         '<h1><span class="bar" id="not-target" aria-labelledby="target"></span></h1>';
       tree = axe.utils.getFlattenedTree(fixture.firstChild);
@@ -110,14 +110,14 @@ describe('utils.selector-cache', function () {
       spanVNode = headingVNode.children[0];
     });
 
-    it('should return undefined if the cache is not primed', function () {
+    it('should return undefined if the cache is not primed', () => {
       tree[0]._selectorMap = null;
-      var expression = convertSelector('div');
+      const expression = convertSelector('div');
       assert.isUndefined(getNodesMatchingExpression(tree, expression));
     });
 
-    it('should return a list of matching nodes by global selector', function () {
-      var expression = convertSelector('*');
+    it('should return a list of matching nodes by global selector', () => {
+      const expression = convertSelector('*');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [
         vNode,
         headingVNode,
@@ -125,24 +125,24 @@ describe('utils.selector-cache', function () {
       ]);
     });
 
-    it('should return a list of matching nodes by nodeName', function () {
-      var expression = convertSelector('div');
+    it('should return a list of matching nodes by nodeName', () => {
+      const expression = convertSelector('div');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
     });
 
-    it('should return a list of matching nodes by id', function () {
-      var expression = convertSelector('#target');
+    it('should return a list of matching nodes by id', () => {
+      const expression = convertSelector('#target');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
     });
 
     (shadowSupported ? it : xit)(
       'should only return nodes matching shadowId when matching by id',
-      function () {
+      () => {
         fixture.innerHTML =
           '<div id="target"></div><div data-shadow><div id="target"></div></div>';
-        var tree = createTree();
-        var expression = convertSelector('#target');
-        var expected = [tree[0].children[0]];
+        tree = createTree();
+        const expression = convertSelector('#target');
+        const expected = [tree[0].children[0]];
         assert.deepEqual(
           getNodesMatchingExpression(tree, expression),
           expected
@@ -150,83 +150,83 @@ describe('utils.selector-cache', function () {
       }
     );
 
-    it('should return a list of matching nodes by class', function () {
-      var expression = convertSelector('.foo');
+    it('should return a list of matching nodes by class', () => {
+      const expression = convertSelector('.foo');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
     });
 
-    it('should return a list of matching nodes by attribute', function () {
-      var expression = convertSelector('[aria-label]');
+    it('should return a list of matching nodes by attribute', () => {
+      const expression = convertSelector('[aria-label]');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
     });
 
-    it('should return an empty array if selector does not match', function () {
-      var expression = convertSelector('main');
+    it('should return an empty array if selector does not match', () => {
+      const expression = convertSelector('main');
       assert.lengthOf(getNodesMatchingExpression(tree, expression), 0);
     });
 
-    it('should return an empty array for complex selector that does not match', function () {
-      var expression = convertSelector('span.missingClass[id]');
+    it('should return an empty array for complex selector that does not match', () => {
+      const expression = convertSelector('span.missingClass[id]');
       assert.lengthOf(getNodesMatchingExpression(tree, expression), 0);
     });
 
-    it('should return an empty array for a non-complex selector that does not match', function () {
-      var expression = convertSelector('div#not-target[id]');
+    it('should return an empty array for a non-complex selector that does not match', () => {
+      const expression = convertSelector('div#not-target[id]');
       assert.lengthOf(getNodesMatchingExpression(tree, expression), 0);
     });
 
-    it('should return nodes for each expression', function () {
+    it('should return nodes for each expression', () => {
       fixture.innerHTML =
         '<div role="button"></div><span aria-label="other"></span>';
-      var tree = createTree();
-      var expression = convertSelector('[role], [aria-label]');
-      var expected = [tree[0].children[0], tree[0].children[1]];
+      tree = createTree();
+      const expression = convertSelector('[role], [aria-label]');
+      const expected = [tree[0].children[0], tree[0].children[1]];
       assert.deepEqual(getNodesMatchingExpression(tree, expression), expected);
     });
 
-    it('should return nodes for child combinator selector', function () {
-      var expression = convertSelector('div span');
+    it('should return nodes for child combinator selector', () => {
+      const expression = convertSelector('div span');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [
         spanVNode
       ]);
     });
 
-    it('should return nodes for direct child combinator selector', function () {
-      var expression = convertSelector('div > h1');
+    it('should return nodes for direct child combinator selector', () => {
+      const expression = convertSelector('div > h1');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [
         headingVNode
       ]);
     });
 
-    it('should not return nodes for direct child combinator selector that does not match', function () {
-      var expression = convertSelector('div > span');
+    it('should not return nodes for direct child combinator selector that does not match', () => {
+      const expression = convertSelector('div > span');
       assert.lengthOf(getNodesMatchingExpression(tree, expression), 0);
     });
 
-    it('should return nodes for attribute value selector', function () {
-      var expression = convertSelector('[id="target"]');
+    it('should return nodes for attribute value selector', () => {
+      const expression = convertSelector('[id="target"]');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
     });
 
-    it('should return undefined for combinator selector with global selector', function () {
-      var expression = convertSelector('body *');
+    it('should return undefined for combinator selector with global selector', () => {
+      const expression = convertSelector('body *');
       assert.isUndefined(getNodesMatchingExpression(tree, expression));
     });
 
-    it('should return nodes for multipart selectors', function () {
-      var expression = convertSelector('div.foo[id]');
+    it('should return nodes for multipart selectors', () => {
+      const expression = convertSelector('div.foo[id]');
       assert.deepEqual(getNodesMatchingExpression(tree, expression), [vNode]);
     });
 
-    it('should remove duplicates', function () {
+    it('should remove duplicates', () => {
       fixture.innerHTML = '<div role="button" aria-label="other"></div>';
-      var tree = createTree();
-      var expression = convertSelector('div[role], [aria-label]');
-      var expected = [tree[0].children[0]];
+      tree = createTree();
+      const expression = convertSelector('div[role], [aria-label]');
+      const expected = [tree[0].children[0]];
       assert.deepEqual(getNodesMatchingExpression(tree, expression), expected);
     });
 
-    it('should sort nodes by added order', function () {
+    it('should sort nodes by added order', () => {
       fixture.innerHTML =
         '<div id="id0"></div>' +
         '<span id="id1"></span>' +
@@ -240,10 +240,10 @@ describe('utils.selector-cache', function () {
         '<span id="id9"></span>';
       tree = createTree();
 
-      var expression = convertSelector('div, span');
-      var nodes = getNodesMatchingExpression(tree, expression);
-      var ids = [];
-      for (var i = 0; i < nodes.length; i++) {
+      const expression = convertSelector('div, span');
+      const nodes = getNodesMatchingExpression(tree, expression);
+      const ids = [];
+      for (let i = 0; i < nodes.length; i++) {
         ids.push(nodes[i].attr('id'));
       }
 
@@ -262,31 +262,31 @@ describe('utils.selector-cache', function () {
       ]);
     });
 
-    it('should filter nodes', function () {
+    it('should filter nodes', () => {
       fixture.innerHTML =
         '<div role="button" aria-label="other"></div><div></div>';
-      var tree = createTree();
+      tree = createTree();
 
       function filter(node) {
         return node.hasAttr('role');
       }
 
-      var nonFilteredNodes = getNodesMatchingExpression(
+      const nonFilteredNodes = getNodesMatchingExpression(
         tree,
         convertSelector('div, [aria-label]')
       );
-      var nonFilteredExpected = [
+      const nonFilteredExpected = [
         tree[0],
         tree[0].children[0],
         tree[0].children[1]
       ];
 
-      var filteredNodes = getNodesMatchingExpression(
+      const filteredNodes = getNodesMatchingExpression(
         tree,
         convertSelector('div, [aria-label]'),
         filter
       );
-      var filteredExpected = [tree[0].children[0]];
+      const filteredExpected = [tree[0].children[0]];
 
       assert.deepEqual(nonFilteredNodes, nonFilteredExpected);
       assert.deepEqual(filteredNodes, filteredExpected);

--- a/test/core/utils/send-command-to-frame.js
+++ b/test/core/utils/send-command-to-frame.js
@@ -1,23 +1,25 @@
-describe('axe.utils.sendCommandToFrame', function () {
-  'use strict';
+describe('axe.utils.sendCommandToFrame', () => {
+  const fixture = document.getElementById('fixture');
+  let params;
+  const captureError = axe.testUtils.captureError;
 
-  var fixture = document.getElementById('fixture');
-  var params = { command: 'rules' };
-  var captureError = axe.testUtils.captureError;
+  beforeEach(() => {
+    params = { command: 'rules' };
+  });
 
-  afterEach(function () {
+  afterEach(() => {
     fixture.innerHTML = '';
     axe._tree = undefined;
     axe._selectorData = undefined;
   });
 
-  var assertNotCalled = function () {
+  const assertNotCalled = () => {
     assert.ok(false, 'should not be called');
   };
 
-  it('should return results from frames', function (done) {
-    var frame = document.createElement('iframe');
-    frame.addEventListener('load', function () {
+  it('should return results from frames', done => {
+    const frame = document.createElement('iframe');
+    frame.addEventListener('load', () => {
       axe.utils.sendCommandToFrame(
         frame,
         params,
@@ -26,7 +28,7 @@ describe('axe.utils.sendCommandToFrame', function () {
           assert.equal(res[0].id, 'html');
           done();
         }, done),
-        function () {
+        () => {
           done(new Error('sendCommandToFrame should not error'));
         }
       );
@@ -37,15 +39,15 @@ describe('axe.utils.sendCommandToFrame', function () {
     fixture.appendChild(frame);
   });
 
-  it('adjusts skips ping with options.pingWaitTime=0', function (done) {
-    var frame = document.createElement('iframe');
-    var params = {
+  it('adjusts skips ping with options.pingWaitTime=0', done => {
+    const frame = document.createElement('iframe');
+    params = {
       command: 'rules',
       options: { pingWaitTime: 0 }
     };
 
-    frame.addEventListener('load', function () {
-      var topics = [];
+    frame.addEventListener('load', () => {
+      const topics = [];
       frame.contentWindow.addEventListener('message', function (event) {
         try {
           topics.push(JSON.parse(event.data).topic);
@@ -56,7 +58,7 @@ describe('axe.utils.sendCommandToFrame', function () {
       axe.utils.sendCommandToFrame(
         frame,
         params,
-        captureError(function () {
+        captureError(() => {
           try {
             assert.deepEqual(topics, ['axe.start']);
             done();
@@ -64,7 +66,7 @@ describe('axe.utils.sendCommandToFrame', function () {
             done(e);
           }
         }, done),
-        function () {
+        () => {
           done(new Error('sendCommandToFrame should not error'));
         }
       );
@@ -75,8 +77,8 @@ describe('axe.utils.sendCommandToFrame', function () {
     fixture.appendChild(frame);
   });
 
-  it('should timeout if there is no response from frame', function (done) {
-    var orig = window.setTimeout;
+  it('should timeout if there is no response from frame', done => {
+    const orig = window.setTimeout;
     window.setTimeout = function (fn, to) {
       if (to === 30000) {
         assert.ok('timeout set');
@@ -88,8 +90,8 @@ describe('axe.utils.sendCommandToFrame', function () {
       return 'cats';
     };
 
-    var frame = document.createElement('iframe');
-    frame.addEventListener('load', function () {
+    const frame = document.createElement('iframe');
+    frame.addEventListener('load', () => {
       axe._tree = axe.utils.getFlattenedTree(document.documentElement);
       axe.utils.sendCommandToFrame(
         frame,

--- a/test/integration/adapter.js
+++ b/test/integration/adapter.js
@@ -1,5 +1,14 @@
 /*global mocha */
 var failedTests = [];
+var flattenTitles = function (test) {
+  var titles = [];
+  while (test.parent.title) {
+    titles.push(test.parent.title);
+    test = test.parent;
+  }
+  return titles.reverse();
+};
+
 (function () {
   'use strict';
 
@@ -9,14 +18,6 @@ var failedTests = [];
     window.mochaResults.reports = failedTests;
   });
   runner.on('fail', function logFailure(test, err) {
-    var flattenTitles = function (test) {
-      var titles = [];
-      while (test.parent.title) {
-        titles.push(test.parent.title);
-        test = test.parent;
-      }
-      return titles.reverse();
-    };
     failedTests.push({
       name: test.title,
       result: false,

--- a/test/integration/adapter.js
+++ b/test/integration/adapter.js
@@ -1,7 +1,7 @@
 /*global mocha */
-var failedTests = [];
-var flattenTitles = function (test) {
-  var titles = [];
+const failedTests = [];
+function flattenTitles (test) {
+  const titles = [];
   while (test.parent.title) {
     titles.push(test.parent.title);
     test = test.parent;

--- a/test/integration/adapter.js
+++ b/test/integration/adapter.js
@@ -1,13 +1,13 @@
 /*global mocha */
 const failedTests = [];
-function flattenTitles (test) {
+function flattenTitles(test) {
   const titles = [];
   while (test.parent.title) {
     titles.push(test.parent.title);
     test = test.parent;
   }
   return titles.reverse();
-};
+}
 
 (function () {
   'use strict';

--- a/test/integration/api/external/index.js
+++ b/test/integration/api/external/index.js
@@ -1,52 +1,50 @@
 // describes the API used by axe Pro
-describe('external API', function () {
-  'use strict';
-
-  afterEach(function () {
+describe('external API', () => {
+  afterEach(() => {
     // setup _tree as needed, always reset
     axe._tree = null;
   });
 
-  describe('axe.commons.text.sanitize', function () {
-    it('must be a function with the signature String -> String', function () {
+  describe('axe.commons.text.sanitize', () => {
+    it('must be a function with the signature String -> String', () => {
       assert.isString(axe.commons.text.sanitize(''));
       assert.isString(axe.commons.text.sanitize('not empty'));
     });
   });
 
-  describe('axe.utils.getBaseLang', function () {
-    it('must be a function with the signature String -> String', function () {
+  describe('axe.utils.getBaseLang', () => {
+    it('must be a function with the signature String -> String', () => {
       assert.isString(axe.utils.getBaseLang(''));
       assert.isString(axe.utils.getBaseLang('not empty'));
     });
   });
 
-  describe('axe.utils.validLangs', function () {
-    it('be a function with the signature * -> [String]', function () {
-      var langs = axe.utils.validLangs();
+  describe('axe.utils.validLangs', () => {
+    it('be a function with the signature * -> [String]', () => {
+      const langs = axe.utils.validLangs();
       assert.isArray(langs);
       langs.forEach(assert.isString);
       assert.isArray(axe.utils.validLangs(document));
     });
   });
 
-  describe('axe.commons.dom.isVisible', function () {
-    it('must be a function with the signature Element -> Boolean', function () {
-      var el = randomNodeInTree(isElement);
+  describe('axe.commons.dom.isVisible', () => {
+    it('must be a function with the signature Element -> Boolean', () => {
+      const el = randomNodeInTree(isElement);
       assert.isBoolean(axe.commons.dom.isVisible(el));
       assert.isBoolean(axe.commons.dom.isVisible(randomNodeInTree(isElement)));
     });
   });
 
-  describe('axe.commons.aria.implicitRole', function () {
-    it('must be a function with the signature Element -> String|null', function () {
+  describe('axe.commons.aria.implicitRole', () => {
+    it('must be a function with the signature Element -> String|null', () => {
       axe.utils.getFlattenedTree(document.documentElement);
-      var implicitRolesOrNull = getEntries(
+      const implicitRolesOrNull = getEntries(
         axe.commons.aria.lookupTable.role
       ).reduce(
         function (roles, entry) {
-          var role = entry[0];
-          var val = entry[1];
+          const role = entry[0];
+          const val = entry[1];
           if (val.implicit) {
             roles.push(role);
           }
@@ -54,18 +52,18 @@ describe('external API', function () {
         },
         [null]
       );
-      var role = axe.commons.aria.implicitRole(randomNodeInTree());
+      const role = axe.commons.aria.implicitRole(randomNodeInTree());
       assert.oneOf(role, implicitRolesOrNull);
     });
   });
 
-  describe('axe.commons.aria.lookupTable.role', function () {
-    it('must be an object (dict)', function () {
+  describe('axe.commons.aria.lookupTable.role', () => {
+    it('must be an object (dict)', () => {
       assert.isObject(axe.commons.aria.lookupTable.role);
     });
-    it('must have the signature String -> String {role.type}', function () {
-      var keys = getKeys(axe.commons.aria.lookupTable.role);
-      var types = getValues(axe.commons.aria.lookupTable.role).map(function (
+    it('must have the signature String -> String {role.type}', () => {
+      const keys = getKeys(axe.commons.aria.lookupTable.role);
+      const types = getValues(axe.commons.aria.lookupTable.role).map(function (
         role
       ) {
         return role.type;
@@ -75,8 +73,8 @@ describe('external API', function () {
     });
   });
 
-  describe('axe.utils.getFlattenedTree', function () {
-    it('must be a function with the signature Element -> [vnode]', function () {
+  describe('axe.utils.getFlattenedTree', () => {
+    it('must be a function with the signature Element -> [vnode]', () => {
       assert.isArray(axe.utils.getFlattenedTree(document.body));
       assert.lengthOf(
         axe.utils.getFlattenedTree(randomNodeInTree(isElement)),
@@ -85,48 +83,48 @@ describe('external API', function () {
     });
   });
 
-  describe('axe.utils.getNodeFromTree', function () {
-    it('must be a function with the signature Node -> vnode', function () {
+  describe('axe.utils.getNodeFromTree', () => {
+    it('must be a function with the signature Node -> vnode', () => {
       axe._tree = axe.utils.getFlattenedTree(document.body);
       assert.oneOf(
         axe.utils.getNodeFromTree(randomNodeInTree()),
         flat(axe._tree[0])
       );
     });
-    it('must return null for nodes not in the axe._tree', function () {
+    it('must return null for nodes not in the axe._tree', () => {
       assert.isNull(axe.utils.getNodeFromTree(randomElement()));
     });
   });
 
-  describe('axe.commons.dom.isOpaque', function () {
-    it('must be a function with the signature Element -> Boolean', function () {
+  describe('axe.commons.dom.isOpaque', () => {
+    it('must be a function with the signature Element -> Boolean', () => {
       assert.isBoolean(axe.commons.dom.isOpaque(randomNodeInTree(isElement)));
     });
   });
 
-  describe('axe.commons.text.accessibleTextVirtual', function () {
-    it('must be a function with the signature Element vnode -> String', function () {
+  describe('axe.commons.text.accessibleTextVirtual', () => {
+    it('must be a function with the signature Element vnode -> String', () => {
       axe._tree = axe.utils.getFlattenedTree(document.body);
-      var vnode = axe.utils.getNodeFromTree(randomNodeInTree(isElement));
+      const vnode = axe.utils.getNodeFromTree(randomNodeInTree(isElement));
       assert.isString(axe.commons.text.accessibleTextVirtual(vnode));
     });
   });
 });
 
-var elements = [
+const elements = [
   document.createElement('div'),
   document.createElement('button'),
   document.createElement('article')
 ];
 
-var inTree = [];
-var walker = collectNodes();
-var next = walker.iterate().next();
+const inTree = [];
+const treeWalker = collectNodes();
+let next = treeWalker.iterate().next();
 while (!next.done) {
   if (next.value.nodeType === 1) {
     inTree.push(next.value);
   }
-  next = walker.iterate().next();
+  next = treeWalker.iterate().next();
 }
 
 function isElement(el) {
@@ -136,8 +134,8 @@ function isElement(el) {
 function random(fromArr) {
   return function (filter) {
     filter = filter || isTrue;
-    var arr = fromArr.filter(filter);
-    var seed = Math.random();
+    const arr = fromArr.filter(filter);
+    const seed = Math.random();
     return arr[Math.floor(seed * arr.length)];
   };
 }
@@ -152,7 +150,7 @@ function randomElement(filter) {
 
 // mimic tree: body and all element and text children
 function collectNodes() {
-  var walker = document.createTreeWalker(
+  const walker = document.createTreeWalker(
     document,
     NodeFilter.SHOW_ALL,
     function (node) {
@@ -163,22 +161,22 @@ function collectNodes() {
     },
     false
   );
-  var next = function () {
-    var value = walker.nextNode();
+  const nextNode = () => {
+    const value = walker.nextNode();
     return {
       value: value,
       done: !value
     };
   };
-  walker.iterate = function () {
-    return { next: next };
+  walker.iterate = () => {
+    return { next: nextNode };
   };
   return walker;
 }
 
 function flat(tree) {
-  var result = [];
-  var insert = function (node) {
+  const result = [];
+  const insert = function (node) {
     result.push(node);
     (node.children || []).forEach(insert);
   };
@@ -193,8 +191,8 @@ function isTrue() {
 }
 
 function getEntries(obj) {
-  var results = [];
-  var key;
+  const results = [];
+  let key;
   for (key in obj) {
     if (obj.hasOwnProperty(key)) {
       results.push([key, obj[key]]);

--- a/test/integration/full/configure-options/configure-options.js
+++ b/test/integration/full/configure-options/configure-options.js
@@ -1,16 +1,14 @@
-describe('Configure Options', function () {
-  'use strict';
+describe('Configure Options', () => {
+  const target = document.querySelector('#target');
 
-  var target = document.querySelector('#target');
-
-  afterEach(function () {
+  afterEach(() => {
     axe.reset();
     target.innerHTML = '';
   });
 
-  describe('Check', function () {
-    describe('aria-allowed-attr', function () {
-      it('should allow an attribute supplied in options', function (done) {
+  describe('Check', () => {
+    describe('aria-allowed-attr', () => {
+      it('should allow an attribute supplied in options', done => {
         target.setAttribute('role', 'separator');
         target.setAttribute('aria-valuenow', '0');
 
@@ -37,7 +35,7 @@ describe('Configure Options', function () {
         );
       });
 
-      it('should not normalize external check options', function (done) {
+      it('should not normalize external check options', done => {
         target.setAttribute('lang', 'en');
 
         axe.configure({
@@ -46,7 +44,7 @@ describe('Configure Options', function () {
               id: 'dylang',
               options: ['dylan'],
               evaluate:
-                'function (node, options) {\n        var lang = (node.getAttribute("lang") || "").trim().toLowerCase();\n        var xmlLang = (node.getAttribute("xml:lang") || "").trim().toLowerCase();\n        var invalid = [];\n        (options || []).forEach(function(cc) {\n          cc = cc.toLowerCase();\n          if (lang && (lang === cc || lang.indexOf(cc.toLowerCase() + "-") === 0)) {\n            lang = null;\n          }\n          if (xmlLang && (xmlLang === cc || xmlLang.indexOf(cc.toLowerCase() + "-") === 0)) {\n            xmlLang = null;\n          }\n        });\n        if (xmlLang) {\n          invalid.push(\'xml:lang="\' + xmlLang + \'"\');\n        }\n        if (lang) {\n          invalid.push(\'lang="\' + lang + \'"\');\n        }\n        if (invalid.length) {\n          this.data(invalid);\n          return true;\n        }\n        return false;\n      }',
+                'function (node, options) {\n        const lang = (node.getAttribute("lang") || "").trim().toLowerCase();\n        const xmlLang = (node.getAttribute("xml:lang") || "").trim().toLowerCase();\n        const invalid = [];\n        (options || []).forEach(function(cc) {\n          cc = cc.toLowerCase();\n          if (lang && (lang === cc || lang.indexOf(cc.toLowerCase() + "-") === 0)) {\n            lang = null;\n          }\n          if (xmlLang && (xmlLang === cc || xmlLang.indexOf(cc.toLowerCase() + "-") === 0)) {\n            xmlLang = null;\n          }\n        });\n        if (xmlLang) {\n          invalid.push(\'xml:lang="\' + xmlLang + \'"\');\n        }\n        if (lang) {\n          invalid.push(\'lang="\' + lang + \'"\');\n        }\n        if (invalid.length) {\n          this.data(invalid);\n          return true;\n        }\n        return false;\n      }',
               messages: {
                 pass: 'Good language',
                 fail: 'You mst use the DYLAN language'
@@ -100,8 +98,8 @@ describe('Configure Options', function () {
       });
     });
 
-    describe('aria-required-attr', function () {
-      it('should report unique attributes when supplied from options', function (done) {
+    describe('aria-required-attr', () => {
+      it('should report unique attributes when supplied from options', done => {
         target.setAttribute('role', 'slider');
         axe.configure({
           checks: [
@@ -131,8 +129,8 @@ describe('Configure Options', function () {
     });
   });
 
-  describe('disableOtherRules', function () {
-    it('disables rules that are not in the `rules` array', function (done) {
+  describe('disableOtherRules', () => {
+    it('disables rules that are not in the `rules` array', done => {
       axe.configure({
         disableOtherRules: true,
         rules: [
@@ -160,9 +158,9 @@ describe('Configure Options', function () {
     });
   });
 
-  describe('noHtml', function () {
-    var captureError = axe.testUtils.captureError;
-    it('prevents html property on nodes', function (done) {
+  describe('noHtml', () => {
+    const captureError = axe.testUtils.captureError;
+    it('prevents html property on nodes', done => {
       target.setAttribute('role', 'slider');
       axe.configure({
         noHtml: true,
@@ -189,8 +187,8 @@ describe('Configure Options', function () {
       );
     });
 
-    it('prevents html property on nodes from iframes', function (done) {
-      var config = {
+    it('prevents html property on nodes from iframes', done => {
+      const config = {
         noHtml: true,
         rules: [
           {
@@ -202,9 +200,9 @@ describe('Configure Options', function () {
         ]
       };
 
-      var iframe = document.createElement('iframe');
+      const iframe = document.createElement('iframe');
       iframe.src = '/test/mock/frames/context.html';
-      iframe.onload = function () {
+      iframe.onload = () => {
         axe.configure(config);
 
         axe.run(
@@ -229,8 +227,8 @@ describe('Configure Options', function () {
       target.appendChild(iframe);
     });
 
-    it('prevents html property in postMesage', function (done) {
-      var config = {
+    it('prevents html property in postMesage', done => {
+      const config = {
         noHtml: true,
         rules: [
           {
@@ -242,9 +240,9 @@ describe('Configure Options', function () {
         ]
       };
 
-      var iframe = document.createElement('iframe');
+      const iframe = document.createElement('iframe');
       iframe.src = '/test/mock/frames/noHtml-config.html';
-      iframe.onload = function () {
+      iframe.onload = () => {
         axe.configure(config);
 
         axe.run('#target', {
@@ -256,14 +254,14 @@ describe('Configure Options', function () {
       };
       target.appendChild(iframe);
 
-      window.addEventListener('message', function (e) {
-        var data = JSON.parse(e.data);
+      window.addEventListener('message', function (evt) {
+        const data = JSON.parse(evt.data);
         if (Array.isArray(data.payload)) {
           try {
             assert.isNull(data.payload[0].nodes[0].node.source);
             done();
-          } catch (e) {
-            done(e);
+          } catch (err) {
+            done(err);
           }
         }
       });

--- a/test/integration/full/contrast/blending.js
+++ b/test/integration/full/contrast/blending.js
@@ -1,7 +1,7 @@
-describe('color-contrast blending test', function () {
-  var include = [];
-  var resultElms = [];
-  var expected = [
+describe('color-contrast blending test', () => {
+  const include = [];
+  const resultElms = [];
+  const expected = [
     // normal
     'rgb(223, 112, 96)',
     'rgb(255, 128, 128)',
@@ -124,8 +124,8 @@ describe('color-contrast blending test', function () {
     'rgb(198, 198, 198)'
   ];
 
-  var fixture = document.querySelector('#fixture');
-  var testGroup = document.querySelector('.test-group');
+  const fixture = document.querySelector('#fixture');
+  const testGroup = document.querySelector('.test-group');
   [
     'multiply',
     'screen',
@@ -138,19 +138,19 @@ describe('color-contrast blending test', function () {
     'soft-light',
     'difference',
     'exclusion'
-  ].forEach(function (blendMode) {
-    var nodes = testGroup.cloneNode(true);
-    var group = testGroup.cloneNode();
+  ].forEach(blendMode => {
+    const nodes = testGroup.cloneNode(true);
+    const group = testGroup.cloneNode();
 
-    var heading = document.createElement('h2');
+    const heading = document.createElement('h2');
     heading.textContent = blendMode;
     fixture.appendChild(heading);
 
-    Array.from(nodes.children).forEach(function (node, index) {
-      var id = node.id;
-      var target = node.querySelector('#' + id + '-target');
-      var result = node.querySelector('#' + id + '-result');
-      var blendModeIndex = blendMode + (index + 1);
+    Array.from(nodes.children).forEach((node, index) => {
+      const id = node.id;
+      const target = node.querySelector('#' + id + '-target');
+      const result = node.querySelector('#' + id + '-result');
+      const blendModeIndex = blendMode + (index + 1);
 
       node.id = blendModeIndex;
       target.id = blendModeIndex + '-target';
@@ -165,37 +165,37 @@ describe('color-contrast blending test', function () {
 
     fixture.appendChild(group);
   });
-  var testElms = Array.from(document.querySelectorAll('.test-group > div'));
-  testElms.forEach(function (testElm) {
-    var id = testElm.id;
-    var target = testElm.querySelector('#' + id + '-target');
-    var result = testElm.querySelector('#' + id + '-result');
+  const testElms = Array.from(document.querySelectorAll('.test-group > div'));
+  testElms.forEach(testElm => {
+    const id = testElm.id;
+    const target = testElm.querySelector('#' + id + '-target');
+    const result = testElm.querySelector('#' + id + '-result');
     include.push(target);
     resultElms.push(result);
   });
 
-  before(function (done) {
+  before(done => {
     axe.run(
       { include: include },
       { runOnly: ['color-contrast'] },
-      function (err, res) {
+      (err, res) => {
         assert.isNull(err);
 
         // don't care where the result goes as we just want to
         // extract the background color for each one
-        var results = []
+        const results = []
           .concat(res.passes)
           .concat(res.violations)
           .concat(res.incomplete);
-        results.forEach(function (result) {
-          result.nodes.forEach(function (node) {
-            var bgColor = node.any[0].data.bgColor;
-            var id = node.target[0].substring(
+        results.forEach(result => {
+          result.nodes.forEach(node => {
+            const bgColor = node.any[0].data.bgColor;
+            const id = node.target[0].substring(
               0,
               node.target[0].lastIndexOf('-')
             );
-            var result = document.querySelector(id + '-result');
-            result.style.backgroundColor = bgColor;
+            const resultNode = document.querySelector(id + '-result');
+            resultNode.style.backgroundColor = bgColor;
           });
         });
 
@@ -204,9 +204,9 @@ describe('color-contrast blending test', function () {
     );
   });
 
-  resultElms.forEach(function (elm, index) {
-    it('produces the correct blended color for ' + elm.id, function () {
-      var style = window.getComputedStyle(elm);
+  resultElms.forEach((elm, index) => {
+    it('produces the correct blended color for ' + elm.id, () => {
+      const style = window.getComputedStyle(elm);
       assert.equal(style.getPropertyValue('background-color'), expected[index]);
     });
   });

--- a/test/integration/full/css-orientation-lock/violations.js
+++ b/test/integration/full/css-orientation-lock/violations.js
@@ -1,9 +1,7 @@
-describe('css-orientation-lock violations test', function () {
-  'use strict';
+describe('css-orientation-lock violations test', () => {
+  const shadowSupported = axe.testUtils.shadowSupport.v1;
 
-  var shadowSupported = axe.testUtils.shadowSupport.v1;
-
-  var styleSheets = [
+  const styleSheets = [
     {
       href: 'https://stackpath.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css'
     },
@@ -12,26 +10,26 @@ describe('css-orientation-lock violations test', function () {
     }
   ];
 
-  before(function (done) {
+  before(done => {
     axe.testUtils
       .addStyleSheets(styleSheets)
-      .then(function () {
+      .then(() => {
         done();
       })
-      .catch(function (error) {
+      .catch(error => {
         done(new Error('Could not load stylesheets for testing. ' + error));
       });
   });
 
   function assertViolatedSelectors(relatedNodes, violatedSelectors) {
-    relatedNodes.forEach(function (node) {
-      var target = node.target[0];
-      var className = Array.isArray(target) ? target.reverse()[0] : target;
+    relatedNodes.forEach(node => {
+      const target = node.target[0];
+      const className = Array.isArray(target) ? target.reverse()[0] : target;
       assert.isTrue(violatedSelectors.indexOf(className) !== -1);
     });
   }
 
-  it('returns VIOLATIONS if preload is set to TRUE', function (done) {
+  it('returns VIOLATIONS if preload is set to TRUE', done => {
     // the sheets included in the html, have styles for transform and rotate, hence the violation
     axe.run(
       {
@@ -40,7 +38,7 @@ describe('css-orientation-lock violations test', function () {
           values: ['css-orientation-lock']
         }
       },
-      function (err, res) {
+      (err, res) => {
         try {
           assert.isNull(err);
           assert.isDefined(res);
@@ -50,11 +48,11 @@ describe('css-orientation-lock violations test', function () {
           assert.lengthOf(res.violations, 1);
 
           // assert the node
-          var checkedNode = res.violations[0].nodes[0];
+          const checkedNode = res.violations[0].nodes[0];
           assert.isTrue(/html/i.test(checkedNode.html));
 
           // assert the relatedNodes
-          var checkResult = checkedNode.all[0];
+          const checkResult = checkedNode.all[0];
           assert.lengthOf(checkResult.relatedNodes, 4);
           assertViolatedSelectors(checkResult.relatedNodes, [
             '.someDiv',
@@ -64,8 +62,8 @@ describe('css-orientation-lock violations test', function () {
           ]);
 
           done();
-        } catch (err) {
-          done(err);
+        } catch (e) {
+          done(e);
         }
       }
     );
@@ -73,9 +71,9 @@ describe('css-orientation-lock violations test', function () {
 
   (shadowSupported ? it : xit)(
     'returns VIOLATIONS whilst also accommodating shadowDOM styles',
-    function (done) {
-      var fixture = document.getElementById('shadow-fixture');
-      var shadow = fixture.attachShadow({ mode: 'open' });
+    done => {
+      const fixture = document.getElementById('shadow-fixture');
+      const shadow = fixture.attachShadow({ mode: 'open' });
       shadow.innerHTML =
         '<style> @media screen and (min-width: 10px) and (max-width: 2000px) and (orientation: portrait) { .shadowDiv { transform: rotate3d(0,0,1,90deg); } } .green { background-color: green; } </style>' +
         '<div class="green">green</div>' +
@@ -88,7 +86,7 @@ describe('css-orientation-lock violations test', function () {
             values: ['css-orientation-lock']
           }
         },
-        function (err, res) {
+        (err, res) => {
           try {
             assert.isNull(err);
             assert.isDefined(res);
@@ -98,11 +96,11 @@ describe('css-orientation-lock violations test', function () {
             assert.lengthOf(res.violations, 1);
 
             // assert the node
-            var checkedNode = res.violations[0].nodes[0];
+            const checkedNode = res.violations[0].nodes[0];
             assert.isTrue(/html/i.test(checkedNode.html));
 
             // assert the relatedNodes
-            var checkResult = checkedNode.all[0];
+            const checkResult = checkedNode.all[0];
             assert.lengthOf(checkResult.relatedNodes, 5);
             assertViolatedSelectors(checkResult.relatedNodes, [
               '.someDiv',
@@ -113,8 +111,8 @@ describe('css-orientation-lock violations test', function () {
             ]);
 
             done();
-          } catch (err) {
-            done(err);
+          } catch (e) {
+            done(e);
           }
         }
       );

--- a/test/integration/full/preload-cssom/preload-cssom.js
+++ b/test/integration/full/preload-cssom/preload-cssom.js
@@ -1,4 +1,3 @@
-/* global axe */
 describe('preload cssom integration test', function () {
   'use strict';
 
@@ -7,8 +6,8 @@ describe('preload cssom integration test', function () {
   // time to resolve tests that we want to throw
   this.timeout(15000);
 
-  var shadowSupported = axe.testUtils.shadowSupport.v1;
-  var styleSheets = {
+  const shadowSupported = axe.testUtils.shadowSupport.v1;
+  const styleSheets = {
     crossOriginLinkHref: {
       id: 'crossOriginLinkHref',
       href: 'https://stackpath.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css'
@@ -43,11 +42,11 @@ describe('preload cssom integration test', function () {
       text: '@import "cyclic-cross-origin-import-1.css";'
     }
   };
-  var stylesForPage;
-  var nestedFrame;
+  let stylesForPage;
+  let nestedFrame;
 
-  before(function (done) {
-    axe.testUtils.awaitNestedLoad(function () {
+  before(done => {
+    axe.testUtils.awaitNestedLoad(() => {
       nestedFrame = document.getElementById('frame1').contentDocument;
       done();
     });
@@ -56,10 +55,10 @@ describe('preload cssom integration test', function () {
   function attachStylesheets(options, callback) {
     axe.testUtils
       .addStyleSheets(options.styles, options.root)
-      .then(function () {
+      .then(() => {
         callback();
       })
-      .catch(function (error) {
+      .catch(error => {
         callback(new Error('Could not load stylesheets for testing. ' + error));
       });
   }
@@ -70,37 +69,37 @@ describe('preload cssom integration test', function () {
     }
     axe.testUtils
       .removeStyleSheets(stylesForPage)
-      .then(function () {
+      .then(() => {
         done();
         stylesForPage = undefined;
       })
-      .catch(function (err) {
+      .catch(err => {
         done(err);
         stylesForPage = undefined;
       });
   }
 
   function getPreloadCssom(root) {
-    var treeRoot = axe.utils.getFlattenedTree(root ? root : document);
+    const treeRoot = axe.utils.getFlattenedTree(root ? root : document);
     return axe.utils.preloadCssom({ treeRoot: treeRoot });
   }
 
   function commonTestsForRootNodeAndNestedFrame(root) {
-    it('returns cross-origin stylesheet', function (done) {
+    it('returns cross-origin stylesheet', done => {
       stylesForPage = [styleSheets.crossOriginLinkHref];
       attachStylesheets(
         {
           root: root,
           styles: stylesForPage
         },
-        function (err) {
+        err => {
           if (err) {
             done(err);
           }
           getPreloadCssom(root)
-            .then(function (sheets) {
+            .then(sheets => {
               assert.lengthOf(sheets, 1);
-              var sheetData = sheets[0].sheet;
+              const sheetData = sheets[0].sheet;
               axe.testUtils.assertStylesheet(
                 sheetData,
                 ':root',
@@ -109,7 +108,7 @@ describe('preload cssom integration test', function () {
               );
               done();
             })
-            .catch(function () {
+            .catch(() => {
               done(new Error('Expected getPreload to resolve.'));
             });
         },
@@ -117,23 +116,23 @@ describe('preload cssom integration test', function () {
       );
     });
 
-    it('returns no stylesheets when cross-origin stylesheets are of media=print', function (done) {
+    it('returns no stylesheets when cross-origin stylesheets are of media=print', done => {
       stylesForPage = [styleSheets.crossOriginLinkHrefMediaPrint];
       attachStylesheets(
         {
           root: root,
           styles: stylesForPage
         },
-        function (err) {
+        err => {
           if (err) {
             done(err);
           }
           getPreloadCssom(root)
-            .then(function (sheets) {
+            .then(sheets => {
               assert.lengthOf(sheets, 0);
               done();
             })
-            .catch(function () {
+            .catch(() => {
               done(new Error('Expected getPreload to resolve.'));
             });
         },
@@ -141,7 +140,7 @@ describe('preload cssom integration test', function () {
       );
     });
 
-    it('throws if cross-origin stylesheet fail to load', function (done) {
+    it('throws if cross-origin stylesheet fail to load', done => {
       stylesForPage = [
         {
           id: 'nonExistingStylesheet',
@@ -153,16 +152,16 @@ describe('preload cssom integration test', function () {
           root: root,
           styles: stylesForPage
         },
-        function (err) {
+        err => {
           if (err) {
             done(err);
           }
           getPreloadCssom(root)
-            .then(function () {
+            .then(() => {
               done(new Error('Expected getPreload to reject.'));
             })
-            .catch(function (err) {
-              assert.isDefined(err);
+            .catch(e => {
+              assert.isDefined(e);
               done();
             });
         },
@@ -171,33 +170,33 @@ describe('preload cssom integration test', function () {
     });
   }
 
-  describe('tests for root (document)', function () {
-    var shadowFixture;
+  describe('tests for root (document)', () => {
+    let shadowFixture;
 
-    beforeEach(function () {
-      var shadowNode = document.createElement('div');
+    beforeEach(() => {
+      const shadowNode = document.createElement('div');
       shadowNode.id = 'shadow-fixture';
       document.body.appendChild(shadowNode);
       shadowFixture = document.getElementById('shadow-fixture');
     });
 
-    afterEach(function (done) {
+    afterEach(done => {
       if (shadowFixture) {
         document.body.removeChild(shadowFixture);
       }
       detachStylesheets(done);
     });
 
-    it('returns stylesheets defined via <style> tag', function (done) {
+    it('returns stylesheets defined via <style> tag', done => {
       stylesForPage = [styleSheets.styleTag];
-      attachStylesheets({ styles: stylesForPage }, function (err) {
+      attachStylesheets({ styles: stylesForPage }, err => {
         if (err) {
           done(err);
         }
         getPreloadCssom()
-          .then(function (sheets) {
+          .then(sheets => {
             assert.lengthOf(sheets, 1);
-            var sheetData = sheets[0].sheet;
+            const sheetData = sheets[0].sheet;
             axe.testUtils.assertStylesheet(
               sheetData,
               '.inline-css-test',
@@ -205,22 +204,22 @@ describe('preload cssom integration test', function () {
             );
             done();
           })
-          .catch(function () {
+          .catch(() => {
             done(new Error('Expected getPreload to resolve.'));
           });
       });
     });
 
-    it('returns stylesheets with in same-origin', function (done) {
+    it('returns stylesheets with in same-origin', done => {
       stylesForPage = [styleSheets.styleTagWithOneImport];
-      attachStylesheets({ styles: stylesForPage }, function (err) {
+      attachStylesheets({ styles: stylesForPage }, err => {
         if (err) {
           done(err);
         }
         getPreloadCssom()
-          .then(function (sheets) {
+          .then(sheets => {
             assert.lengthOf(sheets, 1);
-            var nonCrossOriginSheets = sheets.filter(function (s) {
+            const nonCrossOriginSheets = sheets.filter(s => {
               return !s.isCrossOrigin;
             });
             assert.lengthOf(nonCrossOriginSheets, 1);
@@ -231,7 +230,7 @@ describe('preload cssom integration test', function () {
             );
             done();
           })
-          .catch(function () {
+          .catch(() => {
             done(new Error('Expected getPreload to resolve.'));
           });
       });
@@ -239,8 +238,8 @@ describe('preload cssom integration test', function () {
 
     (shadowSupported ? it : xit)(
       'returns styles from shadow DOM (handles @import in <style>)',
-      function (done) {
-        var shadow = shadowFixture.attachShadow({ mode: 'open' });
+      done => {
+        const shadow = shadowFixture.attachShadow({ mode: 'open' });
         shadow.innerHTML =
           '<style>' +
           // stylesheet -> 1
@@ -250,13 +249,13 @@ describe('preload cssom integration test', function () {
           '</style>' +
           '<div class="initialism">Some text</div>';
         getPreloadCssom(shadowFixture)
-          .then(function (sheets) {
+          .then(sheets => {
             assert.lengthOf(sheets, 2);
-            var nonCrossOriginSheetsWithInShadowDOM = sheets
-              .filter(function (s) {
+            const nonCrossOriginSheetsWithInShadowDOM = sheets
+              .filter(s => {
                 return !s.isCrossOrigin;
               })
-              .filter(function (s) {
+              .filter(s => {
                 return s.shadowId;
               });
             axe.testUtils.assertStylesheet(
@@ -268,7 +267,7 @@ describe('preload cssom integration test', function () {
             );
             done();
           })
-          .catch(function () {
+          .catch(() => {
             done(new Error('Expected getPreload to resolve.'));
           });
       }
@@ -276,8 +275,8 @@ describe('preload cssom integration test', function () {
 
     (shadowSupported ? it : xit)(
       'returns styles from base document and shadow DOM with right priority',
-      function (done) {
-        var shadow = shadowFixture.attachShadow({ mode: 'open' });
+      done => {
+        const shadow = shadowFixture.attachShadow({ mode: 'open' });
         shadow.innerHTML =
           '<style>' +
           // stylesheet -> 1 -> inside shadow DOM
@@ -287,15 +286,15 @@ describe('preload cssom integration test', function () {
 
         // sheet appended to root document
         stylesForPage = [styleSheets.styleTag];
-        attachStylesheets({ styles: stylesForPage }, function (err) {
+        attachStylesheets({ styles: stylesForPage }, err => {
           if (err) {
             done(err);
           }
           getPreloadCssom(shadowFixture)
-            .then(function (sheets) {
+            .then(sheets => {
               assert.lengthOf(sheets, 2);
 
-              var shadowDomStyle = sheets.filter(function (s) {
+              const shadowDomStyle = sheets.filter(s => {
                 return s.shadowId;
               })[0];
               axe.testUtils.assertStylesheet(
@@ -304,7 +303,7 @@ describe('preload cssom integration test', function () {
                 '.style-from-base-css { font-size: 100%; }'
               );
 
-              var rootDocumentStyle = sheets.filter(function (s) {
+              const rootDocumentStyle = sheets.filter(s => {
                 return !s.shadowId;
               })[0];
               assert.isAbove(
@@ -313,25 +312,25 @@ describe('preload cssom integration test', function () {
               );
               done();
             })
-            .catch(function () {
+            .catch(() => {
               done(new Error('Expected getPreload to resolve.'));
             });
         });
       }
     );
 
-    it('returns styles from various @import(ed) styles from an @import(ed) stylesheet', function (done) {
+    it('returns styles from various @import(ed) styles from an @import(ed) stylesheet', done => {
       stylesForPage = [
         styleSheets.styleTagWithMultipleImports // this imports 2 other stylesheets
       ];
-      attachStylesheets({ styles: stylesForPage }, function (err) {
+      attachStylesheets({ styles: stylesForPage }, err => {
         if (err) {
           done(err);
         }
         getPreloadCssom()
-          .then(function (sheets) {
+          .then(sheets => {
             assert.lengthOf(sheets, 2);
-            var nonCrossOriginSheets = sheets.filter(function (s) {
+            const nonCrossOriginSheets = sheets.filter(s => {
               return !s.isCrossOrigin;
             });
             assert.lengthOf(nonCrossOriginSheets, 2);
@@ -347,22 +346,22 @@ describe('preload cssom integration test', function () {
             );
             done();
           })
-          .catch(function () {
+          .catch(() => {
             done(new Error('Expected getPreload to resolve.'));
           });
       });
     });
 
-    it('returns style from nested @import (3 levels deep)', function (done) {
+    it('returns style from nested @import (3 levels deep)', done => {
       stylesForPage = [styleSheets.styleTagWithNestedImports];
-      attachStylesheets({ styles: stylesForPage }, function (err) {
+      attachStylesheets({ styles: stylesForPage }, err => {
         if (err) {
           done(err);
         }
         getPreloadCssom()
-          .then(function (sheets) {
+          .then(sheets => {
             assert.lengthOf(sheets, 1);
-            var nonCrossOriginSheets = sheets.filter(function (s) {
+            const nonCrossOriginSheets = sheets.filter(s => {
               return !s.isCrossOrigin;
             });
             assert.lengthOf(nonCrossOriginSheets, 1);
@@ -373,20 +372,20 @@ describe('preload cssom integration test', function () {
             );
             done();
           })
-          .catch(function () {
+          .catch(() => {
             done(new Error('Expected getPreload to resolve.'));
           });
       });
     });
 
-    it('returns style from cyclic @import (exits recursion successfully)', function (done) {
+    it('returns style from cyclic @import (exits recursion successfully)', done => {
       stylesForPage = [styleSheets.styleTagWithCyclicImports];
-      attachStylesheets({ styles: stylesForPage }, function (err) {
+      attachStylesheets({ styles: stylesForPage }, err => {
         if (err) {
           done(err);
         }
         getPreloadCssom()
-          .then(function (sheets) {
+          .then(sheets => {
             assert.lengthOf(sheets, 1);
             axe.testUtils.assertStylesheet(
               sheets[0].sheet,
@@ -395,20 +394,20 @@ describe('preload cssom integration test', function () {
             );
             done();
           })
-          .catch(function () {
+          .catch(() => {
             done(new Error('Expected getPreload to resolve.'));
           });
       });
     });
 
-    it('returns style from cyclic @import which only imports one cross-origin stylesheet', function (done) {
+    it('returns style from cyclic @import which only imports one cross-origin stylesheet', done => {
       stylesForPage = [styleSheets.styleTagWithCyclicCrossOriginImports];
-      attachStylesheets({ styles: stylesForPage }, function (err) {
+      attachStylesheets({ styles: stylesForPage }, err => {
         if (err) {
           done(err);
         }
         getPreloadCssom()
-          .then(function (sheets) {
+          .then(sheets => {
             assert.lengthOf(sheets, 1);
             axe.testUtils.assertStylesheet(
               sheets[0].sheet,
@@ -417,7 +416,7 @@ describe('preload cssom integration test', function () {
             );
             done();
           })
-          .catch(function () {
+          .catch(() => {
             done(new Error('Expected getPreload to resolve.'));
           });
       });
@@ -426,17 +425,17 @@ describe('preload cssom integration test', function () {
     commonTestsForRootNodeAndNestedFrame();
   });
 
-  describe('tests for nested document', function () {
-    afterEach(function (done) {
+  describe('tests for nested document', () => {
+    afterEach(done => {
       detachStylesheets(done);
     });
 
-    it('returns styles defined using <style> tag', function (done) {
+    it('returns styles defined using <style> tag', done => {
       getPreloadCssom(nestedFrame)
-        .then(function (sheets) {
+        .then(sheets => {
           assert.lengthOf(sheets, 2);
 
-          var nonCrossOriginSheet = sheets.filter(function (s) {
+          const nonCrossOriginSheet = sheets.filter(s => {
             return !s.isCrossOrigin;
           })[0].sheet;
           axe.testUtils.assertStylesheet(
@@ -446,7 +445,7 @@ describe('preload cssom integration test', function () {
           );
           done();
         })
-        .catch(function () {
+        .catch(() => {
           done(new Error('Expected getPreload to resolve.'));
         });
     });

--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -1,9 +1,5 @@
-/* global axe, Promise */
-
-describe('axe.utils.preload integration test', function () {
-  'use strict';
-
-  var styleSheets = {
+describe('axe.utils.preload integration test', () => {
+  const styleSheets = {
     crossOriginLinkHref: {
       id: 'crossOriginLinkHref',
       href: 'https://unpkg.com/gutenberg-css@0.4'
@@ -22,15 +18,15 @@ describe('axe.utils.preload integration test', function () {
       text: '.inline-css-test{font-size:inherit;}'
     }
   };
-  var stylesForPage;
+  let stylesForPage;
 
   function attachStylesheets(options, callback) {
     axe.testUtils
       .addStyleSheets(options.styles, document)
-      .then(function () {
+      .then(() => {
         callback();
       })
-      .catch(function (error) {
+      .catch(error => {
         callback(new Error('Could not load stylesheets for testing. ' + error));
       });
   }
@@ -41,11 +37,11 @@ describe('axe.utils.preload integration test', function () {
     }
     axe.testUtils
       .removeStyleSheets(stylesForPage)
-      .then(function () {
+      .then(() => {
         done();
         stylesForPage = undefined;
       })
-      .catch(function (err) {
+      .catch(err => {
         done(err);
         stylesForPage = undefined;
       });
@@ -62,22 +58,22 @@ describe('axe.utils.preload integration test', function () {
     });
   }
 
-  afterEach(function (done) {
+  afterEach(done => {
     axe._tree = undefined;
     detachStylesheets(done);
   });
 
-  it('returns preloaded assets defined via <style> tag', function (done) {
+  it('returns preloaded assets defined via <style> tag', done => {
     stylesForPage = [styleSheets.styleTag];
-    attachStylesheets({ styles: stylesForPage }, function (err) {
+    attachStylesheets({ styles: stylesForPage }, err => {
       if (err) {
         done(err);
       }
       getPreload()
-        .then(function (preloadedAssets) {
+        .then(preloadedAssets => {
           assert.property(preloadedAssets, 'cssom');
           assert.lengthOf(preloadedAssets.cssom, 1);
-          var sheetData = preloadedAssets.cssom[0].sheet;
+          const sheetData = preloadedAssets.cssom[0].sheet;
           axe.testUtils.assertStylesheet(
             sheetData,
             '.inline-css-test',
@@ -89,14 +85,14 @@ describe('axe.utils.preload integration test', function () {
     });
   });
 
-  it('returns NO preloaded CSSOM assets when requested stylesheets are of media=print', function (done) {
+  it('returns NO preloaded CSSOM assets when requested stylesheets are of media=print', done => {
     stylesForPage = [styleSheets.crossOriginLinkHrefMediaPrint];
-    attachStylesheets({ styles: stylesForPage }, function (err) {
+    attachStylesheets({ styles: stylesForPage }, err => {
       if (err) {
         done(err);
       }
       getPreload()
-        .then(function (preloadedAssets) {
+        .then(preloadedAssets => {
           assert.property(preloadedAssets, 'cssom');
           assert.lengthOf(preloadedAssets.cssom, 0);
           done();
@@ -105,66 +101,66 @@ describe('axe.utils.preload integration test', function () {
     });
   });
 
-  it.skip('returns NO preloaded CSSOM assets when requested stylesheet does not exist`', function (done) {
+  it.skip('returns NO preloaded CSSOM assets when requested stylesheet does not exist`', done => {
     stylesForPage = [styleSheets.crossOriginDoesNotExist];
-    attachStylesheets({ styles: stylesForPage }, function (err) {
+    attachStylesheets({ styles: stylesForPage }, err => {
       if (err) {
         done(err);
       }
       getPreload()
-        .then(function () {
+        .then(() => {
           done(new Error('Not expecting to complete the promise'));
         })
-        .catch(function (err) {
-          assert.isNotNull(err);
-          assert.isTrue(!err.message.includes('Preload assets timed out'));
+        .catch(e => {
+          assert.isNotNull(e);
+          assert.isTrue(!e.message.includes('Preload assets timed out'));
           done();
         })
         .catch(done);
     });
   });
 
-  it.skip('rejects preload function when timed out before fetching assets', function (done) {
+  it.skip('rejects preload function when timed out before fetching assets', done => {
     stylesForPage = [styleSheets.crossOriginLinkHref];
 
-    var origPreloadCssom = axe.utils.preloadCssom;
-    axe.utils.preloadCssom = function () {
-      return new Promise(function (res) {
-        setTimeout(function () {
+    const origPreloadCssom = axe.utils.preloadCssom;
+    axe.utils.preloadCssom = () => {
+      return new Promise(res => {
+        setTimeout(() => {
           res(true);
         }, 2000);
       });
     };
 
-    attachStylesheets({ styles: stylesForPage }, function (err) {
+    attachStylesheets({ styles: stylesForPage }, err => {
       if (err) {
         done(err);
       }
       getPreload(1)
-        .then(function () {
+        .then(() => {
           done(new Error('Not expecting to complete the promise'));
         })
-        .catch(function (err) {
-          assert.isNotNull(err);
-          assert.isTrue(err.message.includes('Preload assets timed out'));
+        .catch(e => {
+          assert.isNotNull(e);
+          assert.isTrue(e.message.includes('Preload assets timed out'));
           axe.utils.preloadCssom = origPreloadCssom;
           done();
         })
-        .catch(function (e) {
+        .catch(e => {
           axe.utils.preloadCssom = origPreloadCssom;
           done(e);
         });
     });
   });
 
-  describe('verify preloaded assets via axe.run against custom rules', function () {
+  describe('verify preloaded assets via axe.run against custom rules', () => {
     function customCheckEvalFn(node, options, virtualNode, context) {
       // populate the data here which is asserted in tests
       this.data(context);
       return true;
     }
 
-    beforeEach(function (done) {
+    beforeEach(done => {
       /**
        * Load custom rule & check
        * -> one check is preload dependent
@@ -209,11 +205,11 @@ describe('axe.utils.preload integration test', function () {
       attachStylesheets({ styles: stylesForPage }, done);
     });
 
-    after(function (done) {
+    after(done => {
       detachStylesheets(done);
     });
 
-    it("returns preloaded assets to the check's evaluate fn for the rule which has `preload:true`", function (done) {
+    it("returns preloaded assets to the check's evaluate fn for the rule which has `preload:true`", done => {
       axe.run(
         {
           runOnly: {
@@ -222,28 +218,28 @@ describe('axe.utils.preload integration test', function () {
           },
           preload: true
         },
-        function (err, res) {
+        (err, res) => {
           assert.isNull(err);
           assert.isDefined(res);
           assert.property(res, 'passes');
           assert.lengthOf(res.passes, 1);
 
-          var checkData = res.passes[0].nodes[0].any[0].data;
+          const checkData = res.passes[0].nodes[0].any[0].data;
           assert.property(checkData, 'cssom');
 
-          var cssom = checkData.cssom;
+          const cssom = checkData.cssom;
 
           // ignores all media='print' styleSheets
           assert.lengthOf(cssom, 2);
 
           // there should be no external sheet returned
-          var crossOriginSheet = cssom.filter(function (s) {
+          const crossOriginSheet = cssom.filter(s => {
             return s.isCrossOrigin;
           });
           assert.lengthOf(crossOriginSheet, 1);
 
           // verify content of stylesheet
-          var inlineStylesheet = cssom.filter(function (s) {
+          const inlineStylesheet = cssom.filter(s => {
             return s.sheet.cssRules.length === 1 && !s.isCrossOrigin;
           })[0].sheet;
           axe.testUtils.assertStylesheet(
@@ -257,7 +253,7 @@ describe('axe.utils.preload integration test', function () {
       );
     });
 
-    it("returns NO preloaded assets to the check which does not require preload'", function (done) {
+    it("returns NO preloaded assets to the check which does not require preload'", done => {
       axe.run(
         {
           runOnly: {
@@ -266,13 +262,13 @@ describe('axe.utils.preload integration test', function () {
           },
           preload: true
         },
-        function (err, res) {
+        (err, res) => {
           assert.isNull(err);
           assert.isDefined(res);
           assert.property(res, 'passes');
           assert.lengthOf(res.passes, 1);
 
-          var checkData = res.passes[0].nodes[0].any[0];
+          const checkData = res.passes[0].nodes[0].any[0];
           assert.notProperty(checkData, 'cssom');
           done();
         }

--- a/test/integration/full/test-webdriver.js
+++ b/test/integration/full/test-webdriver.js
@@ -1,5 +1,3 @@
-/*global window, Promise */
-
 const globby = require('globby');
 const chrome = require('selenium-webdriver/chrome');
 const firefox = require('selenium-webdriver/firefox');
@@ -9,12 +7,12 @@ const args = process.argv.slice(2);
 
 // allow running certain browsers through command line args
 // (only one browser supported, run multiple times for more browsers)
-let browser = 'chrome';
-args.forEach(function (arg) {
+let browserArg = 'chrome';
+args.forEach(arg => {
   // pattern: browsers=Chrome
   const parts = arg.split('=');
   if (parts[0] === 'browser') {
-    browser = parts[1].toLowerCase();
+    browserArg = parts[1].toLowerCase();
   }
 });
 
@@ -24,9 +22,9 @@ args.forEach(function (arg) {
 function collectTestResults(driver) {
   // inject a script that waits half a second
   return driver
-    .executeAsyncScript(function () {
+    .executeAsyncScript(() => {
       const callback = arguments[arguments.length - 1];
-      setTimeout(function () {
+      setTimeout(() => {
         if (!window.mocha) {
           callback('mocha-missing;' + window.location.href);
         }
@@ -34,7 +32,7 @@ function collectTestResults(driver) {
         callback(window.mochaResults);
       }, 500);
     })
-    .then(function (result) {
+    .then(result => {
       // If there are no results, listen a little longer
       if (typeof result === 'string' && result.includes('mocha-missing')) {
         throw new Error(
@@ -64,14 +62,14 @@ function runTestUrls(driver, isMobile, urls, errors) {
     driver
       .get(url)
       // Get results
-      .then(function () {
+      .then(() => {
         return Promise.all([
           driver.getCapabilities(),
           collectTestResults(driver)
         ]);
       })
       // And process them
-      .then(function (promiseResults) {
+      .then(promiseResults => {
         const capabilities = promiseResults[0];
         const result = promiseResults[1];
         const browserName =
@@ -80,7 +78,7 @@ function runTestUrls(driver, isMobile, urls, errors) {
         console.log(url + ' [' + browserName + ']');
 
         // Remember the errors
-        (result.reports || []).forEach(function (err) {
+        (result.reports || []).forEach(err => {
           console.log(err.message);
           err.url = url;
           err.browser = browserName;
@@ -101,7 +99,7 @@ function runTestUrls(driver, isMobile, urls, errors) {
         );
         console.log();
       })
-      .then(function () {
+      .then(() => {
         // Start the next job, if any
         if (urls.length > 0) {
           return runTestUrls(driver, isMobile, urls, errors);
@@ -160,7 +158,7 @@ function start(options) {
       'test/integration/full/**/*.{html,xhtml}',
       '!**/frames/**/*.{html,xhtml}'
     ])
-    .map(function (url) {
+    .map(url => {
       return 'http://localhost:9876/' + url;
     });
 
@@ -190,9 +188,9 @@ function start(options) {
 
   // Test all pages
   runTestUrls(driver, isMobile, testUrls)
-    .then(function (testErrors) {
+    .then(testErrors => {
       // log each error and abort
-      testErrors.forEach(function (err) {
+      testErrors.forEach(err => {
         console.log();
         console.log('URL: ' + err.url);
         console.log('Browser: ' + err.browser);
@@ -206,10 +204,10 @@ function start(options) {
 
       // catch any potential problems
     })
-    .catch(function (err) {
+    .catch(err => {
       console.log(err);
       process.exit(1);
     });
 }
 
-start({ browser: browser });
+start({ browser: browserArg });

--- a/test/integration/rules/runner.js
+++ b/test/integration/rules/runner.js
@@ -1,9 +1,9 @@
-(function () {
+(() => {
   // this line is replaced with the test object in preprocessor.js
-  var test = {}; /*tests*/
+  const testObj = {}; /*tests*/
 
-  var ruleId = test.rule;
-  var testName = test.description || ruleId + ' test';
+  const ruleId = testObj.rule;
+  const testName = testObj.description || ruleId + ' test';
 
   function flattenResult(results) {
     return {
@@ -14,62 +14,63 @@
   }
 
   function waitForFrames(context, cb) {
+    let loaded = 0;
+    const frames = context.querySelectorAll('iframe');
+
     function loadListener() {
       loaded++;
       if (loaded === length) {
         cb();
       }
     }
-    var loaded = 0;
-    var frames = context.querySelectorAll('iframe');
     if (!frames.length) {
       return cb();
     }
-    for (var index = 0, length = frames.length; index < length; index++) {
+    for (let index = 0, length = frames.length; index < length; index++) {
       frames[index].addEventListener('load', loadListener);
     }
   }
 
-  var fixture = document.getElementById('fixture');
-  var rule = axe.utils.getRule(ruleId);
+  const fixture = document.getElementById('fixture');
+  const rule = axe.utils.getRule(ruleId);
 
   if (!rule) {
     return;
   }
 
   // don't run rules that are deprecated and disabled
-  var deprecated = rule.tags.indexOf('deprecated') !== -1;
-  (deprecated && !rule.enabled ? describe.skip : describe)(ruleId, function () {
-    describe(testName, function () {
+  const deprecated = rule.tags.indexOf('deprecated') !== -1;
+  (deprecated && !rule.enabled ? describe.skip : describe)(ruleId, () => {
+    describe(testName, () => {
       function runTest(test, collection) {
         if (!test[collection]) {
           return;
         }
 
-        describe(collection, function () {
-          var nodes;
-          before(function () {
+        describe(collection, () => {
+          let nodes;
+          before(() => {
             if (typeof results[collection] === 'object') {
               nodes = results[collection].nodes;
             }
           });
 
-          test[collection].forEach(function (selector) {
-            it('should find ' + JSON.stringify(selector), function () {
+          test[collection].forEach(selector => {
+            it('should find ' + JSON.stringify(selector), () => {
               if (!nodes) {
                 assert(false, 'there are no ' + collection);
                 return;
               }
 
-              var matches = nodes.filter(function (node) {
-                for (var i = 0; i < selector.length; i++) {
+              const matches = nodes.filter(node => {
+                for (let i = 0; i < selector.length; i++) {
                   if (node.target[i] !== selector[i]) {
                     return false;
                   }
                 }
                 return node.target.length === selector.length;
               });
-              matches.forEach(function (node) {
+              matches.forEach(node => {
                 // remove each node we find
                 nodes.splice(nodes.indexOf(node), 1);
               });
@@ -87,9 +88,9 @@
             });
           });
 
-          it('should not return other results', function () {
+          it('should not return other results', () => {
             if (typeof nodes !== 'undefined') {
-              var targets = nodes.map(function (node) {
+              const targets = nodes.map(node => {
                 return node.target;
               });
               // check that all nodes are removed
@@ -105,10 +106,10 @@
         });
       }
 
-      var results;
-      before(function (done) {
-        fixture.innerHTML = test.content;
-        waitForFrames(fixture, function () {
+      let results;
+      before(done => {
+        fixture.innerHTML = testObj.content;
+        waitForFrames(fixture, () => {
           axe.run(
             fixture,
             {
@@ -120,16 +121,16 @@
               performanceTimer: false,
               runOnly: { type: 'rule', values: [ruleId] }
             },
-            function (err, r) {
+            (err, r) => {
               // assert that there are no errors - if error exists a stack trace is logged.
-              var errStack = err && err.stack ? err.stack : '';
+              const errStack = err && err.stack ? err.stack : '';
               assert.isNull(err, 'Error should be null. ' + errStack);
               // assert that result is defined
               assert.isDefined(r, 'Results are defined.');
               // assert that result has certain keys
               assert.hasAnyKeys(r, ['incomplete', 'violations', 'passes']);
               // assert incomplete(s) does not have error
-              r.incomplete.forEach(function (incomplete) {
+              r.incomplete.forEach(incomplete => {
                 assert.isUndefined(incomplete.error);
               });
               // flatten results
@@ -139,10 +140,10 @@
           );
         });
       });
-      runTest(test, 'passes');
-      runTest(test, 'violations');
-      if (test.incomplete) {
-        runTest(test, 'incomplete');
+      runTest(testObj, 'passes');
+      runTest(testObj, 'violations');
+      if (testObj.incomplete) {
+        runTest(testObj, 'incomplete');
       }
     });
   });

--- a/test/node/jsdom.js
+++ b/test/node/jsdom.js
@@ -1,8 +1,8 @@
-var axe = require('../../');
-var jsdom = require('jsdom');
-var assert = require('assert');
+const axe = require('../../');
+const jsdom = require('jsdom');
+const assert = require('assert');
 
-var domStr =
+const domStr =
   '<!DOCTYPE html>' +
   '<html lang="en">' +
   '<head>' +
@@ -17,9 +17,9 @@ var domStr =
   '</body>' +
   '</html>';
 
-describe('jsdom axe-core', function () {
-  it('should run without setting globals', function () {
-    var dom = new jsdom.JSDOM(domStr);
+describe('jsdom axe-core', () => {
+  it('should run without setting globals', () => {
+    const dom = new jsdom.JSDOM(domStr);
 
     return axe
       .run(dom.window.document.documentElement, {
@@ -30,8 +30,8 @@ describe('jsdom axe-core', function () {
       });
   });
 
-  it('should unset globals so it can run with a new set of globals', function () {
-    var dom = new jsdom.JSDOM(domStr);
+  it('should unset globals so it can run with a new set of globals', () => {
+    let dom = new jsdom.JSDOM(domStr);
 
     return axe
       .run(dom.window.document.documentElement, {
@@ -40,45 +40,45 @@ describe('jsdom axe-core', function () {
       .then(function (results) {
         assert.notStrictEqual(results.violations.length, 0);
 
-        var dom = new jsdom.JSDOM(domStr);
+        dom = new jsdom.JSDOM(domStr);
 
         return axe
           .run(dom.window.document.documentElement, {
             rules: { 'color-contrast': { enabled: false } }
           })
-          .then(function (results) {
-            assert.notStrictEqual(results.violations.length, 0);
+          .then(function (res) {
+            assert.notStrictEqual(res.violations.length, 0);
           });
       });
   });
 
-  describe('audit', function () {
-    var audit = axe._audit;
+  describe('audit', () => {
+    const audit = axe._audit;
 
-    it('should have an empty allowedOrigins', function () {
+    it('should have an empty allowedOrigins', () => {
       // JSDOM does not have window.location, so there is no default origin
       assert.strictEqual(audit.allowedOrigins.length, 0);
     });
   });
 
-  describe('isCurrentPageLink', function () {
+  describe('isCurrentPageLink', () => {
     // because axe only sets the window global when calling axe.run,
     // we'll have to create a custom rule that calls
     // isCurrentPageLink to gain access to the middle of a run with
     // the proper window object
-    afterEach(function () {
+    afterEach(() => {
       axe.teardown();
     });
 
-    it('should return true if url starts with #', function () {
-      var dom = new jsdom.JSDOM(domStr);
-      var anchor = dom.window.document.getElementById('hash-link');
+    it('should return true if url starts with #', () => {
+      const dom = new jsdom.JSDOM(domStr);
+      const anchor = dom.window.document.getElementById('hash-link');
 
       axe.configure({
         checks: [
           {
             id: 'check-current-page-link',
-            evaluate: function () {
+            evaluate: () => {
               return axe.commons.dom.isCurrentPageLink(anchor) === true;
             }
           }
@@ -100,15 +100,15 @@ describe('jsdom axe-core', function () {
         });
     });
 
-    it('should return null for absolute link when url is not set', function () {
-      var dom = new jsdom.JSDOM(domStr);
-      var anchor = dom.window.document.getElementById('skip');
+    it('should return null for absolute link when url is not set', () => {
+      const dom = new jsdom.JSDOM(domStr);
+      const anchor = dom.window.document.getElementById('skip');
 
       axe.configure({
         checks: [
           {
             id: 'check-current-page-link',
-            evaluate: function () {
+            evaluate: () => {
               return axe.commons.dom.isCurrentPageLink(anchor) === null;
             }
           }
@@ -130,15 +130,15 @@ describe('jsdom axe-core', function () {
         });
     });
 
-    it('should return true for absolute link when url is set', function () {
-      var dom = new jsdom.JSDOM(domStr, { url: 'https://page.com' });
-      var anchor = dom.window.document.getElementById('skip');
+    it('should return true for absolute link when url is set', () => {
+      const dom = new jsdom.JSDOM(domStr, { url: 'https://page.com' });
+      const anchor = dom.window.document.getElementById('skip');
 
       axe.configure({
         checks: [
           {
             id: 'check-current-page-link',
-            evaluate: function () {
+            evaluate: () => {
               return axe.commons.dom.isCurrentPageLink(anchor) === true;
             }
           }

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,684 +1,699 @@
-/* global axe, checks */
-
-// Let the user know they need to disable their axe/attest extension before running the tests.
-if (window.__AXE_EXTENSION__) {
-  throw new Error(
-    'You must disable your axe/attest browser extension in order to run the test suite.'
-  );
-}
-
-/*eslint indent: 0*/
-var testUtils = {};
-
 /*eslint no-unused-vars: 0*/
-var checks, commons;
-var originalChecks = (checks = axe._audit.checks);
-var originalAudit = axe._audit;
-var originalRules = axe._audit.rules;
-var originalCommons = (commons = axe.commons);
 
-// Global chai configuration
-if (window.chai) {
-  window.chai.config.truncateThreshold = 0;
-}
+// these are global to the entire test suite so need to be declared at the global
+// level (old architecture that should not be relied on in any new code)
+var checks;
+var commons;
 
-// add fixture to the body if it's not already
-var fixture = document.getElementById('fixture');
-if (!fixture) {
-  fixture = document.createElement('div');
-  fixture.setAttribute('id', 'fixture');
-  document.body.insertBefore(fixture, document.body.firstChild);
-}
-
-// determine which checks are used only in the `none` array of rules
-var noneChecks = [];
-
-function verifyIsNoneCheck(check) {
-  var index = noneChecks.indexOf(check);
-  if (index !== -1) {
-    noneChecks.splice(index, 1);
-  }
-}
-
-axe._audit.rules.forEach(function (rule) {
-  rule.none.forEach(function (check) {
-    check = check.id || check;
-    if (noneChecks.indexOf(check) === -1) {
-      noneChecks.push(check);
-    }
-  });
-});
-
-axe._audit.rules.forEach(function (rule) {
-  rule.any.forEach(verifyIsNoneCheck);
-  rule.all.forEach(verifyIsNoneCheck);
-});
-
-/**
- * Create a check context for mocking/resetting data and relatedNodes in tests
- *
- * @return Object
- */
-testUtils.MockCheckContext = function () {
-  'use strict';
-  return {
-    _relatedNodes: [],
-    _data: null,
-    // When using this.async() in a check, assign a function to _onAsync
-    // to catch the response.
-    _onAsync: null,
-    async: function () {
-      var self = this;
-      return function (result) {
-        // throws if _onAsync isn't set
-        self._onAsync(result, self);
-      };
-    },
-    data: function (d) {
-      this._data = d;
-    },
-    relatedNodes: function (nodes) {
-      this._relatedNodes = Array.isArray(nodes) ? nodes : [nodes];
-    },
-    reset: function () {
-      this._data = null;
-      this._relatedNodes = [];
-      this._onAsync = null;
-    }
-  };
-};
-
-/**
- * Provide an API for determining Shadow DOM v0 and v1 support in tests.
- *
- * @param HTMLDocumentElement		The document of the current context
- * @return Object
- */
-testUtils.shadowSupport = (function (document) {
-  'use strict';
-  var v0 =
-      document.body && typeof document.body.createShadowRoot === 'function',
-    v1 = document.body && typeof document.body.attachShadow === 'function';
-
-  return {
-    v0: v0 === true,
-    v1: v1 === true,
-    undefined:
-      document.body &&
-      typeof document.body.attachShadow === 'undefined' &&
-      typeof document.body.createShadowRoot === 'undefined'
-  };
-})(document);
-
-/**
- * Return the fixture element
- * @return HTMLElement
- */
-testUtils.getFixture = function () {
-  'use strict';
-  return fixture;
-};
-
-/**
- * Method for injecting content into a fixture
- * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
- * @return HTMLElement
- */
-testUtils.injectIntoFixture = function (content) {
-  'use strict';
-  if (typeof content !== 'undefined') {
-    fixture.innerHTML = '';
+(() => {
+  // Let the user know they need to disable their axe/attest extension before running the tests.
+  if (window.__AXE_EXTENSION__) {
+    throw new Error(
+      'You must disable your axe/attest browser extension in order to run the test suite.'
+    );
   }
 
-  if (typeof content === 'string') {
-    fixture.innerHTML = content;
-  } else if (content instanceof Node) {
-    fixture.appendChild(content);
-  } else if (Array.isArray(content)) {
-    content.forEach(function (node) {
-      fixture.appendChild(node);
+  const testUtils = (axe.testUtils = {});
+
+  const originalChecks = (checks = axe._audit.checks);
+  const originalAudit = axe._audit;
+  const originalRules = axe._audit.rules;
+  const originalCommons = (commons = axe.commons);
+
+  // Global chai configuration
+  if (window.chai) {
+    window.chai.config.truncateThreshold = 0;
+  }
+
+  // add fixture to the body if it's not already
+  let fixture = document.getElementById('fixture');
+  if (!fixture) {
+    fixture = document.createElement('div');
+    fixture.setAttribute('id', 'fixture');
+    document.body.insertBefore(fixture, document.body.firstChild);
+  }
+
+  // determine which checks are used only in the `none` array of rules
+  const noneChecks = [];
+
+  function verifyIsNoneCheck(check) {
+    const index = noneChecks.indexOf(check);
+    if (index !== -1) {
+      noneChecks.splice(index, 1);
+    }
+  }
+
+  axe._audit.rules.forEach(function (rule) {
+    rule.none.forEach(function (check) {
+      check = check.id || check;
+      if (noneChecks.indexOf(check) === -1) {
+        noneChecks.push(check);
+      }
     });
-  }
+  });
 
-  return fixture;
-};
+  axe._audit.rules.forEach(function (rule) {
+    rule.any.forEach(verifyIsNoneCheck);
+    rule.all.forEach(verifyIsNoneCheck);
+  });
 
-/**
- * Method for injecting content into a fixture and caching
- * the flattened DOM tree (light and Shadow DOM together)
- *
- * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
- * @return HTMLElement
- */
-testUtils.fixtureSetup = function (content) {
-  'use strict';
-  testUtils.injectIntoFixture(content);
-  axe.teardown();
-  return axe.setup(fixture);
-};
+  /**
+   * Create a check context for mocking/resetting data and relatedNodes in tests
+   *
+   * @return Object
+   */
+  testUtils.MockCheckContext = function () {
+    'use strict';
+    return {
+      _relatedNodes: [],
+      _data: null,
+      // When using this.async() in a check, assign a function to _onAsync
+      // to catch the response.
+      _onAsync: null,
+      async: function () {
+        const self = this;
+        return function (result) {
+          // throws if _onAsync isn't set
+          self._onAsync(result, self);
+        };
+      },
+      data: function (d) {
+        this._data = d;
+      },
+      relatedNodes: function (nodes) {
+        this._relatedNodes = Array.isArray(nodes) ? nodes : [nodes];
+      },
+      reset: function () {
+        this._data = null;
+        this._relatedNodes = [];
+        this._onAsync = null;
+      }
+    };
+  };
 
-/**
- * Create check arguments
- *
- * @param Node|String 	Stuff to go into the fixture (html or node)
- * @param Object				Options argument for the check (optional, default: {})
- * @param String				Target for the check, CSS selector (default: '#target')
- * @return Array
- */
-testUtils.checkSetup = function (content, options, target) {
-  'use strict';
-  // Normalize the params
-  if (typeof options !== 'object') {
-    target = options;
-    options = {};
-  }
-  // Normalize target, allow it to be the inserted node or '#target'
-  target = target || (content instanceof Node ? content : '#target');
-  var rootNode = testUtils.fixtureSetup(content);
+  /**
+   * Provide an API for determining Shadow DOM v0 and v1 support in tests.
+   *
+   * @param HTMLDocumentElement		The document of the current context
+   * @return Object
+   */
+  testUtils.shadowSupport = (function (document) {
+    'use strict';
+    const v0 =
+        document.body && typeof document.body.createShadowRoot === 'function',
+      v1 = document.body && typeof document.body.attachShadow === 'function';
 
-  var node;
-  if (typeof target === 'string') {
-    node = axe.utils.querySelectorAll(rootNode, target)[0];
-  } else if (target instanceof Node) {
-    node = axe.utils.getNodeFromTree(target);
-  } else {
-    node = target;
-  }
-  return [node.actualNode, options, node];
-};
+    return {
+      v0: v0 === true,
+      v1: v1 === true,
+      undefined:
+        document.body &&
+        typeof document.body.attachShadow === 'undefined' &&
+        typeof document.body.createShadowRoot === 'undefined'
+    };
+  })(document);
 
-/**
- * Create a shadow DOM tree on #shadow and setup axe for it, returning #target
- *
- * @param Node|String 	Stuff to go into the fixture (html string or DOM Node)
- * @param Node|String 	Stuff to go into the shadow boundary (html or node)
- * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
- * @return VirtualNode
- */
-testUtils.queryShadowFixture = function (
-  content,
-  shadowContent,
-  targetSelector
-) {
-  'use strict';
+  /**
+   * Return the fixture element
+   * @return HTMLElement
+   */
+  testUtils.getFixture = function () {
+    'use strict';
+    return fixture;
+  };
 
-  // Normalize target, allow it to be the provided string or use '#target' to query composed tree
-  if (typeof targetSelector !== 'string') {
-    targetSelector = '#target';
-  }
-
-  var fixture = testUtils.injectIntoFixture(content);
-  var targetCandidate = fixture.querySelector(targetSelector);
-  var container = targetCandidate;
-  if (!targetCandidate) {
-    // check if content specifies a shadow container
-    container = fixture.querySelector('#shadow');
-    if (!container) {
-      container = fixture.firstChild;
+  /**
+   * Method for injecting content into a fixture
+   * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
+   * @return HTMLElement
+   */
+  testUtils.injectIntoFixture = function (content) {
+    'use strict';
+    if (typeof content !== 'undefined') {
+      fixture.innerHTML = '';
     }
-  }
-  // attach a shadowRoot with the content provided
-  var shadowRoot = container.attachShadow({ mode: 'open' });
-  if (typeof shadowContent === 'string') {
-    shadowRoot.innerHTML = shadowContent;
-  } else if (content instanceof Node) {
-    shadowRoot.appendChild(shadowContent);
-  }
 
-  if (!targetCandidate) {
-    targetCandidate = shadowRoot.querySelector(targetSelector);
-  }
-  if (!targetSelector && !targetCandidate) {
-    throw 'shadowCheckSetup requires at least one fragment to have #target, or a provided targetSelector';
-  }
+    if (typeof content === 'string') {
+      fixture.innerHTML = content;
+    } else if (content instanceof Node) {
+      fixture.appendChild(content);
+    } else if (Array.isArray(content)) {
+      content.forEach(function (node) {
+        fixture.appendChild(node);
+      });
+    }
 
-  // query the composed tree AFTER shadowDOM has been attached
-  axe.setup(fixture);
-  return axe.utils.getNodeFromTree(targetCandidate);
-};
+    return fixture;
+  };
 
-/**
- * Create check arguments with Shadow DOM. Target can be inside or outside of Shadow DOM, queried by
- * adding `id="target"` to a fragment. Or specify a custom selector as the `targetSelector` argument.
- *
- * @param Node|String 	Stuff to go into the fixture (html string or DOM Node)
- * @param Node|String 	Stuff to go into the shadow boundary (html or node)
- * @param Object				Options argument for the check (optional, default: {})
- * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
- * @return Array
- */
-testUtils.shadowCheckSetup = function (
-  content,
-  shadowContent,
-  options,
-  targetSelector
-) {
-  // Normalize the object params
-  if (typeof options !== 'object') {
-    options = {};
-  }
-  var node = testUtils.queryShadowFixture(
+  /**
+   * Method for injecting content into a fixture and caching
+   * the flattened DOM tree (light and Shadow DOM together)
+   *
+   * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
+   * @return HTMLElement
+   */
+  testUtils.fixtureSetup = function (content) {
+    'use strict';
+    testUtils.injectIntoFixture(content);
+    axe.teardown();
+    return axe.setup(fixture);
+  };
+
+  /**
+   * Create check arguments
+   *
+   * @param Node|String 	Stuff to go into the fixture (html or node)
+   * @param Object				Options argument for the check (optional, default: {})
+   * @param String				Target for the check, CSS selector (default: '#target')
+   * @return Array
+   */
+  testUtils.checkSetup = function (content, options, target) {
+    'use strict';
+    // Normalize the params
+    if (typeof options !== 'object') {
+      target = options;
+      options = {};
+    }
+    // Normalize target, allow it to be the inserted node or '#target'
+    target = target || (content instanceof Node ? content : '#target');
+    const rootNode = testUtils.fixtureSetup(content);
+
+    let node;
+    if (typeof target === 'string') {
+      node = axe.utils.querySelectorAll(rootNode, target)[0];
+    } else if (target instanceof Node) {
+      node = axe.utils.getNodeFromTree(target);
+    } else {
+      node = target;
+    }
+    return [node.actualNode, options, node];
+  };
+
+  /**
+   * Create a shadow DOM tree on #shadow and setup axe for it, returning #target
+   *
+   * @param Node|String 	Stuff to go into the fixture (html string or DOM Node)
+   * @param Node|String 	Stuff to go into the shadow boundary (html or node)
+   * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
+   * @return VirtualNode
+   */
+  testUtils.queryShadowFixture = function (
     content,
     shadowContent,
     targetSelector
-  );
-  return [node.actualNode, options, node];
-};
+  ) {
+    'use strict';
 
-/**
- * Setup axe._tree flat tree
- * @param Node   Stuff to go in the flat tree
- * @returns vNode[]
- */
-testUtils.flatTreeSetup = function (content) {
-  axe._tree = axe.utils.getFlattenedTree(content);
-  return axe._tree;
-};
-
-/**
- * Wait for all nested frames to be loaded
- *
- * @param Object				Window to wait for (optional)
- * @param function			Callback, called once resolved
- * @param function      Callback, called once rejected
- */
-testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb, errCb) {
-  'use strict';
-  if (typeof win === 'function') {
-    errCb = cb;
-    cb = win;
-    win = window;
-  }
-  var document = win.document;
-  var q = axe.utils.queue();
-
-  // Wait for page load
-  q.defer(function (resolve) {
-    if (document.readyState === 'complete') {
-      resolve();
-    } else {
-      win.addEventListener('load', resolve);
+    // Normalize target, allow it to be the provided string or use '#target' to query composed tree
+    if (typeof targetSelector !== 'string') {
+      targetSelector = '#target';
     }
-  });
 
-  // Wait for all frames to be loaded
-  Array.from(document.querySelectorAll('iframe')).forEach(function (frame) {
-    q.defer(function (resolve) {
-      return awaitNestedLoad(frame.contentWindow, resolve);
-    });
-  });
-
-  // Complete (don't pass the args on to the callback)
-  q.then(function () {
-    cb();
-  });
-
-  if (errCb) {
-    q.catch(errCb);
-  }
-};
-
-/**
- * Add a given stylesheet dynamically to the document
- *
- * @param {Object} data composite object containing properties to create stylesheet
- * @property {String} data.href relative or absolute url for stylesheet to be loaded
- * @property {Boolean} data.mediaPrint boolean to represent if the constructed sheet is for print media
- * @property {String} data.text text contents to be written to the stylesheet
- * @property {String} data.id id reference to link or style to be added to document
- * @param {Object} rootNode document/fragment to which to append style
- * @returns {Object} axe.utils.queue
- */
-testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
-  var doc = rootNode ? rootNode : document;
-  var q = axe.utils.queue();
-  if (data.href) {
-    q.defer(function (resolve, reject) {
-      var link = doc.createElement('link');
-      link.rel = 'stylesheet';
-      link.href = data.href;
-      if (data.id) {
-        link.id = data.id;
+    const fixtureNode = testUtils.injectIntoFixture(content);
+    let targetCandidate = fixtureNode.querySelector(targetSelector);
+    let container = targetCandidate;
+    if (!targetCandidate) {
+      // check if content specifies a shadow container
+      container = fixtureNode.querySelector('#shadow');
+      if (!container) {
+        container = fixtureNode.firstChild;
       }
-      if (data.mediaPrint) {
-        link.media = 'print';
-      }
-      link.onload = function () {
-        setTimeout(function () {
-          resolve();
-        });
-      };
-      link.onerror = function () {
-        reject();
-      };
-      doc.head.appendChild(link);
-    });
-  } else {
-    q.defer(function (resolve) {
-      var style = doc.createElement('style');
-      if (data.id) {
-        style.id = data.id;
-      }
-      style.type = 'text/css';
-      style.appendChild(doc.createTextNode(data.text));
-      doc.head.appendChild(style);
-      setTimeout(function () {
-        resolve();
-      }, 100); // -> note: gives firefox to load (document.stylesheets), other browsers are fine.
-    });
-  }
-  return q;
-};
-
-/**
- * Add a list of stylesheets
- *
- * @param {Object} sheets array of sheets data object
- * @returns {Object} axe.utils.queue
- */
-testUtils.addStyleSheets = function addStyleSheets(sheets, rootNode) {
-  var q = axe.utils.queue();
-  sheets.forEach(function (data) {
-    q.defer(axe.testUtils.addStyleSheet(data, rootNode));
-  });
-  return q;
-};
-
-/**
- * Remove a list of stylesheets from the document
- * @param {Array<Object>} sheets array of sheets data object
- * @returns {Object} axe.utils.queue
- */
-testUtils.removeStyleSheets = function removeStyleSheets(sheets) {
-  var q = axe.utils.queue();
-  sheets.forEach(function (data) {
-    q.defer(function (resolve, reject) {
-      var node = document.getElementById(data.id);
-      if (!node || !node.parentNode) {
-        reject();
-      }
-      node.parentNode.removeChild(node);
-      resolve();
-    });
-  });
-  return q;
-};
-
-/**
- * Assert a given stylesheet against selectorText and cssText
- *
- * @param {Object} sheet CSS Stylesheet
- * @param {String} selectorText CSS Selector
- * @param {String} cssText CSS Values
- * @param {Boolean} includes (Optional) flag to check if existence of selectorText within cssText
- */
-testUtils.assertStylesheet = function assertStylesheet(
-  sheet,
-  selectorText,
-  cssText,
-  includes
-) {
-  assert.isDefined(sheet);
-  assert.property(sheet, 'cssRules');
-  if (includes) {
-    assert.isTrue(cssText.includes(selectorText));
-  } else {
-    assert.equal(sheet.cssRules[0].selectorText, selectorText);
-
-    // compare the selector properties
-    var styleEl = document.createElement('style');
-    styleEl.type = 'text/css';
-    styleEl.innerHTML = cssText;
-    document.body.appendChild(styleEl);
-
-    var testSheet = document.styleSheets[document.styleSheets.length - 1];
-    var sheetRule = sheet.cssRules[0];
-    var testRule = testSheet.cssRules[0];
-
-    try {
-      for (var i = 0; i < testRule.style.length; i++) {
-        var property = testRule.style[i];
-        assert.equal(sheetRule.style[property], testRule.style[property]);
-      }
-    } finally {
-      styleEl.parentNode.removeChild(styleEl);
     }
-  }
-};
+    // attach a shadowRoot with the content provided
+    const shadowRoot = container.attachShadow({ mode: 'open' });
+    if (typeof shadowContent === 'string') {
+      shadowRoot.innerHTML = shadowContent;
+    } else if (content instanceof Node) {
+      shadowRoot.appendChild(shadowContent);
+    }
 
-/**
- * Injecting content into a fixture and return queried element within fixture
- *
- * @param {String|Node} html - content to go into the fixture (html or DOM node)
- * @param {String} [query=#target] - the CSS selector query to find target DOM node
- * @return {VirtualNode}
- */
-testUtils.queryFixture = function queryFixture(html, query) {
-  query = query || '#target';
-  var rootNode = testUtils.fixtureSetup(html);
-  var vNode = axe.utils.querySelectorAll(rootNode, query)[0];
-  assert.exists(
-    vNode,
-    'Node does not exist in query `' +
-      query +
-      '`. This is usually fixed by adding the default target (`id="target"`) to your html parameter. If you do not intend on querying the fixture for #target, consider using `axe.testUtils.fixtureSetup()` instead.'
-  );
-  return vNode;
-};
+    if (!targetCandidate) {
+      targetCandidate = shadowRoot.querySelector(targetSelector);
+    }
+    if (!targetSelector && !targetCandidate) {
+      throw 'shadowCheckSetup requires at least one fragment to have #target, or a provided targetSelector';
+    }
 
-/**
- * Return the checks evaluate method and apply default options
- * @param {string} checkId - ID of the check
- * @param {} testOptions - Options for the test
- * @returns {evaluateWrapper} evaluateWrapper - Check evaluation wrapper
- */
-testUtils.getCheckEvaluate = function getCheckEvaluate(checkId, testOptions) {
-  var check = checks[checkId];
-  testOptions = testOptions || {};
+    // query the composed tree AFTER shadowDOM has been attached
+    axe.setup(fixtureNode);
+    return axe.utils.getNodeFromTree(targetCandidate);
+  };
 
   /**
-   * Wraps a check for evaluation using .call()
-   * @param {HTMLElement} node
-   * @param {*} options
-   * @param {VirtualNode} virtualNode
-   * @param {Context} context
+   * Create check arguments with Shadow DOM. Target can be inside or outside of Shadow DOM, queried by
+   * adding `id="target"` to a fragment. Or specify a custom selector as the `targetSelector` argument.
+   *
+   * @param Node|String 	Stuff to go into the fixture (html string or DOM Node)
+   * @param Node|String 	Stuff to go into the shadow boundary (html or node)
+   * @param Object				Options argument for the check (optional, default: {})
+   * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
+   * @return Array
    */
-  var evaluateWrapper = function (node, options, virtualNode, context) {
-    var opts = check.getOptions(options);
+  testUtils.shadowCheckSetup = function (
+    content,
+    shadowContent,
+    options,
+    targetSelector
+  ) {
+    // Normalize the object params
+    if (typeof options !== 'object') {
+      options = {};
+    }
+    const node = testUtils.queryShadowFixture(
+      content,
+      shadowContent,
+      targetSelector
+    );
+    return [node.actualNode, options, node];
+  };
 
-    var result = check.evaluate.call(this, node, opts, virtualNode, context);
+  /**
+   * Setup axe._tree flat tree
+   * @param Node   Stuff to go in the flat tree
+   * @returns vNode[]
+   */
+  testUtils.flatTreeSetup = function (content) {
+    axe._tree = axe.utils.getFlattenedTree(content);
+    return axe._tree;
+  };
 
-    // ensure that every result has a corresponding message
-    if (testOptions.verifyMessage !== false) {
-      var messages = axe._audit.data.checks[checkId].messages;
-      var messageKey = this._data && this._data.messageKey;
+  /**
+   * Wait for all nested frames to be loaded
+   *
+   * @param Object				Window to wait for (optional)
+   * @param function			Callback, called once resolved
+   * @param function      Callback, called once rejected
+   */
+  testUtils.awaitNestedLoad = function awaitNestedLoad(win, cb, errCb) {
+    'use strict';
+    if (typeof win === 'function') {
+      errCb = cb;
+      cb = win;
+      win = window;
+    }
+    const document = win.document;
+    const q = axe.utils.queue();
 
-      // see how the check is used to know where to find the message
-      // e.g. a check used only in the `none` array of a rule will look at
-      // the messageKey of a passing result in the `fail` messages
-      var keyResult = result;
-      var isNoneCheck = noneChecks.indexOf(checkId) !== -1;
-      if (isNoneCheck) {
-        keyResult = result === true ? false : result === false ? true : result;
+    // Wait for page load
+    q.defer(function (resolve) {
+      if (document.readyState === 'complete') {
+        resolve();
+      } else {
+        win.addEventListener('load', resolve);
       }
+    });
 
-      var key =
-        keyResult === true
-          ? 'pass'
-          : keyResult === false
-          ? 'fail'
-          : 'incomplete';
-      var noneCheckMessage = isNoneCheck
-        ? '. Note that since this check is only used in the "none" array of all rules, the messages use the inverse of the result (e.g. a result of false uses the "pass" messages)'
-        : '';
+    // Wait for all frames to be loaded
+    Array.from(document.querySelectorAll('iframe')).forEach(function (frame) {
+      q.defer(function (resolve) {
+        return awaitNestedLoad(frame.contentWindow, resolve);
+      });
+    });
 
-      assert.exists(
-        messages[key],
-        'Missing "' +
-          key +
-          '" message for check result of ' +
-          result +
-          noneCheckMessage
+    // Complete (don't pass the args on to the callback)
+    q.then(function () {
+      cb();
+    });
+
+    if (errCb) {
+      q.catch(errCb);
+    }
+  };
+
+  /**
+   * Add a given stylesheet dynamically to the document
+   *
+   * @param {Object} data composite object containing properties to create stylesheet
+   * @property {String} data.href relative or absolute url for stylesheet to be loaded
+   * @property {Boolean} data.mediaPrint boolean to represent if the constructed sheet is for print media
+   * @property {String} data.text text contents to be written to the stylesheet
+   * @property {String} data.id id reference to link or style to be added to document
+   * @param {Object} rootNode document/fragment to which to append style
+   * @returns {Object} axe.utils.queue
+   */
+  testUtils.addStyleSheet = function addStyleSheet(data, rootNode) {
+    const doc = rootNode ? rootNode : document;
+    const q = axe.utils.queue();
+    if (data.href) {
+      q.defer(function (resolve, reject) {
+        const link = doc.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = data.href;
+        if (data.id) {
+          link.id = data.id;
+        }
+        if (data.mediaPrint) {
+          link.media = 'print';
+        }
+        link.onload = function () {
+          setTimeout(function () {
+            resolve();
+          });
+        };
+        link.onerror = function () {
+          reject();
+        };
+        doc.head.appendChild(link);
+      });
+    } else {
+      q.defer(function (resolve) {
+        const style = doc.createElement('style');
+        if (data.id) {
+          style.id = data.id;
+        }
+        style.type = 'text/css';
+        style.appendChild(doc.createTextNode(data.text));
+        doc.head.appendChild(style);
+        setTimeout(function () {
+          resolve();
+        }, 100); // -> note: gives firefox to load (document.stylesheets), other browsers are fine.
+      });
+    }
+    return q;
+  };
+
+  /**
+   * Add a list of stylesheets
+   *
+   * @param {Object} sheets array of sheets data object
+   * @returns {Object} axe.utils.queue
+   */
+  testUtils.addStyleSheets = function addStyleSheets(sheets, rootNode) {
+    const q = axe.utils.queue();
+    sheets.forEach(function (data) {
+      q.defer(axe.testUtils.addStyleSheet(data, rootNode));
+    });
+    return q;
+  };
+
+  /**
+   * Remove a list of stylesheets from the document
+   * @param {Array<Object>} sheets array of sheets data object
+   * @returns {Object} axe.utils.queue
+   */
+  testUtils.removeStyleSheets = function removeStyleSheets(sheets) {
+    const q = axe.utils.queue();
+    sheets.forEach(function (data) {
+      q.defer(function (resolve, reject) {
+        const node = document.getElementById(data.id);
+        if (!node || !node.parentNode) {
+          reject();
+        }
+        node.parentNode.removeChild(node);
+        resolve();
+      });
+    });
+    return q;
+  };
+
+  /**
+   * Assert a given stylesheet against selectorText and cssText
+   *
+   * @param {Object} sheet CSS Stylesheet
+   * @param {String} selectorText CSS Selector
+   * @param {String} cssText CSS Values
+   * @param {Boolean} includes (Optional) flag to check if existence of selectorText within cssText
+   */
+  testUtils.assertStylesheet = function assertStylesheet(
+    sheet,
+    selectorText,
+    cssText,
+    includes
+  ) {
+    assert.isDefined(sheet);
+    assert.property(sheet, 'cssRules');
+    if (includes) {
+      assert.isTrue(cssText.includes(selectorText));
+    } else {
+      assert.equal(sheet.cssRules[0].selectorText, selectorText);
+
+      // compare the selector properties
+      const styleEl = document.createElement('style');
+      styleEl.type = 'text/css';
+      styleEl.innerHTML = cssText;
+      document.body.appendChild(styleEl);
+
+      const testSheet = document.styleSheets[document.styleSheets.length - 1];
+      const sheetRule = sheet.cssRules[0];
+      const testRule = testSheet.cssRules[0];
+
+      try {
+        for (let i = 0; i < testRule.style.length; i++) {
+          const property = testRule.style[i];
+          assert.equal(sheetRule.style[property], testRule.style[property]);
+        }
+      } finally {
+        styleEl.parentNode.removeChild(styleEl);
+      }
+    }
+  };
+
+  /**
+   * Injecting content into a fixture and return queried element within fixture
+   *
+   * @param {String|Node} html - content to go into the fixture (html or DOM node)
+   * @param {String} [query=#target] - the CSS selector query to find target DOM node
+   * @return {VirtualNode}
+   */
+  testUtils.queryFixture = function queryFixture(html, query) {
+    query = query || '#target';
+    const rootNode = testUtils.fixtureSetup(html);
+    const vNode = axe.utils.querySelectorAll(rootNode, query)[0];
+    assert.exists(
+      vNode,
+      'Node does not exist in query `' +
+        query +
+        '`. This is usually fixed by adding the default target (`id="target"`) to your html parameter. If you do not intend on querying the fixture for #target, consider using `axe.testUtils.fixtureSetup()` instead.'
+    );
+    return vNode;
+  };
+
+  /**
+   * Return the checks evaluate method and apply default options
+   * @param {string} checkId - ID of the check
+   * @param {} testOptions - Options for the test
+   * @returns {evaluateWrapper} evaluateWrapper - Check evaluation wrapper
+   */
+  testUtils.getCheckEvaluate = function getCheckEvaluate(checkId, testOptions) {
+    const check = checks[checkId];
+    testOptions = testOptions || {};
+
+    /**
+     * Wraps a check for evaluation using .call()
+     * @param {HTMLElement} node
+     * @param {*} options
+     * @param {VirtualNode} virtualNode
+     * @param {Context} context
+     */
+    const evaluateWrapper = function (node, options, virtualNode, context) {
+      const opts = check.getOptions(options);
+
+      const result = check.evaluate.call(
+        this,
+        node,
+        opts,
+        virtualNode,
+        context
       );
-      if (messageKey) {
+
+      // ensure that every result has a corresponding message
+      if (testOptions.verifyMessage !== false) {
+        const messages = axe._audit.data.checks[checkId].messages;
+        const messageKey = this._data && this._data.messageKey;
+
+        // see how the check is used to know where to find the message
+        // e.g. a check used only in the `none` array of a rule will look at
+        // the messageKey of a passing result in the `fail` messages
+        let keyResult = result;
+        const isNoneCheck = noneChecks.indexOf(checkId) !== -1;
+        if (isNoneCheck) {
+          keyResult =
+            result === true ? false : result === false ? true : result;
+        }
+
+        const key =
+          keyResult === true
+            ? 'pass'
+            : keyResult === false
+            ? 'fail'
+            : 'incomplete';
+        const noneCheckMessage = isNoneCheck
+          ? '. Note that since this check is only used in the "none" array of all rules, the messages use the inverse of the result (e.g. a result of false uses the "pass" messages)'
+          : '';
+
         assert.exists(
-          messages[key][messageKey],
-          'Missing ' +
+          messages[key],
+          'Missing "' +
             key +
-            ' message key "' +
-            messageKey +
-            '" for check result of ' +
+            '" message for check result of ' +
             result +
             noneCheckMessage
         );
+        if (messageKey) {
+          assert.exists(
+            messages[key][messageKey],
+            'Missing ' +
+              key +
+              ' message key "' +
+              messageKey +
+              '" for check result of ' +
+              result +
+              noneCheckMessage
+          );
 
-        var message = axe.utils.processMessage(
-          messages[key][messageKey],
-          this._data
-        );
-        assert.isTrue(
-          message.indexOf('${') === -1,
-          'Data object missing properties for ' +
-            key +
-            ' message key "' +
-            messageKey +
-            '": "' +
-            message +
-            '"'
-        );
-      } else {
-        var message = axe.utils.processMessage(messages[key], this._data);
-        assert.isTrue(
-          message.indexOf('${') === -1,
-          'Data object missing properties for ' +
-            key +
-            ' message: "' +
-            message +
-            '"'
-        );
+          const message = axe.utils.processMessage(
+            messages[key][messageKey],
+            this._data
+          );
+          assert.isTrue(
+            message.indexOf('${') === -1,
+            'Data object missing properties for ' +
+              key +
+              ' message key "' +
+              messageKey +
+              '": "' +
+              message +
+              '"'
+          );
+        } else {
+          const message = axe.utils.processMessage(messages[key], this._data);
+          assert.isTrue(
+            message.indexOf('${') === -1,
+            'Data object missing properties for ' +
+              key +
+              ' message: "' +
+              message +
+              '"'
+          );
+        }
       }
-    }
 
-    return result;
+      return result;
+    };
+    return evaluateWrapper;
   };
-  return evaluateWrapper;
-};
 
-axe.testUtils = testUtils;
-
-if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
-  // prevent setting read-only properties
-  // @see https://github.com/dequelabs/axe-core/issues/3837
-  const readonlyRect = new DOMRectReadOnly();
-  const proto = Object.getPrototypeOf(readonlyRect);
-  ['left', 'right', 'top', 'bottom'].forEach(prop => {
-    Object.defineProperty(proto, prop, {
-      set(value) {
-        throw new TypeError(`setting getter-only property "${prop}"`);
-      }
+  if (typeof beforeEach !== 'undefined' && typeof afterEach !== 'undefined') {
+    // prevent setting read-only properties
+    // @see https://github.com/dequelabs/axe-core/issues/3837
+    const readonlyRect = new DOMRectReadOnly();
+    const proto = Object.getPrototypeOf(readonlyRect);
+    ['left', 'right', 'top', 'bottom'].forEach(prop => {
+      Object.defineProperty(proto, prop, {
+        set(value) {
+          throw new TypeError(`setting getter-only property "${prop}"`);
+        }
+      });
     });
-  });
 
-  beforeEach(function () {
-    // reset from axe._load overriding
-    checks = originalChecks;
-    axe._audit = originalAudit;
-    axe._audit.rules = originalRules;
-    commons = axe.commons = originalCommons;
-  });
+    beforeEach(function () {
+      // reset from axe._load overriding
+      checks = originalChecks;
+      axe._audit = originalAudit;
+      axe._audit.rules = originalRules;
+      commons = axe.commons = originalCommons;
+    });
 
-  afterEach(function () {
-    axe.teardown();
-    fixture.innerHTML = '';
+    afterEach(function () {
+      axe.teardown();
+      fixture.innerHTML = '';
 
-    // remove all attributes from fixture (otherwise a leftover
-    // style attribute would cause avoid-inline-spacing integration
-    // test to fail with [#fixture] being included in the results)
-    var attrs = fixture.attributes;
-    for (var i = 0; i < attrs.length; i++) {
-      var attrName = attrs[i].name;
-      if (attrName !== 'id') {
-        fixture.removeAttribute(attrs[i].name);
+      // remove all attributes from fixture (otherwise a leftover
+      // style attribute would cause avoid-inline-spacing integration
+      // test to fail with [#fixture] being included in the results)
+      const attrs = fixture.attributes;
+      for (let i = 0; i < attrs.length; i++) {
+        const attrName = attrs[i].name;
+        if (attrName !== 'id') {
+          fixture.removeAttribute(attrs[i].name);
+        }
+      }
+
+      // reset html and body styles
+      document.body.removeAttribute('style');
+      document.documentElement.removeAttribute('style');
+    });
+  }
+
+  testUtils.captureError = function captureError(cb, errorHandler) {
+    return function () {
+      try {
+        cb.apply(null, arguments);
+      } catch (e) {
+        errorHandler(e);
+      }
+    };
+  };
+
+  testUtils.runPartialRecursive = function runPartialRecursive(
+    context,
+    options,
+    win
+  ) {
+    options = options || {};
+    win = win || window;
+    const axe = win.axe;
+    const frameContexts = axe.utils.getFrameContexts(context);
+    const promiseResults = [axe.runPartial(context, options)];
+
+    frameContexts.forEach(function (c) {
+      const frame = testUtils.shadowQuerySelector(
+        c.frameSelector,
+        win.document
+      );
+      const frameWin = frame.contentWindow;
+      const frameResults = testUtils.runPartialRecursive(
+        c.frameContext,
+        options,
+        frameWin
+      );
+      promiseResults = promiseResults.concat(frameResults);
+    });
+    return promiseResults;
+  };
+
+  testUtils.shadowQuerySelector = function shadowQuerySelector(
+    axeSelector,
+    doc
+  ) {
+    let elm;
+    doc = doc || document;
+    axeSelector = Array.isArray(axeSelector) ? axeSelector : [axeSelector];
+    axeSelector.forEach(function (selectorStr) {
+      elm = doc && doc.querySelector(selectorStr);
+      doc = elm && elm.shadowRoot;
+    });
+    return elm;
+  };
+
+  testUtils.createNestedShadowDom = function createFixtureShadowTree(
+    fixtureNode,
+    ...htmlCodes
+  ) {
+    if (htmlCodes.length <= 1) {
+      throw new Error(
+        'createNestedShadowDom must contain at least two HTML snippets'
+      );
+    }
+    let htmlCode;
+    while ((htmlCode = htmlCodes.shift())) {
+      appendHtml(fixtureNode, htmlCode);
+      if (htmlCodes.length) {
+        const query = fixtureNode.querySelectorAll('#shadowHost, .shadowHost');
+        fixtureNode = query[query.length - 1];
+        fixtureNode = fixtureNode.attachShadow({ mode: 'open' });
       }
     }
-
-    // reset html and body styles
-    document.body.removeAttribute('style');
-    document.documentElement.removeAttribute('style');
-  });
-}
-
-testUtils.captureError = function captureError(cb, errorHandler) {
-  return function () {
-    try {
-      cb.apply(null, arguments);
-    } catch (e) {
-      errorHandler(e);
-    }
+    return fixtureNode.querySelector('#target');
   };
-};
 
-testUtils.runPartialRecursive = function runPartialRecursive(
-  context,
-  options,
-  win
-) {
-  options = options || {};
-  win = win || window;
-  var axe = win.axe;
-  var frameContexts = axe.utils.getFrameContexts(context);
-  var promiseResults = [axe.runPartial(context, options)];
-
-  frameContexts.forEach(function (c) {
-    var frame = testUtils.shadowQuerySelector(c.frameSelector, win.document);
-    var frameWin = frame.contentWindow;
-    var frameResults = testUtils.runPartialRecursive(
-      c.frameContext,
-      options,
-      frameWin
-    );
-    promiseResults = promiseResults.concat(frameResults);
-  });
-  return promiseResults;
-};
-
-testUtils.shadowQuerySelector = function shadowQuerySelector(axeSelector, doc) {
-  var elm;
-  doc = doc || document;
-  axeSelector = Array.isArray(axeSelector) ? axeSelector : [axeSelector];
-  axeSelector.forEach(function (selectorStr) {
-    elm = doc && doc.querySelector(selectorStr);
-    doc = elm && elm.shadowRoot;
-  });
-  return elm;
-};
-
-testUtils.createNestedShadowDom = function createFixtureShadowTree(
-  fixture,
-  ...htmlCodes
-) {
-  if (htmlCodes.length <= 1) {
-    throw new Error(
-      'createNestedShadowDom must contain at least two HTML snippets'
-    );
-  }
-  let htmlCode;
-  while ((htmlCode = htmlCodes.shift())) {
-    appendHtml(fixture, htmlCode);
-    if (htmlCodes.length) {
-      const query = fixture.querySelectorAll('#shadowHost, .shadowHost');
-      fixture = query[query.length - 1];
-      fixture = fixture.attachShadow({ mode: 'open' });
+  function appendHtml(fixtureNode, htmlCode) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = htmlCode;
+    // Append to avoid clobbering other shadow trees with innerHTML
+    for (let child of tmp.children) {
+      fixtureNode.appendChild(child.cloneNode(true));
     }
   }
-  return fixture.querySelector('#target');
-};
-
-function appendHtml(fixture, htmlCode) {
-  const tmp = document.createElement('div');
-  tmp.innerHTML = htmlCode;
-  // Append to avoid clobbering other shadow trees with innerHTML
-  for (const child of tmp.children) {
-    fixture.appendChild(child.cloneNode(true));
-  }
-}
+})();

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -635,7 +635,7 @@ var commons;
     win = win || window;
     const axe = win.axe;
     const frameContexts = axe.utils.getFrameContexts(context);
-    const promiseResults = [axe.runPartial(context, options)];
+    let promiseResults = [axe.runPartial(context, options)];
 
     frameContexts.forEach(function (c) {
       const frame = testUtils.shadowQuerySelector(


### PR DESCRIPTION
This came up in [a recent pr](https://github.com/dequelabs/axe-core/pull/4086#discussion_r1261194989) so went ahead and did it (hurray for resolving some 111 issues). For every file I touched I did the following:

* Moved default export to the top
* Converted to es6 arrow functions and `const` / `let`
* Refactored some improper uses of `reduce` to better array functions (when the reduce caused the name conflict)
* Removed unneeded `/* global */` eslint strings

In some files that had naming conflict issues the issues were in nested functions so I moved the function outside the nested scope.