### PR TITLE
fix(utils/get-selector): ignore 'xmlns' attribute when generating a selector

### DIFF
--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -22,7 +22,8 @@ const ignoredAttributes = [
   'aria-expanded',
   'aria-grabbed',
   'aria-pressed',
-  'aria-valuenow'
+  'aria-valuenow',
+  'xmlns'
 ];
 const MAXATTRIBUTELENGTH = 31;
 const attrCharsRegex = /([\\"])/g;

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -471,7 +471,8 @@ describe('axe.utils.getSelector', function () {
       'aria-expanded',
       'aria-grabbed',
       'aria-pressed',
-      'aria-valuenow'
+      'aria-valuenow',
+      'xmlns'
     ];
     ignoredAttributes.forEach(function (att) {
       node.setAttribute(att, 'true');


### PR DESCRIPTION
Ignore the "xmlns" attribute when generating a selector, since the selector spec does not support namespaces.

Closes: https://github.com/dequelabs/axe-core/issues/4302
