### PR TITLE
ci: pin chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ restore_build: &restore_build
 commands:
   browser-tools-job:
     steps:
-      -browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
           chrome-version: 116.0.5845.96
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ unix_nightly_box: &unix_nightly_box
 
 orbs:
   puppeteer: threetreeslight/puppeteer@0.1.2
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.4
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
@@ -29,6 +29,13 @@ restore_build: &restore_build
     name: Restore Axe.js Cache
     keys:
       - v9-cache-build-<< pipeline.git.revision >>
+
+commands:
+  browser-tools-job:
+    steps:
+      -browser-tools/install-browser-tools:
+          # TODO: remove when chromedriver downloads are fixed
+          chrome-version: 116.0.5845.96
 
 jobs:
   # Fetch and cache dependencies.
@@ -47,7 +54,7 @@ jobs:
             else
                 echo "node_modules does not exist"
             fi
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *set_npm_auth
       - run: npm ci
       - run: npx browser-driver-manager install chromedriver --verbose
@@ -85,7 +92,7 @@ jobs:
     <<: *unix_box
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -97,7 +104,7 @@ jobs:
     <<: *unix_box
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *restore_dependency_cache_unix
       - <<: *restore_build
       - run: npm run test -- --browsers Firefox
@@ -109,7 +116,7 @@ jobs:
     <<: *unix_box
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -121,7 +128,7 @@ jobs:
     <<: *unix_box
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -133,7 +140,7 @@ jobs:
     <<: *unix_box
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -145,7 +152,7 @@ jobs:
     <<: *unix_box
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -157,7 +164,7 @@ jobs:
     <<: *unix_box
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       - <<: *restore_dependency_cache_unix
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
@@ -192,7 +199,7 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       # install ACT rules
       # install first as for some reason installing a single package
       # also re-installs all repo dependencies as well
@@ -208,7 +215,7 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache_unix
-      - browser-tools/install-browser-tools
+      - browser-tools-job
       # install ARIA practices
       # install first as for some reason installing a single package
       # also re-installs all repo dependencies as well


### PR DESCRIPTION
This should temporarily fix the circleci issue with chromedriver version not existing since it is an upcoming stable and not yet stable but is stable for chrome

Also I made this into a command to easily revert or fix in the future 

Ref: https://github.com/CircleCI-Public/browser-tools-orb/issues/90