### PR TITLE
chore: update act test readme with information on object structure

### DIFF
--- a/test/act-rules/README.md
+++ b/test/act-rules/README.md
@@ -8,5 +8,5 @@ The spec file object allows the following properties:
 
 - `id` - (required) The `ruleId` of the ACT rule, found in the [testcases.json file](https://github.com/w3c/wcag-act-rules/blob/main/content-assets/wcag-act-rules/testcases.json).
 - `title` - (required) The `ruleName` of the ACT rule, found in the [testcases.json file](https://github.com/w3c/wcag-act-rules/blob/main/content-assets/wcag-act-rules/testcases.json).
-- `axeRules` - (required) A list of axe-core rule ids to run. A single ACT rule can require multiple axe-core rules in order to cover all the ACT example (e.g. the ACT rule `button-non-empty` requires both `button-name` and `aria-command-name` to run).
+- `axeRules` - (required) A list of axe-core rule ids to run. A single ACT rule can require multiple axe-core rules in order to cover all the ACT examples (e.g. the ACT rule `button-non-empty` requires both `button-name` and `aria-command-name` to run).
 - `skipTests` - (optional) A list of ACT `testcaseId` to skip. Please be sure to add a comment as to why the test should be skipped. If applicable, please open an issue in axe-core and link to the issue in the code so that we can track the issue and know when we can run the test again.


### PR DESCRIPTION
Adding more information to the ACT test readme about the object structure and how to use it.
