### PR TITLE
chore: don't upgrade glob@11 due to node 18 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,9 @@ updates:
       # @see https://github.com/dequelabs/axe-core/issues/4428
       - dependency-name: 'colorjs.io'
         versions: ['>0.4.3']
+      # Still need to support node 18
+      - dependency-name: 'glob'
+        versions: ['>11.0.0']
     groups:
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,7 @@ updates:
         versions: ['>0.4.3']
       # Still need to support node 18
       - dependency-name: 'glob'
-        versions: ['>11.0.0']
+        versions: ['>=11.0.0']
     groups:
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:


### PR DESCRIPTION
Prevent dependabot upgrade to glob@11 as it drops support for node 18, which we still support in our tests. 

Ref: https://github.com/dequelabs/axe-core/pull/4549