### PR TITLE
Update axe-core-tests.ts

### DIFF
--- a/typings/axe-core/axe-core-tests.ts
+++ b/typings/axe-core/axe-core-tests.ts
@@ -7,7 +7,6 @@ var options: axe.RunOptions = {
   selectors: false,
   elementRef: false
 };
-options.reporter = 'rawEnv';
 options.reporter = 'custom';
 
 axe.run(context, {}, (error: Error, results: axe.AxeResults) => {


### PR DESCRIPTION
The 'rawEnv' value for options.reporter is being overwritten immediately by 'custom'. Remove the duplicate assignment.