### PR TITLE
Allow presentation elements in list

### DIFF
--- a/lib/checks/lists/only-listitems.json
+++ b/lib/checks/lists/only-listitems.json
@@ -2,7 +2,7 @@
   "id": "only-listitems",
   "evaluate": "invalid-children-evaluate",
   "options": {
-    "validRoles": ["listitem"],
+    "validRoles": ["listitem", "presentation"],
     "validNodeNames": ["li"]
   },
   "metadata": {

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -198,6 +198,14 @@ describe('only-listitems', () => {
     });
   });
 
+	it('should return false if the list has elements with role presentation', () => {
+    const checkArgs = checkSetup(
+      '<ol id="target"><li>A list</li><li role="presentation">...</li></ol>'
+    );
+
+    assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
+  });
+
   describe('nodeNames', () => {
     it('returns multiple node names', () => {
       const checkArgs = checkSetup(

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -198,7 +198,7 @@ describe('only-listitems', () => {
     });
   });
 
-	it('should return false if the list has elements with role presentation', () => {
+  it('should return false if the list has elements with role presentation', () => {
     const checkArgs = checkSetup(
       '<ol id="target"><li>A list</li><li role="presentation">...</li></ol>'
     );


### PR DESCRIPTION
Drupal is using markup like this for pagination/pager - the ... element is presentational only.

```html
<ul>
  <li><a href="page-1" class="is-active">Go to page 1</a></li>
  <li><a href="page-2">Go to page 2</a></li>
  <li><a href="page-3">Go to page 3</a></li>
  <li><a href="page-4">Go to page 4</a></li>
  <li role="presentation">...</li>
  <li><a href="page-2">Go to next page</a></li>
</ul>


