### PR TITLE
fix(aria-roledescription): keep disabled with { runOnly: 'wcag2a' }

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -191,7 +191,7 @@ export default class Audit {
     this.checks = {};
     this.brand = 'axe';
     this.application = 'axeAPI';
-    this.tagExclude = ['experimental'];
+    this.tagExclude = ['experimental', 'deprecated'];
     this.noHtml = audit.noHtml;
     this.allowedOrigins = audit.allowedOrigins;
     unpackToObject(audit.rules, this, 'addRule');

--- a/test/core/base/audit.js
+++ b/test/core/base/audit.js
@@ -439,12 +439,12 @@ describe('Audit', () => {
     });
     it('should reset brand tagExlcude', () => {
       axe._load({});
-      assert.deepEqual(axe._audit.tagExclude, ['experimental']);
+      assert.deepEqual(axe._audit.tagExclude, ['experimental', 'deprecated']);
       axe.configure({
         tagExclude: ['ninjas']
       });
       axe._audit.resetRulesAndChecks();
-      assert.deepEqual(axe._audit.tagExclude, ['experimental']);
+      assert.deepEqual(axe._audit.tagExclude, ['experimental', 'deprecated']);
     });
 
     it('should reset noHtml', () => {

--- a/test/core/public/configure.js
+++ b/test/core/public/configure.js
@@ -269,7 +269,7 @@ describe('axe.configure', function () {
 
   it('overrides the default value of audit.tagExclude', function () {
     axe._load({});
-    assert.deepEqual(axe._audit.tagExclude, ['experimental']);
+    assert.deepEqual(axe._audit.tagExclude, ['experimental', 'deprecated']);
 
     axe.configure({
       tagExclude: ['ninjas']

--- a/test/integration/full/configuration/tag-exclude.html
+++ b/test/integration/full/configuration/tag-exclude.html
@@ -20,8 +20,7 @@
     </script>
   </head>
   <body>
-    <p aria-roledescription="my paragraph" id="deprecated">paragraph</p>
-    <div role="link" aria-label="OK" id="experimental">Next</div>
+    <img alt="" />
 
     <div id="mocha"></div>
     <script src="/test/integration/no-ui-reporter.js"></script>

--- a/test/integration/full/configuration/tag-exclude.html
+++ b/test/integration/full/configuration/tag-exclude.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en" xml:lang="en">
+  <head>
+    <title>axe.configure({ tagExclude }) test</title>
+    <meta charset="utf8" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/mocha/mocha.css"
+    />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/axe.js"></script>
+    <script>
+      mocha.setup({
+        timeout: 10000,
+        ui: 'bdd'
+      });
+      var assert = chai.assert;
+    </script>
+  </head>
+  <body>
+    <p aria-roledescription="my paragraph" id="deprecated">paragraph</p>
+    <div role="link" aria-label="OK" id="experimental">Next</div>
+
+    <div id="mocha"></div>
+    <script src="/test/integration/no-ui-reporter.js"></script>
+    <script src="/test/testutils.js"></script>
+    <script src="tag-exclude.js"></script>
+    <script src="/test/integration/adapter.js"></script>
+  </body>
+</html>

--- a/test/integration/full/configuration/tag-exclude.js
+++ b/test/integration/full/configuration/tag-exclude.js
@@ -1,51 +1,82 @@
 describe('all rules test', () => {
-  const experimentalRuleId = 'label-content-name-mismatch';
-  const deprecatedRuleId = 'aria-roledescription';
+  const experimentalRuleId = 'img-alt-experimental';
+  const deprecatedRuleId = 'img-alt-deprecated';
 
-  function joinResults(results) {
+  beforeEach(() => {
+    axe.configure({
+      rules: [
+        {
+          id: experimentalRuleId,
+          impact: 'critical',
+          selector: 'img',
+          tags: ['wcag2a', 'experimental'],
+          enabled: false,
+          metadata: {
+            description:
+              'Ensures <img> elements have alternate text or a role of none or presentation',
+            help: 'Images must have alternate text'
+          },
+          all: [],
+          any: ['has-alt'],
+          none: []
+        },
+        {
+          id: deprecatedRuleId,
+          impact: 'critical',
+          selector: 'img',
+          tags: ['wcag2a', 'deprecated'],
+          enabled: false,
+          metadata: {
+            description:
+              'Ensures <img> elements have alternate text or a role of none or presentation',
+            help: 'Images must have alternate text'
+          },
+          all: [],
+          any: ['has-alt'],
+          none: []
+        }
+      ]
+    });
+  });
+
+  after(() => {
+    axe.reset();
+  });
+
+  function findResult(results, ruleId) {
     return [
       ...results.violations,
       ...results.passes,
       ...results.incomplete,
       ...results.inapplicable
-    ];
+    ].find(result => result.id === ruleId);
   }
 
   it('does not run experimental rules by default', async () => {
     const results = await axe.run({
       runOnly: {
         type: 'tags',
-        values: ['wcag2a', 'wcag21a']
+        values: ['wcag2a']
       }
     });
-
-    const joinedResults = joinResults(results);
-    const experimentalResult = joinedResults.find(
-      result => result.id === experimentalRuleId
-    );
-    assert.isUndefined(experimentalResult);
+    assert.isUndefined(findResult(results, experimentalRuleId));
   });
 
   it('does not run deprecated rules by default', async () => {
     const results = await axe.run({
       runOnly: {
         type: 'tags',
-        values: ['wcag2a', 'wcag21a']
+        values: ['wcag2a']
       }
     });
-
-    const joinedResults = joinResults(results);
-    const deprecatedResult = joinedResults.find(
-      result => result.id === deprecatedRuleId
-    );
-    assert.isUndefined(deprecatedResult);
+    assert.isUndefined(findResult(results, deprecatedRuleId));
   });
 
   it('runs tagExclude rules when enabled with { rules }', async () => {
     const results = await axe.run({
       runOnly: {
         type: 'tags',
-        values: ['wcag2a', 'wcag21a']
+        values: ['wcag2a']
       },
       rules: {
         [experimentalRuleId]: { enabled: true },
@@ -53,15 +84,8 @@ describe('all rules test', () => {
       }
     });
 
-    const joinedResults = joinResults(results);
-    const experimentalResult = joinedResults.find(
-      result => result.id === experimentalRuleId
-    );
-    const deprecatedResult = joinedResults.find(
-      result => result.id === experimentalRuleId
-    );
-    assert.isDefined(experimentalResult);
-    assert.isDefined(deprecatedResult);
+    assert.isDefined(findResult(results, experimentalRuleId));
+    assert.isDefined(findResult(results, deprecatedRuleId));
   });
 
   it('runs tagExclude rules when enabled with { runOnly: { type: rule } }', async () => {
@@ -71,32 +95,18 @@ describe('all rules test', () => {
         values: [experimentalRuleId, deprecatedRuleId]
       }
     });
-    const joinedResults = joinResults(results);
-    const experimentalResult = joinedResults.find(
-      result => result.id === experimentalRuleId
-    );
-    const deprecatedResult = joinedResults.find(
-      result => result.id === experimentalRuleId
-    );
-    assert.isDefined(experimentalResult);
-    assert.isDefined(deprecatedResult);
+    assert.isDefined(findResult(results, experimentalRuleId));
+    assert.isDefined(findResult(results, deprecatedRuleId));
   });
 
   it('runs tagExclude rules when enabled with { runOnly: { type: tag } }', async () => {
     const results = await axe.run({
       runOnly: {
         type: 'tag',
-        values: ['wcag2a', 'wcag21a', 'experimental', 'deprecated']
+        values: ['wcag2a', 'experimental', 'deprecated']
       }
     });
-    const joinedResults = joinResults(results);
-    const experimentalResult = joinedResults.find(
-      result => result.id === experimentalRuleId
-    );
-    const deprecatedResult = joinedResults.find(
-      result => result.id === experimentalRuleId
-    );
-    assert.isDefined(experimentalResult);
-    assert.isDefined(deprecatedResult);
+    assert.isDefined(findResult(results, experimentalRuleId));
+    assert.isDefined(findResult(results, deprecatedRuleId));
   });
 });

--- a/test/integration/full/configuration/tag-exclude.js
+++ b/test/integration/full/configuration/tag-exclude.js
@@ -1,0 +1,102 @@
+describe('all rules test', () => {
+  const experimentalRuleId = 'label-content-name-mismatch';
+  const deprecatedRuleId = 'aria-roledescription';
+
+  function joinResults(results) {
+    return [
+      ...results.violations,
+      ...results.passes,
+      ...results.incomplete,
+      ...results.inapplicable
+    ];
+  }
+
+  it('does not run experimental rules by default', async () => {
+    const results = await axe.run({
+      runOnly: {
+        type: 'tags',
+        values: ['wcag2a', 'wcag21a']
+      }
+    });
+
+    const joinedResults = joinResults(results);
+    const experimentalResult = joinedResults.find(
+      result => result.id === experimentalRuleId
+    );
+    assert.isUndefined(experimentalResult);
+  });
+
+  it('does not run deprecated rules by default', async () => {
+    const results = await axe.run({
+      runOnly: {
+        type: 'tags',
+        values: ['wcag2a', 'wcag21a']
+      }
+    });
+
+    const joinedResults = joinResults(results);
+    const deprecatedResult = joinedResults.find(
+      result => result.id === deprecatedRuleId
+    );
+    assert.isUndefined(deprecatedResult);
+  });
+
+  it('runs tagExclude rules when enabled with { rules }', async () => {
+    const results = await axe.run({
+      runOnly: {
+        type: 'tags',
+        values: ['wcag2a', 'wcag21a']
+      },
+      rules: {
+        [experimentalRuleId]: { enabled: true },
+        [deprecatedRuleId]: { enabled: true }
+      }
+    });
+
+    const joinedResults = joinResults(results);
+    const experimentalResult = joinedResults.find(
+      result => result.id === experimentalRuleId
+    );
+    const deprecatedResult = joinedResults.find(
+      result => result.id === experimentalRuleId
+    );
+    assert.isDefined(experimentalResult);
+    assert.isDefined(deprecatedResult);
+  });
+
+  it('runs tagExclude rules when enabled with { runOnly: { type: rule } }', async () => {
+    const results = await axe.run({
+      runOnly: {
+        type: 'rule',
+        values: [experimentalRuleId, deprecatedRuleId]
+      }
+    });
+    const joinedResults = joinResults(results);
+    const experimentalResult = joinedResults.find(
+      result => result.id === experimentalRuleId
+    );
+    const deprecatedResult = joinedResults.find(
+      result => result.id === experimentalRuleId
+    );
+    assert.isDefined(experimentalResult);
+    assert.isDefined(deprecatedResult);
+  });
+
+  it('runs tagExclude rules when enabled with { runOnly: { type: tag } }', async () => {
+    const results = await axe.run({
+      runOnly: {
+        type: 'tag',
+        values: ['wcag2a', 'wcag21a', 'experimental', 'deprecated']
+      }
+    });
+    const joinedResults = joinResults(results);
+    const experimentalResult = joinedResults.find(
+      result => result.id === experimentalRuleId
+    );
+    const deprecatedResult = joinedResults.find(
+      result => result.id === experimentalRuleId
+    );
+    assert.isDefined(experimentalResult);
+    assert.isDefined(deprecatedResult);
+  });
+});


### PR DESCRIPTION
Deprecated rules are disabled by default, but because they still have WCAG / best-practice tags, using tags can unintentionally turn them back on. This PR makes it so that rules with the `deprecated` tag do not run unless they are explicitly enabled.

Closes: #4523
