### PR TITLE
chore(dependabot): ignore inquirerv9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
         versions: ['>=5.0.0']
       - dependency-name: 'execa'
         versions: ['>=6.0.0']
+      - dependency-name: 'inquirer'
+        versions: ['>=9.0.0']
       # Prevent Webpack error caused by v0.11+ of esbuild
       # @see https://github.com/dequelabs/axe-core/issues/3771
       - dependency-name: 'esbuild'


### PR DESCRIPTION
Saw this in the [dependabot pr to update Inquirer to v9](https://github.com/dequelabs/axe-core/pull/4187). Inquirer v9 [moved to ESM only](https://github.com/SBoudrias/Inquirer.js/releases/tag/inquirer%409.0.0). We use it only for development and only when calling the npm script `rule-gen` to prompt for the name of the rule, if it needs checks, etc.