### PR TITLE
feat(checks): deprecate aria-busy check

### DIFF
--- a/lib/checks/aria/aria-busy.json
+++ b/lib/checks/aria/aria-busy.json
@@ -1,6 +1,7 @@
 {
   "id": "aria-busy",
   "evaluate": "aria-busy-evaluate",
+  "deprecated": true,
   "metadata": {
     "impact": "serious",
     "messages": {


### PR DESCRIPTION
axe-core's only usage of the `aria-busy` check was just removed in #4347, so this check is no longer required.

See #4340