### PR TITLE
chore: refactor away from looking at role attribute

### DIFF
--- a/lib/checks/aria/aria-errormessage-evaluate.js
+++ b/lib/checks/aria/aria-errormessage-evaluate.js
@@ -1,7 +1,7 @@
 import standards from '../../standards';
-import { idrefs } from '../../commons/dom';
+import { idrefs, isVisibleToScreenReaders } from '../../commons/dom';
 import { tokenList } from '../../core/utils';
-import { isVisibleToScreenReaders } from '../../commons/dom';
+import { getExplicitRole } from '../../commons/aria';
 /**
  * Check if `aria-errormessage` references an element that also uses a technique to announce the message (aria-live, aria-describedby, etc.).
  *
@@ -63,7 +63,7 @@ export default function ariaErrormessageEvaluate(node, options, virtualNode) {
         return false;
       }
       return (
-        idref.getAttribute('role') === 'alert' ||
+        getExplicitRole(idref) === 'alert' ||
         idref.getAttribute('aria-live') === 'assertive' ||
         idref.getAttribute('aria-live') === 'polite' ||
         tokenList(virtualNode.attr('aria-describedby')).indexOf(attr) > -1

--- a/lib/checks/aria/has-widget-role-evaluate.js
+++ b/lib/checks/aria/has-widget-role-evaluate.js
@@ -1,4 +1,4 @@
-import { getRoleType } from '../../commons/aria';
+import { getRoleType, getExplicitRole } from '../../commons/aria';
 
 /**
  * Check if an elements `role` attribute uses any widget or composite role values.
@@ -8,8 +8,8 @@ import { getRoleType } from '../../commons/aria';
  * @memberof checks
  * @return {Boolean} True if the element uses a `widget` or `composite` role. False otherwise.
  */
