### PR TITLE
fix: avoid vitest compat issue by reverting Array.from polyfill back to pre-4.9.1 version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,7 +135,8 @@ module.exports = {
       // polyfills are mostly copy-pasted from sources so we don't control their styling
       files: [
         'lib/core/imports/polyfills.js',
-        'lib/core/utils/pollyfill-elements-from-point.js'
+        'lib/core/utils/pollyfill-elements-from-point.js',
+        'lib/core/utils/polyfill-array-from.js'
       ],
       env: {
         browser: false

--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -1,4 +1,5 @@
-import { Colorjs, ArrayFrom } from '../../core/imports';
+import { Colorjs } from '../../core/imports';
+import { polyfillArrayFrom } from '../../core/utils';
 
 const hexRegex = /^#[0-9a-f]{3,8}$/i;
 const hslRegex = /hsl\(\s*([-\d.]+)(rad|turn)/;
@@ -150,7 +151,7 @@ export default class Color {
       let prototypeArrayFrom;
       if ('Prototype' in window && 'Version' in window.Prototype) {
         prototypeArrayFrom = Array.from;
-        Array.from = ArrayFrom;
+        Array.from = polyfillArrayFrom;
       }
 
       // srgb values are between 0 and 1

--- a/lib/core/imports/index.js
+++ b/lib/core/imports/index.js
@@ -6,7 +6,6 @@ import doT from '@deque/dot';
 import emojiRegexText from 'emoji-regex';
 import memoize from 'memoizee';
 import Color from 'colorjs.io';
-import ArrayFrom from 'core-js-pure/actual/array/from';
 
 // prevent striping newline characters from strings (e.g. failure
 // summaries). value must be synced with build/configure.js
@@ -18,11 +17,4 @@ doT.templateSettings.strip = false;
  * @namespace imports
  * @memberof axe
  */
-export {
-  CssSelectorParser,
-  doT,
-  emojiRegexText,
-  memoize,
-  Color as Colorjs,
-  ArrayFrom
-};
+export { CssSelectorParser, doT, emojiRegexText, memoize, Color as Colorjs };

--- a/lib/core/imports/polyfills.js
+++ b/lib/core/imports/polyfills.js
@@ -3,7 +3,8 @@ import { Uint32Array } from 'typedarray';
 import 'weakmap-polyfill';
 import hasOwn from 'core-js-pure/actual/object/has-own';
 import values from 'core-js-pure/actual/object/values';
-import ArrayFrom from 'core-js-pure/actual/array/from';
+// Careful with the import order; this must import the file directly, *not* from the index
+import polyfillArrayFrom from '../utils/polyfill-array-from';
 
 if (!('hasOwn' in Object)) {
   Object.hasOwn = hasOwn;
@@ -178,7 +179,7 @@ if (!Array.prototype.some) {
 }
 
 if (!Array.from) {
-  Array.from = ArrayFrom;
+  Array.from = polyfillArrayFrom;
 }
 
 if (!String.prototype.includes) {

--- a/lib/core/utils/index.js
+++ b/lib/core/utils/index.js
@@ -64,6 +64,7 @@ export { default as parseSameOriginStylesheet } from './parse-sameorigin-stylesh
 export { default as parseStylesheet } from './parse-stylesheet';
 export { default as performanceTimer } from './performance-timer';
 export { pollyfillElementsFromPoint } from './pollyfill-elements-from-point';
+export { default as polyfillArrayFrom } from './polyfill-array-from';
 export { default as preloadCssom } from './preload-cssom';
 export { default as preloadMedia } from './preload-media';
 export { default as preload, shouldPreload, getPreloadConfig } from './preload';

--- a/lib/core/utils/polyfill-array-from.js
+++ b/lib/core/utils/polyfill-array-from.js
@@ -1,0 +1,94 @@
+// Be careful not to import anything from this file; it's imported very early
+// in our import order by polyfills.js and mustn't import anything that might
+// depend on a different polyfill.
+//
+// Ideally we'd use core-js-pure's version of this rather than defining our
+// own, but that triggers a bug in vitest's module loader.
+//
+// See https://github.com/dequelabs/axe-core/issues/4458
+// Production steps of ECMA-262, Edition 6, 22.1.2.1
+export default (function () {
+  var toStr = Object.prototype.toString;
+  var isCallable = function (fn) {
+    return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+  };
+  var toInteger = function (value) {
+    var number = Number(value);
+    if (isNaN(number)) {
+      return 0;
+    }
+    if (number === 0 || !isFinite(number)) {
+      return number;
+    }
+    return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+  };
+  var maxSafeInteger = Math.pow(2, 53) - 1;
+  var toLength = function (value) {
+    var len = toInteger(value);
+    return Math.min(Math.max(len, 0), maxSafeInteger);
+  };
+
+  // The length property of the from method is 1.
+  return function from(arrayLike /*, mapFn, thisArg */) {
+    // 1. Let C be the this value.
+    var C = this;
+
+    // 2. Let items be ToObject(arrayLike).
+    var items = Object(arrayLike);
+
+    // 3. ReturnIfAbrupt(items).
+    if (arrayLike == null) {
+      throw new TypeError(
+        'Array.from requires an array-like object - not null or undefined'
+      );
+    }
+
+    // 4. If mapfn is undefined, then let mapping be false.
+    var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+    var T;
+    if (typeof mapFn !== 'undefined') {
+      // 5. else
+      // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
+      if (!isCallable(mapFn)) {
+        throw new TypeError(
+          'Array.from: when provided, the second argument must be a function'
+        );
+      }
+
+      // 5. b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      if (arguments.length > 2) {
+        T = arguments[2];
+      }
+    }
+
+    // 10. Let lenValue be Get(items, "length").
+    // 11. Let len be ToLength(lenValue).
+    var len = toLength(items.length);
+
+    // 13. If IsConstructor(C) is true, then
+    // 13. a. Let A be the result of calling the [[Construct]] internal method of C with an argument list containing the single item len.
+    // 14. a. Else, Let A be ArrayCreate(len).
+    var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+
+    // 16. Let k be 0.
+    var k = 0;
+    // 17. Repeat, while k < len… (also steps a - h)
+    var kValue;
+    while (k < len) {
+      kValue = items[k];
+      if (mapFn) {
+        A[k] =
+          typeof T === 'undefined'
+            ? mapFn(kValue, k)
+            : mapFn.call(T, kValue, k);
+      } else {
+        A[k] = kValue;
+      }
+      k += 1;
+    }
+    // 18. Let putStatus be Put(A, "length", len, true).
+    A.length = len;
+    // 20. Return A.
+    return A;
+  };
+})();


### PR DESCRIPTION
Closes: #4458 
