### PR TITLE
test(preload): fix link to gutenberg css

### DIFF
--- a/test/integration/full/preload/preload.js
+++ b/test/integration/full/preload/preload.js
@@ -2,7 +2,7 @@ describe('axe.utils.preload integration test', () => {
   const styleSheets = {
     crossOriginLinkHref: {
       id: 'crossOriginLinkHref',
-      href: 'https://unpkg.com/gutenberg-css@0.4'
+      href: 'https://unpkg.com/gutenberg-css@0.4.0/dist/gutenberg.css'
     },
     crossOriginDoesNotExist: {
       id: 'styleTag',
@@ -33,7 +33,7 @@ describe('axe.utils.preload integration test', () => {
 
   function detachStylesheets(done) {
     if (!stylesForPage) {
-      done();
+      return done();
     }
     axe.testUtils
       .removeStyleSheets(stylesForPage)


### PR DESCRIPTION
Seems the unpkg link `https://unpkg.com/gutenberg-css@0.4` now redirects to a `.scss` file rather than a css file, which caused the link to fail to load the resource. Updated the link to hardcode the css file path.

Also added a `return` to the `done` call as it would call done on failure, but then continue to try to remove the stylesheet that didn't exist.