### PR TITLE
Several grammatical/syntax updates for consistency and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Axe is an accessibility testing engine for websites and other HTML-based user in
 
 ## The Accessibility Rules
 
-Axe-core has different types of rules, for WCAG 2.0, 2.1, 2.2 on level A, AA and AAA as well as a number of best practices that help you identify common accessibility practices like ensuring every page has an `h1` heading, and to help you avoid "gotchas" in ARIA like where an ARIA attribute you used will get ignored. The complete list of rules, grouped WCAG level and best practice, can found in [doc/rule-descriptions.md](./doc/rule-descriptions.md).
+Axe-core has different types of rules, for WCAG 2.0, 2.1, 2.2 on level A, AA and AAA as well as a number of best practices that help you identify common accessibility practices like ensuring every page has an `h1` heading, and to help you avoid "gotchas" in ARIA like where an ARIA attribute you used will get ignored. The complete list of rules, grouped WCAG level and best practice, can be found in [doc/rule-descriptions.md](./doc/rule-descriptions.md).
 
 With axe-core, you can find **on average 57% of WCAG issues automatically**. Additionally, axe-core will return elements as "incomplete" where axe-core could not be certain, and manual review is needed.
 
@@ -65,7 +65,7 @@ Axe was built to reflect how web development actually works. It works with all m
 - It's actively supported by [Deque Systems](https://www.deque.com), a major accessibility vendor.
 - It integrates with your existing functional/acceptance automated tests.
 - It automatically determines which rules to run based on the evaluation context.
-- Axe supports in-memory fixtures, static fixtures, integration tests and iframes of infinite depth.
+- Axe supports in-memory fixtures, static fixtures, integration tests, and iframes of infinite depth.
 - Axe is highly configurable.
 
 ## Supported Browsers

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,4 +1,4 @@
-# Axe Javascript Accessibility API
+# Axe JavaScript Accessibility API
 
 ## Table of Contents
 
@@ -49,8 +49,8 @@ This section gives a quick description of how to use the axe APIs to analyze web
 The axe API can be used as part of a broader process that is performed on many, if not all, pages of a website. The API is used to analyze web page content and return a JSON object that lists any accessibility violations found. Here is how to get started:
 
 1. Load page in testing system
-2. Optionally, set configuration options for the javascript API (`axe.configure`)
-3. Call analyze javascript API (`axe.run`)
+2. Optionally, set configuration options for the JavaScript API (`axe.configure`)
+3. Call analyze JavaScript API (`axe.run`)
 4. Either assert against results or save them for later processing
 5. Repeat for any inactive or non-rendered content after making it visible
 
@@ -58,7 +58,7 @@ The axe API can be used as part of a broader process that is performed on many, 
 
 ### Overview
 
-The axe APIs are provided in the javascript file axe.js. It must be included in the web page under test, as well as each `iframe` under test. Parameters are sent as javascript function parameters. Results are returned in JSON format.
+The axe APIs are provided in the JavaScript file axe.js. It must be included in the web page under test, as well as each `iframe` under test. Parameters are sent as JavaScript function parameters. Results are returned in JSON format.
 
 ### Full API Reference for Developers
 
