### PR TITLE
fix(performanceTimer): work in frames

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -380,7 +380,9 @@ Rule.prototype._trackPerformance = function _trackPerformance() {
  * @param {Array} nodes Result of rule.gather
  */
 Rule.prototype._logGatherPerformance = function _logGatherPerformance(nodes) {
-  log('gather (', nodes.length, '):', performanceTimer.timeElapsed() + 'ms');
+  log(
+    `gather for ${this.id} (${nodes.length} nodes): ${performanceTimer.timeElapsed()}ms`
+  );
   performanceTimer.mark(this._markChecksStart);
 };
 

--- a/lib/core/utils/performance-timer.js
+++ b/lib/core/utils/performance-timer.js
@@ -90,11 +90,11 @@ const performanceTimer = (() => {
       ) {
         // only output measures that were started after axe started, otherwise
         // we get measures made by the page before axe ran (which is confusing)
-        const axeStart =
-          window.performance.getEntriesByName('mark_axe_start')[0];
+        const auditStart =
+          window.performance.getEntriesByName('mark_audit_start')[0];
         const measures = window.performance
           .getEntriesByType('measure')
-          .filter(measure => measure.startTime >= axeStart.startTime);
+          .filter(measure => measure.startTime >= auditStart.startTime);
         for (let i = 0; i < measures.length; ++i) {
           const req = measures[i];
           if (req.name === measureName) {


### PR DESCRIPTION
Turns out our performanceTimer errors when running in iframes. I also added some detail to gather so we could see what rule is being gathered.