### PR TITLE
chore(dependabot): ignore esm chai >= 5.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
         versions: ['>=6.0.0']
       - dependency-name: 'inquirer'
         versions: ['>=9.0.0']
+      - dependency-name: 'chai'
+        versions: ['>=5.0.0']
       # Prevent Webpack error caused by v0.11+ of esbuild
       # @see https://github.com/dequelabs/axe-core/issues/3771
       - dependency-name: 'esbuild'

--- a/doc/examples/mocha/package.json
+++ b/doc/examples/mocha/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "axe-core": "^4.6.2",
+    "chai": "^4.4.0",
     "karma": "^6.4.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.1",

--- a/doc/examples/mocha/package.json
+++ b/doc/examples/mocha/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "axe-core": "^4.6.2",
-    "chai": "^4.4.0",
+    "chai": "^4.3.7",
     "karma": "^6.4.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.1",


### PR DESCRIPTION
[Chai 5.0.0 moved to ESM](https://github.com/chaijs/chai/releases/tag/v5.0.0).

Closes: https://github.com/dequelabs/axe-core/pull/4293
