### PR TITLE
fix(axe.d.ts): add typings for preload options object

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -143,9 +143,13 @@ declare namespace axe {
     iframes?: boolean;
     elementRef?: boolean;
     frameWaitTime?: number;
-    preload?: boolean;
+    preload?: boolean | PreloadOptions;
     performanceTimer?: boolean;
     pingWaitTime?: number;
+  }
+  interface PreloadOptions {
+    assets: string[];
+    timeout?: number;
   }
   interface AxeResults extends EnvironmentData {
     toolOptions: RunOptions;

--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -35,6 +35,13 @@ axe.run(
     console.log(error || results);
   }
 );
+// axe.run preload: boolean
+axe.run({ preload: false });
+axe.run({ preload: true });
+// axe.run preload: options
+axe.run({ preload: { assets: ['cssom'] } });
+axe.run({ preload: { assets: ['cssom'], timeout: 50000 } });
+
 export async function runAsync() {
   await axe.run('main'); // Single selector
   await axe.run(['main']); // Array of one selector


### PR DESCRIPTION
Adds the TypeScript typings for passing an object to the `preload` setting for `axe.run`, as documented here: https://www.deque.com/axe/core-documentation/api-documentation/#preload-configuration-details

> Specifying an object


```js
axe.run(
  {
    preload: { assets: ['cssom'], timeout: 50000 }
  },
  (err, results) => {
    // ...
  }
);
 ```