### PR TITLE
tests: rename too generic test titles

### DIFF
--- a/test/core/reporters/helpers/process-aggregate.js
+++ b/test/core/reporters/helpers/process-aggregate.js
@@ -317,7 +317,7 @@ describe('helpers.processAggregate', function () {
             );
           });
 
-          it('should not call DqElement.selector', () => {
+          it('should not call the nodes selector property', () => {
             const dqElm = new axe.utils.DqElement(fixture);
             Object.defineProperty(dqElm, 'selector', {
               get() {
@@ -381,7 +381,7 @@ describe('helpers.processAggregate', function () {
           );
         });
 
-        it('should not call DqElement.ancestry', () => {
+        it('should not call the nodes ancestry property', () => {
           const dqElm = new axe.utils.DqElement(fixture, options, {
             selector: ['div'] // prevent axe._selectorData error
           });
@@ -446,7 +446,7 @@ describe('helpers.processAggregate', function () {
           );
         });
 
-        it('should not call DqElement.xpath', () => {
+        it('should not call the nodes xpath property', () => {
           const dqElm = new axe.utils.DqElement(fixture, options, {
             selector: ['div'] // prevent axe._selectorData error
           });


### PR DESCRIPTION
These tests failed while in-development of https://github.com/dequelabs/axe-core/pull/4452 and it really confused me. Based on how the title is written, I initially thought that it was making sure that `.selector` (etc.) for the DqElement prototype function was never called. But what it's really making sure is that the `.selector` (etc.) property is not called for the one node.

The reason that distinction matters is because `processAggregate` calls `nodeSerializer` which in turn calls the `toJSON` method of a DqElement, which calls the `.selector` (etc.) property. So it would be impossible to never call the DqElement properties.