### PR TITLE
chore: remove make-dir dependency

### DIFF
--- a/build/shared/create-file.js
+++ b/build/shared/create-file.js
@@ -1,8 +1,5 @@
-const fs = require('fs');
-const { promisify } = require('util');
-const { dirname: getDirName } = require('path');
-const makeDir = require('make-dir');
-const writeFile = promisify(fs.writeFile);
+const { promises: fs } = require('fs');
+const { dirname } = require('path');
 
 /**
  * Create file with given contents at specified location
@@ -12,6 +9,8 @@ const writeFile = promisify(fs.writeFile);
  * @returns {Promise}
  */
 const createFile = (path, content) =>
-  makeDir(getDirName(path)).then(() => writeFile(path, content));
+  fs
+    .mkdir(dirname(path), { recursive: true })
+    .then(() => fs.writeFile(path, content));
 
 module.exports = createFile;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "browser-driver-manager": "1.0.4",
         "chai": "^4.3.7",
         "chalk": "^4.x",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "clone": "^2.1.2",
         "colorjs.io": "^0.4.3",
         "conventional-commits-parser": "^3.2.4",
@@ -57,7 +57,6 @@
         "karma-sinon": "^1.0.5",
         "karma-spec-reporter": "^0.0.36",
         "lint-staged": "^13.1.0",
-        "make-dir": "^3.1.0",
         "memoizee": "^0.4.15",
         "minami": "^1.2.3",
         "mocha": "^10.2.0",
@@ -8466,21 +8465,6 @@
       "dev": true,
       "dependencies": {
         "es5-ext": "~0.10.2"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-iterator": {
@@ -18851,15 +18835,6 @@
       "dev": true,
       "requires": {
         "es5-ext": "~0.10.2"
-      }
-    },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.0.0"
       }
     },
     "make-iterator": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "karma-sinon": "^1.0.5",
     "karma-spec-reporter": "^0.0.36",
     "lint-staged": "^13.1.0",
-    "make-dir": "^3.1.0",
     "memoizee": "^0.4.15",
     "minami": "^1.2.3",
     "mocha": "^10.2.0",


### PR DESCRIPTION
Saw in https://github.com/dequelabs/axe-core/pull/4191 that we were going to update `make-dir`. Was wondering what we used it for and saw we only use it in one file (`build/shared/create-file.js`) and that we could just replace it with `fs.mkdir` with the `recursive: true` flag. Also simplified the file to use `fs.promises` instead of `utils.promisify` (all available since node 10.1).