### PR TITLE
feat: Deprecate impact on checks, use rules instead

### DIFF
--- a/build/rule-generator/get-files-metadata.js
+++ b/build/rule-generator/get-files-metadata.js
@@ -24,6 +24,7 @@ const getRuleSpecFileMeta = (ruleName, ruleHasMatches, ruleChecks) => {
     content: JSON.stringify(
       {
         id: `${ruleName}`,
+        impact: '',
         selector: '',
         ...(ruleHasMatches && {
           matches: `${ruleName}-matches`
@@ -116,7 +117,6 @@ const getCheckSpecFileMeta = (name, dir) => {
         id: `${name}`,
         evaluate: `${name}-evaluate`,
         metadata: {
-          impact: '',
           messages: {
             pass: '',
             fail: '',

--- a/build/tasks/validate.js
+++ b/build/tasks/validate.js
@@ -112,8 +112,8 @@ function createSchemas() {
               conform: 'Must have at least two valid messages'
             }
           },
+          // @deprecated: Use impact on rules instead
           impact: {
-            required: true,
             type: 'string',
             enum: ['minor', 'moderate', 'serious', 'critical']
           }
@@ -134,6 +134,7 @@ function createSchemas() {
         type: 'string'
       },
       impact: {
+        required: true,
         type: 'string',
         enum: ['minor', 'moderate', 'serious', 'critical']
       },

--- a/doc/API.md
+++ b/doc/API.md
@@ -228,7 +228,7 @@ axe.configure({
     - The rules attribute is an Array of rule objects
     - each rule object can contain the following attributes
       - `id` - string(required). This uniquely identifies the rule. If the rule already exists, it will be overridden with any of the attributes supplied. The attributes below that are marked required, are only required for new rules.
-      - `impact` - string(optional). Override the impact defined by checks
+      - `impact` - string(required). Sets the impact of that rule's results
       - `reviewOnFail` - boolean(option, default `false`). Override the result of a rule to return "Needs Review" rather than "Violation" if the rule fails.
       - `selector` - string(optional, default `*`). A [CSS selector](./developer-guide.md#supported-css-selectors) used to identify the elements that are passed into the rule for evaluation.
       - `excludeHidden` - boolean(optional, default `true`). This indicates whether elements that are hidden from all users are to be passed into the rule for evaluation.

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -115,12 +115,12 @@ After execution, a Check will return `true`, `false`, or `undefined` depending o
 Rules are defined by JSON files in the [lib/rules directory](../lib/rules). The JSON object is used to seed the [Rule object](../lib/core/base/rule.js#L30). A valid Rule JSON consists of the following:
 
 - `id` - `String` A unique name of the Rule.
+- `impact` - `String` (one of `minor`, `moderate`, `serious`, or `critical`). Sets the impact of the results of this rule
 - `selector` - **optional** `String` which is a [CSS selector](#supported-css-selectors) that specifies the elements of the page on which the Rule runs. axe-core will look inside of the light DOM and _open_ [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Shadow_DOM) trees for elements matching the provided selector. If omitted, the rule will run against every node.
 - `excludeHidden` - **optional** `Boolean` Whether the rule should exclude hidden elements. Defaults to `true`.
 - `enabled` - **optional** `Boolean` Whether the rule is enabled by default. Defaults to `true`.
 - `pageLevel` - **optional** `Boolean` Whether the rule is page level. Page level rules will only run if given an entire `document` as context.
 - `matches` - **optional** `String` The ID of the filtering function that will exclude elements that match the `selector` property. See the [`metadata-function-map`](../lib/core/base/metadata-function-map.js) file for all defined IDs.
-- `impact` - **optional** `String` (one of `minor`, `moderate`, `serious`, or `critical`). Override the impact defined by checks.
 - `tags` - **optional** `Array` Strings of the accessibility guidelines of which the Rule applies.
 - `metadata` - `Object` Consisting of:
   - `description` - `String` Text string that describes what the rule does.
@@ -155,7 +155,7 @@ Similar to Rules, Checks are defined by JSON files in the [lib/checks directory]
 - `after` - **optional** `String` The ID of the function that gets called for checks that operate on a page-level basis, to process the results from the iframes.
 - `options` - **optional** `Object` Any information the Check needs that you might need to customize and/or is locale specific. Options can be overridden at runtime (with the options parameter) or config-time. For example, the [valid-lang](../lib/checks/language/valid-lang.json) Check defines what ISO 639-1 language codes it should accept as valid. Options do not need to follow any specific format or type; it is up to the author of a Check to determine the most appropriate format.
 - `metadata` - `Object` Consisting of:
-  - `impact` - `String` (one of `minor`, `moderate`, `serious`, or `critical`)
+  - `impact` - **Deprecated** `String` (one of `minor`, `moderate`, `serious`, or `critical`)
   - `messages` - `Object` These messages are displayed when the Check passes or fails
     - `pass` - `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check passes
     - `fail` - `String` [doT.js](http://olado.github.io/doT/) template string displayed when the Check fails

--- a/lib/rules/accesskeys.json
+++ b/lib/rules/accesskeys.json
@@ -1,5 +1,6 @@
 {
   "id": "accesskeys",
+  "impact": "serious",
   "selector": "[accesskey]",
   "excludeHidden": false,
   "tags": ["cat.keyboard", "best-practice"],

--- a/lib/rules/area-alt.json
+++ b/lib/rules/area-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "area-alt",
+  "impact": "critical",
   "selector": "map area[href]",
   "excludeHidden": false,
   "tags": [

--- a/lib/rules/aria-allowed-attr.json
+++ b/lib/rules/aria-allowed-attr.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-allowed-attr",
+  "impact": "critical",
   "matches": "aria-allowed-attr-matches",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],
   "actIds": ["5c01ea"],

--- a/lib/rules/aria-allowed-role.json
+++ b/lib/rules/aria-allowed-role.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-allowed-role",
+  "impact": "minor",
   "excludeHidden": false,
   "selector": "[role]",
   "matches": "aria-allowed-role-matches",

--- a/lib/rules/aria-braille-equivalent.json
+++ b/lib/rules/aria-braille-equivalent.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-braille-equivalent",
+  "impact": "serious",
   "selector": "[aria-brailleroledescription], [aria-braillelabel]",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],
   "metadata": {

--- a/lib/rules/aria-command-name.json
+++ b/lib/rules/aria-command-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-command-name",
+  "impact": "serious",
   "selector": "[role=\"link\"], [role=\"button\"], [role=\"menuitem\"]",
   "matches": "no-naming-method-matches",
   "tags": [

--- a/lib/rules/aria-conditional-attr.json
+++ b/lib/rules/aria-conditional-attr.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-conditional-attr",
+  "impact": "serious",
   "matches": "aria-allowed-attr-matches",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],
   "actIds": ["5c01ea"],

--- a/lib/rules/aria-deprecated-role.json
+++ b/lib/rules/aria-deprecated-role.json
@@ -1,9 +1,9 @@
 {
   "id": "aria-deprecated-role",
+  "impact": "minor",
   "selector": "[role]",
   "matches": "no-empty-role-matches",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],
-  "impact": "minor",
   "actIds": ["674b10"],
   "metadata": {
     "description": "Ensures elements do not use deprecated roles",

--- a/lib/rules/aria-dialog-name.json
+++ b/lib/rules/aria-dialog-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-dialog-name",
+  "impact": "serious",
   "selector": "[role=\"dialog\"], [role=\"alertdialog\"]",
   "matches": "no-naming-method-matches",
   "tags": ["cat.aria", "best-practice"],

--- a/lib/rules/aria-hidden-body.json
+++ b/lib/rules/aria-hidden-body.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-hidden-body",
+  "impact": "critical",
   "selector": "body",
   "excludeHidden": false,
   "matches": "is-initiator-matches",

--- a/lib/rules/aria-hidden-focus.json
+++ b/lib/rules/aria-hidden-focus.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-hidden-focus",
+  "impact": "serious",
   "selector": "[aria-hidden=\"true\"]",
   "matches": "aria-hidden-focus-matches",
   "excludeHidden": false,

--- a/lib/rules/aria-input-field-name.json
+++ b/lib/rules/aria-input-field-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-input-field-name",
+  "impact": "serious",
   "selector": "[role=\"combobox\"], [role=\"listbox\"], [role=\"searchbox\"], [role=\"slider\"], [role=\"spinbutton\"], [role=\"textbox\"]",
   "matches": "no-naming-method-matches",
   "tags": [

--- a/lib/rules/aria-meter-name.json
+++ b/lib/rules/aria-meter-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-meter-name",
+  "impact": "serious",
   "selector": "[role=\"meter\"]",
   "matches": "no-naming-method-matches",
   "tags": ["cat.aria", "wcag2a", "wcag111", "EN-301-549", "EN-9.1.1.1"],

--- a/lib/rules/aria-progressbar-name.json
+++ b/lib/rules/aria-progressbar-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-progressbar-name",
+  "impact": "serious",
   "selector": "[role=\"progressbar\"]",
   "matches": "no-naming-method-matches",
   "tags": ["cat.aria", "wcag2a", "wcag111", "EN-301-549", "EN-9.1.1.1"],

--- a/lib/rules/aria-prohibited-attr.json
+++ b/lib/rules/aria-prohibited-attr.json
@@ -1,9 +1,9 @@
 {
   "id": "aria-prohibited-attr",
+  "impact": "serious",
   "matches": "aria-allowed-attr-matches",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],
   "actIds": ["5c01ea"],
-  "impact": "serious",
   "metadata": {
     "description": "Ensures ARIA attributes are not prohibited for an element's role",
     "help": "Elements must only use permitted ARIA attributes"

--- a/lib/rules/aria-required-attr.json
+++ b/lib/rules/aria-required-attr.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-required-attr",
+  "impact": "critical",
   "selector": "[role]",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],
   "actIds": ["4e8ab6"],

--- a/lib/rules/aria-required-children.json
+++ b/lib/rules/aria-required-children.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-required-children",
+  "impact": "critical",
   "selector": "[role]",
   "matches": "aria-required-children-matches",
   "tags": ["cat.aria", "wcag2a", "wcag131", "EN-301-549", "EN-9.1.3.1"],

--- a/lib/rules/aria-required-parent.json
+++ b/lib/rules/aria-required-parent.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-required-parent",
+  "impact": "critical",
   "selector": "[role]",
   "matches": "aria-required-parent-matches",
   "tags": ["cat.aria", "wcag2a", "wcag131", "EN-301-549", "EN-9.1.3.1"],

--- a/lib/rules/aria-roledescription.json
+++ b/lib/rules/aria-roledescription.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-roledescription",
+  "impact": "serious",
   "selector": "[aria-roledescription]",
   "tags": [
     "cat.aria",

--- a/lib/rules/aria-text.json
+++ b/lib/rules/aria-text.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-text",
+  "impact": "serious",
   "selector": "[role=text]",
   "tags": ["cat.aria", "best-practice"],
   "metadata": {

--- a/lib/rules/aria-toggle-field-name.json
+++ b/lib/rules/aria-toggle-field-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-toggle-field-name",
+  "impact": "serious",
   "selector": "[role=\"checkbox\"], [role=\"menuitemcheckbox\"], [role=\"menuitemradio\"], [role=\"radio\"], [role=\"switch\"], [role=\"option\"]",
   "matches": "no-naming-method-matches",
   "tags": [

--- a/lib/rules/aria-tooltip-name.json
+++ b/lib/rules/aria-tooltip-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-tooltip-name",
+  "impact": "serious",
   "selector": "[role=\"tooltip\"]",
   "matches": "no-naming-method-matches",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],

--- a/lib/rules/aria-treeitem-name.json
+++ b/lib/rules/aria-treeitem-name.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-treeitem-name",
+  "impact": "serious",
   "selector": "[role=\"treeitem\"]",
   "matches": "no-naming-method-matches",
   "tags": ["cat.aria", "best-practice"],

--- a/lib/rules/aria-valid-attr.json
+++ b/lib/rules/aria-valid-attr.json
@@ -1,5 +1,6 @@
 {
   "id": "aria-valid-attr",
+  "impact": "critical",
   "matches": "aria-has-attr-matches",
   "tags": ["cat.aria", "wcag2a", "wcag412", "EN-301-549", "EN-9.4.1.2"],
   "actIds": ["5f99a7"],

--- a/lib/rules/audio-caption.json
+++ b/lib/rules/audio-caption.json
@@ -1,5 +1,6 @@
 {
   "id": "audio-caption",
+  "impact": "critical",
   "selector": "audio",
   "enabled": false,
   "excludeHidden": false,

--- a/lib/rules/autocomplete-valid.json
+++ b/lib/rules/autocomplete-valid.json
@@ -1,5 +1,6 @@
 {
   "id": "autocomplete-valid",
+  "impact": "serious",
   "matches": "autocomplete-matches",
   "tags": [
     "cat.forms",

--- a/lib/rules/avoid-inline-spacing.json
+++ b/lib/rules/avoid-inline-spacing.json
@@ -1,5 +1,6 @@
 {
   "id": "avoid-inline-spacing",
+  "impact": "serious",
   "selector": "[style]",
   "matches": "is-visible-on-screen-matches",
   "tags": [

--- a/lib/rules/blink.json
+++ b/lib/rules/blink.json
@@ -1,5 +1,6 @@
 {
   "id": "blink",
+  "impact": "serious",
   "selector": "blink",
   "excludeHidden": false,
   "tags": [

--- a/lib/rules/button-name.json
+++ b/lib/rules/button-name.json
@@ -1,5 +1,6 @@
 {
   "id": "button-name",
+  "impact": "critical",
   "selector": "button",
   "matches": "no-explicit-name-required-matches",
   "tags": [

--- a/lib/rules/bypass.json
+++ b/lib/rules/bypass.json
@@ -1,5 +1,6 @@
 {
   "id": "bypass",
+  "impact": "serious",
   "selector": "html",
   "pageLevel": true,
   "matches": "bypass-matches",

--- a/lib/rules/color-contrast-enhanced.json
+++ b/lib/rules/color-contrast-enhanced.json
@@ -1,5 +1,6 @@
 {
   "id": "color-contrast-enhanced",
+  "impact": "serious",
   "matches": "color-contrast-matches",
   "excludeHidden": false,
   "enabled": false,

--- a/lib/rules/color-contrast.json
+++ b/lib/rules/color-contrast.json
@@ -1,5 +1,6 @@
 {
   "id": "color-contrast",
+  "impact": "serious",
   "matches": "color-contrast-matches",
   "excludeHidden": false,
   "tags": [

--- a/lib/rules/css-orientation-lock.json
+++ b/lib/rules/css-orientation-lock.json
@@ -1,5 +1,6 @@
 {
   "id": "css-orientation-lock",
+  "impact": "serious",
   "selector": "html",
   "tags": [
     "cat.structure",

--- a/lib/rules/definition-list.json
+++ b/lib/rules/definition-list.json
@@ -1,5 +1,6 @@
 {
   "id": "definition-list",
+  "impact": "serious",
   "selector": "dl",
   "matches": "no-role-matches",
   "tags": ["cat.structure", "wcag2a", "wcag131", "EN-301-549", "EN-9.1.3.1"],

--- a/lib/rules/dlitem.json
+++ b/lib/rules/dlitem.json
@@ -1,5 +1,6 @@
 {
   "id": "dlitem",
+  "impact": "serious",
   "selector": "dd, dt",
   "matches": "no-role-matches",
   "tags": ["cat.structure", "wcag2a", "wcag131", "EN-301-549", "EN-9.1.3.1"],

--- a/lib/rules/document-title.json
+++ b/lib/rules/document-title.json
@@ -1,5 +1,6 @@
 {
   "id": "document-title",
+  "impact": "serious",
   "selector": "html",
   "matches": "is-initiator-matches",
   "tags": [

--- a/lib/rules/duplicate-id-active.json
+++ b/lib/rules/duplicate-id-active.json
@@ -1,5 +1,6 @@
 {
   "id": "duplicate-id-active",
+  "impact": "serious",
   "selector": "[id]",
   "matches": "duplicate-id-active-matches",
   "excludeHidden": false,

--- a/lib/rules/duplicate-id-aria.json
+++ b/lib/rules/duplicate-id-aria.json
@@ -1,5 +1,6 @@
 {
   "id": "duplicate-id-aria",
+  "impact": "critical",
   "selector": "[id]",
   "matches": "duplicate-id-aria-matches",
   "excludeHidden": false,

--- a/lib/rules/duplicate-id.json
+++ b/lib/rules/duplicate-id.json
@@ -1,5 +1,6 @@
 {
   "id": "duplicate-id",
+  "impact": "minor",
   "selector": "[id]",
   "matches": "duplicate-id-misc-matches",
   "excludeHidden": false,

--- a/lib/rules/empty-heading.json
+++ b/lib/rules/empty-heading.json
@@ -1,10 +1,10 @@
 {
   "id": "empty-heading",
+  "impact": "minor",
   "selector": "h1, h2, h3, h4, h5, h6, [role=\"heading\"]",
   "matches": "heading-matches",
   "tags": ["cat.name-role-value", "best-practice"],
   "actIds": ["ffd0e9"],
-  "impact": "minor",
   "metadata": {
     "description": "Ensures headings have discernible text",
     "help": "Headings should not be empty"

--- a/lib/rules/empty-table-header.json
+++ b/lib/rules/empty-table-header.json
@@ -1,5 +1,6 @@
 {
   "id": "empty-table-header",
+  "impact": "minor",
   "selector": "th:not([role]), [role=\"rowheader\"], [role=\"columnheader\"]",
   "tags": ["cat.name-role-value", "best-practice"],
   "metadata": {

--- a/lib/rules/focus-order-semantics.json
+++ b/lib/rules/focus-order-semantics.json
@@ -1,5 +1,6 @@
 {
   "id": "focus-order-semantics",
+  "impact": "minor",
   "selector": "div, h1, h2, h3, h4, h5, h6, [role=heading], p, span",
   "matches": "inserted-into-focus-order-matches",
   "tags": ["cat.keyboard", "best-practice", "experimental"],

--- a/lib/rules/form-field-multiple-labels.json
+++ b/lib/rules/form-field-multiple-labels.json
@@ -1,5 +1,6 @@
 {
   "id": "form-field-multiple-labels",
+  "impact": "moderate",
   "selector": "input, select, textarea",
   "matches": "label-matches",
   "tags": [

--- a/lib/rules/frame-focusable-content.json
+++ b/lib/rules/frame-focusable-content.json
@@ -1,5 +1,6 @@
 {
   "id": "frame-focusable-content",
+  "impact": "serious",
   "selector": "html",
   "matches": "frame-focusable-content-matches",
   "tags": [

--- a/lib/rules/frame-tested.json
+++ b/lib/rules/frame-tested.json
@@ -1,5 +1,6 @@
 {
   "id": "frame-tested",
+  "impact": "critical",
   "selector": "html, frame, iframe",
   "tags": ["cat.structure", "best-practice", "review-item"],
   "metadata": {

--- a/lib/rules/frame-title-unique.json
+++ b/lib/rules/frame-title-unique.json
@@ -1,5 +1,6 @@
 {
   "id": "frame-title-unique",
+  "impact": "serious",
   "selector": "frame[title], iframe[title]",
   "matches": "frame-title-has-text-matches",
   "tags": [

--- a/lib/rules/frame-title.json
+++ b/lib/rules/frame-title.json
@@ -1,5 +1,6 @@
 {
   "id": "frame-title",
+  "impact": "serious",
   "selector": "frame, iframe",
   "matches": "no-negative-tabindex-matches",
   "tags": [

--- a/lib/rules/heading-order.json
+++ b/lib/rules/heading-order.json
@@ -1,5 +1,6 @@
 {
   "id": "heading-order",
+  "impact": "moderate",
   "selector": "h1, h2, h3, h4, h5, h6, [role=heading]",
   "matches": "heading-matches",
   "tags": ["cat.semantics", "best-practice"],

--- a/lib/rules/hidden-content.json
+++ b/lib/rules/hidden-content.json
@@ -1,5 +1,6 @@
 {
   "id": "hidden-content",
+  "impact": "minor",
   "selector": "*",
   "excludeHidden": false,
   "tags": ["cat.structure", "best-practice", "experimental", "review-item"],

--- a/lib/rules/html-has-lang.json
+++ b/lib/rules/html-has-lang.json
@@ -1,5 +1,6 @@
 {
   "id": "html-has-lang",
+  "impact": "serious",
   "selector": "html",
   "matches": "is-initiator-matches",
   "tags": [

--- a/lib/rules/html-lang-valid.json
+++ b/lib/rules/html-lang-valid.json
@@ -1,5 +1,6 @@
 {
   "id": "html-lang-valid",
+  "impact": "serious",
   "selector": "html[lang]:not([lang=\"\"]), html[xml\\:lang]:not([xml\\:lang=\"\"])",
   "tags": [
     "cat.language",

--- a/lib/rules/html-xml-lang-mismatch.json
+++ b/lib/rules/html-xml-lang-mismatch.json
@@ -1,5 +1,6 @@
 {
   "id": "html-xml-lang-mismatch",
+  "impact": "moderate",
   "selector": "html[lang][xml\\:lang]",
   "matches": "xml-lang-mismatch-matches",
   "tags": [

--- a/lib/rules/identical-links-same-purpose.json
+++ b/lib/rules/identical-links-same-purpose.json
@@ -1,5 +1,6 @@
 {
   "id": "identical-links-same-purpose",
+  "impact": "minor",
   "selector": "a[href], area[href], [role=\"link\"]",
   "excludeHidden": false,
   "enabled": false,

--- a/lib/rules/image-alt.json
+++ b/lib/rules/image-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "image-alt",
+  "impact": "critical",
   "selector": "img",
   "matches": "no-explicit-name-required-matches",
   "tags": [

--- a/lib/rules/img-redundant-alt.json
+++ b/lib/rules/img-redundant-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "image-redundant-alt",
+  "impact": "minor",
   "selector": "img",
   "tags": ["cat.text-alternatives", "best-practice"],
   "metadata": {

--- a/lib/rules/input-button-name.json
+++ b/lib/rules/input-button-name.json
@@ -1,5 +1,6 @@
 {
   "id": "input-button-name",
+  "impact": "critical",
   "selector": "input[type=\"button\"], input[type=\"submit\"], input[type=\"reset\"]",
   "matches": "no-explicit-name-required-matches",
   "tags": [

--- a/lib/rules/input-image-alt.json
+++ b/lib/rules/input-image-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "input-image-alt",
+  "impact": "critical",
   "selector": "input[type=\"image\"]",
   "matches": "no-explicit-name-required-matches",
   "tags": [

--- a/lib/rules/label-content-name-mismatch.json
+++ b/lib/rules/label-content-name-mismatch.json
@@ -1,5 +1,6 @@
 {
   "id": "label-content-name-mismatch",
+  "impact": "serious",
   "matches": "label-content-name-mismatch-matches",
   "tags": [
     "cat.semantics",

--- a/lib/rules/label-title-only.json
+++ b/lib/rules/label-title-only.json
@@ -1,5 +1,6 @@
 {
   "id": "label-title-only",
+  "impact": "serious",
   "selector": "input, select, textarea",
   "matches": "label-matches",
   "tags": ["cat.forms", "best-practice"],

--- a/lib/rules/label.json
+++ b/lib/rules/label.json
@@ -1,5 +1,6 @@
 {
   "id": "label",
+  "impact": "critical",
   "selector": "input, textarea",
   "matches": "label-matches",
   "tags": [

--- a/lib/rules/landmark-banner-is-top-level.json
+++ b/lib/rules/landmark-banner-is-top-level.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-banner-is-top-level",
+  "impact": "moderate",
   "selector": "header:not([role]), [role=banner]",
   "matches": "landmark-has-body-context-matches",
   "tags": ["cat.semantics", "best-practice"],

--- a/lib/rules/landmark-complementary-is-top-level.json
+++ b/lib/rules/landmark-complementary-is-top-level.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-complementary-is-top-level",
+  "impact": "moderate",
   "selector": "aside:not([role]), [role=complementary]",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/landmark-contentinfo-is-top-level.json
+++ b/lib/rules/landmark-contentinfo-is-top-level.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-contentinfo-is-top-level",
+  "impact": "moderate",
   "selector": "footer:not([role]), [role=contentinfo]",
   "matches": "landmark-has-body-context-matches",
   "tags": ["cat.semantics", "best-practice"],

--- a/lib/rules/landmark-main-is-top-level.json
+++ b/lib/rules/landmark-main-is-top-level.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-main-is-top-level",
+  "impact": "moderate",
   "selector": "main:not([role]), [role=main]",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/landmark-no-duplicate-banner.json
+++ b/lib/rules/landmark-no-duplicate-banner.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-no-duplicate-banner",
+  "impact": "moderate",
   "selector": "header:not([role]), [role=banner]",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/landmark-no-duplicate-contentinfo.json
+++ b/lib/rules/landmark-no-duplicate-contentinfo.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-no-duplicate-contentinfo",
+  "impact": "moderate",
   "selector": "footer:not([role]), [role=contentinfo]",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/landmark-no-duplicate-main.json
+++ b/lib/rules/landmark-no-duplicate-main.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-no-duplicate-main",
+  "impact": "moderate",
   "selector": "main:not([role]), [role=main]",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/landmark-one-main.json
+++ b/lib/rules/landmark-one-main.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-one-main",
+  "impact": "moderate",
   "selector": "html",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/landmark-unique.json
+++ b/lib/rules/landmark-unique.json
@@ -1,5 +1,6 @@
 {
   "id": "landmark-unique",
+  "impact": "moderate",
   "selector": "[role=banner], [role=complementary], [role=contentinfo], [role=main], [role=navigation], [role=region], [role=search], [role=form], form, footer, header, aside, main, nav, section",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/link-in-text-block.json
+++ b/lib/rules/link-in-text-block.json
@@ -1,5 +1,6 @@
 {
   "id": "link-in-text-block",
+  "impact": "serious",
   "selector": "a[href], [role=link]",
   "matches": "link-in-text-block-matches",
   "excludeHidden": false,

--- a/lib/rules/link-name.json
+++ b/lib/rules/link-name.json
@@ -1,5 +1,6 @@
 {
   "id": "link-name",
+  "impact": "serious",
   "selector": "a[href]",
   "tags": [
     "cat.name-role-value",

--- a/lib/rules/list.json
+++ b/lib/rules/list.json
@@ -1,5 +1,6 @@
 {
   "id": "list",
+  "impact": "serious",
   "selector": "ul, ol",
   "matches": "no-role-matches",
   "tags": ["cat.structure", "wcag2a", "wcag131", "EN-301-549", "EN-9.1.3.1"],

--- a/lib/rules/listitem.json
+++ b/lib/rules/listitem.json
@@ -1,5 +1,6 @@
 {
   "id": "listitem",
+  "impact": "serious",
   "selector": "li",
   "matches": "no-role-matches",
   "tags": ["cat.structure", "wcag2a", "wcag131", "EN-301-549", "EN-9.1.3.1"],

--- a/lib/rules/marquee.json
+++ b/lib/rules/marquee.json
@@ -1,5 +1,6 @@
 {
   "id": "marquee",
+  "impact": "serious",
   "selector": "marquee",
   "excludeHidden": false,
   "tags": [

--- a/lib/rules/meta-refresh-no-exceptions.json
+++ b/lib/rules/meta-refresh-no-exceptions.json
@@ -1,5 +1,6 @@
 {
   "id": "meta-refresh-no-exceptions",
+  "impact": "minor",
   "selector": "meta[http-equiv=\"refresh\"][content]",
   "excludeHidden": false,
   "enabled": false,

--- a/lib/rules/meta-refresh.json
+++ b/lib/rules/meta-refresh.json
@@ -1,5 +1,6 @@
 {
   "id": "meta-refresh",
+  "impact": "critical",
   "selector": "meta[http-equiv=\"refresh\"][content]",
   "excludeHidden": false,
   "tags": [

--- a/lib/rules/meta-viewport-large.json
+++ b/lib/rules/meta-viewport-large.json
@@ -1,5 +1,6 @@
 {
   "id": "meta-viewport-large",
+  "impact": "minor",
   "selector": "meta[name=\"viewport\"]",
   "matches": "is-initiator-matches",
   "excludeHidden": false,

--- a/lib/rules/meta-viewport.json
+++ b/lib/rules/meta-viewport.json
@@ -1,5 +1,6 @@
 {
   "id": "meta-viewport",
+  "impact": "critical",
   "selector": "meta[name=\"viewport\"]",
   "matches": "is-initiator-matches",
   "excludeHidden": false,

--- a/lib/rules/nested-interactive.json
+++ b/lib/rules/nested-interactive.json
@@ -1,5 +1,6 @@
 {
   "id": "nested-interactive",
+  "impact": "serious",
   "matches": "nested-interactive-matches",
   "tags": [
     "cat.keyboard",

--- a/lib/rules/no-autoplay-audio.json
+++ b/lib/rules/no-autoplay-audio.json
@@ -1,5 +1,6 @@
 {
   "id": "no-autoplay-audio",
+  "impact": "moderate",
   "excludeHidden": false,
   "selector": "audio[autoplay], video[autoplay]",
   "matches": "no-autoplay-audio-matches",

--- a/lib/rules/object-alt.json
+++ b/lib/rules/object-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "object-alt",
+  "impact": "serious",
   "selector": "object[data]",
   "matches": "object-is-loaded-matches",
   "tags": [

--- a/lib/rules/p-as-heading.json
+++ b/lib/rules/p-as-heading.json
@@ -1,5 +1,6 @@
 {
   "id": "p-as-heading",
+  "impact": "serious",
   "selector": "p",
   "matches": "p-as-heading-matches",
   "tags": [

--- a/lib/rules/page-has-heading-one.json
+++ b/lib/rules/page-has-heading-one.json
@@ -1,5 +1,6 @@
 {
   "id": "page-has-heading-one",
+  "impact": "moderate",
   "selector": "html",
   "tags": ["cat.semantics", "best-practice"],
   "metadata": {

--- a/lib/rules/presentation-role-conflict.json
+++ b/lib/rules/presentation-role-conflict.json
@@ -1,5 +1,6 @@
 {
   "id": "presentation-role-conflict",
+  "impact": "minor",
   "selector": "img[alt=''], [role=\"none\"], [role=\"presentation\"]",
   "matches": "has-implicit-chromium-role-matches",
   "tags": ["cat.aria", "best-practice", "ACT"],

--- a/lib/rules/region.json
+++ b/lib/rules/region.json
@@ -1,5 +1,6 @@
 {
   "id": "region",
+  "impact": "moderate",
   "selector": "body *",
   "tags": ["cat.keyboard", "best-practice"],
   "metadata": {

--- a/lib/rules/role-img-alt.json
+++ b/lib/rules/role-img-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "role-img-alt",
+  "impact": "serious",
   "selector": "[role='img']:not(img, area, input, object)",
   "matches": "html-namespace-matches",
   "tags": [

--- a/lib/rules/scrollable-region-focusable.json
+++ b/lib/rules/scrollable-region-focusable.json
@@ -1,5 +1,6 @@
 {
   "id": "scrollable-region-focusable",
+  "impact": "serious",
   "selector": "*:not(select,textarea)",
   "matches": "scrollable-region-focusable-matches",
   "tags": [

--- a/lib/rules/select-name.json
+++ b/lib/rules/select-name.json
@@ -1,5 +1,6 @@
 {
   "id": "select-name",
+  "impact": "critical",
   "selector": "select",
   "tags": [
     "cat.forms",

--- a/lib/rules/server-side-image-map.json
+++ b/lib/rules/server-side-image-map.json
@@ -1,5 +1,6 @@
 {
   "id": "server-side-image-map",
+  "impact": "minor",
   "selector": "img[ismap]",
   "tags": [
     "cat.text-alternatives",

--- a/lib/rules/skip-link.json
+++ b/lib/rules/skip-link.json
@@ -1,5 +1,6 @@
 {
   "id": "skip-link",
+  "impact": "moderate",
   "selector": "a[href^=\"#\"], a[href^=\"/#\"]",
   "matches": "skip-link-matches",
   "tags": ["cat.keyboard", "best-practice"],

--- a/lib/rules/svg-img-alt.json
+++ b/lib/rules/svg-img-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "svg-img-alt",
+  "impact": "serious",
   "selector": "[role=\"img\"], [role=\"graphics-symbol\"], svg[role=\"graphics-document\"]",
   "matches": "svg-namespace-matches",
   "tags": [

--- a/lib/rules/tabindex.json
+++ b/lib/rules/tabindex.json
@@ -1,5 +1,6 @@
 {
   "id": "tabindex",
+  "impact": "serious",
   "selector": "[tabindex]",
   "tags": ["cat.keyboard", "best-practice"],
   "metadata": {

--- a/lib/rules/table-duplicate-name.json
+++ b/lib/rules/table-duplicate-name.json
@@ -1,5 +1,6 @@
 {
   "id": "table-duplicate-name",
+  "impact": "minor",
   "selector": "table",
   "tags": ["cat.tables", "best-practice"],
   "metadata": {

--- a/lib/rules/table-fake-caption.json
+++ b/lib/rules/table-fake-caption.json
@@ -1,5 +1,6 @@
 {
   "id": "table-fake-caption",
+  "impact": "serious",
   "selector": "table",
   "matches": "data-table-matches",
   "tags": [

--- a/lib/rules/target-size.json
+++ b/lib/rules/target-size.json
@@ -1,5 +1,6 @@
 {
   "id": "target-size",
+  "impact": "serious",
   "selector": "*",
   "enabled": false,
   "matches": "widget-not-inline-matches",

--- a/lib/rules/td-has-header.json
+++ b/lib/rules/td-has-header.json
@@ -1,5 +1,6 @@
 {
   "id": "td-has-header",
+  "impact": "critical",
   "selector": "table",
   "matches": "data-table-large-matches",
   "tags": [

--- a/lib/rules/td-headers-attr.json
+++ b/lib/rules/td-headers-attr.json
@@ -1,5 +1,6 @@
 {
   "id": "td-headers-attr",
+  "impact": "serious",
   "selector": "table",
   "matches": "table-or-grid-role-matches",
   "tags": [

--- a/lib/rules/th-has-data-cells.json
+++ b/lib/rules/th-has-data-cells.json
@@ -1,5 +1,6 @@
 {
   "id": "th-has-data-cells",
+  "impact": "serious",
   "selector": "table",
   "matches": "data-table-matches",
   "tags": [

--- a/lib/rules/valid-lang.json
+++ b/lib/rules/valid-lang.json
@@ -1,5 +1,6 @@
 {
   "id": "valid-lang",
+  "impact": "serious",
   "selector": "[lang]:not(html), [xml\\:lang]:not(html)",
   "tags": [
     "cat.language",

--- a/lib/rules/video-caption.json
+++ b/lib/rules/video-caption.json
@@ -1,5 +1,6 @@
 {
   "id": "video-caption",
+  "impact": "critical",
   "selector": "video",
   "tags": [
     "cat.text-alternatives",


### PR DESCRIPTION
Impact is now required on rules, rather than on checks. This makes impact on checks obsolete. As of axe-core 4.8, impact on checks is **deprecated**.

Closes: #4066
