### PR TITLE
fix(aria-allowed-role): Add math to allowed roles for img element

### DIFF
--- a/lib/standards/html-elms.js
+++ b/lib/standards/html-elms.js
@@ -360,6 +360,7 @@ const htmlElms = {
           'button',
           'checkbox',
           'link',
+          'math',
           'menuitem',
           'menuitemcheckbox',
           'menuitemradio',

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -258,7 +258,7 @@
   id="pass-img-valid-role-meter"
 />
 <img role="doc-cover" aria-label="foo" id="pass-img-valid-role-aria-label" />
-<img role="math" id="pass-img-valid-role-math" />
+<img role="math" aria-label="test" id="pass-img-valid-role-math" />
 <img role="menuitem" title="bar" id="pass-img-valid-role-title" />
 <div id="image-baz">hazaar</div>
 <img

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.html
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.html
@@ -258,6 +258,7 @@
   id="pass-img-valid-role-meter"
 />
 <img role="doc-cover" aria-label="foo" id="pass-img-valid-role-aria-label" />
+<img role="math" id="pass-img-valid-role-math" />
 <img role="menuitem" title="bar" id="pass-img-valid-role-title" />
 <div id="image-baz">hazaar</div>
 <img

--- a/test/integration/rules/aria-allowed-role/aria-allowed-role.json
+++ b/test/integration/rules/aria-allowed-role/aria-allowed-role.json
@@ -83,6 +83,7 @@
     ["#pass-img-valid-role-title"],
     ["#pass-img-valid-role-aria-labelledby"],
     ["#pass-img-valid-role-radio"],
+    ["#pass-img-valid-role-math"],
     ["#pass-img-valid-role-meter"],
     ["#pass-imgmap-1"],
     ["#pass-imgmap-2"],


### PR DESCRIPTION
img element can have 'math' as its role

Closes: #4657 
