### PR TITLE
chore: set minimum node version for dev to 18

### DIFF
--- a/build/check-node-version.js
+++ b/build/check-node-version.js
@@ -2,7 +2,7 @@
 
 const currentVersion = process.version.replace('v', '');
 
-const minimumVersionMajor = 12;
+const minimumVersionMajor = 18;
 const currentVersionMajor = parseInt(currentVersion.split('.')[0]);
 
 const usesMinimumVersion = currentVersionMajor >= minimumVersionMajor;


### PR DESCRIPTION
We have dev dependencies that require Node 18 minimum. There's no reason to be on anything older than that.