### PR TITLE
chore: avoid auto-formatter workflow failing on fork PRs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,10 +1,18 @@
 name: Formatter
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   prettier:
+    # This conditional prevents running the job on PRs from forks; won't
+    # have permissions to commit changes, so the job would fail if it ran.
+    # PRs from forks will instead rely on failing the fmt_check job in test.yml
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,18 @@ jobs:
           path: axe.js
           retention-days: 1
 
+  fmt_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run fmt:check
+
   test_node:
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "sri-update": "grunt build && node build/sri-update && git add sri-history.json",
     "sri-validate": "node build/sri-update --validate",
     "fmt": "prettier --write .",
+    "fmt:check": "prettier --check .",
     "prepare": "husky && npm run patch",
     "prebuild": "node ./build/check-node-version.js",
     "pretest": "node ./build/check-node-version.js",


### PR DESCRIPTION
It bothered me that every PR from a fork always had a red check from the autoformatter PR. This sets up the autoformatter to only run on PRs from non-forks, and adds a new `fmt:check` step to the tests workflow that will work even in forks. This lets our team still use the autoformatter without causing noise for external contributors, and also enforces our formatting requirements for PRs from forks where previously we would typically admin-merge past the check (which causes noise like #4599).

Once this PR merges, we'll want to update the repo's branch protection rules to add the new fmt-check job as a required check.