### PR TITLE
chore: fix prettier format for built files

### DIFF
--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -70,11 +70,16 @@ module.exports = function (grunt) {
       const destFile = this.data.destFile;
       // Format the content so Prettier doesn't create a diff after running.
       // See https://github.com/dequelabs/axe-core/issues/1310.
-      format(content, destFile).then(formattedContent => {
-        // write `aria supported` file contents
-        grunt.file.write(destFile, formattedContent);
-        done();
-      });
+      format(content, destFile)
+        .then(formattedContent => {
+          // write `aria supported` file contents
+          grunt.file.write(destFile, formattedContent);
+          done();
+        })
+        .catch(err => {
+          console.error(err.message);
+          done(false);
+        });
 
       /**
        * Get list of aria attributes, from `aria-query`

--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -15,6 +15,7 @@ module.exports = function (grunt) {
        * as `axe` does not exist until grunt task `build:uglify` is complete,
        * hence cannot be required at the top of the file.
        */
+      const done = this.async();
       const { langs } = this.options();
       const fileNameSuffix = langs && langs.length > 0 ? `${langs[0]}` : '';
       const axe = require(`../../axe${fileNameSuffix}`);
@@ -69,10 +70,11 @@ module.exports = function (grunt) {
       const destFile = this.data.destFile;
       // Format the content so Prettier doesn't create a diff after running.
       // See https://github.com/dequelabs/axe-core/issues/1310.
-      const formattedContent = format(content, destFile);
-
-      // write `aria supported` file contents
-      grunt.file.write(destFile, formattedContent);
+      format(content, destFile).then(formattedContent => {
+        // write `aria supported` file contents
+        grunt.file.write(destFile, formattedContent);
+        done();
+      });
 
       /**
        * Get list of aria attributes, from `aria-query`

--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -28,12 +28,15 @@ module.exports = function (grunt) {
 
           // Format the content so Prettier doesn't create a diff after running.
           // See https://github.com/dequelabs/axe-core/issues/1310.
-          format(result.descriptions, file.dest.descriptions).then(
-            descriptionsContent => {
+          format(result.descriptions, file.dest.descriptions)
+            .then(descriptionsContent => {
               grunt.file.write(file.dest.descriptions, descriptionsContent);
               done();
-            }
-          );
+            })
+            .catch(err => {
+              console.error(err.message);
+              done(false);
+            });
         });
       });
     }

--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -1,15 +1,15 @@
 /*eslint-env node */
 'use strict';
-var buildRules = require('../configure');
-var format = require('../shared/format');
+const buildRules = require('../configure');
+const format = require('../shared/format');
 
 module.exports = function (grunt) {
   grunt.registerMultiTask(
     'configure',
     'Task for configuring rules and checks',
     function () {
-      var done = this.async();
-      var options = this.options({
+      const done = this.async();
+      const options = this.options({
         rules: ['lib/rules/**/*.json'],
         checks: ['lib/checks/**/*.json'],
         misc: ['lib/misc/**/*.json'],
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
       });
 
       this.files.forEach(function (file) {
-        var match = file.dest.auto.match(/\.([a-z]{2,3})\.js/);
+        const match = file.dest.auto.match(/\.([a-z]{2,3})\.js/);
         if (match) {
           options.locale = match[1];
         }
@@ -28,12 +28,12 @@ module.exports = function (grunt) {
 
           // Format the content so Prettier doesn't create a diff after running.
           // See https://github.com/dequelabs/axe-core/issues/1310.
-          const descriptionsContent = format(
-            result.descriptions,
-            file.dest.descriptions
+          format(result.descriptions, file.dest.descriptions).then(
+            descriptionsContent => {
+              grunt.file.write(file.dest.descriptions, descriptionsContent);
+              done();
+            }
           );
-          grunt.file.write(file.dest.descriptions, descriptionsContent);
-          done();
         });
       });
     }


### PR DESCRIPTION
Prettier api was made [async in v3](https://prettier.io/blog/2023/07/05/3.0.0.html#change-public-apis-to-asynchronous-12574httpsgithubcomprettierprettierpull12574-12788httpsgithubcomprettierprettierpull12788-12790httpsgithubcomprettierprettierpull12790-13265httpsgithubcomprettierprettierpull13265-by-fiskerhttpsgithubcomfisker). This updates the build files where the `format` script was used to wait for the promise instead of writing the promise object to the files.