### PR TITLE
docs: add readme to locales dir to note _template is generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ or equivalently:
 
 This will create a new build for axe, called `axe.<lang>.js` and `axe.<lang>.min.js`. If you want to build all localized versions, simply pass in `--all-lang` instead. If you want to build multiple localized versions (but not all of them), you can pass in a comma-separated list of languages to the `--lang` flag, like `--lang=nl,ja`.
 
-To create a new translation for axe, start by running `grunt translate --lang=<langcode>`. This will create a json file fin the `./locales` directory, with the default English text in it for you to translate. Alternatively, you could copy `./locales/_template.json`. We welcome any localization for axe-core. For details on how to contribute, see the Contributing section below. For details on the message syntax, see [Check Message Template](/doc/check-message-template.md).
+To create a new translation for axe, start by running `grunt translate --lang=<langcode>`. This will create a json file in the `./locales` directory, with the default English text in it for you to translate. Alternatively, you could copy `./locales/_template.json`. We welcome any localization for axe-core. For details on how to contribute, see the Contributing section below. For details on the message syntax, see [Check Message Template](/doc/check-message-template.md).
 
-To update existing translation file, re-run `grunt translate --lang=<langcode>`. This will add new messages used in English and remove messages which were not used in English.
+To update an existing translation file, re-run `grunt translate --lang=<langcode>`. This will add new messages used in English and remove messages which were not used in English.
 
 Additionally, locale can be applied at runtime by passing a `locale` object to `axe.configure()`. The locale object must be of the same shape as existing locales in the `./locales` directory. For example:
 

--- a/locales/README.md
+++ b/locales/README.md
@@ -1,0 +1,9 @@
+# Localizations
+
+We welcome any localization for axe-core. For details on how to contribute, see the [Contributing section](../README.md#contributing) of the main README. For details on the message syntax, see [Check Message Template](../doc/check-message-template.md).
+
+To create a new translation for axe, start by running `grunt translate --lang=<langcode>`. This will create a json file with the default English text in it for you to translate. Alternatively, you could copy `_template.json`.
+
+To update an existing translation file, re-run `grunt translate --lang=<langcode>`. This will add new messages used in English and remove messages which were not used in English.
+
+`_template.json` is a generated file which is created every time axe is built. It's compiled using each rules' `description` and `help` properties as well as each checks' `metadata.messages` property. To update the `_template.json` file you'll need to update the corresponding [rule](../lib/rules) or [check](../lib/checks) metadata file and rebuild.


### PR DESCRIPTION
Just clarifying that the `_template.json` file is generated so contributors don't edit it without knowing. The rest of the text is mostly copied from the root level README, which I also corrected gramatical mistakes.