@@ -72,7 +72,7 @@ For a full listing of API offered by axe, clone the repository and run `npm run 
 
 ### Axe-core Tags
 
-Each rule in axe-core has a number of tags. These provide metadata about the rule. Each rule has one tag that indicates which WCAG version / level it belongs to, or if it doesn't it have the `best-practice` tag. If the rule is required by WCAG, there is a tag that references the success criterion number. For example, the `wcag111` tag means a rule is required for WCAG 2 success criterion 1.1.1.
+Each rule in axe-core has a number of tags. These provide metadata about the rule. Each rule has one tag that indicates which WCAG version / level it belongs to, or if it doesn't, it has the `best-practice` tag. If the rule is required by WCAG, there is a tag that references the success criterion number. For example, the `wcag111` tag means a rule is required for WCAG 2 success criterion 1.1.1.
 
 The `experimental`, `ACT`, `TT`, and `section508` tags are only added to some rules. Each rule with a `section508` tag also has a tag to indicate what requirement in old Section 508 the rule is required by. For example `section508.22.a`.
 
@@ -182,7 +182,7 @@ In this example, we pass in the WCAG 2 A and AA tags into `axe.getRules` to retr
 
 To configure the format of the data used by axe. This can be used to add new rules, which must be registered with the library to execute.
 
-**important**: `axe.configure()` does not communicate configuration calls into iframes. Instead `axe.configure()` must be called with the same argument in each `frame` / `iframe` individually.
+**Important**: `axe.configure()` does not communicate configuration calls into iframes. Instead `axe.configure()` must be called with the same argument in each `frame` / `iframe` individually.
 
 #### Description
 
@@ -213,7 +213,7 @@ axe.configure({
   - `reporter` - Used to set the output format that the axe.run function will pass to the callback function. Can pass a reporter name or a custom reporter function. Valid names are:
     - `v1` to use the previous version's format: `axe.configure({ reporter: "v1" });`
     - `v2` to use the current version's format: `axe.configure({ reporter: "v2" });`
-    - `raw` to return the raw result data without formating: `axe.configure({ reporter: "raw" });`
+    - `raw` to return the raw result data without formatting: `axe.configure({ reporter: "raw" });`
     - `raw-env` to return the raw result data with environment data: `axe.configure({ reporter: "raw-env" });`
     - `no-passes` to return only violation results: `axe.configure({ reporter: "no-passes" });`
   - `checks` - Used to add checks to the list of checks used by rules, or to override the properties of existing checks
@@ -567,7 +567,7 @@ The `resultTypes` option can be used to limit the number of nodes for a rule to 
 
 After axe has processed all rules normally, it generates a unique selector for all nodes in all rules. This process can be time consuming, especially for pages with lots of nodes. By limiting the nodes to a maximum of one for result types you are not interested in, you can greatly speed up the tail end performance of axe.
 
-Types listed in this option will cause rules that fall under those types to show all nodes. Types _not_ listed will causes rules that fall under one of the missing types to show a maximum of one node. This allows you to still see those results and inform the user of them if appropriate.
+Types listed in this option will cause rules that fall under those types to show all nodes. Types _not_ listed will cause rules that fall under one of the missing types to show a maximum of one node. This allows you to still see those results and inform the user of them if appropriate.
 
 ```js
 axe.run(
@@ -670,7 +670,7 @@ The results of axe are grouped according to their outcome into the following arr
 - `passes`: These results indicate what elements passed the rules
 - `violations`: These results indicate what elements failed the rules
 - `inapplicable`: These results indicate which rules did not run because no matching content was found on the page. For example, with no video, those rules won't run.
-- `incomplete`: Also known as "needs review," these results were aborted and require further testing. This can happen either because of technical restrictions to what the rule can test, or because a javascript error occurred.
+- `incomplete`: Also known as "needs review," these results were aborted and require further testing. This can happen either because of technical restrictions to what the rule can test, or because a JavaScript error occurred.
 
 Each object returned in these arrays have the following properties:
 
@@ -834,7 +834,7 @@ axe.teardown();
 
 ### API Name: axe.frameMessenger
 
-Set up a alternative communication channel between parent and child frames. By default, axe-core uses `window.postMessage()`. See [frame-messenger.md](frame-messenger.md) for details.
+Set up an alternative communication channel between parent and child frames. By default, axe-core uses `window.postMessage()`. See [frame-messenger.md](frame-messenger.md) for details.
 
 ### API name: axe.runPartial / axe.finishRun
 
@@ -931,7 +931,7 @@ The top-level document or shadow DOM document fragment
 
 This package contains examples for [jasmine](examples/jasmine), [mocha](examples/mocha), [qunit](examples/qunit), and [generating HTML from the violations array](examples/html-handlebars.md). Each of these examples is in the [doc/examples](examples) folder. In each folder, there is a README.md file which contains specific information about each example.
 
-See [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs#axe-webdriverjs) for selenium webdriver javascript examples.
+See [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs#axe-webdriverjs) for selenium webdriver JavaScript examples.
 
 ## Section 4: Performance
 

--- a/doc/accessibility-supported.md
+++ b/doc/accessibility-supported.md
@@ -6,7 +6,7 @@ In order to adhere to the manifesto and at the same time be useful to developers
 
 Accessibility supported means that in order for a technique to pass, it must work in some predefined set of browsers and assistive technologies. For axe-core this means that for a screen reader, browser, or environment to be added to the list of supported combinations, the following two criteria must be met:
 
-1. Be used by more than 1% of users (currently extrapolated from the [WebAims Screen Reader User Survey](https://webaim.org/projects/screenreadersurvey10/#browsercombos))
+1. Be used by more than 1% of users (currently extrapolated from the [WebAim Screen Reader User Survey](https://webaim.org/projects/screenreadersurvey10/#browsercombos))
 1. Introduce new coverage for a screen reader, browser, or environment not currently accessibility supported
 
 We currently test the following AT combinations for support
@@ -32,6 +32,6 @@ In addition, we disallow invalid attributes starting with `aria-` and invalid at
 
 ## Best practices
 
-We recognize that there are best practices that significantly improve the usability of application, even though they are not strictly required in order to conform with WCAG 2. We develop the best practice rules to help content developers to identify these and adhere to them.
+We recognize that there are best practices that significantly improve the usability of an application, even though they are not strictly required in order to conform with WCAG 2. We develop the best practice rules to help content developers to identify these and adhere to them.
 
 We recognize that this topic is somewhat controversial and the rules we have represent Deque's opinion on what constitutes a best practice.

--- a/doc/act-rules-format.md
+++ b/doc/act-rules-format.md
@@ -1,6 +1,6 @@
 # W3C Standardized Rules
 
-Deque Systems is one of leading organizations in the development of standardized accessibility conformance testing rules. The [axe-core rules proposal format](./rule-proposal.md) is an adaptation of the [Accessibility Conformance Testing Rules Format](https://www.w3.org/TR/act-rules-format/).
+Deque Systems is one of the leading organizations in the development of standardized accessibility conformance testing rules. The [axe-core rules proposal format](./rule-proposal.md) is an adaptation of the [Accessibility Conformance Testing Rules Format](https://www.w3.org/TR/act-rules-format/).
 
 There are two ways a rule written in the axe-core rule format can be transformed into the ACT Rules format:
 
@@ -9,9 +9,9 @@ There are two ways a rule written in the axe-core rule format can be transformed
 This method is useful for rules with a small number of checks.
 
 1. Add the test input type to it: `rendered page`
-2. Add an `assumptions` section, add possible assumptions to it
+2. Add an `assumptions` section, including possible assumptions to it
 3. Add an `outcomes` section, describing the different possible outcomes of the rule
-4. Add a `Validation Tests` section, that links to the integration tests
+4. Add a `Validation Tests` section that links to the integration tests
 5. Update the check to return pass/fail/cantTell instead of true/false/undefined
 6. Add control flow to the checks:
 
@@ -19,7 +19,7 @@ This method is useful for rules with a small number of checks.
 - `all` and `none` checks should only return `pass` in the last step. All steps leading up to it either return `fail` or say `continue to the next step`.
 
 7. Rename `checks` to `steps` and add a `step X` (where X is the step number) to the heading with the check name.
-8. Replace the `tags` section with a `Accessibility Requirements`. The requirements can be determined based on the `wcag###` tags.
+8. Replace the `tags` section with an `Accessibility Requirements`. The requirements can be determined based on the `wcag###` tags.
 
 ## Method 2: Create a rule group
 
@@ -34,4 +34,4 @@ This method is useful for larger rules with `any` checks. This effectively turns
 7. Update the check to return pass/fail/cantTell instead of true/false/undefined
 8. Add a `Validation Tests` section, that links to only those integration tests relevant for this check (now a new rule).
 9. Indicate that the new rule is part of a group, using the original axe-core rule ID as the group name.
-10. Replace the `tags` section with a `Accessibility Requirements`. The requirements can be determined based on the `wcag###` tags.
+10. Replace the `tags` section with an `Accessibility Requirements`. The requirements can be determined based on the `wcag###` tags.

--- a/doc/backwards-compatibility-doc.md
+++ b/doc/backwards-compatibility-doc.md
@@ -8,7 +8,7 @@ The axe-core API includes:
 - The selectors generated and included in the node information in the results arrays for any given HTML page
 - The JSON structures passed into and out of any API functions
 - Any functions in the `axe.utils` and `axe.commons` collections that are used by one of our standard rules (this document refers to these as the “Public Utils”). This includes use in any of the “matches”, “eval” and “after” functions.
-- The implicit function signature of the matches, eval and after functions (the names of the parameters that are passed-to the functions and the values returned by them)
+- The implicit function signature of the matches, eval and after functions (the names of the parameters that are passed to the functions and the values returned by them)
 
 ## What is not included in the public axe-core API?
 
@@ -20,7 +20,7 @@ We guarantee that the API signatures and the return values of functions will not
 
 In a minor release, we may change the implementation of Public Utils to fix bugs or improve performance. This means that a call to a Public Util may return a different value across patch versions.
 
-We will not add or remove rules in a patch release. We will not add support for new technologies in a patch release. We will endeavour to return the exact same results across patch releases with the exception of changes that are due to bug fixes. This means that the likelihood of a patch release finding issues on a page that was clean in a previous release is very close to zero but not zero.
+We will not add or remove rules in a patch release. We will not add support for new technologies in a patch release. We will endeavor to return the exact same results across patch releases with the exception of changes that are due to bug fixes. This means that the likelihood of a patch release finding issues on a page that was clean in a previous release is very close to zero but not zero.
 
 In a minor release, we may add support for new technologies in the Public Utils or in existing rules and we may add or disable rules. We may also change an experimental rule to become a standard rule (essentially equivalent to adding rule). This means that pages that did not return violations in a particular minor release may return violations in a subsequent release. Rule tags, including the "wcag\*" tags, and whether or not something is reported as best-practice can be changed in minor releases.
 
@@ -44,7 +44,7 @@ Major releases may remove rules.
 | APIs removed                                  | May be removed (will remove previously deprecated APIs) | Will not be removed   | Will not be removed        |
 | **Public Utils**                              |                                                         |                       |                            |
 | Implementation of Public Utils                | May change                                              | May change            | Will not change            |
-| New public Utils                              | May add                                                 | May add               | Will not add               |
+| New Public Utils                              | May add                                                 | May add               | Will not add               |
 | **Rules**                                     |                                                         |                       |                            |
 | Add rules                                     | May add                                                 | May add               | Will not add               |
 | Disable or remove rules                       | May remove (will remove previously deprecated rules)    | May disable or remove | Will not disable or remove |
@@ -61,7 +61,7 @@ Patch release upgrades can be applied in CI environments with a high degree of c
 
 ### Custom Rules
 
-A custom rule configuration (with-or-without custom rules) is guaranteed to run on any newer version that shares the same major version number as the version for which it was created. A custom rule configuration (with-or-without custom rules) is not guaranteed to work with an older version of axe-core than the version for which it was created.
+A custom rule configuration (with or without custom rules) is guaranteed to run on any newer version that shares the same major version number as the version for which it was created. A custom rule configuration (with or without custom rules) is not guaranteed to work with an older version of axe-core than the version for which it was created.
 
 You can write custom rules that utilize the Public Utils and the parameters that are passed to a check function, secure in the knowledge that the API will not change unless a major version is released.
 

--- a/doc/check-message-template.md
+++ b/doc/check-message-template.md
@@ -4,7 +4,7 @@ Axe-core uses a custom template to handle dynamic check messages (messages that 
 
 ## Simple Message
 
-A simple message is just a string that doesn't use the `data` property. Most checks uses this format.
+A simple message is just a string that doesn't use the `data` property. Most checks use this format.
 
 ```json
 {
@@ -51,7 +51,7 @@ this.data({
 
 ## Singular and Plural Messages
 
-If the message needs to to know how many items are in the `data` property to determine the type of language to use (singular or plural), you can structure the message to use `singular` and `plural` properties. Use the syntax `${data.values}` to have the message output a comma-separated list of the items (`data.values` is provided by the template code for you).
+If the message needs to know how many items are in the `data` property to determine the type of language to use (singular or plural), you can structure the message to use `singular` and `plural` properties. Use the syntax `${data.values}` to have the message output a comma-separated list of the items (`data.values` is provided by the template code for you).
 
 ```js
 // check.js
@@ -96,15 +96,15 @@ The messages can still use the syntax `${data.propName}` to access other propert
 
 ## Migrating From doT.js Template in Translations
 
-Axe-core use to use doT.js for it's temple library. To migrate from doT.js in a translation file, do the following:
+Axe-core formerly used doT.js for it's template library. To migrate from doT.js in a translation file, do the following:
 
 - If the message used `{{=it.data}}` or `{{=it.data.propName}}`, change the message to use the syntax `${data}` or `${data.propName}`.
 
 ```diff
 {
     "messages": {
--       "incomplete": "Check that the <label> does not need be part of the ARIA {{=it.data}} field's name"
-+       "incomplete": "Check that the <label> does not need be part of the ARIA ${data} field's name"
+-       "incomplete": "Check that the <label> does not need to be part of the ARIA {{=it.data}} field's name"
++       "incomplete": "Check that the <label> does not need to be part of the ARIA ${data} field's name"
     }
 }
 ```

--- a/doc/code-submission-guidelines.md
+++ b/doc/code-submission-guidelines.md
@@ -14,7 +14,7 @@ will kindly ask you to resubmit it in the correct format.
 
 ### Default Export at Top
 
-When coding using [JavaScipt modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), the `default export` should be at the top of the file right after any import statements and module level variables. This ensures that when you open the file the main code path is the first thing you read.
+When coding using [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), the `default export` should be at the top of the file right after any import statements and module level variables. This ensures that when you open the file the main code path is the first thing you read.
 
 If you encounter any code that we maintain that does not put the `default export` at the top, you should update the file to do so.
 
@@ -109,12 +109,12 @@ export default async function validateAxeReport(filePath = '') {
 
 </details>
 
-### Docblock Comments
+### DocBlock Comments
 
-We use [Docblock comments](https://en.wikipedia.org/wiki/Docblock) in our code. Docblock comments are a way to describe what a function does, its signature, and describe its inputs.
+We use [DocBlock comments](https://en.wikipedia.org/wiki/Docblock) in our code. DocBlock comments are a way to describe what a function does, its signature, and describe its inputs.
 
 <details>
-  <summary>Example of Docblock comment</summary>
+  <summary>Example of DocBlock comment</summary>
 
 ```ts
 /**
@@ -134,7 +134,7 @@ function distance(pointA, pointB) {
 
 All code changes should include tests to validate that the code works as expected. Both unit tests and integration tests (where applicable) should be included in all `fix` and `feat` pull requests. `chore` pull requests do not typically need tests.
 
-#### Integrations Test
+#### Integration Test
 
 All changes that affect a rule should include an integration test. Most rules integration tests can be found in `test/integration/rules`. When updating tests in this directory, you'll need to write the new HTML code to be tested and give the element that should trigger the rule a unique `id`. Then you'll need to update the companion JSON file to add the id to either the `violations` or `passes` array.
 
@@ -201,7 +201,7 @@ Closes issue #1
 
 **Note:** We do not link issues to be closed as we have our QA team verify the issue is resolved before closing. Instead use `Closes issue #` to link to the issue the pr resolves but won't close it once merged.
 
-> Commit messages should be 100 characters or less to make them easy to read on Github and
+> Commit messages should be 100 characters or less to make them easy to read on GitHub and
 > various git tools.
 
 ### How to structure your commits:
@@ -243,7 +243,7 @@ Use the imperative, present tense: "change" not "changed" nor "changes", just li
 
 #### Footer
 
-Reference any issue that this commit closes with its fully qualified URL to support both Bitbucket and Github.
+Reference any issue that this commit closes with its fully qualified URL to support both Bitbucket and GitHub.
 
 If needed, the footer should contain any information about [Breaking Changes](https://www.conventionalcommits.org/en/v1.0.0/). Deprecation notices or breaking changes in the Changelog should inform users if they'll need to modify their code after this commit.
 
@@ -275,7 +275,7 @@ git push origin head -f
 
 If a pull request has many commits (especially if they don't follow our [commit policy](#git-commits)), you'll want to squash them into one clean commit.
 
-In the Github UI, you can use the new [Squash and Merge](https://github.com/blog/2141-squash-your-commits) feature to make this easy. If there are merge conflicts preventing this, either ask the committer to rebase from develop following the [PR submission steps above](#submitting-a-pull-request), or use the manual method below.
+In the GitHub UI, you can use the new [Squash and Merge](https://github.com/blog/2141-squash-your-commits) feature to make this easy. If there are merge conflicts preventing this, either ask the committer to rebase from develop following the [PR submission steps above](#submitting-a-pull-request), or use the manual method below.
 
 To apply a pull request manually, make sure your local develop branch is up to date. Then, create a new branch for that pull request.
 

--- a/doc/context.md
+++ b/doc/context.md
@@ -4,11 +4,11 @@ Axe-core's `context` argument is a powerful tool for controlling precisely which
 
 1. [Test specific elements](#test-specific-elements)
 1. [Test DOM nodes](#test-dom-nodes)
-1. [Exclude elements from test](#exclude-elements-from-test)
+1. [Exclude Elements from Test](#exclude-elements-from-test)
 1. [Select from prior tests](#select-from-prior-tests)
 1. [Limit frame testing](#limit-frame-testing)
 1. [Limit shadow DOM testing](#limit-shadow-dom-testing)
-1. [Combine shadow DOM and frame context](#combine-shadow-dom-and-frame-context)
+1. [Combine Shadow DOM and Frame Context](#combine-shadow-dom-and-frame-context)
 1. [Implicit frame and shadow DOM selection](#implicit-frame-and-shadow-dom-selection)
 
 ## Test Specific Elements
@@ -23,7 +23,7 @@ await axe.run('nav, main');
 await axe.run(['nav', '.sideBar', '#header']);
 ```
 
-**Tip**: Sometimes pages are worked on by multiple teams. If you mark your team's sections up with a unique class, axe can use that class to only test the sections your team works on.
+**Tip**: Sometimes, pages are worked on by multiple teams. If you mark your team's sections up with a unique class, axe can use that class to only test the sections your team works on.
 
 Axe-core is commonly used through browser driver APIs such as Selenium, Puppeteer, and Playwright. Most of these APIs do not pass a context object in directly. Instead, the following is achieved through the `.include()` method. Visit the docs of your API for more information. For most cases, this will look like the following:
 
@@ -55,7 +55,7 @@ await axe.run([navbar, cookiePopup]);
 
 ### Component Frameworks
 
-Because axe requires a DOM to test, components such as those created for React, Vue and Angular must be rendered before they are tested. The following example shows how to render the `<MyApp>` React component before testing it with axe:
+Because axe requires a DOM to test, components such as those created for React, Vue, and Angular must be rendered before they are tested. The following example shows how to render the `<MyApp>` React component before testing it with axe:
 
 ```jsx
 const appRoot = document.getElementById('app');

--- a/doc/frame-messenger.md
+++ b/doc/frame-messenger.md
@@ -33,7 +33,7 @@ axe.frameMessenger({
 
 ## axe.frameMessenger({ open })
 
-`open` is a function that should setup the communication channel with iframes. It is passed a `topicHandler` function, which must be called when a message is received from another frame.
+`open` is a function that should set up the communication channel with iframes. It is passed a `topicHandler` function, which must be called when a message is received from another frame.
 
 The `topicHandler` function takes two arguments: the `data` object and a callback function that is called when the subscribed listener completes. The `data` object is exclusively passed data that can be serialized with `JSON.stringify()`, which depending on the system may need to be used.
 
@@ -45,7 +45,7 @@ The `open` function can `return` an optional `close` function. Axe-core will onl
 
 Currently, axe-core will only require `replyHandler` to be called once, so promises can also be used here. This may change in the future, so it is preferable to make it possible for `replyHandler` to be called multiple times. Some axe-core [plugins](plugins.md) may rely on this feature.
 
-A second frameMessenger feature available to plugins, but not used in axe-core by default is to reply to a reply. This works by passing `replyHandler` a `responder` callback as a second argument. This requires a different setup, in which callbacks are stored based on their `channelId` property.
+A second frameMessenger feature available to plugins, but not used in axe-core by default is to reply to a reply. This works by passing `replyHandler` a `responder` callback as a second argument. This requires a different setup in which callbacks are stored based on their `channelId` property.
 
 ```js
 // store handlers based on channelId
@@ -100,9 +100,9 @@ function createResponder(frameWin, channelId) {
 
 ## Error handling & Timeouts
 
-If for some reason the frameMessenger fails to open, post, or close you should not throw an error. Axe-core will handle missing results by reporting on them in the `frame-tested` rule. It should not be possible for the `topicHandler` and `replyHandler` callbacks to throw an error. If this happens, please file an issue.
+If for some reason the frameMessenger fails to open, post, or close you should not throw an error. Axe-core will handle missing results by reporting them in the `frame-tested` rule. It should not be possible for the `topicHandler` and `replyHandler` callbacks to throw an error. If this happens, please file an issue.
 
-Axe-core has a timeout mechanism built in, which pings frames to see if they respond before instructing them to run. There is no retry behavior in axe-core, which assumes that whatever channel is used is stable. If this isn't the case, this will need to be built into frameMessenger.
+Axe-core has a built-in timeout mechanism, which pings frames to see if they respond before instructing them to run. There is no retry behavior in axe-core, which assumes that whatever channel is used is stable. If this isn't the case, this will need to be built into frameMessenger.
 
 The `message` passed to responder may be an `Error`. If axe-core passes an `Error`, this should be propagated "as is". If this is not possible because the message needs to be serialized, a new `Error` object must be constructed as part of deserialization.
 
@@ -113,7 +113,7 @@ When axe-core tests frames, it first sends a ping to that frame, to check that t
 In situations where communication between frames can be slow, it may be necessary to increase the ping timeout. This can be done with the `pingWaitTime` option. By default, this is 500ms. This can be configured in the following way:
 
 ```js
-const results = await axe.run(context, { pingWaitTime: 1000 }));
+const results = await axe.run(context, { pingWaitTime: 1000 });
 ```
 
-It is possible to skip this ping altogether by setting `pingWaitTime` to `0`. This can slightly speed up performance, but should only be used when long wait times for unresponsive frames can be avoided. Axe-core handles timeout errors the same way it handles any other frame communication errors. Therefore if a custom frame messenger has a timeout, it can inform axe by calling `replyHandler` with an `Error` object.
+It is possible to skip this ping altogether by setting `pingWaitTime` to `0`. This can slightly speed up performance, but should only be used when long wait times for unresponsive frames are avoided. Axe-core handles timeout errors the same way it handles any other frame communication errors. Therefore if a custom frame messenger has a timeout, it can inform axe by calling `replyHandler` with an `Error` object.

--- a/doc/issue_impact.md
+++ b/doc/issue_impact.md
@@ -1,14 +1,14 @@
 # Issue Impacts
 
-Axe-core assigns an impact according to our assessment of the likely impact of an issue on a user with a disability that would be affected by this issue. In any given context the actual impact for the user could be lower; in some instances, it could be higher. For this reason, we encourage users of tools to evaluate each individual issue and assess the impact in the context of their application or content.
+Axe-core assigns an impact according to our assessment of the likely impact of an issue on users with disabilities who would be affected by this issue. In any given context, the actual impact for the user could be lower; in some instances, it could be higher. For this reason, we encourage users of tools to evaluate each individual issue and assess the impact in the context of their application or content.
 
-For a list of each rule and their associated impacts, see [rule-descriptions.md](./rule-descriptions.md)
+For a list of all rules and their associated impacts, see [rule-descriptions.md](./rule-descriptions.md)
 
 ## Definitions
 
 ### Minor
 
-Considered to be a nuisance or an annoyance bug. Prioritize fixing if the fix only takes a few minutes and the developer is working on the same screen/feature at the same time, otherwise the issue should not be prioritized. Will still get in the way of compliance if not fixed.
+Considered to be a nuisance or an annoyance bug. Prioritize fixing it if the fix only takes a few minutes and the developer is working on the same screen/feature at the same time, otherwise the issue should not be prioritized. This issue will still get in the way of compliance if not fixed.
 
 ### Moderate
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -8,15 +8,15 @@ The plugin system was initially designed to support functionality like highlight
 
 Plugins can be viewed as a registry of tools. The plugins themselves are registered with axe and then allow themselves for the registration of plugin instances.
 
-Lets walk through a plugin implementation as an example to illustrate how plugins and plugin instances work.
+Let's walk through a plugin implementation as an example to illustrate how plugins and plugin instances work.
 
 ### A simple "act" plugin
 
 The act plugin will simply perform an action of some sort inside every iframe on the page. An example of how such a plugin might be used is to implement an instance of this plugin that performs highlighting of all of the elements of a particular type on the page.
 
-Plugins currently support two functions, a "run" function and a "collect" function. Together these functions can be combined to implement complex behaviors on top of the axe system.
+Plugins currently support two functions: a "run" function and a "collect" function. Together these functions can be combined to implement complex behaviors on top of the axe system.
 
-In order to create such a plugin, we need to implement the "run" function for the plugin, and the command that registers and executes the "run" function within each iframe on the page that contains axe. Lets look at what a noop implementation of this run function would look like:
+To create such a plugin, we need to implement the 'run' function and the command that registers and executes the 'run' function within each iframe on the page containing axe. Let's look at what a noop implementation of this run function would look like:
 
 #### Basic plugin
 
@@ -94,7 +94,7 @@ Once all the iframes' run functions have been executed, the callback is called. 
 
 #### Basic plugin instance
 
-Lets implement a basic plugin instance to see how this works. This instance will implement a "highlight" function (to place a basic frame around the bounding box of an element on each iframe on a page)
+Let's implement a basic plugin instance to see how this works. This instance will implement a "highlight" function (to place a basic frame around the bounding box of an element on each iframe on a page)
 
 ```js
 var highlight = {

--- a/doc/release-and-support.md
+++ b/doc/release-and-support.md
@@ -2,11 +2,11 @@
 
 ## Release Cadence
 
-Axe-core is used in many [projects and environments](./projects.md). Not all of these are able to upgrade at a rapid pace. Because of this, updates in axe-core are limited in the following ways. For details on what types of changes can come in these releases see [backward compatibility](./backwards-compatibility-doc.md).
+Axe-core is used in many [projects and environments](./projects.md). Not all of these are able to upgrade at a rapid pace. Because of this, updates to axe-core are limited in the following ways. For details on what types of changes can come in these releases, see [backward compatibility](./backwards-compatibility-doc.md).
 
 - **Major releases**: Major axe-core releases likely include breaking changes, and provide opportunities for Deque to remove previously deprecated features. As an absolute minimum, there will be a 12 month period between major releases of axe-core, except if this is necessary for security.
 
-- **Minor Releases**; Axe-core strives to publish three to five minor releases every year. There will be at least 3 weeks between each minor release, except if this is necessary for security.
+- **Minor Releases**: Axe-core strives to publish three to five minor releases every year. There will be at least 3 weeks between each minor release, except if this is necessary for security.
 
 - **Patch Releases**: There are no restrictions on the number of patches released for axe-core.
 
@@ -16,12 +16,12 @@ For all major and minor releases a milestone will be created at least three week
 
 Once a new major or minor version is released, the prior versions will no longer be updated, except if this is necessary for security. Security updates will be provided for major and minor versions **up to 18 months** old. For example, if version 4.0.0 was released 17 months ago, and a security issue is discovered a new patch will be released on the 4.0 line. However if 3.5.0 was released 20 months ago, even if 3.5.2 was released 17 months ago, a security patch for the 3.5 line may **not** be provided.
 
-The axe-core team considered security its very highest priority. While security vulnerabilities in axe-core are rare, they do happen. When they do, resolving the issue becomes are highest priority. Any commitments made prior to the discovery may be dropped.
+The axe-core team considers security its very highest priority. While security vulnerabilities in axe-core are rare, they do happen. When they do, resolving the issue becomes our highest priority. Any commitments made prior to the discovery may be dropped.
 
 ## Recommended Use of Versions
 
-In order to ensure the best quality from axe-core, we encourage everyone to regularly upgrade their version of axe-core, to try to stay as close to the latest release as possible. Depending on how axe-core is used, upgrading to a new minor or major version may result in new issues getting reported. To handle this, we recommend that you plan time to upgrade your version of axe-core at least twice a year.
+In order to ensure the best quality from axe-core, we encourage everyone to regularly upgrade their version of axe-core, to try to stay as close to the latest release as possible. Depending on how axe-core is used, upgrading to a new minor or major version may result in new issues getting reported. To handle this, we recommend that you set aside time to upgrade your version of axe-core at least twice a year.
 
-Additionally, we recommend that you always use the latest patch version of whatever minor version you are on. For example if you are using axe-core 3.5.5, and 3.5.6 is released it is best to upgrade immediately. Patch releases of axe-core should not find new issues, although they occasionally resolve issues in the case of false positives.
+Additionally, we recommend that you always use the latest patch version of whichever minor version you are on. For example if you are using axe-core 3.5.5, and 3.5.6 is released it is best to upgrade immediately. Patch releases of axe-core should not find new issues, although they occasionally resolve issues in the case of false positives.
 
-Ensuring you always use the latest available patch version of axe-core on any minor line guarantees you always the most secure version of axe-core. This minor line must have been released within the last 18 months. See [security updates](#security-updates).
+Ensuring that you always use the latest available patch version of axe-core guarantees that you are using the most secure version. This minor line must have been released within the last 18 months. See [security updates](#security-updates).

--- a/doc/rule-development.md
+++ b/doc/rule-development.md
@@ -1,6 +1,6 @@
 # Developing Axe-core Rules
 
-Before you start writing axe-core rules, be sure to create a proposal for them in a github issue. Read [Proposing Axe-core rules](./rule-proposal.md) for details.
+Before you start writing axe-core rules, be sure to create a proposal for them in a GitHub issue. Read [Proposing Axe-core rules](./rule-proposal.md) for details.
 
 A rule is a JSON Object that defines a test for axe-core to run. At a high level, think of a rule as doing two things. First it finds all elements that it should test, and after that it runs a number of checks to see if those selected elements pass or fail the rule.
 
@@ -8,14 +8,14 @@ A rule is a JSON Object that defines a test for axe-core to run. At a high level
 
 Each rule has a `selector` and optionally a `matches` property. The selector is a CSS selector. Each element matching this selector will be tested by the rule, unless the matches function says otherwise. The `matches` property is a reference to a function that returns a boolean, which indicates if the element should be tested.
 
-The last thing that may influence if an element is selected for testing in the rule is it's visibility. By default, hidden elements are ignored by the rule, unless the `excludeHidden` is set to 'false'.
+The last thing that may influence if an element is selected for testing in the rule is its visibility. By default, hidden elements are ignored by the rule, unless `excludeHidden` is set to 'false'.
 
 ## Using Checks in Rules
 
 The actual testing of elements in axe-core is done by checks. A rule has one or more checks which end up generating a result. There are three properties with which to define a rule's checks. Each of them deals differently:
 
 - **All**: Takes an array of check names, **all** of which has to return true for the rule to pass.
-- **none**: Takes an array of check names, **none** of which can to return true for the rule to pass.
+- **none**: Takes an array of check names, **none** of which can return true for the rule to pass.
 - **any**: Takes an array of check names, **at least one** of which has to return true for the rule to pass.
 
 ## Rule Properties
@@ -49,7 +49,7 @@ The actual testing of elements in axe-core is done by checks. A rule has one or 
 | metadata.messages.incomplete | Describes why the check didn’t complete        |
 
 Incomplete results occur when axe-core can’t produce a clear pass or fail result,
-giving users the opportunity to review it manually. Incomplete messages can take
+giving users the opportunity to manually review the result. Incomplete messages can take
 the form of a string, or an object with arbitrary keys matching the data returned
 from the check.
 
@@ -57,7 +57,7 @@ A pass message is required, while fail and incomplete are dependent on the check
 
 ### Incomplete message string
 
-As one example, the audio and video caption checks return an incomplete string:
+For example, the audio and video caption checks return an incomplete string:
 
 ```js
 messages: {
@@ -84,7 +84,7 @@ messages: {
 ```
 
 To wire up an incomplete message with a specific reason it returned undefined,
-the check needs matching data. Otherwise, it will fall back to the `default` message.
+the check needs matching data. Otherwise, it falls back to the `default` message.
 Reasons are arbitrary for the check (such as 'bgImage') but they must match the
 data returned:
 
@@ -100,7 +100,7 @@ Axe-core handles shadow DOM and cross-domain iframe rules very well - as long as
 
 The rule callbacks all receive both a `node` and a `virtualNode` argument (in addition to the `options` argument). `node` points to the DOM Node that is to be evaluated, whereas `virtualNode` points to the node in the flattened tree (the hierarchy that shadow DOM creates that is used for parent child relationships across shadow DOM boundaries).
 
-If your rule looks at any hierarchical context (parents or children) then you need to operate on the `virtualNode` for those operations. Calls to `isHidden` and the accessible name calculation calls will all evaluate the hierarchy. The commons and utils functions will all fetch the `virtualNode` from the flattened tree if you use the `node` implementation (and then simply call the virtualNode one) and are there for backwards compatibility. This backwards compatibility comes at a performance cost that can be avoided by simply using the `virtualNode` to start with. We will ask you to change this during PR review, so you might as well just start out by using the `virtualNode`.
+If your rule looks at any hierarchical context (parents or children) then you need to operate on the `virtualNode` for those operations. Calls to `isHidden` and the accessible name calculation calls will all evaluate the hierarchy. The commons and utils functions will all fetch the `virtualNode` from the flattened tree if you use the `node` implementation (and then simply call the virtualNode one) and are there for backward compatibility. This backward compatibility comes at a performance cost that can be avoided by simply using the `virtualNode` to start with. We will ask you to change this during PR review, so you might as well just start out by using the `virtualNode`.
 
 ## iframes
 

--- a/doc/rule-proposal.md
+++ b/doc/rule-proposal.md
@@ -2,9 +2,9 @@
 
 This document outlines the process of proposing a rule. For a technical description on how to build a rule, read [Developing Axe-core Rules](./rule-development.md)
 
-Before you start coding a new rule for axe-core, you _must_ create a Github issue to document the rule you want to create. There are many considerations to writing a good rule. It must have no false positives, which is difficult, because there are always many many edge cases to consider. Additionally, a known problem of accessibility testing, is that not all testers hold the same interpretation of the accessibility guidelines. All rules _must_ be consistent with the interpretation of Deque Systems, the developer behind Axe-core.
+Before you start coding a new rule for axe-core, you _must_ create a GitHub issue to document the rule you want to create. There are many considerations to writing a good rule. It must have no false positives, which is difficult, because there are always many many edge cases to consider. Additionally, a known problem of accessibility testing is that not all testers hold the same interpretation of the accessibility guidelines. All rules _must_ be consistent with the interpretation of Deque Systems, the developer behind Axe-core.
 
-In addition to giving the axe-core development team an opportunity to provide feedback on the proposed rule, the Github Issue will serve as documentation of that rule for the future.
+In addition to giving the axe-core development team an opportunity to provide feedback on the proposed rule, the GitHub Issue will serve as documentation of that rule for the future.
 
 ## WCAG interpretation
 
@@ -12,7 +12,7 @@ Please read our [principles for deciding on rules](./accessibility-supported.md)
 
 ## Rules Format
 
-All Github issues that propose a rule must be tagged as _rule_, and must use the following format:
+All GitHub issues that propose a rule must be tagged as _rule_, and must use the following format:
 
 ### Intro
 

--- a/doc/run-partial.md
+++ b/doc/run-partial.md
@@ -1,8 +1,8 @@
 # axe runPartial / finishRun
 
-`axe.runPartial` and `axe.finishRun` are two methods which allow axe to test a page in two stages. This is different from `axe.run()`, in that `axe.runPartial` and `axe.finishRun` does not require communication between frames. This can be useful when frame communication is not possible or not secure. See [axe.frameMessenger](frame-messenger.md) for information on frame communication.
+`axe.runPartial` and `axe.finishRun` are two methods which allow axe to test a page in two stages. This is different from `axe.run()`, in that `axe.runPartial` and `axe.finishRun` do not require communication between frames. This can be useful when frame communication is not possible or not secure. See [axe.frameMessenger](frame-messenger.md) for information on frame communication.
 
-To use these methods, call `axe.runPartial()` in the top window, and in all nested frames and iframes. The results are then put into an array, and then passed to `axe.finishRun()`. `axe.finishRun()` then complete the test and generates the axe report.
+To use these methods, call `axe.runPartial()` in the top window, and in all nested frames and iframes. The results are put into an array, and then passed to `axe.finishRun()`. `axe.finishRun()` then completes the test and generates the axe report.
 
 This results in code that looks something like the following. The `context` and `options` arguments used are the same as would be passed to `axe.run`. See [API.md](api.md) for details.
 
@@ -42,7 +42,7 @@ function runPartialRecursive(context, options = {}, win = window) {
 
 **important**: The order in which these methods are called matters for performance. Internally, axe-core constructs a flattened tree when `axe.utils.getFrameContexts` is called. This is fairly slow, and so should not happen more than once per frame. When `axe.runPartial` is called, that tree will be used if it still exists. Since this tree can get out of sync with the actual DOM, it is important to call `axe.runPartial` immediately after `axe.utils.getFrameContexts`.
 
-To run efficiently, `axe.runPartial` calls should happen in parallel, so that when possible browsers can test multiple frames simultaneously.
+To run efficiently, axe.runPartial calls should happen in parallel, so that, when possible, browsers can test multiple frames simultaneously.
 
 ## axe.finishRun(partialResults, options): Promise<AxeResults>
 
@@ -84,7 +84,7 @@ The `options` object takes the same RunOptions object that axe.run accepts. When
 
 ## Custom Rulesets and Reporters
 
-Because `axe.finishRun` does not run inside the page, the `reporter` and `after` methods do not have access to the top-level `window` and `document` objects, and might not have access to common browser APIs. Axe-core reporter use the `environmentData` property that is set on the partialResult object of the initiator.
+Because `axe.finishRun` does not run inside the page, the `reporter` and `after` methods do not have access to the top-level `window` and `document` objects, and might not have access to common browser APIs. Axe-core reporters use the `environmentData` property that is set on the partialResult object of the initiator.
 
 Because of this constraint, custom reporters, and custom rulesets that add `after` methods must not rely on browser APIs or globals. Any data needed for either should either be taken from the `environmentData` property, or collected in an `evaluate` method of a check, and stored using its `.data()` method.
 

--- a/doc/standards-object.md
+++ b/doc/standards-object.md
@@ -1,6 +1,6 @@
 # Standards Object
 
-The [standards object](../lib/standards) is JSON object of ARIA and HTML spec information that axe-core uses to validate ARIA roles, attributes, and use. For example, the `aria-valid-attr` rule uses the [`ariaAttrs`](../lib/standards/aria-attrs.js) object to determine if the aria attribute is a valid ARIA attribute. To configure how axe-core validates ARIA information, you'll most likely configure the standards object to your needs. Below is a list of each object, their structure, and which rules will use that information
+The [standards object](../lib/standards) is a JSON object of ARIA and HTML spec information that axe-core uses to validate ARIA roles, attributes, and use. For example, the `aria-valid-attr` rule uses the [`ariaAttrs`](../lib/standards/aria-attrs.js) object to determine if the aria attribute is a valid ARIA attribute. To configure how axe-core validates ARIA information, you'll most likely configure the standards object to your needs. Below is a list of each object, its structure, and which rules will use that information
 
 ```js
 axe.configure({
@@ -39,13 +39,13 @@ The [`ariaAttrs`](../lib/standards/aria-attrs.js) object defines valid ARIA attr
 - `type` - string(required). The attribute type which dictates the valid values of the attribute. Valid types are:
   - `boolean` - Boolean attributes only accept `true` or `false` as valid values (e.g. `aria-selected`).
   - `nmtoken` - Name token attributes accept a single value from a list of valid values (e.g. `aria-orientation`).
-  - `mntokens` - Name tokens attributes accept a space separated list of values from a list of valid values (e.g. `aria-relevant`).
+  - `nmtokens` - Name tokens attributes accept a space separated list of values from a list of valid values (e.g. `aria-relevant`).
   - `idref` - ID reference attributes accept an ID to point to another element in the DOM (e.g. `aria-activedescendant`).
   - `idrefs` - ID references attributes accept a space separated list of IDs that point to multiple elements in the DOM (e.g. `aria-labelledby`).
   - `string` - String attributes accept any string (e.g. `aria-label`).
   - `decimal` - Decimal attributes accept any number or decimal value (e.g. `aria-valuemax`).
   - `int` - Integer attributes only accept whole number values (e.g. `aria-level`).
-- `values` - array(required for only `mntoken` and `mntokens`). The list of valid values for the attribute.
+- `values` - array(required for only `nmtoken` and `nmtokens`). The list of valid values for the attribute.
 - `minValue` - number(required for only `int`). The minimum value allowed for the attribute.
 - `allowEmpty` - boolean(optional, default `false`). If the attribute is allowed to have no value.
 - `global` - boolean(optional, default `false`). If the attribute is a [global ARIA attribute](https://www.w3.org/TR/wai-aria-1.1/#global_states).
@@ -108,7 +108,7 @@ The [`htmlElms`](../lib/standards/html-elms.js) object defines valid HTML elemen
   - `phrasing`
   - `embedded`
   - `interactive`
-- `allowedRoles` - boolean or array(required). If element is allowed to use ARIA roles. A value of `true` means any role while a list of roles means only those are allowed. A value of `false` means no roles are allowed.
+- `allowedRoles` - boolean or array(required). If element is allowed to use ARIA roles, a value of `true` means any role while a list of roles means only those are allowed. A value of `false` means no roles are allowed.
 - `noAriaAttrs` - boolean(optional. Defaults `true`). If the element is allowed to use global ARIA attributes and any allowed for the elements role.
 - `shadowRoot` - boolean(optional. Default `false`). If the element is allowed to have a shadow root.
 - `implicitAttrs` - object(optional. Default `{}`). Any implicit ARIA attributes for the element and their default value.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "browser-driver-manager": "1.0.4",
         "chai": "^4.3.7",
         "chalk": "^4.x",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "clean-jsdoc-theme": "^4.2.17",
         "clone": "^2.1.2",
         "colorjs.io": "0.4.3",

--- a/test/node/package-lock.json
+++ b/test/node/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "node",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
<< Describe the changes >>

Several edits to the documentation. 

Many edits were grammatical in nature:

* Capitalization of proper nouns, proper use of contractions (i.e let's, its, etc.)

* Switched to proper use of nmtoken and not mntoken

* Removal of redundant hyphens, addition of some new ones

* Several other edits
