### PR TITLE
fix(performanceTimer): throwing in axe catch clause

### DIFF
--- a/lib/core/utils/performance-timer.js
+++ b/lib/core/utils/performance-timer.js
@@ -93,7 +93,11 @@ const performanceTimer = (() => {
       if (!window.performance?.measure) {
         return;
       }
-      window.performance.measure(measureName, startMark, endMark);
+      try {
+        window.performance.measure(measureName, startMark, endMark);
+      } catch (e) {
+        this._log(e);
+      }
       if (!keepMarks) {
         this.clearMark(startMark, endMark);
       }

--- a/test/core/utils/performance-timer.js
+++ b/test/core/utils/performance-timer.js
@@ -83,16 +83,19 @@ describe('performance timer', () => {
 
   describe('.measure', () => {
     it('logs an error if the start mark is not present', () => {
+      performanceTimer.mark('foo_end');
       performanceTimer.measure('foo', 'foo_start', 'foo_end');
       assert.equal(messages.length, 1);
-      assert.match(messages[0], /The mark 'foo_start' does not exist./);
+      // non-specific message, Firefox has a different message from Chromium
+      assert.match(messages[0], /foo_start/);
     });
 
     it('logs an error if the end mark is not present', () => {
       performanceTimer.mark('foo_start');
       performanceTimer.measure('foo', 'foo_start', 'foo_end');
       assert.equal(messages.length, 1);
-      assert.match(messages[0], /The mark 'foo_end' does not exist./);
+      // non-specific message, Firefox has a different message from Chromium
+      assert.match(messages[0], /foo_end/);
     });
   });
 

--- a/test/core/utils/performance-timer.js
+++ b/test/core/utils/performance-timer.js
@@ -81,6 +81,21 @@ describe('performance timer', () => {
     assert.match(messages[0], /Measure audit_start_to_end took [0-9.]+ms/);
   });
 
+  describe('.measure', () => {
+    it('logs an error if the start mark is not present', () => {
+      performanceTimer.measure('foo', 'foo_start', 'foo_end');
+      assert.equal(messages.length, 1);
+      assert.match(messages[0], /The mark 'foo_start' does not exist./);
+    });
+
+    it('logs an error if the end mark is not present', () => {
+      performanceTimer.mark('foo_start');
+      performanceTimer.measure('foo', 'foo_start', 'foo_end');
+      assert.equal(messages.length, 1);
+      assert.match(messages[0], /The mark 'foo_end' does not exist./);
+    });
+  });
+
   describe('logMeasures', () => {
     beforeEach(() => {
       performanceTimer.start();


### PR DESCRIPTION
I ran into a problem with this:

https://github.com/dequelabs/axe-core/blob/e7dae4ec48cbfef74de9f833fdcfb178c1002985/lib/core/base/rule.js#L297-L300

If the end mark isn't set, performance.measure throws an error. Since we call performance.measure in the catch, it is quite possible that the end mark doesn't exist. And then throwing from a catch completely throws the run. I don't think axe should fail if the performance measure fails, so instead I'm going to have it just log the error and move forward.