### PR TITLE
test: don't load axe.min

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -100,7 +100,7 @@ module.exports = function (config) {
         served: true
       },
       'axe.js',
-      'axe.min.js',
+      { pattern: 'axe.min.js', included: false, served: true },
       'test/testutils.js'
     ].concat(testPaths),
     proxies: {


### PR DESCRIPTION
Noticed this while trying to debug a test that we were loading `axe.min.js` into the unit tests instead of using `axe.js`. This made debugging impossible, so I'm just serving the file needed for the [colorjs test](https://github.com/dequelabs/axe-core/blob/develop/test/integration/full/patch/patch.mjs#L43) instead of loading it for the entire test run.

No QA required