### PR TITLE
fix(target-size): support translucent elements within pseudo-stacking-context ancestors with implicit z-order

### DIFF
--- a/lib/commons/dom/create-grid.js
+++ b/lib/commons/dom/create-grid.js
@@ -139,6 +139,7 @@ function isStackingContext(vNode, parentVNode) {
   }
 
   // elements with an opacity value less than 1.
+  // See https://www.w3.org/TR/css-color-3/#transparency
   if (vNode.getComputedStylePropertyValue('opacity') !== '1') {
     return true;
   }
@@ -270,9 +271,7 @@ function createStackingOrder(vNode, parentVNode, treeOrder) {
   // that point (step #5 and step #8)
   // @see https://www.w3.org/Style/css2-updates/css2/zindex.html
   if (isStackingContext(vNode, parentVNode)) {
-    const index = stackingOrder.findIndex(({ stackLevel }) =>
-      [ROOT_LEVEL, FLOAT_LEVEL, POSITION_LEVEL].includes(stackLevel)
-    );
+    const index = stackingOrder.findIndex(isFakeStackingContext);
     if (index !== -1) {
       stackingOrder.splice(index, stackingOrder.length - index);
     }
@@ -302,6 +301,23 @@ function createStackingContext(stackLevel, treeOrder, vNode) {
   };
 }
 
+function isFakeStackingContext(stackingContext) {
+  const { stackLevel, vNode } = stackingContext;
+
+  // elements with opacity < 1 must be treated as their own stacking context,
+  // even if drawn POSITION_LEVEL layer order.
+  // See https://www.w3.org/TR/css-color-3/#transparency
+  if (vNode && vNode.getComputedStylePropertyValue('opacity') !== '1') {
+    return false;
+  }
+
+  if ([ROOT_LEVEL, FLOAT_LEVEL, POSITION_LEVEL].includes(stackLevel)) {
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * Calculate the level of the stacking context.
  * @param {VirtualNode} vNode - The virtual node container of the stacking context
@@ -321,6 +337,15 @@ function getStackLevel(vNode, parentVNode) {
 
   // Put positioned elements above floated elements
   if (vNode.getComputedStylePropertyValue('position') !== 'static') {
+    return POSITION_LEVEL;
+  }
+
+  // From https://www.w3.org/TR/css-color-3/#transparency:
+  //
+  // > If an element with opacity less than 1 is not positioned, then it is
+  // > painted on the same layer, within its parent stacking context, as positioned
+  // > elements with stack level 0.
+  if (vNode.getComputedStylePropertyValue('opacity') !== '1') {
     return POSITION_LEVEL;
   }
 

--- a/test/integration/rules/target-size/target-size.html
+++ b/test/integration/rules/target-size/target-size.html
@@ -28,7 +28,7 @@ this should not effect their outcome -->
   </textarea>
 </p>
 
-<!-- Nested controls-->
+<!-- Nested controls -->
 <p>
   <a
     role="link"
@@ -52,6 +52,14 @@ this should not effect their outcome -->
     Wide link <button id="fail7">y</button>
   </a>
 </p>
+
+<!-- Regression test for stacking context behavior from #4350 -->
+<div style="margin: 30px; height: 50px">
+  <div style="position: absolute; transform: scale(1)">
+    <a href="#" id="pass9">wide enough</a>
+    <a href="#" id="pass10" style="opacity: 0.6">also wide enough</a>
+  </div>
+</div>
 
 <!-- Failed examples -->
 <p>

--- a/test/integration/rules/target-size/target-size.json
+++ b/test/integration/rules/target-size/target-size.json
@@ -20,6 +20,8 @@
     ["#pass6"],
     ["#pass7"],
     ["#pass8"],
+    ["#pass9"],
+    ["#pass10"],
     ["#pass-adjacent"],
     ["#pass-fixed"]
   ],


### PR DESCRIPTION
Draft until researching/testing more on:

- do elements with transform properties need similar treatment (and are there other cases where we should be treating "fake" stacking contexts as true?)
- how to write more complete tests for this (particularly, distinguishing the cases that would be solved by the POSITION_LEVEL part of the change and the treat-as-true-stacking-context part)
- double check browser support (validated current cases on stable chrome, firefox, safari)

Closes: #4350
