### PR TITLE
test(link-in-text-block): fix firefox nightly update to link color

### DIFF
--- a/test/checks/color/link-in-text-block.js
+++ b/test/checks/color/link-in-text-block.js
@@ -286,7 +286,7 @@ describe('link-in-text-block', () => {
     it('should return the proper values stored in data (fgContrast)', () => {
       fixture.innerHTML =
         '<div> <span style="display:block; color: #100" id="parent">' +
-        ' <p style="display:inline"><a href="" id="link">' +
+        ' <p style="display:inline"><a href="" id="link" style="color: #00e">' +
         '    link text ' +
         ' </a> inside block </p> inside block' +
         '</span> outside block </div>';


### PR DESCRIPTION
Axe-core nightly tests seem to be failing because Firefox nightly changed their link color.  It use to be `rgb(0,0,238)` but now is `rgb(0,102,204)`. This is causing one of our link-in-text block tests to fail as the link is now passing color contrast ratio with 3.68 (instead of failing with 2.18) https://app.circleci.com/pipelines/github/dequelabs/axe-core/6974/workflows/ba733cb4-6dc9-4a15-8002-660c46e6cf55/jobs/75535

This hard codes the expected foreground color on the link as the test is expecting a specific value for the data.