### PR TITLE
fix(all-rules): fix flakey all-rules firefox test

### DIFF
--- a/test/integration/full/all-rules/all-rules.html
+++ b/test/integration/full/all-rules/all-rules.html
@@ -94,7 +94,7 @@
         <p tabindex="-1">Paragraph.</p>
         <input type="button" />
         <input type="image" src="img.jpg" />
-        <marquee>This content is inside a marquee.</marquee>
+        <marquee scrollamount="0">This content is inside a marquee.</marquee>
         <div role="navigation">
           <div role="banner"></div>
           <div role="complementary"></div>


### PR DESCRIPTION
wilco and I believe marque is to blame because it is animated


This fixes the `all-rules` check, particularly on Firefox. We believe the issue is because marque has a moving bounding client rect, leading to inconsistent results. So instead we set the motion to none for a consistent testing environment.

---

To see that it works, I've run the CI tests on this branch five times. It only failed on one unrelated flakey test this does not address.

Also, https://github.com/dequelabs/axe-core/pull/4456 finally builds after many consistent test failures in the same place in a row after rebasing on this change.

We can see this test failing on other branches, such as `develop` in places like this: https://app.circleci.com/pipelines/github/dequelabs/axe-core/6332/workflows/b3e2a293-c89b-4201-898d-1c6c64ee2764 which shows it has nothing to do with the other PR.