### PR TITLE
add clarification about the applied license.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,11 @@
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not distributed with this file, You can obtain one
+at http://mozilla.org/MPL/2.0/.
+
+
+The full text of the license follows:
+
 Mozilla Public License, version 2.0
 
 1. Definitions


### PR DESCRIPTION
<< Describe the changes >>

Closes: #4680 by adding the required text by MPL 2.0 (Annex A) clarifying that the license is vanilla MPL 2.0
