### PR TITLE
fix(aria-allowed-role): add gridcell, separator, slider and treeitem to allowed roles of button element

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -140,14 +140,18 @@ const htmlElms = {
     allowedRoles: [
       'checkbox',
       'combobox',
+      'gridcell',
       'link',
       'menuitem',
       'menuitemcheckbox',
       'menuitemradio',
       'option',
       'radio',
+      'separator',
+      'slider',
       'switch',
-      'tab'
+      'tab',
+      'treeitem'
     ],
     // 5.4 button Element
     namingMethods: ['subtreeText']

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -207,6 +207,12 @@
 ></div>
 <div id="pass-graphics-object" role="graphics-object"></div>
 <div id="pass-graphics-symbol" role="graphics-symbol"></div>
+<button
+  id="pass-button-role-gridcell"
+  role="gridcell"
+  title="IconCheckmark"
+  aria-label="IconCheckmark icon"
+></button>
 
 <dd id="fail-dd-no-role" role="link"></dd>
 <dt id="fail-dt-no-role" role="banner"></dt>
@@ -219,12 +225,7 @@
 <button id="fail-button-role-cell" role="cell"></button>
 <aside id="fail-aside-doc-foreword" role="doc-foreword"></aside>
 <aside id="fail-aside-role-tab" role="tab"></aside>
-<button
-  id="fail-button-role-gridcell"
-  role="gridcell"
-  title="IconCheckmark"
-  aria-label="IconCheckmark icon"
-></button>
+
 <input id="fail-input-role-gridcell-multiple-role" role="gridcell combobox" />
 <div style="display: none">
   <button

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.json
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.json
@@ -88,7 +88,8 @@
     ["#pass-imgmap-2"],
     ["#pass-navnone-1"],
     ["#pass-navnone-2"],
-    ["#pass-search-elm"]
+    ["#pass-search-elm"],
+    ["#pass-button-role-gridcell"]
   ],
   "violations": [
     ["#fail-dd-no-role"],
@@ -102,7 +103,6 @@
     ["#fail-button-role-cell"],
     ["#fail-aside-doc-foreword"],
     ["#fail-aside-role-tab"],
-    ["#fail-button-role-gridcell"],
     ["#fail-input-role-gridcell-multiple-role"],
     ["#fail-dpub-1"],
     ["#fail-dpub-2"],


### PR DESCRIPTION
Closes: https://github.com/dequelabs/axe-core/issues/4397