### PR TITLE
chore: update ACT tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "typedarray": "^0.0.7",
         "typescript": "^5.2.2",
         "uglify-js": "^3.17.4",
-        "wcag-act-rules": "github:w3c/wcag-act-rules#2341a1b",
+        "wcag-act-rules": "github:w3c/wcag-act-rules#485104c",
         "weakmap-polyfill": "^2.0.4"
       },
       "engines": {
@@ -12123,7 +12123,7 @@
       }
     },
     "node_modules/wcag-act-rules": {
-      "resolved": "git+ssh://git@github.com/w3c/wcag-act-rules.git#2341a1ba4d47bc4cdccd5a3b7534e67b52c59002",
+      "resolved": "git+ssh://git@github.com/w3c/wcag-act-rules.git#485104c5c9a87a15b6a2a6ee1993b5e8259ba00f",
       "dev": true
     },
     "node_modules/wcwidth": {
@@ -21596,9 +21596,9 @@
       }
     },
     "wcag-act-rules": {
-      "version": "git+ssh://git@github.com/w3c/wcag-act-rules.git#2341a1ba4d47bc4cdccd5a3b7534e67b52c59002",
+      "version": "git+ssh://git@github.com/w3c/wcag-act-rules.git#485104c5c9a87a15b6a2a6ee1993b5e8259ba00f",
       "dev": true,
-      "from": "wcag-act-rules@github:w3c/wcag-act-rules#2341a1b"
+      "from": "wcag-act-rules@github:w3c/wcag-act-rules#485104c"
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "typedarray": "^0.0.7",
     "typescript": "^5.2.2",
     "uglify-js": "^3.17.4",
-    "wcag-act-rules": "github:w3c/wcag-act-rules#2341a1b",
+    "wcag-act-rules": "github:w3c/wcag-act-rules#485104c",
     "weakmap-polyfill": "^2.0.4"
   },
   "lint-staged": {

--- a/test/act-rules/aria-required-id-references-in6db8.spec.js
+++ b/test/act-rules/aria-required-id-references-in6db8.spec.js
@@ -1,0 +1,7 @@
+require('./act-runner.js')({
+  id: 'in6db8',
+  title: 'ARIA required ID references exist',
+  axeRules: ['aria-valid-attr-value'],
+  // See: https://github.com/dequelabs/axe-core/issues/4202
+  skipTests: ['97bd98302238b32e9131d042174502a83db2a4b2']
+});

--- a/test/act-rules/letter-spacing-not-important-24afc2.spec.js
+++ b/test/act-rules/letter-spacing-not-important-24afc2.spec.js
@@ -1,5 +1,10 @@
 require('./act-runner.js')({
   id: '24afc2',
   title: 'Letter spacing in style attributes is not !important',
-  axeRules: ['avoid-inline-spacing']
+  axeRules: ['avoid-inline-spacing'],
+  // See: https://github.com/dequelabs/axe-core/issues/4232
+  skipTests: [
+    '9af5662e9957191c22c558a1a8511bae709a2b36',
+    'd6d5bf7c081939e64d10022dd29f5e31d2153d50'
+  ]
 });

--- a/test/act-rules/meta-viewport-b4f0c3.spec.js
+++ b/test/act-rules/meta-viewport-b4f0c3.spec.js
@@ -1,5 +1,10 @@
 require('./act-runner.js')({
   id: 'b4f0c3',
   title: 'meta viewport allows for zoom',
-  axeRules: ['meta-viewport']
+  axeRules: ['meta-viewport'],
+  // See: https://github.com/dequelabs/axe-core/issues/4231
+  skipTests: [
+    '9f288c284df9ade53aa33e50ec50c879d5aba4ef',
+    'c94a59f8c3b17d722781af36da3556ff4b418776'
+  ]
 });

--- a/test/act-rules/word-spacing-not-important-9e45ec.spec.js
+++ b/test/act-rules/word-spacing-not-important-9e45ec.spec.js
@@ -1,5 +1,11 @@
 require('./act-runner.js')({
   id: '9e45ec',
   title: 'Word spacing in style attributes is not !important',
-  axeRules: ['avoid-inline-spacing']
+  axeRules: ['avoid-inline-spacing'],
+  // See: https://github.com/dequelabs/axe-core/issues/4232
+  skipTests: [
+    '15905a239d6755102be6a60aa152ad963d5b1dbb',
+    '8d2baed183149375922c23a9a5f42b52b627d713',
+    'fdd3c30f28464b32eb8a1397f70a41dfd3b2cb1c'
+  ]
 });


### PR DESCRIPTION
Updated to the latest ACT tests (with some notes on things that are no longer consistent). This should prevent nightly from failing.