### PR TITLE
refactor: refactor flatten-tree to use return early style

### DIFF
--- a/lib/core/utils/get-flattened-tree.js
+++ b/lib/core/utils/get-flattened-tree.js
@@ -86,7 +86,27 @@ function createNode(node, parent, shadowId) {
 }
 
 /**
- * Recursvely returns an array of the virtual DOM nodes at this level
+ * Add children to the parent virtual node
+ * @param {Node[]} childNodes the children of the parent
+ * @param {VirtualNode} parent the parent VirtualNode
+ * @param {String} shadowId, optional ID of the shadow DOM that is the closest shadow
+ *                           ancestor of the node
+ */
+function createChildren(childNodes, parent, shadowId) {
+  const children = [];
+
+  childNodes.forEach(childNode => {
+    const child = flattenTree(childNode, shadowId, parent);
+    if (child) {
+      children.push(...child);
+    }
+  });
+
+  return children;
+}
+
+/**
+ * Recursively returns an array of the virtual DOM nodes at this level
  * excluding comment nodes and the shadow DOM nodes <content> and <slot>
  *
  * @param {Node} node the current node
@@ -95,15 +115,7 @@ function createNode(node, parent, shadowId) {
  * @param {VirtualNode} parent the parent VirtualNode
  */
 function flattenTree(node, shadowId, parent) {
-  // using a closure here and therefore cannot easily refactor toreduce the statements
   let retVal, realArray;
-  function reduceShadowDOM(res, child, parentVNode) {
-    const replacements = flattenTree(child, shadowId, parentVNode);
-    if (replacements) {
-      res = res.concat(replacements);
-    }
-    return res;
-  }
 
   if (node.documentElement) {
     // document
@@ -119,59 +131,52 @@ function flattenTree(node, shadowId, parent) {
     retVal = createNode(node, parent, shadowId);
     shadowId = 'a' + Math.random().toString().substring(2);
     realArray = Array.from(node.shadowRoot.childNodes);
-    retVal.children = realArray.reduce((res, child) => {
-      return reduceShadowDOM(res, child, retVal);
-    }, []);
+    retVal.children = createChildren(realArray, retVal, shadowId);
 
     return [retVal];
-  } else {
-    if (
-      nodeName === 'content' &&
-      typeof node.getDistributedNodes === 'function'
-    ) {
-      realArray = Array.from(node.getDistributedNodes());
-      return realArray.reduce((res, child) => {
-        return reduceShadowDOM(res, child, parent);
-      }, []);
-    } else if (
-      nodeName === 'slot' &&
-      typeof node.assignedNodes === 'function'
-    ) {
-      realArray = Array.from(node.assignedNodes());
-      if (!realArray.length) {
-        // fallback content
-        realArray = getSlotChildren(node);
-      }
-      const styl = window.getComputedStyle(node);
-      // check the display property
-      if (false && styl.display !== 'contents') {
-        // intentionally commented out
-        // has a box
-        retVal = createNode(node, parent, shadowId);
-        retVal.children = realArray.reduce((res, child) => {
-          return reduceShadowDOM(res, child, retVal);
-        }, []);
-
-        return [retVal];
-      } else {
-        return realArray.reduce((res, child) => {
-          return reduceShadowDOM(res, child, parent);
-        }, []);
-      }
-    } else {
-      if (node.nodeType === 1) {
-        retVal = createNode(node, parent, shadowId);
-        realArray = Array.from(node.childNodes);
-        retVal.children = realArray.reduce((res, child) => {
-          return reduceShadowDOM(res, child, retVal);
-        }, []);
-
-        return [retVal];
-      } else if (node.nodeType === 3) {
-        // text
-        return [createNode(node, parent)];
-      }
-      return undefined;
-    }
   }
+
+  if (
+    nodeName === 'content' &&
+    typeof node.getDistributedNodes === 'function'
+  ) {
+    realArray = Array.from(node.getDistributedNodes());
+    return createChildren(realArray, parent, shadowId);
+  }
+
+  if (nodeName === 'slot' && typeof node.assignedNodes === 'function') {
+    realArray = Array.from(node.assignedNodes());
+    if (!realArray.length) {
+      // fallback content
+      realArray = getSlotChildren(node);
+    }
+
+    const styl = window.getComputedStyle(node);
+
+    // check the display property. intentionally does not run, see notable information above
+    if (false && styl.display !== 'contents') {
+      // has a box
+      retVal = createNode(node, parent, shadowId);
+      retVal.children = createChildren(realArray, retVal, shadowId);
+
+      return [retVal];
+    }
+
+    return createChildren(realArray, parent, shadowId);
+  }
+
+  if (node.nodeType === 1) {
+    retVal = createNode(node, parent, shadowId);
+    realArray = Array.from(node.childNodes);
+    retVal.children = createChildren(realArray, retVal, shadowId);
+
+    return [retVal];
+  }
+
+  if (node.nodeType === 3) {
+    // text
+    return [createNode(node, parent)];
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
Was making changes to this file and always found it hard to read through with the multiple nesting of if statements and the reduces. refactored to use early return style to prevent the nesting and moved away from array.reduce to just use a forEach over the array to add them (as well as a function to do this since we do it multiple times).