### PR TITLE
ci: pin chrome version to `118.0.5993.70`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,9 @@ restore_build: &restore_build
 commands:
   browser-tools-job:
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          # https://googlechromelabs.github.io/chrome-for-testing/ - 118.0.5993.70
+          chrome-version: 118.0.5993.70
 
 jobs:
   # Fetch and cache dependencies.


### PR DESCRIPTION
This is required since chromedriver version stable is currently 118.0.5993.70 but chrome is a higher version and that version of chrome does not exist for chromedriver so we should pin to the latest stable version.