### PR TITLE
chore: ignore colorjs.io updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,10 @@ updates:
       # @see https://github.com/dequelabs/axe-core/issues/3771
       - dependency-name: 'esbuild'
         versions: ['>=0.11.0']
+      # Prevent colorjs.io issue caused by v0.5.0+
+      # @see https://github.com/dequelabs/axe-core/issues/4428
+      - dependency-name: 'colorjs.io'
+        version: ['>=0.5.0']
     groups:
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:


### PR DESCRIPTION
Ref: https://github.com/dequelabs/axe-core/pull/4449#pullrequestreview-2061020322