### PR TITLE
fix: Use correct copyright year

### DIFF
--- a/lib/intro.stub
+++ b/lib/intro.stub
@@ -1,5 +1,5 @@
 /*! axe v<%= pkg.version %>
- * Copyright (c) <%= grunt.template.today("yyyy") %> Deque Systems, Inc.
+ * Copyright (c) 2015 Deque Systems, Inc.
  *
  * Your use of this Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
This patch corrects the copyright year included in the built `axe.js` and `axe.min.js` files. Deque Systems, Inc has held the copyright for axe-core since 2015.