### PR TITLE
chore: make cherry-pick script executable

### DIFF
--- a/build/cherry-pick.js
+++ b/build/cherry-pick.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const { execSync } = require('child_process');
 const conventionalCommitsParser = require('conventional-commits-parser');
 const chalk = require('chalk');


### PR DESCRIPTION
The build script wasn't committed as executable, nor had the node comment.

No QA needed