### PR TITLE
chore: update to use `@axe-core/webdriverjs` 4.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.10.3",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@axe-core/webdriverjs": "^4.9.0",
+        "@axe-core/webdriverjs": "^4.10.2",
         "@babel/core": "^7.20.12",
         "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
         "@babel/preset-env": "^7.20.2",
@@ -21,7 +21,7 @@
         "browser-driver-manager": "1.0.4",
         "chai": "^4.3.7",
         "chalk": "^4.x",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "clean-jsdoc-theme": "^4.2.17",
         "clone": "^2.1.2",
         "colorjs.io": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "postbuild": "prettier --write ./locales/_template.json ./doc/rule-descriptions.md"
   },
   "devDependencies": {
-    "@axe-core/webdriverjs": "^4.9.0",
+    "@axe-core/webdriverjs": "^4.10.2",
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-env": "^7.20.2",


### PR DESCRIPTION
Updates `@axe-core/webdriverjs` to current [latest version](https://github.com/dequelabs/axe-core-npm/releases/tag/v4.10.2)

no qa required