### PR TITLE
fix(aria-required-children): never fail if given aria-busy=true

### DIFF
--- a/lib/checks/aria/aria-required-children-evaluate.js
+++ b/lib/checks/aria/aria-required-children-evaluate.js
@@ -34,6 +34,11 @@ export default function ariaRequiredChildrenEvaluate(
     return true;
   }
 
+  if (virtualNode.attr('aria-busy') === 'true') {
+    this.data({ messageKey: 'aria-busy' });
+    return true;
+  }
+
   const ownedRoles = getOwnedRoles(virtualNode, required);
   const unallowed = ownedRoles.filter(
     ({ role, vNode }) => vNode.props.nodeType === 1 && !required.includes(role)
@@ -52,11 +57,6 @@ export default function ariaRequiredChildrenEvaluate(
   }
 
   if (hasRequiredChildren(required, ownedRoles)) {
-    return true;
-  }
-
-  if (virtualNode.attr('aria-busy') === 'true') {
-    this.data({ messageKey: 'aria-busy' });
     return true;
   }
 

--- a/test/checks/aria/required-children.js
+++ b/test/checks/aria/required-children.js
@@ -146,15 +146,13 @@ describe('aria-required-children', () => {
     });
   });
 
-  it('should fail list with an unallowed child, even if aria-busy="true"', () => {
+  it('should pass list with an unallowed child, if given aria-busy="true"', () => {
     const params = checkSetup(`
       <div id="target" role="list" aria-busy="true"><div role="tabpanel"></div></div>
     `);
-    assert.isFalse(requiredChildrenCheck.apply(checkContext, params));
-
+    assert.isTrue(requiredChildrenCheck.apply(checkContext, params));
     assert.deepEqual(checkContext._data, {
-      messageKey: 'unallowed',
-      values: '[role=tabpanel]'
+      messageKey: 'aria-busy'
     });
   });
 

--- a/test/integration/rules/aria-required-children/aria-required-children.html
+++ b/test/integration/rules/aria-required-children/aria-required-children.html
@@ -114,8 +114,8 @@
   <div aria-busy="true"></div>
 </div>
 
-<div role="list" id="fail13" aria-busy="true">
-  <div role="alert">unallowed role</div>
+<div role="list" id="pass20" aria-busy="true">
+  <div role="alert">ignored role</div>
 </div>
 
 <div role="doc-bibliography" id="inapplicable1"></div>

--- a/test/integration/rules/aria-required-children/aria-required-children.json
+++ b/test/integration/rules/aria-required-children/aria-required-children.json
@@ -13,8 +13,7 @@
     ["#fail9"],
     ["#fail10"],
     ["#fail11"],
-    ["#fail12"],
-    ["#fail13"]
+    ["#fail12"]
   ],
   "passes": [
     ["#pass1"],
@@ -35,7 +34,8 @@
     ["#pass16"],
     ["#pass17"],
     ["#pass18"],
-    ["#pass19"]
+    ["#pass19"],
+    ["#pass20"]
   ],
   "incomplete": [
     ["#incomplete1"],


### PR DESCRIPTION
I think we made a mistake in https://github.com/dequelabs/axe-core/pull/4347/, where we allowed an element with aria-busy=true to fail if it has children it is not allowed to have. While that's a likely failure, I don't think axe can say it fails for certain.

Closes: #4626
