### PR TITLE
fix(build): limit locales to valid files when using the --all-lang option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,9 +22,13 @@ module.exports = function (grunt) {
     });
   } else if (grunt.option('all-lang')) {
     var localeFiles = require('fs').readdirSync('./locales');
-    langs = localeFiles.map(function (file) {
-      return '.' + file.replace('.json', '');
-    });
+    langs = localeFiles
+      .filter(function (file) {
+        return !file.startsWith('_') && file.endsWith('.json');
+      })
+      .map(function (file) {
+        return '.' + file.replace('.json', '');
+      });
     langs.unshift(''); // Add default
   } else {
     langs = [''];


### PR DESCRIPTION
This change updates the code path that is invoked when the build is run using the `--all-lang` option. When assembling the list of locale files from the `/locales` directory, this change only includes files that satisfy _both_ of the following criteria:

- Does not start with `_`
- Ends with `.json`

This effectively excludes `_template.json` and `README.md`, and may proactively filter out future utility files that do not follow the typical locale-file naming standard.

Closes: #4485 
