### PR TITLE
ci: update browser-tools orb for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ unix_nightly_box: &unix_nightly_box
 
 orbs:
   puppeteer: threetreeslight/puppeteer@0.1.2
-  browser-tools: circleci/browser-tools@1.4.4
+  browser-tools: circleci/browser-tools@1.4.6
 
 set_npm_auth: &set_npm_auth
   run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH


### PR DESCRIPTION
As of 1.4.5 they added a fallback https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.4.5. Hopefully this resolves https://app.circleci.com/pipelines/github/dequelabs/axe-core/5786/workflows/f9a6a8cb-8628-4021-a5eb-6a0e9e74a308/jobs/63785

No QA Required