### PR TITLE
fix(aria-allowed-role): add form to allowed roles of form element

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -261,7 +261,7 @@ const htmlElms = {
   },
   form: {
     contentTypes: ['flow'],
-    allowedRoles: ['search', 'none', 'presentation']
+    allowedRoles: ['form', 'search', 'none', 'presentation']
   },
   h1: {
     contentTypes: ['heading', 'flow'],


### PR DESCRIPTION
The ARIA in HTML spec [allows a form element to have role=form](https://www.w3.org/TR/html-aria/#allowed-aria-roles-states-and-properties#el-form), but [axe does not allow it](https://github.com/dequelabs/axe-core/blob/develop/lib/standards/html-elms.js#L264). This PR adds form to the allowedRoles of form.
