### PR TITLE
chore: ignore conventional-commits-parser >= 6 as esm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,8 @@ updates:
         versions: ['>=9.0.0']
       - dependency-name: 'chai'
         versions: ['>=5.0.0']
+      - dependency-name: 'conventional-commits-parser'
+        versions: ['>=6.0.0']
       # Prevent Webpack error caused by v0.11+ of esbuild
       # @see https://github.com/dequelabs/axe-core/issues/3771
       - dependency-name: 'esbuild'


### PR DESCRIPTION
Conventional commits upgraded to ESM only in v6.

Closes: https://github.com/dequelabs/axe-core/pull/4476