-function hasWidgetRoleEvaluate(node) {
-  const role = node.getAttribute('role');
+function hasWidgetRoleEvaluate(node, options, virtualNode) {
+  const role = getExplicitRole(virtualNode);
   if (role === null) {
     return false;
   }

--- a/lib/checks/keyboard/landmark-is-top-level-evaluate.js
+++ b/lib/checks/keyboard/landmark-is-top-level-evaluate.js
@@ -1,4 +1,4 @@
-import { getRole, implicitRole } from '../../commons/aria';
+import { getRole, implicitRole, getExplicitRole } from '../../commons/aria';
 import { getAriaRolesByType } from '../../commons/standards';
 import { getComposedParent } from '../../commons/dom';
 
@@ -10,7 +10,7 @@ function landmarkIsTopLevelEvaluate(node) {
   this.data({ role: nodeRole });
 
   while (parent) {
-    let role = parent.getAttribute('role');
+    let role = getExplicitRole(parent);
     if (!role && parent.nodeName.toUpperCase() !== 'FORM') {
       role = implicitRole(parent);
     }

--- a/lib/checks/tables/th-has-data-cells-evaluate.js
+++ b/lib/checks/tables/th-has-data-cells-evaluate.js
@@ -1,5 +1,6 @@
 import * as tableUtils from '../../commons/table';
 import { sanitize } from '../../commons/text';
+import { getExplicitRole } from '../../commons/aria';
 
 function thHasDataCellsEvaluate(node) {
   const cells = tableUtils.getAllCells(node);
@@ -26,7 +27,7 @@ function thHasDataCellsEvaluate(node) {
     }
     return (
       cell.nodeName.toUpperCase() === 'TH' ||
-      ['rowheader', 'columnheader'].indexOf(cell.getAttribute('role')) !== -1
+      ['rowheader', 'columnheader'].indexOf(getExplicitRole(cell)) !== -1
     );
   });
 

--- a/lib/commons/table/get-scope.js
+++ b/lib/commons/table/get-scope.js
@@ -2,6 +2,7 @@ import toGrid from './to-grid';
 import getCellPosition from './get-cell-position';
 import findUp from '../dom/find-up';
 import { nodeLookup } from '../../core/utils';
+import getExplicitRole from '../aria/get-explicit-role';
 
 /**
  * Determine if a `HTMLTableCellElement` is a column header, if so get the scope of the header
@@ -15,7 +16,7 @@ export default function getScope(el) {
   const { vNode, domNode: cell } = nodeLookup(el);
 
   const scope = vNode.attr('scope');
-  const role = vNode.attr('role');
+  const role = getExplicitRole(vNode);
 
   if (!['td', 'th'].includes(vNode.props.nodeName)) {
     throw new TypeError('Expected TD or TH element');

--- a/lib/commons/table/is-data-cell.js
+++ b/lib/commons/table/is-data-cell.js
@@ -1,4 +1,4 @@
-import isValidRole from '../aria/is-valid-role';
+import getExplicitRole from '../aria/get-explicit-role';
 
 /**
  * Determine if a `HTMLTableCellElement` is a data cell
@@ -13,8 +13,8 @@ function isDataCell(cell) {
   if (!cell.children.length && !cell.textContent.trim()) {
     return false;
   }
-  const role = cell.getAttribute('role');
-  if (isValidRole(role)) {
+  const role = getExplicitRole(cell);
+  if (role) {
     return ['cell', 'gridcell'].includes(role);
   } else {
     return cell.nodeName.toUpperCase() === 'TD';

--- a/lib/commons/table/is-data-table.js
+++ b/lib/commons/table/is-data-table.js
@@ -1,4 +1,5 @@
 import getRoleType from '../aria/get-role-type';
+import getExplicitRole from '../aria/get-explicit-role';
 import isFocusable from '../dom/is-focusable';
 import findUp from '../dom/find-up';
 import getElementCoordinates from '../dom/get-element-coordinates';
@@ -14,7 +15,7 @@ import getViewportSize from '../dom/get-viewport-size';
  * @see http://asurkov.blogspot.co.uk/2011/10/data-vs-layout-table.html
  */
 function isDataTable(node) {
-  const role = (node.getAttribute('role') || '').toLowerCase();
+  const role = getExplicitRole(node);
 
   // The element is not focusable and has role=presentation
   if ((role === 'presentation' || role === 'none') && !isFocusable(node)) {
@@ -93,11 +94,7 @@ function isDataTable(node) {
       ) {
         return true;
       }
-      if (
-        ['columnheader', 'rowheader'].includes(
-          (cell.getAttribute('role') || '').toLowerCase()
-        )
-      ) {
+      if (['columnheader', 'rowheader'].includes(getExplicitRole(cell))) {
         return true;
       }
       // abbr element as a single child element of table cell

--- a/lib/rules/autocomplete-matches.js
+++ b/lib/rules/autocomplete-matches.js
@@ -2,6 +2,7 @@ import { sanitize } from '../commons/text';
 import standards from '../standards';
 import { isVisibleToScreenReaders, isVisibleOnScreen } from '../commons/dom';
 import { parseTabindex } from '../core/utils';
+import { getExplicitRole } from '../commons/aria';
 
 function autocompleteMatches(node, virtualNode) {
   const autocomplete = virtualNode.attr('autocomplete');
@@ -43,9 +44,10 @@ function autocompleteMatches(node, virtualNode) {
 
   // The element has `tabindex="-1"` and has a [[semantic role]] that is
   //   not a [widget](https://www.w3.org/TR/wai-aria-1.1/#widget_roles)
-  const role = virtualNode.attr('role');
+  const role = getExplicitRole(virtualNode);
+  console.log({ role });
   const tabIndex = parseTabindex(virtualNode.attr('tabindex'));
-  if (tabIndex < 0 && role) {
+  if (tabIndex < 0 && virtualNode.hasAttr('role')) {
     const roleDef = standards.ariaRoles[role];
     if (roleDef === undefined || roleDef.type !== 'widget') {
       return false;

--- a/lib/rules/link-in-text-block-matches.js
+++ b/lib/rules/link-in-text-block-matches.js
@@ -1,9 +1,10 @@
 import { sanitize } from '../commons/text';
 import { isVisibleOnScreen, isInTextBlock } from '../commons/dom';
+import { getExplicitRole } from '../commons/aria';
 
 function linkInTextBlockMatches(node) {
   const text = sanitize(node.innerText);
-  const role = node.getAttribute('role');
+  const role = getExplicitRole(node);
 
   if (role && role !== 'link') {
     return false;

--- a/test/checks/aria/has-widget-role.js
+++ b/test/checks/aria/has-widget-role.js
@@ -1,572 +1,573 @@
-describe('has-widget-role', function () {
-  'use strict';
+describe('has-widget-role', () => {
+  const queryFixture = axe.testUtils.queryFixture;
+  const checkContext = axe.testUtils.MockCheckContext();
 
-  var fixture = document.getElementById('fixture');
-  var node;
-  var checkContext = axe.testUtils.MockCheckContext();
-
-  afterEach(function () {
-    node.innerHTML = '';
+  afterEach(() => {
     checkContext._data = null;
   });
 
-  it('should return false for elements with no role', function () {
-    node = document.createElement('div');
-    fixture.appendChild(node);
+  it('should return false for elements with no role', () => {
+    const vNode = queryFixture('<div id="target"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for elements with nonsensical roles', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'buttonbuttonbutton');
-    fixture.appendChild(node);
+  it('should return false for elements with nonsensical roles', () => {
+    const vNode = queryFixture(
+      '<div id="target" role="buttonbuttonbutton"></div>'
+    );
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
   // Widget roles
-  it('should return true for role=button', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'button');
-    fixture.appendChild(node);
+  it('should return true for role=button', () => {
+    const vNode = queryFixture('<div id="target" role="button"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=checkbox', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'checkbox');
-    fixture.appendChild(node);
+  it('should return true for role=checkbox', () => {
+    const vNode = queryFixture('<div id="target" role="checkbox"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=gridcell', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'gridcell');
-    fixture.appendChild(node);
+  it('should return true for role=gridcell', () => {
+    const vNode = queryFixture('<div id="target" role="gridcell"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=link', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'link');
-    fixture.appendChild(node);
+  it('should return true for role=link', () => {
+    const vNode = queryFixture('<div id="target" role="link"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=menuitem', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'menuitem');
-    fixture.appendChild(node);
+  it('should return true for role=menuitem', () => {
+    const vNode = queryFixture('<div id="target" role="menuitem"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=menuitemcheckbox', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'menuitemcheckbox');
-    fixture.appendChild(node);
+  it('should return true for role=menuitemcheckbox', () => {
+    const vNode = queryFixture(
+      '<div id="target" role="menuitemcheckbox"></div>'
+    );
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=menuitemradio', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'menuitemradio');
-    fixture.appendChild(node);
+  it('should return true for role=menuitemradio', () => {
+    const vNode = queryFixture('<div id="target" role="menuitemradio"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=option', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'option');
-    fixture.appendChild(node);
+  it('should return true for role=option', () => {
+    const vNode = queryFixture('<div id="target" role="option"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=progressbar', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'progressbar');
-    fixture.appendChild(node);
+  it('should return true for role=progressbar', () => {
+    const vNode = queryFixture('<div id="target" role="progressbar"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=radio', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'radio');
-    fixture.appendChild(node);
+  it('should return true for role=radio', () => {
+    const vNode = queryFixture('<div id="target" role="radio"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=scrollbar', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'scrollbar');
-    fixture.appendChild(node);
+  it('should return true for role=scrollbar', () => {
+    const vNode = queryFixture('<div id="target" role="scrollbar"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=searchbox', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'searchbox');
-    fixture.appendChild(node);
+  it('should return true for role=searchbox', () => {
+    const vNode = queryFixture('<div id="target" role="searchbox"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=slider', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'slider');
-    fixture.appendChild(node);
+  it('should return true for role=slider', () => {
+    const vNode = queryFixture('<div id="target" role="slider"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=spinbutton', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'spinbutton');
-    fixture.appendChild(node);
+  it('should return true for role=spinbutton', () => {
+    const vNode = queryFixture('<div id="target" role="spinbutton"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=switch', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'switch');
-    fixture.appendChild(node);
+  it('should return true for role=switch', () => {
+    const vNode = queryFixture('<div id="target" role="switch"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=tab', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'tab');
-    fixture.appendChild(node);
+  it('should return true for role=tab', () => {
+    const vNode = queryFixture('<div id="target" role="tab"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=textbox', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'textbox');
-    fixture.appendChild(node);
+  it('should return true for role=textbox', () => {
+    const vNode = queryFixture('<div id="target" role="textbox"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=treeitem', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'treeitem');
-    fixture.appendChild(node);
+  it('should return true for role=treeitem', () => {
+    const vNode = queryFixture('<div id="target" role="treeitem"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
   // Composite widget roles
-  it('should return true for role=combobox', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'combobox');
-    fixture.appendChild(node);
+  it('should return true for role=combobox', () => {
+    const vNode = queryFixture('<div id="target" role="combobox"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=grid', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'grid');
-    fixture.appendChild(node);
+  it('should return true for role=grid', () => {
+    const vNode = queryFixture('<div id="target" role="grid"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=listbox', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'listbox');
-    fixture.appendChild(node);
+  it('should return true for role=listbox', () => {
+    const vNode = queryFixture('<div id="target" role="listbox"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=menu', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'menu');
-    fixture.appendChild(node);
+  it('should return true for role=menu', () => {
+    const vNode = queryFixture('<div id="target" role="menu"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=menubar', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'menubar');
-    fixture.appendChild(node);
+  it('should return true for role=menubar', () => {
+    const vNode = queryFixture('<div id="target" role="menubar"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=radiogroup', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'radiogroup');
-    fixture.appendChild(node);
+  it('should return true for role=radiogroup', () => {
+    const vNode = queryFixture('<div id="target" role="radiogroup"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=tablist', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'tablist');
-    fixture.appendChild(node);
+  it('should return true for role=tablist', () => {
+    const vNode = queryFixture('<div id="target" role="tablist"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=tree', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'tree');
-    fixture.appendChild(node);
+  it('should return true for role=tree', () => {
+    const vNode = queryFixture('<div id="target" role="tree"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return true for role=treegrid', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'treegrid');
-    fixture.appendChild(node);
+  it('should return true for role=treegrid', () => {
+    const vNode = queryFixture('<div id="target" role="treegrid"></div>');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=application', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'application');
-    fixture.appendChild(node);
+  it('should return false for role=application', () => {
+    const vNode = queryFixture('<div id="target" role="application"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=article', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'article');
-    fixture.appendChild(node);
+  it('should return false for role=article', () => {
+    const vNode = queryFixture('<div id="target" role="article"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=cell', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'cell');
-    fixture.appendChild(node);
+  it('should return false for role=cell', () => {
+    const vNode = queryFixture('<div id="target" role="cell"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=columnheader', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'columnheader');
-    fixture.appendChild(node);
+  it('should return false for role=columnheader', () => {
+    const vNode = queryFixture('<div id="target" role="columnheader"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=definition', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'definition');
-    fixture.appendChild(node);
+  it('should return false for role=definition', () => {
+    const vNode = queryFixture('<div id="target" role="definition"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=directory', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'directory');
-    fixture.appendChild(node);
+  it('should return false for role=directory', () => {
+    const vNode = queryFixture('<div id="target" role="directory"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=document', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'document');
-    fixture.appendChild(node);
+  it('should return false for role=document', () => {
+    const vNode = queryFixture('<div id="target" role="document"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=feed', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'feed');
-    fixture.appendChild(node);
+  it('should return false for role=feed', () => {
+    const vNode = queryFixture('<div id="target" role="feed"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=figure', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'figure');
-    fixture.appendChild(node);
+  it('should return false for role=figure', () => {
+    const vNode = queryFixture('<div id="target" role="figure"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=group', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'group');
-    fixture.appendChild(node);
+  it('should return false for role=group', () => {
+    const vNode = queryFixture('<div id="target" role="group"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=heading', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'heading');
-    fixture.appendChild(node);
+  it('should return false for role=heading', () => {
+    const vNode = queryFixture('<div id="target" role="heading"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=img', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'img');
-    fixture.appendChild(node);
+  it('should return false for role=img', () => {
+    const vNode = queryFixture('<div id="target" role="img"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=list', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'list');
-    fixture.appendChild(node);
+  it('should return false for role=list', () => {
+    const vNode = queryFixture('<div id="target" role="list"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=listitem', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'listitem');
-    fixture.appendChild(node);
+  it('should return false for role=listitem', () => {
+    const vNode = queryFixture('<div id="target" role="listitem"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=math', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'math');
-    fixture.appendChild(node);
+  it('should return false for role=math', () => {
+    const vNode = queryFixture('<div id="target" role="math"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=none', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'none');
-    fixture.appendChild(node);
+  it('should return false for role=none', () => {
+    const vNode = queryFixture('<div id="target" role="none"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=note', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'note');
-    fixture.appendChild(node);
+  it('should return false for role=note', () => {
+    const vNode = queryFixture('<div id="target" role="note"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=presentation', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'presentation');
-    fixture.appendChild(node);
+  it('should return false for role=presentation', () => {
+    const vNode = queryFixture('<div id="target" role="presentation"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=row', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'row');
-    fixture.appendChild(node);
+  it('should return false for role=row', () => {
+    const vNode = queryFixture('<div id="target" role="row"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=rowgroup', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'rowgroup');
-    fixture.appendChild(node);
+  it('should return false for role=rowgroup', () => {
+    const vNode = queryFixture('<div id="target" role="rowgroup"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=rowheader', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'rowheader');
-    fixture.appendChild(node);
+  it('should return false for role=rowheader', () => {
+    const vNode = queryFixture('<div id="target" role="rowheader"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=table', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'table');
-    fixture.appendChild(node);
+  it('should return false for role=table', () => {
+    const vNode = queryFixture('<div id="target" role="table"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=tabpanel', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'tabpanel');
-    fixture.appendChild(node);
+  it('should return false for role=tabpanel', () => {
+    const vNode = queryFixture('<div id="target" role="tabpanel"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=term', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'term');
-    fixture.appendChild(node);
+  it('should return false for role=term', () => {
+    const vNode = queryFixture('<div id="target" role="term"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=toolbar', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'toolbar');
-    fixture.appendChild(node);
+  it('should return false for role=toolbar', () => {
+    const vNode = queryFixture('<div id="target" role="toolbar"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
   // Landmark Roles
-  it('should return false for role=banner', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'banner');
-    fixture.appendChild(node);
+  it('should return false for role=banner', () => {
+    const vNode = queryFixture('<div id="target" role="banner"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=complementary', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'complementary');
-    fixture.appendChild(node);
+  it('should return false for role=complementary', () => {
+    const vNode = queryFixture('<div id="target" role="complementary"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=contentinfo', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'contentinfo');
-    fixture.appendChild(node);
+  it('should return false for role=contentinfo', () => {
+    const vNode = queryFixture('<div id="target" role="contentinfo"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=form', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'form');
-    fixture.appendChild(node);
+  it('should return false for role=form', () => {
+    const vNode = queryFixture('<div id="target" role="form"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=main', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'main');
-    fixture.appendChild(node);
+  it('should return false for role=main', () => {
+    const vNode = queryFixture('<div id="target" role="main"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=navigation', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'navigation');
-    fixture.appendChild(node);
+  it('should return false for role=navigation', () => {
+    const vNode = queryFixture('<div id="target" role="navigation"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=region', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'region');
-    fixture.appendChild(node);
+  it('should return false for role=region', () => {
+    const vNode = queryFixture('<div id="target" role="region"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 
-  it('should return false for role=search', function () {
-    node = document.createElement('div');
-    node.setAttribute('role', 'search');
-    fixture.appendChild(node);
+  it('should return false for role=search', () => {
+    const vNode = queryFixture('<div id="target" role="search"></div>');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('has-widget-role').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('has-widget-role')
+        .call(checkContext, null, null, vNode)
     );
   });
 });

--- a/test/checks/keyboard/landmark-is-top-level.js
+++ b/test/checks/keyboard/landmark-is-top-level.js
@@ -1,18 +1,16 @@
-describe('landmark-is-top-level', function () {
-  'use strict';
+describe('landmark-is-top-level', () => {
+  const shadowSupported = axe.testUtils.shadowSupport.v1;
+  const checkSetup = axe.testUtils.checkSetup;
+  const shadowCheckSetup = axe.testUtils.shadowCheckSetup;
+  const check = checks['landmark-is-top-level'];
+  const checkContext = new axe.testUtils.MockCheckContext();
 
-  var shadowSupported = axe.testUtils.shadowSupport.v1;
-  var checkSetup = axe.testUtils.checkSetup;
-  var shadowCheckSetup = axe.testUtils.shadowCheckSetup;
-  var check = checks['landmark-is-top-level'];
-  var checkContext = new axe.testUtils.MockCheckContext();
-
-  afterEach(function () {
+  afterEach(() => {
     checkContext.reset();
   });
 
-  it('should return false if the main landmark is in another landmark', function () {
-    var params = checkSetup(
+  it('should return false if the main landmark is in another landmark', () => {
+    const params = checkSetup(
       '<div role="banner"><main id="target"></main></div>'
     );
     // landmark-is-top-level requires a complete tree to work properly
@@ -21,8 +19,8 @@ describe('landmark-is-top-level', function () {
     assert.deepEqual(checkContext._data, { role: 'main' });
   });
 
-  it('should return false if the complementary landmark is in another landmark', function () {
-    var params = checkSetup(
+  it('should return false if the complementary landmark is in another landmark', () => {
+    const params = checkSetup(
       '<nav><div role="complementary" id="target"></div></nav>'
     );
     axe.utils.getFlattenedTree(document.documentElement);
@@ -30,8 +28,8 @@ describe('landmark-is-top-level', function () {
     assert.deepEqual(checkContext._data, { role: 'complementary' });
   });
 
-  it('should return true if the complementary landmark is in main landmark', function () {
-    var params = checkSetup(
+  it('should return true if the complementary landmark is in main landmark', () => {
+    const params = checkSetup(
       '<main><div role="complementary" id="target"></div></main>'
     );
     axe.utils.getFlattenedTree(document.documentElement);
@@ -39,8 +37,8 @@ describe('landmark-is-top-level', function () {
     assert.deepEqual(checkContext._data, { role: 'complementary' });
   });
 
-  it('should return false if div with role set to main is in another landmark', function () {
-    var params = checkSetup(
+  it('should return false if div with role set to main is in another landmark', () => {
+    const params = checkSetup(
       '<div role="navigation"><div role="main" id="target"></div></div>'
     );
     axe.utils.getFlattenedTree(document.documentElement);
@@ -48,8 +46,8 @@ describe('landmark-is-top-level', function () {
     assert.deepEqual(checkContext._data, { role: 'main' });
   });
 
-  it('should return true if the landmark is not in another landmark', function () {
-    var params = checkSetup(
+  it('should return true if the landmark is not in another landmark', () => {
+    const params = checkSetup(
       '<div><footer id="target"></footer><div role="banner"></div></div>'
     );
     axe.utils.getFlattenedTree(document.documentElement);
@@ -57,8 +55,8 @@ describe('landmark-is-top-level', function () {
     assert.deepEqual(checkContext._data, { role: 'contentinfo' });
   });
 
-  it('should return true if div with role set to main is not in another landmark', function () {
-    var params = checkSetup(
+  it('should return true if div with role set to main is not in another landmark', () => {
+    const params = checkSetup(
       '<div><div role="main" id="target"></div><div role="navigation"></div></div>'
     );
     axe.utils.getFlattenedTree(document.documentElement);
@@ -66,8 +64,8 @@ describe('landmark-is-top-level', function () {
     assert.deepEqual(checkContext._data, { role: 'main' });
   });
 
-  it('should return true if the banner landmark is not in form landmark', function () {
-    var params = checkSetup(
+  it('should return true if the banner landmark is not in form landmark', () => {
+    const params = checkSetup(
       '<div><div role="banner" id="target"></div><div role="form"></div></div>'
     );
     axe.utils.getFlattenedTree(document.documentElement);
@@ -77,8 +75,8 @@ describe('landmark-is-top-level', function () {
 
   (shadowSupported ? it : xit)(
     'should test if the landmark in shadow DOM is top level',
-    function () {
-      var params = shadowCheckSetup(
+    () => {
+      const params = shadowCheckSetup(
         '<div></div>',
         '<main id="target">Main content</main>'
       );

--- a/test/checks/tables/th-has-data-cells.js
+++ b/test/checks/tables/th-has-data-cells.js
@@ -1,16 +1,13 @@
-describe('th-has-data-cells', function () {
-  'use strict';
+describe('th-has-data-cells', () => {
+  const fixture = document.getElementById('fixture');
+  const shadowSupport = axe.testUtils.shadowSupport.v1;
+  const checkContext = axe.testUtils.MockCheckContext();
 
-  var fixture = document.getElementById('fixture');
-  var shadowSupport = axe.testUtils.shadowSupport.v1;
-  var checkContext = axe.testUtils.MockCheckContext();
-
-  afterEach(function () {
-    fixture.innerHTML = '';
+  afterEach(() => {
     checkContext.reset();
   });
 
-  it('should return true each row header has a non-empty cell', function () {
+  it('should return true each row header has a non-empty cell', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <th>hi</th> <td>hello</td> </tr>' +
@@ -18,7 +15,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -26,7 +23,7 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return true each non-empty column header has a cell', function () {
+  it('should return true each non-empty column header has a cell', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <th>H</th> <th>H</th> </tr>' +
@@ -34,7 +31,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -42,7 +39,7 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return true if referred to with headers attr', function () {
+  it('should return true if referred to with headers attr', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <td headers="a">hi</td> <td headers="b">hello</td></tr>' +
@@ -50,7 +47,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -58,7 +55,7 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return true if referred to with aria-labelledby', function () {
+  it('should return true if referred to with aria-labelledby', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <td aria-labelledby="a">hi</td> <td aria-labelledby="b">hello</td></tr>' +
@@ -66,7 +63,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -74,14 +71,14 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return true if the th element is empty', function () {
+  it('should return true if the th element is empty', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <th></th> <th></th> </tr>' +
       '  <tr> <th></th> <th></th> </tr>' +
       '</table>';
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -89,7 +86,7 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return true when the td has a content element', function () {
+  it('should return true when the td has a content element', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <th>hi</th> <td><input type="text"></td> </tr>' +
@@ -102,7 +99,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -110,7 +107,7 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return undefined if a th has no data cells', function () {
+  it('should return undefined if a th has no data cells', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <th>hi</th> </tr>' +
@@ -118,7 +115,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -126,7 +123,7 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return true if all data cells are empty', function () {
+  it('should return true if all data cells are empty', () => {
     fixture.innerHTML =
       '<table>' +
       '  <tr> <th>hi</th> <td></td> </tr>' +
@@ -134,7 +131,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -142,14 +139,14 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return undefined if a td with role=columnheader is used that has no data cells', function () {
+  it('should return undefined if a td with role=columnheader is used that has no data cells', () => {
     fixture.innerHTML =
       '<table id="fail4">' +
       '  <tr> <td>axe</td> <td role="columnheader">AXE</th> </tr>' +
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -157,7 +154,7 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  it('should return undefined if table cell points to a different header', function () {
+  it('should return undefined if table cell points to a different header', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr>' +
@@ -171,7 +168,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')
@@ -179,9 +176,9 @@ describe('th-has-data-cells', function () {
     );
   });
 
-  (shadowSupport ? it : xit)('recognizes shadow tree content', function () {
+  (shadowSupport ? it : xit)('recognizes shadow tree content', () => {
     fixture.innerHTML = '<div id="shadow"> <b>data</b> </div>';
-    var shadow = fixture
+    const shadow = fixture
       .querySelector('#shadow')
       .attachShadow({ mode: 'open' });
     shadow.innerHTML =
@@ -191,7 +188,7 @@ describe('th-has-data-cells', function () {
       '</table>';
 
     axe.testUtils.flatTreeSetup(fixture);
-    var node = axe.utils.querySelectorAll(axe._tree, 'table')[0].actualNode;
+    const node = axe.utils.querySelectorAll(axe._tree, 'table')[0].actualNode;
     assert.isTrue(
       axe.testUtils
         .getCheckEvaluate('th-has-data-cells')

--- a/test/commons/aria/get-explicit-role.js
+++ b/test/commons/aria/get-explicit-role.js
@@ -1,141 +1,140 @@
-describe('aria.getExplicitRole', function () {
-  'use strict';
-  var aria = axe.commons.aria;
-  var roleDefinitions = aria.lookupTable.role;
-  var flatTreeSetup = axe.testUtils.flatTreeSetup;
+describe('aria.getExplicitRole', () => {
+  const aria = axe.commons.aria;
+  const roleDefinitions = aria.lookupTable.role;
+  const flatTreeSetup = axe.testUtils.flatTreeSetup;
 
-  it('returns valid roles', function () {
-    var node = document.createElement('div');
+  it('returns valid roles', () => {
+    const node = document.createElement('div');
     node.setAttribute('role', 'button');
-    var vNode = flatTreeSetup(node)[0];
+    const vNode = flatTreeSetup(node)[0];
     assert.equal(aria.getExplicitRole(vNode), 'button');
   });
 
-  it('handles case sensitivity', function () {
-    var node = document.createElement('div');
+  it('handles case sensitivity', () => {
+    const node = document.createElement('div');
     node.setAttribute('role', 'BUTTON');
-    var vNode = flatTreeSetup(node)[0];
+    const vNode = flatTreeSetup(node)[0];
     assert.equal(aria.getExplicitRole(vNode), 'button');
   });
 
-  it('handles whitespacing', function () {
-    var node = document.createElement('div');
+  it('handles whitespacing', () => {
+    const node = document.createElement('div');
     node.setAttribute('role', ' button  ');
-    var vNode = flatTreeSetup(node)[0];
+    const vNode = flatTreeSetup(node)[0];
     assert.equal(aria.getExplicitRole(vNode), 'button');
   });
 
-  it('returns null when there is no role', function () {
-    var node = document.createElement('div');
-    var vNode = flatTreeSetup(node)[0];
+  it('returns null when there is no role', () => {
+    const node = document.createElement('div');
+    const vNode = flatTreeSetup(node)[0];
     assert.isNull(aria.getExplicitRole(vNode));
   });
 
-  it('returns the explicit role if it is valid and non-abstract', function () {
-    var node = document.createElement('li');
+  it('returns the explicit role if it is valid and non-abstract', () => {
+    const node = document.createElement('li');
     node.setAttribute('role', 'menuitem');
-    var vNode = flatTreeSetup(node)[0];
+    const vNode = flatTreeSetup(node)[0];
     assert.equal(aria.getExplicitRole(vNode), 'menuitem');
   });
 
-  it('ignores fallback roles by default', function () {
-    var node = document.createElement('div');
+  it('ignores fallback roles by default', () => {
+    const node = document.createElement('div');
     node.setAttribute('role', 'spinbutton button');
-    var vNode = flatTreeSetup(node)[0];
+    const vNode = flatTreeSetup(node)[0];
     assert.isNull(aria.getExplicitRole(vNode));
   });
 
-  it('returns null if the node is not an element', function () {
-    var node = document.createTextNode('foo bar baz');
-    var vNode = flatTreeSetup(node)[0];
+  it('returns null if the node is not an element', () => {
+    const node = document.createTextNode('foo bar baz');
+    const vNode = flatTreeSetup(node)[0];
     assert.isNull(aria.getExplicitRole(vNode));
   });
 
-  describe('abstracts', function () {
-    it('ignores abstract roles by default', function () {
-      var node = document.createElement('li');
+  describe('abstracts', () => {
+    it('ignores abstract roles by default', () => {
+      const node = document.createElement('li');
       node.setAttribute('role', 'section');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(roleDefinitions.section.type, 'abstract');
       assert.isNull(aria.getExplicitRole(vNode));
     });
 
-    it('returns abstract roles with `abstracts: true`', function () {
-      var node = document.createElement('li');
+    it('returns abstract roles with `abstracts: true`', () => {
+      const node = document.createElement('li');
       node.setAttribute('role', 'section');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(roleDefinitions.section.type, 'abstract');
       assert.equal(aria.getExplicitRole(vNode, { abstracts: true }), 'section');
     });
 
-    it('does not returns abstract roles with `abstracts: false`', function () {
-      var node = document.createElement('li');
+    it('does not returns abstract roles with `abstracts: false`', () => {
+      const node = document.createElement('li');
       node.setAttribute('role', 'section');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(roleDefinitions.section.type, 'abstract');
       assert.isNull(aria.getExplicitRole(vNode, { abstracts: false }));
     });
   });
 
-  describe('dpub', function () {
-    it('ignores DPUB roles by default', function () {
-      var node = document.createElement('section');
+  describe('dpub', () => {
+    it('ignores DPUB roles by default', () => {
+      const node = document.createElement('section');
       node.setAttribute('role', 'doc-chapter');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.isNull(aria.getExplicitRole(vNode));
     });
 
-    it('returns DPUB roles with `dpub: true`', function () {
-      var node = document.createElement('section');
+    it('returns DPUB roles with `dpub: true`', () => {
+      const node = document.createElement('section');
       node.setAttribute('role', 'doc-chapter');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(aria.getExplicitRole(vNode, { dpub: true }), 'doc-chapter');
     });
 
-    it('does not returns DPUB roles with `dpub: false`', function () {
-      var node = document.createElement('section');
+    it('does not returns DPUB roles with `dpub: false`', () => {
+      const node = document.createElement('section');
       node.setAttribute('role', 'doc-chapter');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.isNull(aria.getExplicitRole(vNode, { dpub: false }));
     });
   });
 
-  describe('fallback', function () {
-    it('returns the first valid item in the list', function () {
-      var node = document.createElement('div');
+  describe('fallback', () => {
+    it('returns the first valid item in the list', () => {
+      const node = document.createElement('div');
       node.setAttribute('role', 'link button');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(aria.getExplicitRole(vNode, { fallback: true }), 'link');
     });
 
-    it('skips over invalid roles', function () {
-      var node = document.createElement('div');
+    it('skips over invalid roles', () => {
+      const node = document.createElement('div');
       node.setAttribute('role', 'foobar button');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(aria.getExplicitRole(vNode, { fallback: true }), 'button');
     });
 
-    it('returns the null if all roles are invalid and there is no implicit role', function () {
-      var node = document.createElement('div');
+    it('returns the null if all roles are invalid and there is no implicit role', () => {
+      const node = document.createElement('div');
       node.setAttribute('role', 'foo bar baz');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.isNull(aria.getExplicitRole(vNode, { fallback: true }));
     });
 
-    it('respect the `abstracts` option', function () {
-      var node = document.createElement('li');
+    it('respect the `abstracts` option', () => {
+      const node = document.createElement('li');
       node.setAttribute('role', 'doc-chapter section');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(
         aria.getExplicitRole(vNode, { fallback: true, abstracts: true }),
         'section'
       );
     });
 
-    it('respect the `dpub` option', function () {
-      var node = document.createElement('li');
+    it('respect the `dpub` option', () => {
+      const node = document.createElement('li');
       node.setAttribute('role', 'doc-chapter section');
-      var vNode = flatTreeSetup(node)[0];
+      const vNode = flatTreeSetup(node)[0];
       assert.equal(
         aria.getExplicitRole(vNode, { fallback: true, dpub: true }),
         'doc-chapter'

--- a/test/commons/table/is-data-cell.js
+++ b/test/commons/table/is-data-cell.js
@@ -1,93 +1,92 @@
-describe('table.isDataCell', function () {
-  'use strict';
-  function $id(id) {
-    return document.getElementById(id);
-  }
+describe('table.isDataCell', () => {
+  const fixture = document.getElementById('fixture');
+  const flatTreeSetup = axe.testUtils.flatTreeSetup;
 
-  var fixture = $id('fixture');
-
-  afterEach(function () {
-    fixture.innerHTML = '';
-  });
-
-  it('should work with TH', function () {
+  it('should work with TH', () => {
     fixture.innerHTML =
       '<table>' + '<tr><th id="target">1</th></tr>' + '</table>';
+    flatTreeSetup(fixture);
 
-    var target = $id('target');
+    const target = document.getElementById('target');
 
     assert.isFalse(axe.commons.table.isDataCell(target));
   });
 
-  it('should work with TD', function () {
+  it('should work with TD', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td id="target">1</td></tr>' + '</table>';
+    flatTreeSetup(fixture);
 
-    var target = $id('target');
+    const target = document.getElementById('target');
 
     assert.isTrue(axe.commons.table.isDataCell(target));
   });
 
-  it('should work with empty TD', function () {
+  it('should work with empty TD', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td id="target"></td></tr>' + '</table>';
+    flatTreeSetup(fixture);
 
-    var target = $id('target');
+    const target = document.getElementById('target');
 
     assert.isFalse(axe.commons.table.isDataCell(target));
   });
 
-  it('should ignore TDs with a valid role other than (grid)cell', function () {
+  it('should ignore TDs with a valid role other than (grid)cell', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr><td id="target1" role="columnheader">heading</td></tr>' +
       '<tr><td id="target2" role="rowheader">heading</td></tr>' +
       '<tr><td id="target3" role="presentation">heading</td></tr>' +
       '</table>';
+    flatTreeSetup(fixture);
 
-    var target1 = $id('target1');
-    var target2 = $id('target2');
-    var target3 = $id('target3');
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
+    const target3 = document.getElementById('target3');
     assert.isFalse(axe.commons.table.isDataCell(target1));
     assert.isFalse(axe.commons.table.isDataCell(target2));
     assert.isFalse(axe.commons.table.isDataCell(target3));
   });
 
-  it('should return true for elements with role="(grid)cell"', function () {
+  it('should return true for elements with role="(grid)cell"', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr><th id="target1" role="cell">heading</th></tr>' +
       '<tr><th id="target2" role="gridcell">heading</th></tr>' +
       '</table>';
+    flatTreeSetup(fixture);
 
-    var target1 = $id('target1');
-    var target2 = $id('target2');
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
     assert.isTrue(axe.commons.table.isDataCell(target1));
     assert.isTrue(axe.commons.table.isDataCell(target2));
   });
 
-  it('should ignore invalid roles', function () {
+  it('should ignore invalid roles', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr><td id="target1" role="foobar">heading</td></tr>' +
       '<tr><th id="target2" role="foobar">heading</th></tr>' +
       '</table>';
+    flatTreeSetup(fixture);
 
-    var target1 = $id('target1');
-    var target2 = $id('target2');
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
     assert.isTrue(axe.commons.table.isDataCell(target1));
     assert.isFalse(axe.commons.table.isDataCell(target2));
   });
 
-  it('should ignore abstract roles', function () {
+  it('should ignore abstract roles', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr><td id="target1" role="section">heading</td></tr>' +
       '<tr><th id="target2" role="section">heading</th></tr>' +
       '</table>';
+    flatTreeSetup(fixture);
 
-    var target1 = $id('target1');
-    var target2 = $id('target2');
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
     assert.isTrue(axe.commons.table.isDataCell(target1));
     assert.isFalse(axe.commons.table.isDataCell(target2));
   });

--- a/test/commons/table/is-data-table.js
+++ b/test/commons/table/is-data-table.js
@@ -1,38 +1,31 @@
-describe('table.isDataTable', function () {
-  'use strict';
+describe('table.isDataTable', () => {
+  const fixture = document.getElementById('fixture');
 
-  var fixture = document.getElementById('fixture');
-
-  afterEach(function () {
-    fixture.innerHTML = '';
-    axe._tree = undefined;
-  });
-
-  it('should be false if the table has role=presentation', function () {
+  it('should be false if the table has role=presentation', () => {
     fixture.innerHTML =
       '<table role="presentation">' +
       '<thead><tr><th>1</th><th>2</th></tr></thead>' +
       '<tbody><tr><td>One</td><td>Two</td></tr></tbody>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if the table has role=none', function () {
+  it('should be false if the table has role=none', () => {
     fixture.innerHTML =
       '<table role="none">' +
       '<thead><tr><th>1</th><th>2</th></tr></thead>' +
       '<tbody><tr><td>One</td><td>Two</td></tr></tbody>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table is inside an editable area', function () {
+  it('should be true if the table is inside an editable area', () => {
     fixture.innerHTML =
       '<div contenteditable="true">' +
       '<table>' +
@@ -41,212 +34,212 @@ describe('table.isDataTable', function () {
       '</table>' +
       '</div>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a role of grid', function () {
+  it('should be true if the table has a role of grid', () => {
     fixture.innerHTML = '<table role="grid"></table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a role of treegrid', function () {
+  it('should be true if the table has a role of treegrid', () => {
     fixture.innerHTML = '<table role="treegrid"></table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the element has a role of table', function () {
+  it('should be true if the element has a role of table', () => {
     fixture.innerHTML = '<div role="table"></div>';
 
-    var node = fixture.querySelector('[role="table"]');
+    const node = fixture.querySelector('[role="table"]');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  describe('should be true if the table has a landmark role', function () {
-    it('application', function () {
+  describe('should be true if the table has a landmark role', () => {
+    it('application', () => {
       fixture.innerHTML = '<table role="application"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
-    it('banner', function () {
+    it('banner', () => {
       fixture.innerHTML = '<table role="banner"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
-    it('complementary', function () {
+    it('complementary', () => {
       fixture.innerHTML = '<table role="complementary"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
-    it('contentinfo', function () {
+    it('contentinfo', () => {
       fixture.innerHTML = '<table role="contentinfo"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
-    it('form', function () {
+    it('form', () => {
       fixture.innerHTML = '<table role="form"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
-    it('main', function () {
+    it('main', () => {
       fixture.innerHTML = '<table role="main"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
-    it('navigation', function () {
+    it('navigation', () => {
       fixture.innerHTML = '<table role="navigation"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
-    it('search', function () {
+    it('search', () => {
       fixture.innerHTML = '<table role="search"></table>';
 
-      var node = fixture.querySelector('table');
+      const node = fixture.querySelector('table');
       axe.testUtils.flatTreeSetup(fixture.firstChild);
       assert.isTrue(axe.commons.table.isDataTable(node));
     });
   });
 
-  it('should be false if the table has datatable=0', function () {
+  it('should be false if the table has datatable=0', () => {
     fixture.innerHTML =
       '<table datatable="0">' +
       '<thead><tr><th>1</th><th>2</th></tr></thead>' +
       '<tbody><tr><td>One</td><td>Two</td></tr></tbody>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a summary attribute', function () {
+  it('should be true if the table has a summary attribute', () => {
     fixture.innerHTML = '<table summary="Hello">' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a caption element', function () {
+  it('should be true if the table has a caption element', () => {
     fixture.innerHTML = '<table>' + '<caption>Hello</caption>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a col element', function () {
+  it('should be true if the table has a col element', () => {
     fixture.innerHTML = '<table>' + '<col>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a colgroup element', function () {
+  it('should be true if the table has a colgroup element', () => {
     fixture.innerHTML = '<table>' + '<colgroup></colgroup>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a thead element', function () {
+  it('should be true if the table has a thead element', () => {
     fixture.innerHTML = '<table>' + '<thead></thead>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a tfoot element', function () {
+  it('should be true if the table has a tfoot element', () => {
     fixture.innerHTML = '<table>' + '<tfoot></tfoot>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a th element', function () {
+  it('should be true if the table has a th element', () => {
     fixture.innerHTML = '<table>' + '<tr><th></th></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a rowheader', function () {
+  it('should be true if the table has a rowheader', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td role="rowheader"></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a columnheader', function () {
+  it('should be true if the table has a columnheader', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td role="columnheader"></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a cell with headers attribute', function () {
+  it('should be true if the table has a cell with headers attribute', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td headers="yes"></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a cell with scope attribute', function () {
+  it('should be true if the table has a cell with scope attribute', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td scope="col"></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a cell with abbr attribute', function () {
+  it('should be true if the table has a cell with abbr attribute', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td abbr="yes"></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if the table has a cell with an abbr element as a single child', function () {
+  it('should be true if the table has a cell with an abbr element as a single child', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td><div><abbr>ok</abbr></div></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    let node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
 
@@ -265,59 +258,59 @@ describe('table.isDataTable', function () {
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if it has a nested table', function () {
+  it('should be false if it has a nested table', () => {
     fixture.innerHTML =
       '<table id="out"><tr><td>' +
       '<table><tr><td></td></tr></table>' +
       '</td></tr></table>';
 
-    var node = fixture.querySelector('#out');
+    const node = fixture.querySelector('#out');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if it has only one column', function () {
+  it('should be false if it has only one column', () => {
     fixture.innerHTML =
       '<table>' + '<tr><td></td></tr>' + '<tr><td></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if it has only one row', function () {
+  it('should be false if it has only one row', () => {
     fixture.innerHTML = '<table>' + '<tr><td></td><td></td></tr>' + '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if it has 5 or more columns', function () {
+  it('should be true if it has 5 or more columns', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr><td></td><td></td><td></td><td></td><td></td></tr>' +
       '<tr><td></td><td></td><td></td><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if it has borders around cells', function () {
+  it('should be true if it has borders around cells', () => {
     fixture.innerHTML =
       '<table border="1">' +
       '<tr><td></td><td></td></tr>' +
       '<tr><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if it has zebra rows', function () {
+  it('should be true if it has zebra rows', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr><td></td><td></td></tr>' +
@@ -325,12 +318,12 @@ describe('table.isDataTable', function () {
       '<tr><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
 
-  it('should be true if it has zebra rows - background image', function () {
+  it('should be true if it has zebra rows - background image', () => {
     fixture.innerHTML =
       '<table>' +
       '<tr><td></td><td></td></tr>' +
@@ -341,98 +334,98 @@ describe('table.isDataTable', function () {
       '<tr><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
-  it('should be true if it has 20 or more rows', function () {
+  it('should be true if it has 20 or more rows', () => {
     fixture.innerHTML =
       '<table>' +
       new Array(21).join('<tr><td></td><td></td><td></td></tr>') +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });
-  it('should be false if its width is 95% of the document width', function () {
+  it('should be false if its width is 95% of the document width', () => {
     fixture.innerHTML =
       '<table style="width: 95.5%">' +
       new Array(3).join('<tr><td></td><td></td><td></td></tr>') +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if it has less than 10 cells', function () {
+  it('should be false if it has less than 10 cells', () => {
     fixture.innerHTML =
       '<table>' +
       new Array(4).join('<tr><td></td><td></td><td></td></tr>') +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if has an iframe element descendent', function () {
+  it('should be false if has an iframe element descendent', () => {
     fixture.innerHTML =
       '<table>' +
       new Array(4).join('<tr><td></td><td></td><td></td></tr>') +
       '<tr><td><iframe src="javascript: void 0;"></iframe></td><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if has an object element descendent', function () {
+  it('should be false if has an object element descendent', () => {
     fixture.innerHTML =
       '<table>' +
       new Array(4).join('<tr><td></td><td></td><td></td></tr>') +
       '<tr><td><object></object></td><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should be false if has an embed element descendent', function () {
+  it('should be false if has an embed element descendent', () => {
     fixture.innerHTML =
       '<table>' +
       new Array(4).join('<tr><td></td><td></td><td></td></tr>') +
       '<tr><td><embed></td><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
   // Causing sauce labs tests to fail & don't really care about applets
-  it.skip('should be false if has an applet element descendent', function () {
+  it.skip('should be false if has an applet element descendent', () => {
     fixture.innerHTML =
       '<table>' +
       new Array(4).join('<tr><td></td><td></td><td></td></tr>') +
       '<tr><td><applet></applet></td><td></td><td></td></tr>' +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isFalse(axe.commons.table.isDataTable(node));
   });
 
-  it('should otherwise be true', function () {
+  it('should otherwise be true', () => {
     fixture.innerHTML =
       '<table>' +
       new Array(4).join('<tr><td></td><td></td><td></td><td></td></tr>') +
       '</table>';
 
-    var node = fixture.querySelector('table');
+    const node = fixture.querySelector('table');
     axe.testUtils.flatTreeSetup(fixture.firstChild);
     assert.isTrue(axe.commons.table.isDataTable(node));
   });

--- a/test/rule-matches/link-in-text-block-matches.js
+++ b/test/rule-matches/link-in-text-block-matches.js
@@ -1,6 +1,4 @@
 describe('link-in-text-block-matches', () => {
-  'use strict';
-
   const { fixtureSetup } = axe.testUtils;
   const rule = axe.utils.getRule('link-in-text-block');
 


### PR DESCRIPTION
This work is in preparation to support fallback roles. Any part of the code that used `.getAttribute('role')` or `.attr('role')` was migrated to use `getEplicitRole()` instead. There are a few places that still look at the role attribute directly, but those cases are validating the attributes value for different things so it's a valid use case (e.g. looking for abstract roles, invalid roles, fallback roles, unallowed roles, etc.).

Also migrates some of the older test code to use arrow functions and `const` rather than `var` (which is a tech debt strategy to slowly move updating the code as we touch the files).

Part of https://github.com/dequelabs/axe-core/issues/3768