### PR TITLE
test: improve heading-matches test cases

### DIFF
--- a/locales/README.md
+++ b/locales/README.md
@@ -2,8 +2,8 @@
 
 We welcome any localization for axe-core. For details on how to contribute, see the [Contributing section](../README.md#contributing) of the main README. For details on the message syntax, see [Check Message Template](../doc/check-message-template.md).
 
-To create a new translation for axe, start by running `grunt translate --lang=<langcode>`. This will create a json file with the default English text in it for you to translate. Alternatively, you could copy `_template.json`.
+To create a new translation for axe, start by running `grunt translate --lang=<langcode>`. This will create a JSON file with the default English text in it for you to translate. Alternatively, you could copy `_template.json`.
 
-To update an existing translation file, re-run `grunt translate --lang=<langcode>`. This will add new messages used in English and remove messages which were not used in English.
+To update an existing translation file, re-run `grunt translate --lang=<langcode>`. This will add new messages used in English and remove messages that are no longer used in English.
 
-`_template.json` is a generated file which is created every time axe is built. It's compiled using each rules' `description` and `help` properties as well as each checks' `metadata.messages` property. To update the `_template.json` file you'll need to update the corresponding [rule](../lib/rules) or [check](../lib/checks) metadata file and rebuild.
+`_template.json` is a generated file which is created every time axe is built. It's compiled using each rule's `description` and `help` properties, as well as each check's `metadata.messages` property. To update the `_template.json` file you'll need to update the corresponding [rule](../lib/rules) or [check](../lib/checks) metadata file and rebuild.

--- a/test/rule-matches/heading-matches.js
+++ b/test/rule-matches/heading-matches.js
@@ -6,6 +6,8 @@ describe('heading-matches', function () {
 
   beforeEach(function () {
     rule = axe.utils.getRule('empty-heading');
+    assert.isObject(rule, 'Rule object should be available');
+    assert.isFunction(rule.matches, 'Rule should have a matches function');
   });
 
   it('is a function', function () {
@@ -29,22 +31,22 @@ describe('heading-matches', function () {
     }
   });
 
-  it('should return false on headings with their role changes', function () {
+  it('should return false on headings that no longer function as headings due to a valid role change', function () {
     const vNode = queryFixture('<h1 role="banner" id="target"></h1>');
     assert.isFalse(rule.matches(null, vNode));
   });
 
-  it('should return true on headings with their role changes to an invalid role', function () {
+  it('should return true on headings with their role changed to an invalid role', function () {
     const vNode = queryFixture('<h1 role="bruce" id="target"></h1>');
     assert.isTrue(rule.matches(null, vNode));
   });
 
-  it('should return true on headings with their role changes to an abstract role', function () {
+  it('should return true on headings with their role changed to an abstract role', function () {
     const vNode = queryFixture('<h1 role="widget" id="target"></h1>');
     assert.isTrue(rule.matches(null, vNode));
   });
 
-  it('should return true on headings with explicit role="none" and an empty aria-label to account for presentation conflict resolution', function () {
+  it('should return true on headings with explicit role="none" and an empty aria-label (handling presentation conflict resolution)', function () {
     const vNode = queryFixture(
       '<h1 aria-label="" role="none" id="target"></h1>'
     );


### PR DESCRIPTION
- In the beforeEach, it's fetching the empty-heading rule using axe.utils.getRule('empty-heading'). Ensure that this rule actually includes the matches function. If not, the first test (assert.isFunction(rule.matches)) will fail.
- some test case descriptions are misleading so it clarifies that