### PR TITLE
fix: usage of deprecated `set-output` command

### DIFF
--- a/.github/workflows/update-generated-files.yaml
+++ b/.github/workflows/update-generated-files.yaml
@@ -32,7 +32,7 @@ jobs:
           changes=$(git status --porcelain)
           # see https://unix.stackexchange.com/a/509498
           echo $changes | grep . && echo "Changes detected" || echo "No changes"
-          echo ::set-output name=changes::"$changes"
+          echo "changes=$changes" >> $GITHUB_OUTPUT
 
       - name: Check branch exists
         id: branchExists
@@ -40,7 +40,7 @@ jobs:
         run: |
           exists=$(git ls-remote --heads origin $BRANCH_NAME)
           echo $exists | grep . && echo "Branch '$BRANCH_NAME' already exists on remote" || echo "Branch does not exists in remote"
-          echo ::set-output name=exists::"$exists"
+          echo "exists=$exists" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         if: ${{ steps.changes.outputs.changes && !steps.branchExists.outputs.exists }}


### PR DESCRIPTION
This updates [`update_generated_files`](https://github.com/dequelabs/axe-core/actions/runs/15423378840/job/43404124451#logs) so that it uses `Environment Files` instead of the deprecated `set-output` command.

Fixes #4793