### PR TITLE
feat(DqElement): Truncate large `html` strings when the element has a large outerHTML string

### DIFF
--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -43,8 +43,13 @@ export function truncateElement(element) {
   let str = getOuterHtml(shallowNode);
 
   if (str.length < maxLen) {
-    const endingTagIndex = str.lastIndexOf('<');
-    str = str.substring(0, endingTagIndex);
+    let attrString = '';
+    for (const { name, value } of elementNodeMap) {
+      const attr = { name, value };
+      attrString += ` ${attr.name}="${attr.value}"`;
+    }
+
+    str = `<${nodeName}${attrString}>`;
     return str;
   }
   let strLen = `<${nodeName}>`.length;
@@ -55,8 +60,8 @@ export function truncateElement(element) {
     }
 
     const attr = { name, value };
-    let attrName = attr.name,
-      attrValue = attr.value;
+    let attrName = attr.name;
+    let attrValue = attr.value;
 
     attrName =
       attrName.length > maxAttrNameOrValueLen

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -5,6 +5,7 @@ import getNodeFromTree from './get-node-from-tree';
 import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
 import cache from '../base/cache';
 import memoize from './memoize';
+import getNodeAttributes from './get-node-attributes';
 
 const CACHE_KEY = 'DqElm.RunOptions';
 
@@ -18,67 +19,60 @@ function getOuterHtml(element) {
   return source || '';
 }
 
-function truncateAttributes(element, truncatedAttributeSet) {
-  if (!element) {
-    return '';
+/**
+ * Truncates the outerHTML property of an element
+ * @param  {Node}   element the element node which needs to be truncated
+ */
+
+export function truncateElement(element) {
+  const maxLen = 300;
+  const maxAttrNameOrValueLen = 20;
+
+  const deepStr = getOuterHtml(element);
+
+  if (deepStr.length < maxLen) {
+    return deepStr;
   }
 
-  let str = getOuterHtml(element);
-  if (!truncatedAttributeSet || truncatedAttributeSet.size === 0) {
-    return str;
+  const attributeStrList = [];
+  const shallowNode = element.cloneNode(false);
+  const elementNodeMap = getNodeAttributes(shallowNode);
+
+  let str = getOuterHtml(shallowNode);
+  let strLen = `<${shallowNode.nodeName.toLowerCase()}>`.length;
+
+  for (const { name, value } of elementNodeMap) {
+    if (strLen > maxLen) {break;}
+
+    const attr = { name, value };
+    let attrName = attr.name,
+      attrValue = attr.value;
+
+    attrName =
+      attrName.length > maxAttrNameOrValueLen
+        ? attrName.substring(0, maxAttrNameOrValueLen) + '...'
+        : attrName;
+    attrValue =
+      attrValue.length > maxAttrNameOrValueLen
+        ? attrValue.substring(0, maxAttrNameOrValueLen) + '...'
+        : attrValue;
+
+    const strAttr = `${attrName}="${attrValue}"`;
+    strLen += (' ' + strAttr).length;
+    attributeStrList.push(strAttr);
   }
 
-  let intermediateAttrString = '';
-  const openingTagEndIndex = str.indexOf('>');
-
-  for (const truncatedAttr of truncatedAttributeSet) {
-    intermediateAttrString += ` ${truncatedAttr.substring(0, 20)}...`;
+  if (attributeStrList.length < elementNodeMap.length) {
+    str = `<${shallowNode.nodeName.toLowerCase()} ${attributeStrList.join(' ')} ...>`;
+  } else {
+    str = `<${shallowNode.nodeName.toLowerCase()} ${attributeStrList.join(' ')}>`;
   }
 
-  str =
-    str.substring(0, openingTagEndIndex) +
-    intermediateAttrString +
-    ' ' +
-    str.substring(openingTagEndIndex);
+  if (str.length > maxLen) {
+    str = str.substring(0, maxLen) + '... >';
+  }
+
   return str;
-}
-
-function truncateElement(element, maxLength, maxAttributeLength) {
-  maxLength = maxLength || 100;
-  maxAttributeLength = maxAttributeLength || 20;
-
-  const copyNode = element.cloneNode(true);
-  const attributesToTruncate = new Set();
-
-  const elementAttributes = element.attributes;
-  const lastIndex = elementAttributes.length - 1;
-  let currElementStr = truncateAttributes(copyNode, attributesToTruncate);
-
-  for (let i = lastIndex; i >= 0; i--) {
-    if (currElementStr.indexOf('>') < maxLength) {
-      break;
-    }
-
-    const attribute = elementAttributes[i];
-    const attributeLength = attribute.value.length + attribute.name.length;
-
-    if (attributeLength > maxAttributeLength) {
-      attributesToTruncate.add(attribute.name);
-      copyNode.attributes.removeNamedItem(attribute.name);
-      currElementStr = truncateAttributes(copyNode, attributesToTruncate);
-    }
-  }
-
-  if (currElementStr.indexOf('>') > maxLength) {
-    currElementStr = currElementStr.substring(0, maxLength) + '...>';
-  }
-
-  if (currElementStr.length > 3 * maxLength) {
-    const endIndex = currElementStr.indexOf('>');
-    currElementStr = currElementStr.substring(0, endIndex + 1);
-  }
-
-  return currElementStr;
 }
 
 function getSource(element) {

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -9,10 +9,6 @@ import memoize from './memoize';
 const CACHE_KEY = 'DqElm.RunOptions';
 
 function getOuterHtml(element) {
-  if (!element?.outerHTML) {
-    return '';
-  }
-
   let source = element.outerHTML;
 
   if (!source && typeof window.XMLSerializer === 'function') {
@@ -22,27 +18,29 @@ function getOuterHtml(element) {
   return source || '';
 }
 
-function createTruncatedAttributeOuterHtml(element, truncatedAttributeSet) {
-  if (!element) {return;}
+function truncateAttributes(element, truncatedAttributeSet) {
+  if (!element) {
+    return '';
+  }
 
-  const copyNode = element.cloneNode(true);
-
-  let str = getOuterHtml(copyNode);
-  if (!truncatedAttributeSet || truncatedAttributeSet.size === 0) {return str;}
+  let str = getOuterHtml(element);
+  if (!truncatedAttributeSet || truncatedAttributeSet.size === 0) {
+    return str;
+  }
 
   let intermediateAttrString = '';
-  const tagNameEnd = str.indexOf('>');
+  const openingTagEndIndex = str.indexOf('>');
 
   for (const truncatedAttr of truncatedAttributeSet) {
     intermediateAttrString += `${truncatedAttr.substring(0, 20)}... `;
   }
 
   str =
-    str.substring(0, tagNameEnd) +
+    str.substring(0, openingTagEndIndex) +
     ' ' +
     intermediateAttrString +
     ' ' +
-    str.substring(tagNameEnd);
+    str.substring(openingTagEndIndex);
   return str;
 }
 
@@ -55,45 +53,37 @@ function truncateElement(element, maxLength, maxAttributeLength) {
 
   const elementAttributes = element.attributes;
   const lastIndex = elementAttributes.length - 1;
+  let currElementStr = truncateAttributes(copyNode, attributesToTruncate);
 
   for (let i = lastIndex; i >= 0; i--) {
-    const attribute = elementAttributes[i];
+    if (currElementStr.indexOf('>') < maxLength) {
+      break;
+    }
 
+    const attribute = elementAttributes[i];
     const attributeLength = attribute.value.length + attribute.name.length;
-    if (
-      createTruncatedAttributeOuterHtml(copyNode, attributesToTruncate).indexOf(
-        '>'
-      ) < maxLength
-    )
-      {break;}
 
     if (attributeLength > maxAttributeLength) {
       attributesToTruncate.add(attribute.name);
       copyNode.attributes.removeNamedItem(attribute.name);
+      currElementStr = truncateAttributes(copyNode, attributesToTruncate);
     }
   }
 
-  let modifiedCurrentStr = createTruncatedAttributeOuterHtml(
-    copyNode,
-    attributesToTruncate
-  );
-
-  if (modifiedCurrentStr.indexOf('>') > maxLength) {
-    modifiedCurrentStr = modifiedCurrentStr.substring(0, maxLength) + '...>';
+  if (currElementStr.indexOf('>') > maxLength) {
+    currElementStr = currElementStr.substring(0, maxLength) + ' ...>';
   }
 
-  if (modifiedCurrentStr.length > maxLength) {
-    modifiedCurrentStr = modifiedCurrentStr.substring(
-      0,
-      modifiedCurrentStr.indexOf('>') + 1
-    );
+  if (currElementStr.length > maxLength) {
+    const endIndex = currElementStr.indexOf('>');
+    currElementStr = currElementStr.substring(0, endIndex + 1);
   }
 
-  return modifiedCurrentStr;
+  return currElementStr;
 }
 
 function getSource(element) {
-  if (!element?.outerHTML) {
+  if (!element) {
     return '';
   }
 

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -9,7 +9,9 @@ import memoize from './memoize';
 const CACHE_KEY = 'DqElm.RunOptions';
 
 function getOuterHtml(element) {
-  if (!element?.outerHTML) {return '';}
+  if (!element?.outerHTML) {
+    return '';
+  }
 
   let source = element.outerHTML;
 
@@ -20,12 +22,36 @@ function getOuterHtml(element) {
   return source || '';
 }
 
+function createTruncatedAttributeOuterHtml(element, truncatedAttributeSet) {
+  if (!element) {return;}
+
+  const copyNode = element.cloneNode(true);
+
+  let str = getOuterHtml(copyNode);
+  if (!truncatedAttributeSet || truncatedAttributeSet.size === 0) {return str;}
+
+  let intermediateAttrString = '';
+  const tagNameEnd = str.indexOf('>');
+
+  for (const truncatedAttr of truncatedAttributeSet) {
+    intermediateAttrString += `${truncatedAttr.substring(0, 20)}... `;
+  }
+
+  str =
+    str.substring(0, tagNameEnd) +
+    ' ' +
+    intermediateAttrString +
+    ' ' +
+    str.substring(tagNameEnd);
+  return str;
+}
+
 function truncateElement(element, maxLength, maxAttributeLength) {
   maxLength = maxLength || 100;
   maxAttributeLength = maxAttributeLength || 20;
 
-  const trueOuterHtml = getOuterHtml(element);
-  let finalStr = trueOuterHtml;
+  const copyNode = element.cloneNode(true);
+  const attributesToTruncate = new Set();
 
   const elementAttributes = element.attributes;
   const lastIndex = elementAttributes.length - 1;
@@ -34,26 +60,36 @@ function truncateElement(element, maxLength, maxAttributeLength) {
     const attribute = elementAttributes[i];
 
     const attributeLength = attribute.value.length + attribute.name.length;
-    if (finalStr.indexOf('>') < maxLength) {break;}
+    if (
+      createTruncatedAttributeOuterHtml(copyNode, attributesToTruncate).indexOf(
+        '>'
+      ) < maxLength
+    )
+      {break;}
 
     if (attributeLength > maxAttributeLength) {
-      element.attributes.removeNamedItem(attribute.name);
-      finalStr = finalStr.replace(
-        `${attribute.name}="${attribute.value}"`,
-        `${attribute.name.substring(0, maxAttributeLength)}...`
-      );
+      attributesToTruncate.add(attribute.name);
+      copyNode.attributes.removeNamedItem(attribute.name);
     }
   }
 
-  if (finalStr.indexOf('>') > maxLength) {
-    finalStr = finalStr.substring(0, maxLength) + '...>';
+  let modifiedCurrentStr = createTruncatedAttributeOuterHtml(
+    copyNode,
+    attributesToTruncate
+  );
+
+  if (modifiedCurrentStr.indexOf('>') > maxLength) {
+    modifiedCurrentStr = modifiedCurrentStr.substring(0, maxLength) + '...>';
   }
 
-  if (finalStr.length > maxLength) {
-    finalStr = finalStr.substring(0, finalStr.indexOf('>') + 1);
+  if (modifiedCurrentStr.length > maxLength) {
+    modifiedCurrentStr = modifiedCurrentStr.substring(
+      0,
+      modifiedCurrentStr.indexOf('>') + 1
+    );
   }
 
-  return finalStr;
+  return modifiedCurrentStr;
 }
 
 function getSource(element) {

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -8,26 +8,60 @@ import memoize from './memoize';
 
 const CACHE_KEY = 'DqElm.RunOptions';
 
-function truncate(str, maxLength) {
-  maxLength = maxLength || 300;
+function getOuterHtml(element) {
+  if (!element?.outerHTML) {return '';}
 
-  if (str.length > maxLength) {
-    const index = str.indexOf('>');
-    str = str.substring(0, index + 1);
+  let source = element.outerHTML;
+
+  if (!source && typeof window.XMLSerializer === 'function') {
+    source = new window.XMLSerializer().serializeToString(element);
   }
 
-  return str;
+  return source || '';
+}
+
+function truncateElement(element, maxLength, maxAttributeLength) {
+  maxLength = maxLength || 100;
+  maxAttributeLength = maxAttributeLength || 20;
+
+  const trueOuterHtml = getOuterHtml(element);
+  let finalStr = trueOuterHtml;
+
+  const elementAttributes = element.attributes;
+  const lastIndex = elementAttributes.length - 1;
+
+  for (let i = lastIndex; i >= 0; i--) {
+    const attribute = elementAttributes[i];
+
+    const attributeLength = attribute.value.length + attribute.name.length;
+    if (finalStr.indexOf('>') < maxLength) {break;}
+
+    if (attributeLength > maxAttributeLength) {
+      element.attributes.removeNamedItem(attribute.name);
+      finalStr = finalStr.replace(
+        `${attribute.name}="${attribute.value}"`,
+        `${attribute.name.substring(0, maxAttributeLength)}...`
+      );
+    }
+  }
+
+  if (finalStr.indexOf('>') > maxLength) {
+    finalStr = finalStr.substring(0, maxLength) + '...>';
+  }
+
+  if (finalStr.length > maxLength) {
+    finalStr = finalStr.substring(0, finalStr.indexOf('>') + 1);
+  }
+
+  return finalStr;
 }
 
 function getSource(element) {
   if (!element?.outerHTML) {
     return '';
   }
-  let source = element.outerHTML;
-  if (!source && typeof window.XMLSerializer === 'function') {
-    source = new window.XMLSerializer().serializeToString(element);
-  }
-  return truncate(source || '');
+
+  return truncateElement(element);
 }
 
 /**

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -32,12 +32,11 @@ function truncateAttributes(element, truncatedAttributeSet) {
   const openingTagEndIndex = str.indexOf('>');
 
   for (const truncatedAttr of truncatedAttributeSet) {
-    intermediateAttrString += `${truncatedAttr.substring(0, 20)}... `;
+    intermediateAttrString += ` ${truncatedAttr.substring(0, 20)}...`;
   }
 
   str =
     str.substring(0, openingTagEndIndex) +
-    ' ' +
     intermediateAttrString +
     ' ' +
     str.substring(openingTagEndIndex);
@@ -74,7 +73,7 @@ function truncateElement(element, maxLength, maxAttributeLength) {
     currElementStr = currElementStr.substring(0, maxLength) + '...>';
   }
 
-  if (currElementStr.length > maxLength) {
+  if (currElementStr.length > 3 * maxLength) {
     const endIndex = currElementStr.indexOf('>');
     currElementStr = currElementStr.substring(0, endIndex + 1);
   }

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -6,6 +6,7 @@ import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
 import cache from '../base/cache';
 import memoize from './memoize';
 import getNodeAttributes from './get-node-attributes';
+import VirtualNode from '../../core/base/virtual-node/virtual-node';
 
 const CACHE_KEY = 'DqElm.RunOptions';
 
@@ -29,6 +30,7 @@ export function truncateElement(element) {
   const maxAttrNameOrValueLen = 20;
 
   const deepStr = getOuterHtml(element);
+  const { nodeName } = new VirtualNode(element).props;
 
   if (deepStr.length < maxLen) {
     return deepStr;
@@ -39,10 +41,18 @@ export function truncateElement(element) {
   const elementNodeMap = getNodeAttributes(shallowNode);
 
   let str = getOuterHtml(shallowNode);
-  let strLen = `<${shallowNode.nodeName.toLowerCase()}>`.length;
+
+  if (str.length < maxLen) {
+    const endingTagIndex = str.lastIndexOf('<');
+    str = str.substring(0, endingTagIndex);
+    return str;
+  }
+  let strLen = `<${nodeName}>`.length;
 
   for (const { name, value } of elementNodeMap) {
-    if (strLen > maxLen) {break;}
+    if (strLen > maxLen) {
+      break;
+    }
 
     const attr = { name, value };
     let attrName = attr.name,
@@ -62,14 +72,11 @@ export function truncateElement(element) {
     attributeStrList.push(strAttr);
   }
 
-  if (attributeStrList.length < elementNodeMap.length) {
-    str = `<${shallowNode.nodeName.toLowerCase()} ${attributeStrList.join(' ')} ...>`;
-  } else {
-    str = `<${shallowNode.nodeName.toLowerCase()} ${attributeStrList.join(' ')}>`;
-  }
-
+  str = `<${nodeName} ${attributeStrList.join(' ')}>`;
   if (str.length > maxLen) {
-    str = str.substring(0, maxLen) + '... >';
+    str = str.substring(0, maxLen) + ' ...>';
+  } else if (attributeStrList.length < elementNodeMap.length) {
+    str = str.substring(0, str.length - 1) + ' ...>';
   }
 
   return str;

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -30,7 +30,11 @@ export function truncateElement(element) {
   const maxAttrNameOrValueLen = 20;
 
   const deepStr = getOuterHtml(element);
-  const { nodeName } = new VirtualNode(element).props;
+  let vNode = getNodeFromTree(element);
+  if (!vNode) {
+    vNode = new VirtualNode(element);
+  }
+  const { nodeName } = vNode.props;
 
   if (deepStr.length < maxLen) {
     return deepStr;

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -71,7 +71,7 @@ function truncateElement(element, maxLength, maxAttributeLength) {
   }
 
   if (currElementStr.indexOf('>') > maxLength) {
-    currElementStr = currElementStr.substring(0, maxLength) + ' ...>';
+    currElementStr = currElementStr.substring(0, maxLength) + '...>';
   }
 
   if (currElementStr.length > maxLength) {

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -91,7 +91,7 @@ describe('DqElement', () => {
       const result = new DqElement(vNode);
       assert.equal(
         result.source,
-        `<div id="target" attribute="value" attribute1="value1" attribute22="value22" attribute333="value333" ...>`
+        `<div id="target" attribute="value" attribute1="value1" attribute22="value22" attribute333="value333"...>`
       );
     });
 

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -81,6 +81,21 @@ describe('DqElement', () => {
       assert.equal(result.source, '<div class="foo" id="target">');
     });
 
+    it('should truncate large attributes', () => {
+      const el = document.createElement('div');
+      let attributeName = 'data-';
+      for (let i = 0; i < 10000000; i++) {
+        attributeName += 'foo';
+      }
+      el.setAttribute(attributeName, 'bar');
+
+      const vNode = new DqElement(el);
+      assert.equal(
+        vNode.source,
+        `<div ${attributeName.substring(0, 20)}... ></div>`
+      );
+    });
+
     it('should truncate an element having a large number of attributes', () => {
       let customElement = '<div id="target"';
       for (let i = 0; i < 10; i++) {

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -81,33 +81,36 @@ describe('DqElement', () => {
       assert.equal(result.source, '<div class="foo" id="target">');
     });
 
-    it('should truncate large attributes', () => {
+    it('should truncate large attributes of large element', () => {
       const el = document.createElement('div');
-      let attributeName = 'data-';
-      for (let i = 0; i < 10000000; i++) {
+      let attributeName = 'data-',
+        attributeValue = '';
+      for (let i = 0; i < 500; i++) {
         attributeName += 'foo';
+        attributeValue += i;
       }
-      el.setAttribute(attributeName, 'bar');
+      el.setAttribute(attributeName, attributeValue);
 
       const vNode = new DqElement(el);
       assert.equal(
         vNode.source,
-        `<div ${attributeName.substring(0, 20)}... ></div>`
+        `<div ${attributeName.substring(0, 20)}...="${attributeValue.substring(0, 20)}...">`
       );
     });
 
-    it('should truncate an element having a large number of attributes', () => {
+    it('should remove attributes for a large element having a large number of attributes', () => {
       let customElement = '<div id="target"';
-      for (let i = 0; i < 10; i++) {
-        customElement += ` attribute${Array(i + 1).join(i)}="value${Array(i + 1).join(i)}"`;
+
+      for (let i = 0; i < 100; i++) {
+        customElement += ` attr${i}="value${i}"`;
       }
+
       customElement += `><div>`;
       const vNode = queryFixture(customElement);
       const result = new DqElement(vNode);
-      assert.equal(
-        result.source,
-        `<div id="target" attribute="value" attribute1="value1" attribute22="value22" attribute333="value333"...>`
-      );
+      const truncatedAttrCount = (result.source.match(/attr/g) || []).length;
+      assert.isTrue(truncatedAttrCount < 100);
+      assert.isTrue(truncatedAttrCount > 0);
     });
 
     it('should truncate a large element with long custom tag name', () => {
@@ -115,7 +118,7 @@ describe('DqElement', () => {
       let customElement = `<${longCustomElementTagName} id="target">A</${longCustomElementTagName}>`;
       const vNode = queryFixture(customElement);
       const result = new DqElement(vNode);
-      assert.equal(result.source, `<${Array(99 + 1).join('b')}...>`);
+      assert.equal(result.source, `${customElement.substring(0, 300)}... >`);
     });
 
     it('should use spec object over passed element', () => {

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -83,8 +83,8 @@ describe('DqElement', () => {
 
     it('should truncate large attributes of large element', () => {
       const el = document.createElement('div');
-      let attributeName = 'data-',
-        attributeValue = '';
+      let attributeName = 'data-';
+      let attributeValue = '';
       for (let i = 0; i < 500; i++) {
         attributeName += 'foo';
         attributeValue += i;
@@ -118,7 +118,22 @@ describe('DqElement', () => {
       let customElement = `<${longCustomElementTagName} id="target">A</${longCustomElementTagName}>`;
       const vNode = queryFixture(customElement);
       const result = new DqElement(vNode);
-      assert.equal(result.source, `${customElement.substring(0, 300)}... >`);
+      assert.equal(result.source, `${customElement.substring(0, 300)} ...>`);
+    });
+
+    it('should not truncate attributes if children are long but attribute itself is within limits', () => {
+      let el = document.createElement('div');
+      let attributeValue = '';
+      let innerHtml = '';
+      for (let i = 0; i < 50; i++) {
+        attributeValue += 'a';
+        innerHtml += 'foobar';
+      }
+      el.setAttribute('long-attribute', attributeValue);
+      el.innerHTML = innerHtml;
+
+      const vNode = new DqElement(el);
+      assert.equal(vNode.source, `<div long-attribute="${attributeValue}">`);
     });
 
     it('should use spec object over passed element', () => {

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -109,8 +109,8 @@ describe('DqElement', () => {
       const vNode = queryFixture(customElement);
       const result = new DqElement(vNode);
       const truncatedAttrCount = (result.source.match(/attr/g) || []).length;
-      assert.isTrue(truncatedAttrCount < 100);
-      assert.isTrue(truncatedAttrCount > 0);
+      assert.isBelow(truncatedAttrCount, 100);
+      assert.isAtLeast(truncatedAttrCount, 10);
     });
 
     it('should truncate a large element with long custom tag name', () => {

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -81,6 +81,28 @@ describe('DqElement', () => {
       assert.equal(result.source, '<div class="foo" id="target">');
     });
 
+    it('should truncate a large element and its attributes', () => {
+      let customElement = '<div id="target"';
+      for (let i = 0; i < 10; i++) {
+        customElement += ` attribute${Array(i + 1).join('A') + (i + 1)}="value${Array(i + 1).join('B') + (i + 1)}"`;
+      }
+      customElement += `><div>`;
+      const vNode = queryFixture(customElement);
+      const result = new DqElement(vNode);
+      assert.equal(
+        result.source,
+        `<div id="target" attribute1="value1" attributea2="valueB2" attributeaa3="valueBB3" attributeaaa4... ...>`
+      );
+    });
+
+    it('should truncate a large element with long custom tag', () => {
+      let longCustomElementTagName = new Array(300).join('b');
+      let customElement = `<${longCustomElementTagName} id="target">A</${longCustomElementTagName}>`;
+      const vNode = queryFixture(customElement);
+      const result = new DqElement(vNode);
+      assert.equal(result.source, `<${Array(99 + 1).join('b')}...>`);
+    });
+
     it('should use spec object over passed element', () => {
       const vNode = queryFixture('<div id="target" class="bar">Hello!</div>');
       const spec = { source: 'woot' };

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -84,14 +84,14 @@ describe('DqElement', () => {
     it('should truncate an element having a large number of attributes', () => {
       let customElement = '<div id="target"';
       for (let i = 0; i < 10; i++) {
-        customElement += ` attribute${Array(i + 1).join('A') + (i + 1)}="value${Array(i + 1).join('B') + (i + 1)}"`;
+        customElement += ` attribute${Array(i + 1).join(i)}="value${Array(i + 1).join(i)}"`;
       }
       customElement += `><div>`;
       const vNode = queryFixture(customElement);
       const result = new DqElement(vNode);
       assert.equal(
         result.source,
-        `<div id="target" attribute1="value1" attributea2="valueB2" attributeaa3="valueBB3" attributeaaaaaaaa...>`
+        `<div id="target" attribute="value" attribute1="value1" attribute22="value22" attribute333="value333" ...>`
       );
     });
 

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -81,7 +81,7 @@ describe('DqElement', () => {
       assert.equal(result.source, '<div class="foo" id="target">');
     });
 
-    it('should truncate a large element and its attributes', () => {
+    it('should truncate an element having a large number of attributes', () => {
       let customElement = '<div id="target"';
       for (let i = 0; i < 10; i++) {
         customElement += ` attribute${Array(i + 1).join('A') + (i + 1)}="value${Array(i + 1).join('B') + (i + 1)}"`;
@@ -91,11 +91,11 @@ describe('DqElement', () => {
       const result = new DqElement(vNode);
       assert.equal(
         result.source,
-        `<div id="target" attribute1="value1" attributea2="valueB2" attributeaa3="valueBB3" attributeaaa4... ...>`
+        `<div id="target" attribute1="value1" attributea2="valueB2" attributeaa3="valueBB3" attributeaaaaaaaa...>`
       );
     });
 
-    it('should truncate a large element with long custom tag', () => {
+    it('should truncate a large element with long custom tag name', () => {
       let longCustomElementTagName = new Array(300).join('b');
       let customElement = `<${longCustomElementTagName} id="target">A</${longCustomElementTagName}>`;
       const vNode = queryFixture(customElement);


### PR DESCRIPTION
feat(DqElement): Fixed truncation logic for large outerHTML for the the element itself

Changed truncation logic to also truncate the element of DqElement's source, while preserving the earlier truncation logic.

Closes: Issue #4544 
