### PR TITLE
fix(aria-allowed-attr): allow meter role allowed aria-* attributes on meter element

### DIFF
--- a/lib/commons/standards/implicit-html-roles.js
+++ b/lib/commons/standards/implicit-html-roles.js
@@ -151,6 +151,7 @@ const implicitHtmlRoles = {
   main: 'main',
   math: 'math',
   menu: 'list',
+  meter: 'meter',
   nav: 'navigation',
   ol: 'list',
   optgroup: 'group',

--- a/test/integration/rules/aria-allowed-attr/passes.html
+++ b/test/integration/rules/aria-allowed-attr/passes.html
@@ -2118,7 +2118,16 @@
 <dl aria-label="value" id="pass84"></dl>
 <input aria-label="value" id="pass85" />
 <label aria-label="value" id="pass86"></label>
-<meter aria-label="value" id="pass87"></meter>
+<meter
+  id="pass87"
+  aria-label="value"
+  aria-valuemin="0"
+  aria-valuemax="0"
+  aria-valuenow="40"
+  aria-valuetext="40%"
+>
+  40
+</meter>
 <object aria-label="value" id="pass88"></object>
 <svg aria-label="value" id="pass89"></svg>
 <video aria-label="value" id="pass90" controls></video>


### PR DESCRIPTION
Turns out we didn't list the `meter` element's implicit role.

Ref: https://github.com/w3c/html-aria/issues/517

QA notes: verify a `meter` element allows non-global aria attributes from the [`meter` role](https://www.w3.org/TR/wai-aria-1.2/#meter).
