### PR TITLE
perf: cache selector creation

### DIFF
--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -96,7 +96,10 @@ DqElement.prototype = {
    * @return {String}
    */
   get selector() {
-    return this.spec.selector || [getSelector(this.element, this._options)];
+    if (!this.spec.selector) {
+      this.spec.selector = [getSelector(this.element, this._options)];
+    }
+    return this.spec.selector;
   },
 
   /**
@@ -104,7 +107,10 @@ DqElement.prototype = {
    * @return {String}
    */
   get ancestry() {
-    return this.spec.ancestry || [getAncestry(this.element)];
+    if (!this.spec.ancestry) {
+      this.spec.ancestry = [getAncestry(this.element)];
+    }
+    return this.spec.ancestry;
   },
 
   /**
@@ -112,7 +118,10 @@ DqElement.prototype = {
    * @return {String}
    */
   get xpath() {
-    return this.spec.xpath || [getXpath(this.element)];
+    if (!this.spec.xpath) {
+      this.spec.xpath = [getXpath(this.element)];
+    }
+    return this.spec.xpath;
   },
 
   /**


### PR DESCRIPTION
Closes: https://github.com/dequelabs/axe-pro-ml-service/issues/490

Selector generation is slow. We should avoid doing it more than once.