### PR TITLE
fix(jsdom): allow axe.setup() without a global window

### DIFF
--- a/doc/examples/jsdom/test/a11y.js
+++ b/doc/examples/jsdom/test/a11y.js
@@ -1,10 +1,11 @@
 /* global describe, it */
+const axe = require('axe-core');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
 const assert = require('assert');
 
 describe('axe', () => {
-  const { window } = new JSDOM(`<!DOCTYPE html>
+  const { document } = new JSDOM(`<!DOCTYPE html>
   <html lang="en">
     <head>
       <title>JSDOM Example</title>
@@ -18,30 +19,30 @@ describe('axe', () => {
         <p>Not a label</p><input type="text" id="no-label">
       </div>
     </body>
-  </html>`);
-
-  const axe = require('axe-core');
+  </html>`).window;
   const config = {
     rules: {
       'color-contrast': { enabled: false }
     }
   };
 
-  it('should report that good HTML is good', function (done) {
-    var n = window.document.getElementById('working');
-    axe.run(n, config, function (err, result) {
-      assert.equal(err, null, 'Error is not null');
-      assert.equal(result.violations.length, 0, 'Violations is not empty');
-      done();
-    });
+  it('reports that good HTML is good', async () => {
+    const node = document.getElementById('working');
+    const result = await axe.run(node, config);
+    assert.equal(result.violations.length, 0, 'Violations is not empty');
   });
 
-  it('should report that bad HTML is bad', function (done) {
-    var n = window.document.getElementById('broken');
-    axe.run(n, config, function (err, result) {
-      assert.equal(err, null, 'Error is not null');
-      assert.equal(result.violations.length, 1, 'Violations.length is not 1');
-      done();
-    });
+  it('reports that bad HTML is bad', async () => {
+    const node = document.getElementById('broken');
+    const results = await axe.run(node, config);
+    assert.equal(results.violations.length, 1, 'Violations.length is not 1');
+  });
+
+  it('allows commons after axe.setup() is called', () => {
+    axe.setup(document);
+    const input = document.querySelector('input');
+    const role = axe.commons.aria.getRole(input);
+    assert.equal(role, 'textbox');
+    axe.teardown();
   });
 });

--- a/lib/core/public/run.js
+++ b/lib/core/public/run.js
@@ -1,6 +1,6 @@
 import { getReporter } from './reporter';
 import normalizeRunParams from './run/normalize-run-params';
-import { setupGlobals, resetGlobals } from './run/globals-setup';
+import { setupGlobals } from './run/globals-setup';
 import { assert } from '../utils';
 
 const noop = () => {};
@@ -36,10 +36,10 @@ export default function run(...args) {
     axe.utils.performanceTimer.start();
   }
 
-  function handleRunRules(rawResults, cleanup) {
+  function handleRunRules(rawResults, teardown) {
     const respond = results => {
       axe._running = false;
-      cleanup();
+      teardown();
       try {
         callback(null, results);
       } catch (e) {
@@ -55,7 +55,7 @@ export default function run(...args) {
       createReport(rawResults, options, respond);
     } catch (err) {
       axe._running = false;
-      cleanup();
+      teardown();
       callback(err);
       reject(err);
     }
@@ -66,7 +66,6 @@ export default function run(...args) {
       axe.utils.performanceTimer.end();
     }
     axe._running = false;
-    resetGlobals();
     callback(err);
     reject(err);
   }
@@ -97,7 +96,6 @@ function createReport(rawResults, options, respond) {
 }
 
 function handleError(err, callback) {
-  resetGlobals();
   if (typeof callback === 'function' && callback !== noop) {
     callback(err.message);
     return;

--- a/lib/core/public/setup.js
+++ b/lib/core/public/setup.js
@@ -1,4 +1,5 @@
 import { getFlattenedTree, getSelectorData } from '../utils';
+import { setupGlobals } from './run/globals-setup';
 
 /**
  * Setup axe-core so axe.common functions can work properly.
@@ -10,7 +11,16 @@ function setup(node) {
       'Axe is already setup. Call `axe.teardown()` before calling `axe.setup` again.'
     );
   }
+  // Normalize document
+  if (
+    node &&
+    typeof node.documentElement === 'object' &&
+    typeof node.defaultView === 'object'
+  ) {
+    node = node.documentElement;
+  }
 
+  setupGlobals(node);
   axe._tree = getFlattenedTree(node);
   axe._selectorData = getSelectorData(axe._tree);
 

--- a/test/core/public/setup.js
+++ b/test/core/public/setup.js
@@ -32,6 +32,11 @@ describe('axe.setup', function () {
     assert.exists(axe._selectorData);
   });
 
+  it('takes documentElement when passed the document', () => {
+    axe.setup(document);
+    assert.equal(axe._tree[0].actualNode, document.documentElement);
+  });
+
   it('should throw if called twice in a row', function () {
     function fn() {
       axe.setup();

--- a/test/node/jsdom.js
+++ b/test/node/jsdom.js
@@ -179,7 +179,7 @@ describe('jsdom axe-core', () => {
 
       const skipLink = document.querySelector('#skip');
       assert.equal(axe.commons.aria.getRole(skipLink), 'link');
-      assert.equal(axe.commons.text.accessibleText(skipLink), 'Skip link');
+      assert.equal(axe.commons.text.accessibleText(skipLink), 'Skip Link');
     });
 
     it('is cleaned up with axe.teardown()', () => {

--- a/test/node/jsdom.js
+++ b/test/node/jsdom.js
@@ -160,4 +160,37 @@ describe('jsdom axe-core', () => {
         });
     });
   });
+
+  describe('axe.setup()', () => {
+    afterEach(() => {
+      axe.teardown();
+    });
+
+    it('sets up the tree', function () {
+      const { document } = new jsdom.JSDOM(domStr).window;
+      const tree = axe.setup(document.body);
+      assert.equal(tree, axe._tree[0]);
+      assert.equal(tree.actualNode, document.body);
+    });
+
+    it('can use commons after axe.setup()', () => {
+      const { document } = new jsdom.JSDOM(domStr).window;
+      axe.setup(document);
+
+      const skipLink = document.querySelector('#skip');
+      assert.equal(axe.commons.aria.getRole(skipLink), 'link');
+      assert.equal(axe.commons.text.accessibleText(skipLink), 'Skip link');
+    });
+
+    it('is cleaned up with axe.teardown()', () => {
+      const { document } = new jsdom.JSDOM(domStr).window;
+      axe.setup(document);
+      axe.teardown();
+      const skipLink = document.querySelector('#skip');
+
+      assert.throws(() => {
+        assert.equal(axe.commons.aria.getRole(skipLink), 'link');
+      });
+    });
+  });
 });


### PR DESCRIPTION
`axe.setup()` should set up temporary globals when `globalThis.window` and/or `globalThis.document` aren't set up. This PR fixes that.

Closes #3962

