### PR TITLE
build: lint-staged prettier before eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,8 +189,8 @@
       "prettier --write"
     ],
     "*.js": [
-      "eslint --fix",
-      "prettier --write"
+      "prettier --write",
+      "eslint --fix"
     ]
   }
 }


### PR DESCRIPTION
prettier autofixes some issues eslint finds, letting prettier run first leads to less developer hassle

for example, I've forgotten for weeks to change how my editor does tabs instead of spaces and I've been manually running `npm run fmt` to get around this. While yes I will also correct my editor, this feels like a positive change for all contributors

<< Describe the changes >>

Closes:
