### PR TITLE
fix: fix building axe-core translation files with region locales

### DIFF
--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -18,9 +18,11 @@ module.exports = function (grunt) {
       });
 
       this.files.forEach(function (file) {
-        const match = file.dest.auto.match(/\.([a-z]{2,3})\.js/);
-        if (match) {
-          options.locale = match[1];
+        // locale will always be the 2nd to last part of the file
+        // filename and in the format of "<filename>.<locale>.js"
+        const parts = file.dest.auto.split('.');
+        if (parts.length > 2) {
+          options.locale = parts[parts.length - 2];
         }
 
         buildRules(grunt, options, null, function (result) {

--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -18,8 +18,8 @@ module.exports = function (grunt) {
       });
 
       this.files.forEach(function (file) {
-        // locale will always be the 2nd to last part of the file
-        // filename and in the format of "<filename>.<locale>.js"
+        // locale will always be the 2nd to last part of the
+        // filename and in the format of "<name>.<locale>.js"
         const parts = file.dest.auto.split('.');
         if (parts.length > 2) {
           options.locale = parts[parts.length - 2];


### PR DESCRIPTION
Figured a simple `split` would do the job without needing to write a complicated regex to do it. Otherwise we'd need something like `/\.([a-zA-Z_]+)\.js$/`

Closes: #4388 
