### PR TITLE
fix(link-in-text-block): take into account ancestor inline element styles

### DIFF
--- a/lib/checks/color/link-in-text-block-style-evaluate.js
+++ b/lib/checks/color/link-in-text-block-style-evaluate.js
@@ -15,8 +15,10 @@ export default function linkInTextBlockStyleEvaluate(node) {
     return false;
   }
 
-  var parentBlock = getComposedParent(node);
+  let parentBlock = getComposedParent(node);
+  const inlineNodes = [node];
   while (parentBlock && parentBlock.nodeType === 1 && !isBlock(parentBlock)) {
+    inlineNodes.push(parentBlock);
     parentBlock = getComposedParent(parentBlock);
   }
 
@@ -26,18 +28,22 @@ export default function linkInTextBlockStyleEvaluate(node) {
 
   this.relatedNodes([parentBlock]);
 
-  if (elementIsDistinct(node, parentBlock)) {
-    return true;
+  for (const inlineNode of inlineNodes) {
+    if (elementIsDistinct(inlineNode, parentBlock)) {
+      return true;
+    }
+
+    if (hasPseudoContent(inlineNode)) {
+      this.data({ messageKey: 'pseudoContent' });
+      return undefined;
+    }
   }
-  if (hasPseudoContent(node)) {
-    this.data({ messageKey: 'pseudoContent' });
-    return undefined;
-  }
+
   return false;
 }
 
 function isBlock(elm) {
-  var display = window.getComputedStyle(elm).getPropertyValue('display');
+  const display = window.getComputedStyle(elm).getPropertyValue('display');
   return blockLike.indexOf(display) !== -1 || display.substr(0, 6) === 'table-';
 }
 

--- a/lib/checks/color/link-in-text-block-style-evaluate.js
+++ b/lib/checks/color/link-in-text-block-style-evaluate.js
@@ -28,11 +28,11 @@ export default function linkInTextBlockStyleEvaluate(node) {
 
   this.relatedNodes([parentBlock]);
 
-  for (const inlineNode of inlineNodes) {
-    if (elementIsDistinct(inlineNode, parentBlock)) {
-      return true;
-    }
+  if (elementIsDistinct(node, parentBlock)) {
+    return true;
+  }
 
+  for (const inlineNode of inlineNodes) {
     if (hasPseudoContent(inlineNode)) {
       this.data({ messageKey: 'pseudoContent' });
       return undefined;

--- a/lib/commons/color/element-is-distinct.js
+++ b/lib/commons/color/element-is-distinct.js
@@ -1,4 +1,5 @@
 import Color from './color';
+import { getComposedParent } from '../dom';
 
 /**
  * Creates a string array of fonts for given CSSStyleDeclaration object
@@ -25,7 +26,7 @@ function _getFonts(style) {
  * @return {Boolean}
  */
 function elementIsDistinct(node, ancestorNode) {
-  var nodeStyle = window.getComputedStyle(node);
+  const nodeStyle = window.getComputedStyle(node);
 
   // Check if the link has a background
   if (nodeStyle.getPropertyValue('background-image') !== 'none') {
@@ -33,52 +34,72 @@ function elementIsDistinct(node, ancestorNode) {
   }
 
   // Check if the link has a border or outline
-  var hasBorder = ['border-bottom', 'border-top', 'outline'].reduce(
-    (result, edge) => {
-      var borderClr = new Color();
-      borderClr.parseString(nodeStyle.getPropertyValue(edge + '-color'));
+  const hasBorder = ['border-bottom', 'border-top', 'outline'].some(edge => {
+    const borderClr = new Color();
+    borderClr.parseString(nodeStyle.getPropertyValue(edge + '-color'));
 
-      // Check if a border/outline was specified
-      return (
-        result ||
-        // or if the current border edge / outline
-        (nodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
-          parseFloat(nodeStyle.getPropertyValue(edge + '-width')) > 0 &&
-          borderClr.alpha !== 0)
-      );
-    },
-    false
-  );
+    // Check if a border/outline was specified
+    return (
+      nodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
+      parseFloat(nodeStyle.getPropertyValue(edge + '-width')) > 0 &&
+      borderClr.alpha !== 0
+    );
+  });
 
   if (hasBorder) {
     return true;
   }
 
-  var parentStyle = window.getComputedStyle(ancestorNode);
-  // Compare fonts
-  if (_getFonts(nodeStyle)[0] !== _getFonts(parentStyle)[0]) {
+  const ancestorStyle = window.getComputedStyle(ancestorNode);
+  let curNode = node;
+  while (curNode !== ancestorNode) {
+    const curNodeStyle = window.getComputedStyle(curNode);
+
+    // text decoration styles are not inherited so we need
+    // to check each node from the target node to the
+    // ancestor node
+    const hasStyle = ['text-decoration-line', 'text-decoration-style'].some(
+      cssProp => {
+        const ancestorValue = ancestorStyle.getPropertyValue(cssProp);
+        const curNodeValue = curNodeStyle.getPropertyValue(cssProp);
+
+        /*
+        For logic purposes we can treat the target node and all inline ancestors as a single logic point since if any of them define a text-decoration style it will visually apply that style to the target.
+
+        A target node is distinct if it defines a text-decoration and either the ancestor does not define one or the target's text-decoration is different than the ancestor. A target that does not define a text-decoration can never be distinct from the ancestor.
+      */
+        return (
+          curNodeValue !== 'none' &&
+          (ancestorValue === 'none' || curNodeValue !== ancestorValue)
+        );
+      }
+    );
+
+    if (hasStyle) {
+      return true;
+    }
+
+    curNode = getComposedParent(curNode);
+  }
+
+  // font styles are inherited so we only need to check
+  // the target node
+  if (_getFonts(nodeStyle)[0] !== _getFonts(ancestorStyle)[0]) {
     return true;
   }
 
-  var hasStyle = [
-    'text-decoration-line',
-    'text-decoration-style',
-    'font-weight',
-    'font-style',
-    'font-size'
-  ].reduce((result, cssProp) => {
+  let hasStyle = ['font-weight', 'font-style', 'font-size'].some(cssProp => {
     return (
-      result ||
       nodeStyle.getPropertyValue(cssProp) !==
-        parentStyle.getPropertyValue(cssProp)
+      ancestorStyle.getPropertyValue(cssProp)
     );
-  }, false);
+  });
 
-  var tDec = nodeStyle.getPropertyValue('text-decoration');
+  const tDec = nodeStyle.getPropertyValue('text-decoration');
   if (tDec.split(' ').length < 3) {
     // old style CSS text decoration
     hasStyle =
-      hasStyle || tDec !== parentStyle.getPropertyValue('text-decoration');
+      hasStyle || tDec !== ancestorStyle.getPropertyValue('text-decoration');
   }
 
   return hasStyle;

--- a/lib/commons/color/element-is-distinct.js
+++ b/lib/commons/color/element-is-distinct.js
@@ -28,36 +28,34 @@ function _getFonts(style) {
 function elementIsDistinct(node, ancestorNode) {
   const nodeStyle = window.getComputedStyle(node);
 
-  // Check if the link has a background
-  if (nodeStyle.getPropertyValue('background-image') !== 'none') {
-    return true;
-  }
-
-  // Check if the link has a border or outline
-  const hasBorder = ['border-bottom', 'border-top', 'outline'].some(edge => {
-    const borderClr = new Color();
-    borderClr.parseString(nodeStyle.getPropertyValue(edge + '-color'));
-
-    // Check if a border/outline was specified
-    return (
-      nodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
-      parseFloat(nodeStyle.getPropertyValue(edge + '-width')) > 0 &&
-      borderClr.alpha !== 0
-    );
-  });
-
-  if (hasBorder) {
-    return true;
-  }
-
   const ancestorStyle = window.getComputedStyle(ancestorNode);
   let curNode = node;
   while (curNode !== ancestorNode) {
     const curNodeStyle = window.getComputedStyle(curNode);
 
-    // text decoration styles are not inherited so we need
-    // to check each node from the target node to the
-    // ancestor node
+    // Check if the link has a background
+    if (curNodeStyle.getPropertyValue('background-image') !== 'none') {
+      return true;
+    }
+
+    // Check if the link has a border or outline
+    const hasBorder = ['border-bottom', 'border-top', 'outline'].some(edge => {
+      const borderClr = new Color();
+      borderClr.parseString(curNodeStyle.getPropertyValue(edge + '-color'));
+
+      // Check if a border/outline was specified
+      return (
+        curNodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
+        parseFloat(curNodeStyle.getPropertyValue(edge + '-width')) > 0 &&
+        borderClr.alpha !== 0
+      );
+    });
+
+    if (hasBorder) {
+      return true;
+    }
+
+    // Check if the link has text-decoration styles
     const hasStyle = ['text-decoration-line', 'text-decoration-style'].some(
       cssProp => {
         const ancestorValue = ancestorStyle.getPropertyValue(cssProp);

--- a/lib/commons/color/element-is-distinct.js
+++ b/lib/commons/color/element-is-distinct.js
@@ -25,9 +25,9 @@ export default function elementIsDistinct(node, ancestorNode) {
     }
 
     if (
-      hasDifferentText(node, curNode) ||
-      hasVisibleBorder(curNodeStyle) ||
-      hasVisibleTextDecortation(curNodeStyle, ancestorStyle)
+      hasSameText(node, curNode) &&
+      (hasVisibleBorder(curNodeStyle) ||
+        hasVisibleTextDecortation(curNodeStyle, ancestorStyle))
     ) {
       return true;
     }
@@ -73,12 +73,12 @@ function getFonts(style) {
     });
 }
 
-function hasDifferentText(node, ancestorNode) {
+function hasSameText(node, ancestorNode) {
   // 3 is an arbitrary number that helps account for punctuation
   // and emoji that takes up two characters
   return ancestorNode.textContent
     .split(node.textContent)
-    .some(text => sanitize(text).length > 3);
+    .every(text => sanitize(text).length <= 3);
 }
 
 function hasVisibleBorder(nodeStyle) {

--- a/lib/commons/color/element-is-distinct.js
+++ b/lib/commons/color/element-is-distinct.js
@@ -1,20 +1,6 @@
 import Color from './color';
+import { sanitize } from '../text';
 import { getComposedParent } from '../dom';
-
-/**
- * Creates a string array of fonts for given CSSStyleDeclaration object
- * @private
- * @param {Object} style CSSStyleDeclaration object
- * @return {Array}
- */
-function _getFonts(style) {
-  return style
-    .getPropertyValue('font-family')
-    .split(/[,;]/g)
-    .map(font => {
-      return font.trim().toLowerCase();
-    });
-}
 
 /**
  * Determine if the text content of two nodes is styled in a way that they can be distinguished without relying on color
@@ -25,7 +11,7 @@ function _getFonts(style) {
  * @param  {HTMLElement} ancestorNode The ancestor node element to check
  * @return {Boolean}
  */
-function elementIsDistinct(node, ancestorNode) {
+export default function elementIsDistinct(node, ancestorNode) {
   const nodeStyle = window.getComputedStyle(node);
 
   const ancestorStyle = window.getComputedStyle(ancestorNode);
@@ -38,42 +24,11 @@ function elementIsDistinct(node, ancestorNode) {
       return true;
     }
 
-    // Check if the link has a border or outline
-    const hasBorder = ['border-bottom', 'border-top', 'outline'].some(edge => {
-      const borderClr = new Color();
-      borderClr.parseString(curNodeStyle.getPropertyValue(edge + '-color'));
-
-      // Check if a border/outline was specified
-      return (
-        curNodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
-        parseFloat(curNodeStyle.getPropertyValue(edge + '-width')) > 0 &&
-        borderClr.alpha !== 0
-      );
-    });
-
-    if (hasBorder) {
-      return true;
-    }
-
-    // Check if the link has text-decoration styles
-    const hasStyle = ['text-decoration-line', 'text-decoration-style'].some(
-      cssProp => {
-        const ancestorValue = ancestorStyle.getPropertyValue(cssProp);
-        const curNodeValue = curNodeStyle.getPropertyValue(cssProp);
-
-        /*
-        For logic purposes we can treat the target node and all inline ancestors as a single logic point since if any of them define a text-decoration style it will visually apply that style to the target.
-
-        A target node is distinct if it defines a text-decoration and either the ancestor does not define one or the target's text-decoration is different than the ancestor. A target that does not define a text-decoration can never be distinct from the ancestor.
-      */
-        return (
-          curNodeValue !== 'none' &&
-          (ancestorValue === 'none' || curNodeValue !== ancestorValue)
-        );
-      }
-    );
-
-    if (hasStyle) {
+    if (
+      hasDifferentText(node, curNode) ||
+      hasVisibleBorder(curNodeStyle) ||
+      hasVisibleTextDecortation(curNodeStyle, ancestorStyle)
+    ) {
       return true;
     }
 
@@ -82,7 +37,7 @@ function elementIsDistinct(node, ancestorNode) {
 
   // font styles are inherited so we only need to check
   // the target node
-  if (_getFonts(nodeStyle)[0] !== _getFonts(ancestorStyle)[0]) {
+  if (getFonts(nodeStyle)[0] !== getFonts(ancestorStyle)[0]) {
     return true;
   }
 
@@ -103,4 +58,58 @@ function elementIsDistinct(node, ancestorNode) {
   return hasStyle;
 }
 
-export default elementIsDistinct;
+/**
+ * Creates a string array of fonts for given CSSStyleDeclaration object
+ * @private
+ * @param {Object} style CSSStyleDeclaration object
+ * @return {Array}
+ */
+function getFonts(style) {
+  return style
+    .getPropertyValue('font-family')
+    .split(/[,;]/g)
+    .map(font => {
+      return font.trim().toLowerCase();
+    });
+}
+
+function hasDifferentText(node, ancestorNode) {
+  // 3 is an arbitrary number that helps account for punctuation
+  // and emoji that takes up two characters
+  return ancestorNode.textContent
+    .split(node.textContent)
+    .some(text => sanitize(text).length > 3);
+}
+
+function hasVisibleBorder(nodeStyle) {
+  // Check if the link has a border or outline
+  return ['border-bottom', 'border-top', 'outline'].some(edge => {
+    const borderClr = new Color();
+    borderClr.parseString(nodeStyle.getPropertyValue(edge + '-color'));
+
+    // Check if a border/outline was specified
+    return (
+      nodeStyle.getPropertyValue(edge + '-style') !== 'none' &&
+      parseFloat(nodeStyle.getPropertyValue(edge + '-width')) > 0 &&
+      borderClr.alpha !== 0
+    );
+  });
+}
+
+function hasVisibleTextDecortation(nodeStyle, ancestorStyle) {
+  // Check if the link has text-decoration styles
+  return ['text-decoration-line', 'text-decoration-style'].some(cssProp => {
+    const ancestorValue = ancestorStyle.getPropertyValue(cssProp);
+    const nodeValue = nodeStyle.getPropertyValue(cssProp);
+
+    /*
+        For logic purposes we can treat the target node and all inline ancestors as a single logic point since if any of them define a text-decoration style it will visually apply that style to the target.
+
+        A target node is distinct if it defines a text-decoration and either the ancestor does not define one or the target's text-decoration is different than the ancestor. A target that does not define a text-decoration can never be distinct from the ancestor.
+      */
+    return (
+      nodeValue !== 'none' &&
+      (ancestorValue === 'none' || nodeValue !== ancestorValue)
+    );
+  });
+}

--- a/test/checks/color/link-in-text-block-style.js
+++ b/test/checks/color/link-in-text-block-style.js
@@ -212,20 +212,20 @@ describe('link-in-text-block-style', () => {
     });
 
     Object.entries(testSuites).forEach(([property, styles]) => {
-      it(`returns true if link has ${property}`, () => {
-        const { linkElm, parentElm } = getLinkElm(styles);
-        assert.isTrue(linkInBlockStyleCheck.call(checkContext, linkElm));
-        assert.equal(checkContext._relatedNodes[0], parentElm);
-        assert.isNull(checkContext._data);
-      });
-    });
+      describe(`with ${property}`, () => {
+        it(`returns true if link has ${property}`, () => {
+          const { linkElm, parentElm } = getLinkElm(styles);
+          assert.isTrue(linkInBlockStyleCheck.call(checkContext, linkElm));
+          assert.equal(checkContext._relatedNodes[0], parentElm);
+          assert.isNull(checkContext._data);
+        });
 
-    Object.entries(testSuites).forEach(([property, styles]) => {
-      it(`returns true if ancestor inline element has ${property}`, () => {
-        const { linkElm, parentElm } = getLinkElm({}, styles);
-        assert.isTrue(linkInBlockStyleCheck.call(checkContext, linkElm));
-        assert.equal(checkContext._relatedNodes[0], parentElm);
-        assert.isNull(checkContext._data);
+        it(`returns true if ancestor inline element has ${property}`, () => {
+          const { linkElm, parentElm } = getLinkElm({}, styles);
+          assert.isTrue(linkInBlockStyleCheck.call(checkContext, linkElm));
+          assert.equal(checkContext._relatedNodes[0], parentElm);
+          assert.isNull(checkContext._data);
+        });
       });
     });
 

--- a/test/commons/color/element-is-distinct.js
+++ b/test/commons/color/element-is-distinct.js
@@ -1,271 +1,355 @@
 describe('color.elementIsDistinct', () => {
-  let styleElm;
-  let elementIsDistinct;
+  const elementIsDistinct = axe.commons.color.elementIsDistinct;
+  const fixtureSetup = axe.testUtils.fixtureSetup;
+  const fixture = document.querySelector('#fixture');
 
-  const fixture = document.getElementById('fixture');
-
-  before(() => {
-    styleElm = document.createElement('style');
-    document.head.appendChild(styleElm);
-  });
-
-  const defaultStyle = {
-    color: '#000',
-    textDecoration: 'none'
-  };
-
-  function createStyleString(selector, outerStyle) {
-    // Merge style with the default
-    const styleObj = {};
-    for (const prop in defaultStyle) {
-      if (defaultStyle.hasOwnProperty(prop)) {
-        styleObj[prop] = defaultStyle[prop];
-      }
-    }
-    for (const prop in outerStyle) {
-      if (outerStyle.hasOwnProperty(prop)) {
-        styleObj[prop] = outerStyle[prop];
-      }
-    }
-
-    const cssLines = Object.keys(styleObj)
-      .map(prop => {
-        // Make camelCase prop dash separated
-        const cssPropName = prop
-          .trim()
-          .split(/(?=[A-Z])/g)
-          .reduce((name, propPiece) => {
-            if (!name) {
-              return propPiece;
-            } else {
-              return name + '-' + propPiece.toLowerCase();
-            }
-          }, null);
-
-        // Return indented line of style code
-        return '  ' + cssPropName + ':' + styleObj[prop] + ';';
-      })
-      .join('\n');
-
-    // Add to the style element
-    styleElm.innerHTML += selector + ' {\n' + cssLines + '\n}\n';
+  function convertStylePropsToString(props = {}) {
+    return Object.entries(props)
+      .map(([name, value]) => `${name}: ${value}`)
+      .join(';');
   }
 
-  function getLinkElm(linkStyle, paragraphStyle) {
-    // Get a random id and build the style string
-    const linkId = 'linkid-' + Math.floor(Math.random() * 100000);
-    const parId = 'parid-' + Math.floor(Math.random() * 100000);
+  function createTestFixture({ target, root, inline } = {}) {
+    const linkStyles = convertStylePropsToString(target);
+    const paragraphStyles = convertStylePropsToString(root);
+    const spanStyles = convertStylePropsToString(inline);
 
-    createStyleString('#' + linkId, linkStyle);
-    createStyleString('#' + parId, paragraphStyle);
+    fixtureSetup(`
+      <p style="color: black; ${paragraphStyles}">
+        <span style="${spanStyles}">
+          <a href="#" style="text-decoration: none; color: black; ${linkStyles}">Hello World</a>
+        </span>
+      </p>
+    `);
 
-    fixture.innerHTML +=
-      '<p id="' +
-      parId +
-      '"> Text ' +
-      '<a href="/" id="' +
-      linkId +
-      '">link</a>' +
-      '</p>';
     return {
-      link: document.getElementById(linkId),
-      par: document.getElementById(parId)
+      root: fixture.querySelector('p'),
+      inline: fixture.querySelector('span'),
+      target: fixture.querySelector('a')
     };
   }
 
-  beforeEach(() => {
-    createStyleString('p', defaultStyle);
-    elementIsDistinct = axe.commons.color.elementIsDistinct;
-  });
-
-  afterEach(() => {
-    fixture.innerHTML = '';
-    styleElm.innerHTML = '';
-  });
-
-  after(() => {
-    styleElm.parentNode.removeChild(styleElm);
-  });
-
   it('returns false without style adjustments', () => {
-    const elms = getLinkElm({});
-    const result = elementIsDistinct(elms.link, elms.par);
+    const elms = createTestFixture();
+    const result = elementIsDistinct(elms.target, elms.root);
 
     assert.isFalse(result);
   });
 
   it('returns true with background-image set', () => {
-    const elms = getLinkElm({
-      background: 'url(icon.png) no-repeat'
+    const elms = createTestFixture({
+      target: { background: 'url(icon.png) no-repeat' }
     });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns true with border: dashed 1px black', () => {
-    const elms = getLinkElm({
-      border: 'dashed 1px black'
+    const elms = createTestFixture({
+      target: { border: 'dashed 1px black' }
     });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns true with border-bottom: dashed 1px black', () => {
-    const elms = getLinkElm({
-      borderBottom: 'dashed 1px black'
+    const elms = createTestFixture({
+      target: { 'border-bottom': 'dashed 1px black' }
     });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns false with border: solid 0px black', () => {
-    const elms = getLinkElm({
-      border: 'solid 0px black'
+    const elms = createTestFixture({
+      target: { border: 'solid 0px black' }
     });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isFalse(result);
   });
 
   it('returns false with border: none 1px black', () => {
-    const elms = getLinkElm({
-      border: 'none 1px black'
+    const elms = createTestFixture({
+      target: { border: 'none 1px black' }
     });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isFalse(result);
   });
 
   it('returns false with border: solid 1px transparent', () => {
-    const elms = getLinkElm({
-      border: 'solid 1px transparent'
+    const elms = createTestFixture({
+      target: { border: 'solid 1px transparent' }
     });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isFalse(result);
   });
 
   it('returns true with outline: solid 1px black', () => {
-    const elms = getLinkElm({
-      outline: 'solid 1px black'
+    const elms = createTestFixture({
+      target: { outline: 'solid 1px black' }
     });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns true if font-weight is different', () => {
-    const elms = getLinkElm(
-      {
-        fontWeight: 'bold'
+    const elms = createTestFixture({
+      target: {
+        'font-weight': 'bold'
       },
-      {
-        fontWeight: 'normal'
+      root: {
+        'font-weight': 'normal'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns false if font-weight is the same', () => {
-    const elms = getLinkElm(
-      {
-        fontWeight: 'bold'
+    const elms = createTestFixture({
+      target: {
+        'font-weight': 'bold'
       },
-      {
-        fontWeight: 'bold'
+      root: {
+        'font-weight': 'bold'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isFalse(result);
   });
 
   it('compares font numbers and labels correctly', () => {
-    const elms = getLinkElm(
-      {
-        fontWeight: 'bold'
+    const elms = createTestFixture({
+      target: {
+        'font-weight': 'bold'
       },
-      {
-        fontWeight: '700'
+      root: {
+        'font-weight': '700'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isFalse(result);
   });
 
   it('returns true if text-decoration is different', () => {
-    const elms = getLinkElm(
-      {
-        textDecoration: 'underline'
+    const elms = createTestFixture({
+      target: {
+        'text-decoration': 'underline'
       },
-      {
-        textDecoration: 'none'
+      root: {
+        'text-decoration': 'none'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns false if text-decoration is the same', () => {
-    const elms = getLinkElm(
-      {
-        textDecoration: 'underline'
+    const elms = createTestFixture({
+      target: {
+        'text-decoration': 'underline'
       },
-      {
-        textDecoration: 'underline'
+      root: {
+        'text-decoration': 'underline'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isFalse(result);
   });
 
   it('returns true if font-size is different', () => {
-    const elms = getLinkElm(
-      {
-        fontSize: '14px'
+    const elms = createTestFixture({
+      target: {
+        'font-size': '14px'
       },
-      {
-        fontSize: '12px'
+      root: {
+        'font-size': '12px'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns true if font-family is different', () => {
-    const elms = getLinkElm(
-      {
-        fontFamily: 'Arial'
+    const elms = createTestFixture({
+      target: {
+        'font-family': 'Arial'
       },
-      {
-        fontFamily: 'Arial-black'
+      root: {
+        'font-family': 'Arial-black'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isTrue(result);
   });
 
   it('returns false if the first font-family is identical', () => {
-    const elms = getLinkElm(
-      {
-        fontFamily: 'Arial-black, Arial'
+    const elms = createTestFixture({
+      target: {
+        'font-family': 'Arial-black, Arial'
       },
-      {
-        fontFamily: 'Arial-black, sans-serif'
+      root: {
+        'font-family': 'Arial-black, sans-serif'
       }
-    );
+    });
 
-    const result = elementIsDistinct(elms.link, elms.par);
+    const result = elementIsDistinct(elms.target, elms.root);
     assert.isFalse(result);
+  });
+
+  describe('inline element', () => {
+    describe('text-decoration-line', () => {
+      it('returns true if inline adds', () => {
+        const elms = createTestFixture({
+          inline: {
+            'text-decoration': 'underline'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns true if target has text-decoration:none and inline adds', () => {
+        const elms = createTestFixture({
+          target: {
+            'text-decoration': 'none'
+          },
+          inline: {
+            'text-decoration': 'underline'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns false if inline and root use same value', () => {
+        const elms = createTestFixture({
+          root: {
+            'text-decoration': 'underline'
+          },
+          inline: {
+            'text-decoration': 'underline'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns true if inline and root use different value', () => {
+        const elms = createTestFixture({
+          root: {
+            'text-decoration': 'underline'
+          },
+          inline: {
+            'text-decoration': 'overline'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+    });
+
+    describe('text-decoration-style', () => {
+      it('returns true if inline adds', () => {
+        const elms = createTestFixture({
+          inline: {
+            'text-decoration': 'underline solid'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns true if target has text-decoration:none and inline adds', () => {
+        const elms = createTestFixture({
+          target: {
+            'text-decoration': 'none'
+          },
+          inline: {
+            'text-decoration': 'underline solid'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns false if inline and root use same value', () => {
+        const elms = createTestFixture({
+          root: {
+            'text-decoration': 'underline solid'
+          },
+          inline: {
+            'text-decoration': 'underline solid'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns true if inline and root use different value', () => {
+        const elms = createTestFixture({
+          root: {
+            'text-decoration': 'underline solid'
+          },
+          inline: {
+            'text-decoration': 'underline wavy'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+    });
+
+    describe('font', () => {
+      it('returns true if inline adds', () => {
+        const elms = createTestFixture({
+          inline: {
+            'font-weight': 'bold'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns false if target has same font as root and inline adds', () => {
+        const elms = createTestFixture({
+          target: {
+            'font-weight': 'normal'
+          },
+          root: {
+            'font-weight': 'normal'
+          },
+          inline: {
+            'font-weight': 'bold'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isFalse(result);
+      });
+    });
   });
 });

--- a/test/commons/color/element-is-distinct.js
+++ b/test/commons/color/element-is-distinct.js
@@ -225,71 +225,6 @@ describe('color.elementIsDistinct', () => {
       });
     });
 
-    describe('text', () => {
-      it('returns true if the targetWrap has more than 3 characters before target', () => {
-        const elms = createTestFixture();
-        elms.targetWrap.innerHTML = `Hows ${elms.target.outerHTML}`;
-        const target = elms.targetWrap.querySelector('a');
-
-        const result = elementIsDistinct(target, elms.root);
-        assert.isTrue(result);
-      });
-
-      it('returns true if the targetWrap has more than 3 characters after target', () => {
-        const elms = createTestFixture();
-        elms.targetWrap.innerHTML = `${elms.target.outerHTML} Hows`;
-        const target = elms.targetWrap.querySelector('a');
-
-        const result = elementIsDistinct(target, elms.root);
-        assert.isTrue(result);
-      });
-
-      it('returns false if the targetWrap has 3 characters before target', () => {
-        const elms = createTestFixture();
-        elms.targetWrap.innerHTML = `the ${elms.target.outerHTML}`;
-        const target = elms.targetWrap.querySelector('a');
-
-        const result = elementIsDistinct(target, elms.root);
-        assert.isFalse(result);
-      });
-
-      it('returns false if the targetWrap has 3 characters after target', () => {
-        const elms = createTestFixture();
-        elms.targetWrap.innerHTML = `${elms.target.outerHTML} the`;
-        const target = elms.targetWrap.querySelector('a');
-
-        const result = elementIsDistinct(target, elms.root);
-        assert.isFalse(result);
-      });
-
-      it('returns false if the targetWrap has less than 3 characters before target', () => {
-        const elms = createTestFixture();
-        elms.targetWrap.innerHTML = `: ${elms.target.outerHTML}`;
-        const target = elms.targetWrap.querySelector('a');
-
-        const result = elementIsDistinct(target, elms.root);
-        assert.isFalse(result);
-      });
-
-      it('returns false if the targetWrap has less than 3 characters after target', () => {
-        const elms = createTestFixture();
-        elms.targetWrap.innerHTML = `${elms.target.outerHTML}: `;
-        const target = elms.targetWrap.querySelector('a');
-
-        const result = elementIsDistinct(target, elms.root);
-        assert.isFalse(result);
-      });
-
-      it('ignores whitespace', () => {
-        const elms = createTestFixture();
-        elms.targetWrap.innerHTML = `\n\t       ${elms.target.outerHTML}`;
-        const target = elms.targetWrap.querySelector('a');
-
-        const result = elementIsDistinct(target, elms.root);
-        assert.isFalse(result);
-      });
-    });
-
     describe('border', () => {
       it('returns true if targetWrap adds border', () => {
         const elms = createTestFixture({
@@ -466,6 +401,99 @@ describe('color.elementIsDistinct', () => {
         });
 
         const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+    });
+
+    describe('text', () => {
+      it('returns true if targetWrap adds border and has <= 3 characters before target', () => {
+        const elms = createTestFixture({
+          targetWrap: {
+            'border-bottom': '1px solid'
+          }
+        });
+        elms.targetWrap.innerHTML = `the ${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns true if targetWrap adds outline and has <= 3 characters after target', () => {
+        const elms = createTestFixture({
+          targetWrap: {
+            outline: '1px solid'
+          }
+        });
+        elms.targetWrap.innerHTML = `${elms.target.outerHTML} the`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns true if targetWrap adds text-decoration and has <= 3 characters before target', () => {
+        const elms = createTestFixture({
+          targetWrap: {
+            'text-decoration': 'underline'
+          }
+        });
+        elms.targetWrap.innerHTML = `the ${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns false if targetWrap adds border and has > 3 characters before target', () => {
+        const elms = createTestFixture({
+          targetWrap: {
+            'border-bottom': '1px solid'
+          }
+        });
+        elms.targetWrap.innerHTML = `World ${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns false if targetWrap adds outline and has <= 3 characters after target', () => {
+        const elms = createTestFixture({
+          targetWrap: {
+            outline: '1px solid'
+          }
+        });
+        elms.targetWrap.innerHTML = `${elms.target.outerHTML} World`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns false if targetWrap adds text-decoration and has > 3 characters after target', () => {
+        const elms = createTestFixture({
+          targetWrap: {
+            'text-decoration': 'underline'
+          }
+        });
+        elms.targetWrap.innerHTML = `${elms.target.outerHTML} World`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('ignores whitespace differences', () => {
+        const elms = createTestFixture({
+          targetWrap: {
+            'text-decoration': 'underline'
+          }
+        });
+        elms.targetWrap.innerHTML = `\t   \n${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
         assert.isTrue(result);
       });
     });

--- a/test/commons/color/element-is-distinct.js
+++ b/test/commons/color/element-is-distinct.js
@@ -9,10 +9,10 @@ describe('color.elementIsDistinct', () => {
       .join(';');
   }
 
-  function createTestFixture({ target, root, inline } = {}) {
+  function createTestFixture({ target, root, targetWrap } = {}) {
     const linkStyles = convertStylePropsToString(target);
     const paragraphStyles = convertStylePropsToString(root);
-    const spanStyles = convertStylePropsToString(inline);
+    const spanStyles = convertStylePropsToString(targetWrap);
 
     fixtureSetup(`
       <p style="color: black; ${paragraphStyles}">
@@ -24,7 +24,7 @@ describe('color.elementIsDistinct', () => {
 
     return {
       root: fixture.querySelector('p'),
-      inline: fixture.querySelector('span'),
+      targetWrap: fixture.querySelector('span'),
       target: fixture.querySelector('a')
     };
   }
@@ -211,11 +211,11 @@ describe('color.elementIsDistinct', () => {
     assert.isFalse(result);
   });
 
-  describe('inline element', () => {
+  describe('targetWrap element', () => {
     describe('background-image', () => {
-      it('returns true if inline adds background-image', () => {
+      it('returns true if targetWrap adds background-image', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             background: 'url(icon.png) no-repeat'
           }
         });
@@ -225,10 +225,75 @@ describe('color.elementIsDistinct', () => {
       });
     });
 
+    describe('text', () => {
+      it('returns true if the targetWrap has more than 3 characters before target', () => {
+        const elms = createTestFixture();
+        elms.targetWrap.innerHTML = `Hows ${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns true if the targetWrap has more than 3 characters after target', () => {
+        const elms = createTestFixture();
+        elms.targetWrap.innerHTML = `${elms.target.outerHTML} Hows`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns false if the targetWrap has 3 characters before target', () => {
+        const elms = createTestFixture();
+        elms.targetWrap.innerHTML = `the ${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns false if the targetWrap has 3 characters after target', () => {
+        const elms = createTestFixture();
+        elms.targetWrap.innerHTML = `${elms.target.outerHTML} the`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns false if the targetWrap has less than 3 characters before target', () => {
+        const elms = createTestFixture();
+        elms.targetWrap.innerHTML = `: ${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns false if the targetWrap has less than 3 characters after target', () => {
+        const elms = createTestFixture();
+        elms.targetWrap.innerHTML = `${elms.target.outerHTML}: `;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('ignores whitespace', () => {
+        const elms = createTestFixture();
+        elms.targetWrap.innerHTML = `\n\t       ${elms.target.outerHTML}`;
+        const target = elms.targetWrap.querySelector('a');
+
+        const result = elementIsDistinct(target, elms.root);
+        assert.isFalse(result);
+      });
+    });
+
     describe('border', () => {
-      it('returns true if inline adds border', () => {
+      it('returns true if targetWrap adds border', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             'border-bottom': '1px solid'
           }
         });
@@ -237,9 +302,9 @@ describe('color.elementIsDistinct', () => {
         assert.isTrue(result);
       });
 
-      it('returns false if inline adds border with 0 width', () => {
+      it('returns false if targetWrap adds border with 0 width', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             'border-top': '0 solid'
           }
         });
@@ -248,9 +313,9 @@ describe('color.elementIsDistinct', () => {
         assert.isFalse(result);
       });
 
-      it('returns false if inline adds border with 0 alpha', () => {
+      it('returns false if targetWrap adds border with 0 alpha', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             'border-bottom': '2px solid rgba(255,255,255,0)'
           }
         });
@@ -261,9 +326,9 @@ describe('color.elementIsDistinct', () => {
     });
 
     describe('outline', () => {
-      it('returns true if inline adds outline', () => {
+      it('returns true if targetWrap adds outline', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             outline: '1px solid'
           }
         });
@@ -272,9 +337,9 @@ describe('color.elementIsDistinct', () => {
         assert.isTrue(result);
       });
 
-      it('returns false if inline adds outline with 0 width', () => {
+      it('returns false if targetWrap adds outline with 0 width', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             outline: '0 solid'
           }
         });
@@ -283,9 +348,9 @@ describe('color.elementIsDistinct', () => {
         assert.isFalse(result);
       });
 
-      it('returns false if inline adds outline with 0 alpha', () => {
+      it('returns false if targetWrap adds outline with 0 alpha', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             outline: '2px solid rgba(255,255,255,0)'
           }
         });
@@ -296,9 +361,9 @@ describe('color.elementIsDistinct', () => {
     });
 
     describe('text-decoration-line', () => {
-      it('returns true if inline adds text-decoration-line', () => {
+      it('returns true if targetWrap adds text-decoration-line', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             'text-decoration': 'underline'
           }
         });
@@ -307,12 +372,12 @@ describe('color.elementIsDistinct', () => {
         assert.isTrue(result);
       });
 
-      it('returns true if target has text-decoration:none and inline adds', () => {
+      it('returns true if target has text-decoration:none and targetWrap adds', () => {
         const elms = createTestFixture({
           target: {
             'text-decoration': 'none'
           },
-          inline: {
+          targetWrap: {
             'text-decoration': 'underline'
           }
         });
@@ -321,12 +386,12 @@ describe('color.elementIsDistinct', () => {
         assert.isTrue(result);
       });
 
-      it('returns false if inline and root use same value', () => {
+      it('returns false if targetWrap and root use same value', () => {
         const elms = createTestFixture({
           root: {
             'text-decoration': 'underline'
           },
-          inline: {
+          targetWrap: {
             'text-decoration': 'underline'
           }
         });
@@ -335,12 +400,12 @@ describe('color.elementIsDistinct', () => {
         assert.isFalse(result);
       });
 
-      it('returns true if inline and root use different value', () => {
+      it('returns true if targetWrap and root use different value', () => {
         const elms = createTestFixture({
           root: {
             'text-decoration': 'underline'
           },
-          inline: {
+          targetWrap: {
             'text-decoration': 'overline'
           }
         });
@@ -351,9 +416,9 @@ describe('color.elementIsDistinct', () => {
     });
 
     describe('text-decoration-style', () => {
-      it('returns true if inline adds text-decoration-style', () => {
+      it('returns true if targetWrap adds text-decoration-style', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             'text-decoration': 'underline solid'
           }
         });
@@ -362,12 +427,12 @@ describe('color.elementIsDistinct', () => {
         assert.isTrue(result);
       });
 
-      it('returns true if target has text-decoration:none and inline adds', () => {
+      it('returns true if target has text-decoration:none and targetWrap adds', () => {
         const elms = createTestFixture({
           target: {
             'text-decoration': 'none'
           },
-          inline: {
+          targetWrap: {
             'text-decoration': 'underline solid'
           }
         });
@@ -376,12 +441,12 @@ describe('color.elementIsDistinct', () => {
         assert.isTrue(result);
       });
 
-      it('returns false if inline and root use same value', () => {
+      it('returns false if targetWrap and root use same value', () => {
         const elms = createTestFixture({
           root: {
             'text-decoration': 'underline solid'
           },
-          inline: {
+          targetWrap: {
             'text-decoration': 'underline solid'
           }
         });
@@ -390,12 +455,12 @@ describe('color.elementIsDistinct', () => {
         assert.isFalse(result);
       });
 
-      it('returns true if inline and root use different value', () => {
+      it('returns true if targetWrap and root use different value', () => {
         const elms = createTestFixture({
           root: {
             'text-decoration': 'underline solid'
           },
-          inline: {
+          targetWrap: {
             'text-decoration': 'underline wavy'
           }
         });
@@ -406,9 +471,9 @@ describe('color.elementIsDistinct', () => {
     });
 
     describe('font', () => {
-      it('returns true if inline adds', () => {
+      it('returns true if targetWrap adds', () => {
         const elms = createTestFixture({
-          inline: {
+          targetWrap: {
             'font-weight': 'bold'
           }
         });
@@ -417,7 +482,7 @@ describe('color.elementIsDistinct', () => {
         assert.isTrue(result);
       });
 
-      it('returns false if target has same font as root and inline adds', () => {
+      it('returns false if target has same font as root and targetWrap adds', () => {
         const elms = createTestFixture({
           target: {
             'font-weight': 'normal'
@@ -425,7 +490,7 @@ describe('color.elementIsDistinct', () => {
           root: {
             'font-weight': 'normal'
           },
-          inline: {
+          targetWrap: {
             'font-weight': 'bold'
           }
         });

--- a/test/commons/color/element-is-distinct.js
+++ b/test/commons/color/element-is-distinct.js
@@ -212,8 +212,91 @@ describe('color.elementIsDistinct', () => {
   });
 
   describe('inline element', () => {
+    describe('background-image', () => {
+      it('returns true if inline adds background-image', () => {
+        const elms = createTestFixture({
+          inline: {
+            background: 'url(icon.png) no-repeat'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+    });
+
+    describe('border', () => {
+      it('returns true if inline adds border', () => {
+        const elms = createTestFixture({
+          inline: {
+            'border-bottom': '1px solid'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns false if inline adds border with 0 width', () => {
+        const elms = createTestFixture({
+          inline: {
+            'border-top': '0 solid'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns false if inline adds border with 0 alpha', () => {
+        const elms = createTestFixture({
+          inline: {
+            'border-bottom': '2px solid rgba(255,255,255,0)'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isFalse(result);
+      });
+    });
+
+    describe('outline', () => {
+      it('returns true if inline adds outline', () => {
+        const elms = createTestFixture({
+          inline: {
+            outline: '1px solid'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isTrue(result);
+      });
+
+      it('returns false if inline adds outline with 0 width', () => {
+        const elms = createTestFixture({
+          inline: {
+            outline: '0 solid'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isFalse(result);
+      });
+
+      it('returns false if inline adds outline with 0 alpha', () => {
+        const elms = createTestFixture({
+          inline: {
+            outline: '2px solid rgba(255,255,255,0)'
+          }
+        });
+
+        const result = elementIsDistinct(elms.target, elms.root);
+        assert.isFalse(result);
+      });
+    });
+
     describe('text-decoration-line', () => {
-      it('returns true if inline adds', () => {
+      it('returns true if inline adds text-decoration-line', () => {
         const elms = createTestFixture({
           inline: {
             'text-decoration': 'underline'
@@ -268,7 +351,7 @@ describe('color.elementIsDistinct', () => {
     });
 
     describe('text-decoration-style', () => {
-      it('returns true if inline adds', () => {
+      it('returns true if inline adds text-decoration-style', () => {
         const elms = createTestFixture({
           inline: {
             'text-decoration': 'underline solid'

--- a/test/integration/rules/link-in-text-block/link-in-text-block.html
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.html
@@ -74,6 +74,32 @@
   >
 </p>
 
+<p style="color: black">
+  paragraph of text (pass: ancestor span is bolder than paragraph)
+  <span style="font-weight: bolder">
+    <a
+      style="text-decoration: none; color: black"
+      href="#"
+      id="pass-ancestor-different-weight"
+    >
+      Link text</a
+    >
+  </span>
+</p>
+
+<p style="color: black">
+  paragraph of text (pass: ancestor span uses border)
+  <span style="border-bottom: 1px">
+    <a
+      style="text-decoration: none; color: black"
+      href="#"
+      id="pass-ancestor-border"
+    >
+      Link text</a
+    >
+  </span>
+</p>
+
 <h1>Color change tests</h1>
 <b
   >Note that these tests limit changes to one variable per test. No attempt is

--- a/test/integration/rules/link-in-text-block/link-in-text-block.html
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.html
@@ -55,7 +55,7 @@
 <p style="color: black">
   paragraph of text (pass: link is bolder than paragraph)
   <a
-    style="text-decoration: none; font-weight: bolder; color: black"
+    style="text-decoration: none; font-weight: bolder; color: #222"
     href="#"
     id="pass-different-weight"
   >
@@ -66,7 +66,7 @@
 <p style="color: black">
   paragraph of text (pass: link is larger that paragraph)
   <a
-    style="text-decoration: none; font-size: larger; color: black"
+    style="text-decoration: none; font-size: larger; color: #222"
     href="#"
     id="pass-different-size"
   >
@@ -78,7 +78,7 @@
   paragraph of text (pass: ancestor span is bolder than paragraph)
   <span style="font-weight: bolder">
     <a
-      style="text-decoration: none; color: black"
+      style="text-decoration: none; color: #222"
       href="#"
       id="pass-ancestor-different-weight"
     >
@@ -89,9 +89,9 @@
 
 <p style="color: black">
   paragraph of text (pass: ancestor span uses border)
-  <span style="border-bottom: 1px solid black">
+  <span style="border-bottom: 1px solid">
     <a
-      style="text-decoration: none; color: black"
+      style="text-decoration: none; color: #222"
       href="#"
       id="pass-ancestor-border"
     >

--- a/test/integration/rules/link-in-text-block/link-in-text-block.html
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.html
@@ -89,7 +89,7 @@
 
 <p style="color: black">
   paragraph of text (pass: ancestor span uses border)
-  <span style="border-bottom: 1px">
+  <span style="border-bottom: 1px solid black">
     <a
       style="text-decoration: none; color: black"
       href="#"

--- a/test/integration/rules/link-in-text-block/link-in-text-block.html
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.html
@@ -100,6 +100,15 @@
   </span>
 </p>
 
+<p style="color: black">
+  paragraph of text (pass: ancestor is a <code>u</code> element)
+  <u>
+    <a style="text-decoration: none; color: #222" href="#" id="pass-ancestor-u">
+      Link text</a
+    >
+  </u>
+</p>
+
 <h1>Color change tests</h1>
 <b
   >Note that these tests limit changes to one variable per test. No attempt is

--- a/test/integration/rules/link-in-text-block/link-in-text-block.json
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.json
@@ -10,6 +10,8 @@
     ["#pass-default-styling-aria-hidden"],
     ["#pass-different-weight"],
     ["#pass-different-size"],
+    ["#pass-ancestor-different-weight"],
+    ["#pass-ancestor-border"],
     ["#pass-background-color"],
     ["#pass-text-color"],
     ["#pass-same-colors"]

--- a/test/integration/rules/link-in-text-block/link-in-text-block.json
+++ b/test/integration/rules/link-in-text-block/link-in-text-block.json
@@ -12,6 +12,7 @@
     ["#pass-different-size"],
     ["#pass-ancestor-different-weight"],
     ["#pass-ancestor-border"],
+    ["#pass-ancestor-u"],
     ["#pass-background-color"],
     ["#pass-text-color"],
     ["#pass-same-colors"]


### PR DESCRIPTION
First of 2 for #4126 allowing `link-in-text-block` to use an ancestor inline element's styles when considering the style of the link. While doing this I noticed that the unit tests didn't test any of the styles we consider to be distinct, so went ahead and added them.