### PR TITLE
fix(aria-allowed-attr): pass aria-expanded on checkbox & switch

### DIFF
--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -75,9 +75,9 @@ const ariaRoles = {
     allowedAttrs: [
       'aria-colindex',
       'aria-colspan',
-      'aria-expanded',
       'aria-rowindex',
-      'aria-rowspan'
+      'aria-rowspan',
+      'aria-expanded'
     ],
     superclassRole: ['section'],
     nameFromContent: true
@@ -197,9 +197,9 @@ const ariaRoles = {
   },
   feed: {
     type: 'structure',
+    requiredOwned: ['article'],
     // Aria-expanded removed as of 1.3
     allowedAttrs: ['aria-expanded'],
-    requiredOwned: ['article'],
     superclassRole: ['list']
   },
   figure: {

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -812,8 +812,6 @@ const ariaRoles = {
   },
   time: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
-    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   timer: {

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -18,13 +18,13 @@
 const ariaRoles = {
   alert: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   alertdialog: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded', 'aria-modal'],
     superclassRole: ['alert', 'dialog'],
     accessibleNameRequired: true
@@ -40,13 +40,13 @@ const ariaRoles = {
   },
   article: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-posinset', 'aria-setsize', 'aria-expanded'],
     superclassRole: ['document']
   },
   banner: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
@@ -71,7 +71,7 @@ const ariaRoles = {
   cell: {
     type: 'structure',
     requiredContext: ['row'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-colindex',
       'aria-colspan',
@@ -101,7 +101,7 @@ const ariaRoles = {
   columnheader: {
     type: 'structure',
     requiredContext: ['row'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-sort',
       'aria-colindex',
@@ -138,7 +138,7 @@ const ariaRoles = {
   },
   complementary: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
@@ -148,7 +148,7 @@ const ariaRoles = {
   },
   contentinfo: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
@@ -159,7 +159,7 @@ const ariaRoles = {
   },
   definition: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
@@ -170,7 +170,7 @@ const ariaRoles = {
   },
   dialog: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded', 'aria-modal'],
     superclassRole: ['window'],
     accessibleNameRequired: true
@@ -178,7 +178,7 @@ const ariaRoles = {
   directory: {
     type: 'structure',
     deprecated: true,
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['list'],
     // Note: spec difference
@@ -186,7 +186,7 @@ const ariaRoles = {
   },
   document: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['structure']
   },
@@ -198,13 +198,13 @@ const ariaRoles = {
   feed: {
     type: 'structure',
     requiredOwned: ['article'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['list']
   },
   figure: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
@@ -212,14 +212,14 @@ const ariaRoles = {
   },
   form: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   grid: {
     type: 'composite',
     requiredOwned: ['rowgroup', 'row'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-level',
       'aria-multiselectable',
@@ -251,14 +251,14 @@ const ariaRoles = {
   },
   group: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-activedescendant', 'aria-expanded'],
     superclassRole: ['section']
   },
   heading: {
     type: 'structure',
     requiredAttrs: ['aria-level'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['sectionhead'],
     // Note: spec difference
@@ -267,7 +267,7 @@ const ariaRoles = {
   },
   img: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     accessibleNameRequired: true,
@@ -296,7 +296,7 @@ const ariaRoles = {
   list: {
     type: 'structure',
     requiredOwned: ['listitem'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
@@ -329,25 +329,25 @@ const ariaRoles = {
   },
   log: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   main: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   marquee: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   math: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     childrenPresentational: true
@@ -363,7 +363,7 @@ const ariaRoles = {
       'menu',
       'separator'
     ],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-activedescendant',
       'aria-expanded',
@@ -382,7 +382,7 @@ const ariaRoles = {
       'menu',
       'separator'
     ],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-activedescendant',
       'aria-expanded',
@@ -445,7 +445,7 @@ const ariaRoles = {
   },
   navigation: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
@@ -456,7 +456,7 @@ const ariaRoles = {
   },
   note: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
@@ -489,7 +489,7 @@ const ariaRoles = {
   },
   progressbar: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-expanded',
       'aria-valuemax',
@@ -515,7 +515,7 @@ const ariaRoles = {
   radiogroup: {
     type: 'composite',
     // Note: spec difference (no required owned)
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-readonly',
       'aria-required',
@@ -533,7 +533,7 @@ const ariaRoles = {
   },
   region: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark'],
     // Note: spec difference
@@ -570,7 +570,7 @@ const ariaRoles = {
   rowheader: {
     type: 'structure',
     requiredContext: ['row'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-sort',
       'aria-colindex',
@@ -609,7 +609,7 @@ const ariaRoles = {
   },
   search: {
     type: 'landmark',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
@@ -697,7 +697,7 @@ const ariaRoles = {
   },
   status: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
@@ -738,6 +738,7 @@ const ariaRoles = {
   tab: {
     type: 'widget',
     requiredContext: ['tablist'],
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-posinset',
       'aria-selected',
@@ -751,7 +752,7 @@ const ariaRoles = {
   table: {
     type: 'structure',
     requiredOwned: ['rowgroup', 'row'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-colcount', 'aria-rowcount', 'aria-expanded'],
     // NOTE: although the spec says this is not named from contents,
     // the accessible text acceptance tests (#139 and #140) require
@@ -778,7 +779,7 @@ const ariaRoles = {
   },
   tabpanel: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
@@ -786,7 +787,7 @@ const ariaRoles = {
   },
   term: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
@@ -816,13 +817,13 @@ const ariaRoles = {
   },
   timer: {
     type: 'widget',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['status']
   },
   toolbar: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-orientation',
       'aria-activedescendant',
@@ -833,7 +834,7 @@ const ariaRoles = {
   },
   tooltip: {
     type: 'structure',
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     nameFromContent: true
@@ -841,7 +842,7 @@ const ariaRoles = {
   tree: {
     type: 'composite',
     requiredOwned: ['group', 'treeitem'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-multiselectable',
       'aria-required',
@@ -856,7 +857,7 @@ const ariaRoles = {
   treegrid: {
     type: 'composite',
     requiredOwned: ['rowgroup', 'row'],
-    // Aria-expanded removed as of 1.3
+    // Spec difference: Aria-expanded removed in 1.2
     allowedAttrs: [
       'aria-activedescendant',
       'aria-colcount',

--- a/lib/standards/aria-roles.js
+++ b/lib/standards/aria-roles.js
@@ -18,11 +18,14 @@
 const ariaRoles = {
   alert: {
     type: 'widget',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   alertdialog: {
     type: 'widget',
-    allowedAttrs: ['aria-modal'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded', 'aria-modal'],
     superclassRole: ['alert', 'dialog'],
     accessibleNameRequired: true
   },
@@ -37,11 +40,14 @@ const ariaRoles = {
   },
   article: {
     type: 'structure',
-    allowedAttrs: ['aria-posinset', 'aria-setsize'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-posinset', 'aria-setsize', 'aria-expanded'],
     superclassRole: ['document']
   },
   banner: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   blockquote: {
@@ -65,9 +71,11 @@ const ariaRoles = {
   cell: {
     type: 'structure',
     requiredContext: ['row'],
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
       'aria-colindex',
       'aria-colspan',
+      'aria-expanded',
       'aria-rowindex',
       'aria-rowspan'
     ],
@@ -93,10 +101,12 @@ const ariaRoles = {
   columnheader: {
     type: 'structure',
     requiredContext: ['row'],
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
       'aria-sort',
       'aria-colindex',
       'aria-colspan',
+      'aria-expanded',
       'aria-readonly',
       'aria-required',
       'aria-rowindex',
@@ -128,6 +138,8 @@ const ariaRoles = {
   },
   complementary: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   composite: {
@@ -136,6 +148,8 @@ const ariaRoles = {
   },
   contentinfo: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   comment: {
@@ -145,6 +159,8 @@ const ariaRoles = {
   },
   definition: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   deletion: {
@@ -154,19 +170,24 @@ const ariaRoles = {
   },
   dialog: {
     type: 'widget',
-    allowedAttrs: ['aria-modal'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded', 'aria-modal'],
     superclassRole: ['window'],
     accessibleNameRequired: true
   },
   directory: {
     type: 'structure',
     deprecated: true,
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['list'],
     // Note: spec difference
     nameFromContent: true
   },
   document: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['structure']
   },
   emphasis: {
@@ -176,28 +197,36 @@ const ariaRoles = {
   },
   feed: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     requiredOwned: ['article'],
     superclassRole: ['list']
   },
   figure: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
     nameFromContent: true
   },
   form: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   grid: {
     type: 'composite',
     requiredOwned: ['rowgroup', 'row'],
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
       'aria-level',
       'aria-multiselectable',
       'aria-readonly',
       'aria-activedescendant',
       'aria-colcount',
+      'aria-expanded',
       'aria-rowcount'
     ],
     superclassRole: ['composite', 'table'],
@@ -222,12 +251,15 @@ const ariaRoles = {
   },
   group: {
     type: 'structure',
-    allowedAttrs: ['aria-activedescendant'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-activedescendant', 'aria-expanded'],
     superclassRole: ['section']
   },
   heading: {
     type: 'structure',
     requiredAttrs: ['aria-level'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['sectionhead'],
     // Note: spec difference
     accessibleNameRequired: false,
@@ -235,6 +267,8 @@ const ariaRoles = {
   },
   img: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     accessibleNameRequired: true,
     childrenPresentational: true
@@ -261,7 +295,9 @@ const ariaRoles = {
   },
   list: {
     type: 'structure',
-    requiredOwned: ['group', 'listitem'],
+    requiredOwned: ['listitem'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   listbox: {
@@ -293,18 +329,26 @@ const ariaRoles = {
   },
   log: {
     type: 'widget',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   main: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   marquee: {
     type: 'widget',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   math: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     childrenPresentational: true
   },
@@ -319,7 +363,12 @@ const ariaRoles = {
       'menu',
       'separator'
     ],
-    allowedAttrs: ['aria-activedescendant', 'aria-orientation'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: [
+      'aria-activedescendant',
+      'aria-expanded',
+      'aria-orientation'
+    ],
     superclassRole: ['select']
   },
   menubar: {
@@ -333,7 +382,12 @@ const ariaRoles = {
       'menu',
       'separator'
     ],
-    allowedAttrs: ['aria-activedescendant', 'aria-orientation'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: [
+      'aria-activedescendant',
+      'aria-expanded',
+      'aria-orientation'
+    ],
     superclassRole: ['menu']
   },
   menuitem: {
@@ -391,6 +445,8 @@ const ariaRoles = {
   },
   navigation: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   none: {
@@ -400,6 +456,8 @@ const ariaRoles = {
   },
   note: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   option: {
@@ -431,7 +489,9 @@ const ariaRoles = {
   },
   progressbar: {
     type: 'widget',
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
+      'aria-expanded',
       'aria-valuemax',
       'aria-valuemin',
       'aria-valuenow',
@@ -455,10 +515,12 @@ const ariaRoles = {
   radiogroup: {
     type: 'composite',
     // Note: spec difference (no required owned)
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
       'aria-readonly',
       'aria-required',
       'aria-activedescendant',
+      'aria-expanded',
       'aria-orientation'
     ],
     superclassRole: ['select'],
@@ -471,6 +533,8 @@ const ariaRoles = {
   },
   region: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark'],
     // Note: spec difference
     accessibleNameRequired: false
@@ -506,10 +570,12 @@ const ariaRoles = {
   rowheader: {
     type: 'structure',
     requiredContext: ['row'],
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
       'aria-sort',
       'aria-colindex',
       'aria-colspan',
+      'aria-expanded',
       'aria-readonly',
       'aria-required',
       'aria-rowindex',
@@ -543,6 +609,8 @@ const ariaRoles = {
   },
   search: {
     type: 'landmark',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['landmark']
   },
   searchbox: {
@@ -629,6 +697,8 @@ const ariaRoles = {
   },
   status: {
     type: 'widget',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   strong: {
@@ -681,7 +751,8 @@ const ariaRoles = {
   table: {
     type: 'structure',
     requiredOwned: ['rowgroup', 'row'],
-    allowedAttrs: ['aria-colcount', 'aria-rowcount'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-colcount', 'aria-rowcount', 'aria-expanded'],
     // NOTE: although the spec says this is not named from contents,
     // the accessible text acceptance tests (#139 and #140) require
     // table be named from content (we even had to special case
@@ -700,18 +771,23 @@ const ariaRoles = {
       'aria-level',
       'aria-multiselectable',
       'aria-orientation',
-      'aria-activedescendant'
+      'aria-activedescendant',
+      'aria-expanded'
     ],
     superclassRole: ['composite']
   },
   tabpanel: {
     type: 'widget',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
     accessibleNameRequired: false
   },
   term: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     // Note: spec difference
     nameFromContent: true
@@ -736,30 +812,43 @@ const ariaRoles = {
   },
   time: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section']
   },
   timer: {
     type: 'widget',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['status']
   },
   toolbar: {
     type: 'structure',
-    allowedAttrs: ['aria-orientation', 'aria-activedescendant'],
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: [
+      'aria-orientation',
+      'aria-activedescendant',
+      'aria-expanded'
+    ],
     superclassRole: ['group'],
     accessibleNameRequired: true
   },
   tooltip: {
     type: 'structure',
+    // Aria-expanded removed as of 1.3
+    allowedAttrs: ['aria-expanded'],
     superclassRole: ['section'],
     nameFromContent: true
   },
   tree: {
     type: 'composite',
     requiredOwned: ['group', 'treeitem'],
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
       'aria-multiselectable',
       'aria-required',
       'aria-activedescendant',
+      'aria-expanded',
       'aria-orientation'
     ],
     superclassRole: ['select'],
@@ -769,9 +858,11 @@ const ariaRoles = {
   treegrid: {
     type: 'composite',
     requiredOwned: ['rowgroup', 'row'],
+    // Aria-expanded removed as of 1.3
     allowedAttrs: [
       'aria-activedescendant',
       'aria-colcount',
+      'aria-expanded',
       'aria-level',
       'aria-multiselectable',
       'aria-orientation',

--- a/test/integration/rules/aria-allowed-attr/passes.html
+++ b/test/integration/rules/aria-allowed-attr/passes.html
@@ -1901,6 +1901,7 @@
 <div
   role="switch"
   id="pass62"
+  aria-expanded="value"
   aria-checked="value"
   aria-atomic="value"
   aria-braillelabel="value"
@@ -2092,8 +2093,9 @@
 <button id="pass73" aria-roledescription="attachment button"></button>
 <input
   type="checkbox"
-  aria-roledescription="cuisine type checkbox"
   id="pass74"
+  aria-roledescription="cuisine type checkbox"
+  aria-expanded="false"
 />
 
 <span role="radio" id="pass75" aria-checked="false">I am RED!</span>


### PR DESCRIPTION
WAI-ARIA 1.3 has proposed to dramatically change which roles allow aria-expanded. Per this PR, `checkbox` and `switch` now allow this attribute. Quite a few more roles no longer allow `aria-expanded`.

I've opened up an issue requesting that ARIA 1.3 deprecate aria-expanded on those roles, instead of simply removing them. I think simply removing them would create a lot of unnecessary friction. If the W3C decides not to stay backward compatible we may have to figure out a different way to present this, but by far the best solution here would be to use deprecation, which is what they've also done in other places. See https://github.com/w3c/aria/issues/1990

Closes #3339, closes #3343
