### PR TITLE
test(object-is-loaded-matches): prevent test flakiness by allowing more time to load <object> data

### DIFF
--- a/test/rule-matches/object-is-loaded-matches.js
+++ b/test/rule-matches/object-is-loaded-matches.js
@@ -3,7 +3,7 @@ describe('object-is-loaded-matches', () => {
   const data = `data:text/html,Object%20content`;
 
   // Give enough time for the browser to load / decide it cannot load objects
-  async function delayedQueryFixture(html, delay = 50) {
+  async function delayedQueryFixture(html, delay = 250) {
     fixture.innerHTML = html;
     await new Promise(r => setTimeout(r, delay));
     const tree = axe.setup();


### PR DESCRIPTION
These test failures are happening because the test isn't allowing sufficient time for slower test scenarios (headed browsers in CI machines) to finish setting up test fixtures before testing against them.

I experimented with using `load`/`error` events on the fixtures instead of a flat time, but this didn't work reliably; in the case where the browser renders fallback content, it fires the `error` event *before* the fallback content is ready, at least in Chromium stable. I wanted to stick to a timebox for this so I settled for just increasing the time allotment instead.

Closes: #4529
