### PR TITLE
docs: fix mismatched parenthesis

### DIFF
--- a/lib/checks/label/implicit.json
+++ b/lib/checks/label/implicit.json
@@ -6,7 +6,7 @@
     "messages": {
       "pass": "Form element has an implicit (wrapped) <label>",
       "fail": "Form element does not have an implicit (wrapped) <label>",
-      "incomplete": "Unable to determine if form element has an implicit (wrapped} <label>"
+      "incomplete": "Unable to determine if form element has an implicit (wrapped) <label>"
     }
   }
 }


### PR DESCRIPTION
Noticed this while reviewing a translation file