### PR TITLE
feat(DqElement): deprecate fromFrame function

### DIFF
--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -212,7 +212,7 @@ DqElement.prototype = {
   }
 };
 
-// @deprecated
+/** @deprecated */
 DqElement.fromFrame = function fromFrame(node, options, frame) {
   const spec = DqElement.mergeSpecs(node, frame);
   return new DqElement(frame.element, options, spec);

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -212,6 +212,7 @@ DqElement.prototype = {
   }
 };
 
+// @deprecated
 DqElement.fromFrame = function fromFrame(node, options, frame) {
   const spec = DqElement.mergeSpecs(node, frame);
   return new DqElement(frame.element, options, spec);


### PR DESCRIPTION
The function is no longer used in the code base and was replaced in #4093 

Closes: https://github.com/dequelabs/axe-core/issues/4129