### PR TITLE
test: suppress "visible label in accessible name" ACT test issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "typedarray": "^0.0.7",
         "typescript": "^5.2.2",
         "uglify-js": "^3.17.4",
-        "wcag-act-rules": "github:w3c/wcag-act-rules#485104c",
+        "wcag-act-rules": "github:w3c/wcag-act-rules#dc90495a5533d326b300ee5a9487afdfc6d493c0",
         "weakmap-polyfill": "^2.0.4"
       },
       "engines": {
@@ -12627,7 +12627,7 @@
       }
     },
     "node_modules/wcag-act-rules": {
-      "resolved": "git+ssh://git@github.com/w3c/wcag-act-rules.git#485104c5c9a87a15b6a2a6ee1993b5e8259ba00f",
+      "resolved": "git+ssh://git@github.com/w3c/wcag-act-rules.git#dc90495a5533d326b300ee5a9487afdfc6d493c0",
       "dev": true
     },
     "node_modules/wcwidth": {
@@ -22487,9 +22487,9 @@
       }
     },
     "wcag-act-rules": {
-      "version": "git+ssh://git@github.com/w3c/wcag-act-rules.git#485104c5c9a87a15b6a2a6ee1993b5e8259ba00f",
+      "version": "git+ssh://git@github.com/w3c/wcag-act-rules.git#dc90495a5533d326b300ee5a9487afdfc6d493c0",
       "dev": true,
-      "from": "wcag-act-rules@github:w3c/wcag-act-rules#485104c"
+      "from": "wcag-act-rules@github:w3c/wcag-act-rules#dc90495a5533d326b300ee5a9487afdfc6d493c0"
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "typedarray": "^0.0.7",
     "typescript": "^5.2.2",
     "uglify-js": "^3.17.4",
-    "wcag-act-rules": "github:w3c/wcag-act-rules#485104c",
+    "wcag-act-rules": "github:w3c/wcag-act-rules#dc90495a5533d326b300ee5a9487afdfc6d493c0",
     "weakmap-polyfill": "^2.0.4"
   },
   "lint-staged": {

--- a/test/act-rules/visible-label-in-accessible-name-2ee8b8.spec.js
+++ b/test/act-rules/visible-label-in-accessible-name-2ee8b8.spec.js
@@ -1,5 +1,7 @@
 require('./act-runner.js')({
   id: '2ee8b8',
   title: 'Visible label is part of accessible name',
-  axeRules: ['label-content-name-mismatch']
+  axeRules: ['label-content-name-mismatch'],
+  // See: https://github.com/dequelabs/axe-core/issues/4311
+  skipTests: ['e9bbdbec137223e2973c6d2896050770c84c26e5']
 });


### PR DESCRIPTION
Temporarily suppresses the ACT mismatch described by #4311 to avoid nightly ACT test noise until we can fix the inconsistency

~Reviewer note: this suppression only has any effect if you're using ACT content that we haven't yet picked up; you'll need to `npm install w3c/wcag-act-rules#main` (like the nightly build does) to meaningfully validate the change locally.~ As of 9a370b6, this can be tested without updating to main

No QA required