### PR TITLE
fix(get-ancestry): don't error when there is no parent

### DIFF
--- a/lib/core/utils/get-ancestry.js
+++ b/lib/core/utils/get-ancestry.js
@@ -9,7 +9,7 @@ function generateAncestry(node) {
   if (
     nodeName !== 'head' &&
     nodeName !== 'body' &&
-    parentNode.children.length > 1
+    parentNode?.children.length > 1
   ) {
     const index = Array.prototype.indexOf.call(parentNode.children, node) + 1;
     nthChild = `:nth-child(${index})`;

--- a/test/core/utils/get-ancestry.js
+++ b/test/core/utils/get-ancestry.js
@@ -26,6 +26,11 @@ describe('axe.utils.getAncestry', () => {
     assert.isNotNull(document.querySelector(sel1));
   });
 
+  it('should not throw when there is no parent', () => {
+    const node = document.createElement('section');
+    assert.doesNotThrow(() => axe.utils.getAncestry(node));
+  });
+
   it('generates selectors of nested shadow trees', () => {
     const node = document.createElement('section');
     fixture.appendChild(node);


### PR DESCRIPTION
Seems I removed the conditional check on the children lookup during a refactor. Adding it back in and ensuring there's a test so this doesn't happen again.