### PR TITLE
docs: update required develop node version to 18

### DIFF
--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -31,7 +31,7 @@ Axe 3.0 supports open Shadow DOM: see our virtual DOM APIs and test utilities fo
 
 ### Environment Pre-requisites
 
-1. You must have NodeJS version 12 or higher installed.
+1. You must have NodeJS version 18 or higher installed.
 1. Install npm development dependencies. In the root folder of your axe-core repository, run `npm install`
 
 ### Building axe.js


### PR DESCRIPTION
Was the only reference to a required node version I could find in the docs. Our node version script is already set to 18.

Closes: https://github.com/dequelabs/axe-core/issues/4323
