### PR TITLE
ci: pin jsdom version to 26.1.0 for node 18 support

### DIFF
--- a/test/node/node.js
+++ b/test/node/node.js
@@ -40,7 +40,8 @@ function initJsdom(callback) {
       10: '16.7.0',
       12: '19.0.0',
       14: '21.1.2',
-      16: '22.1.0'
+      16: '22.1.0',
+      18: '26.1.0'
     };
 
     var majorNodeVersion = process.versions.node.split('.')[0];


### PR DESCRIPTION
Jsdom released a new version [that dropped node 18 support](https://github.com/jsdom/jsdom/releases/tag/27.0.0), so adding a new line to our node test file to use the previous version, otherwise [our tests fail](https://github.com/dequelabs/axe-core/actions/runs/17770977359/job/50507215672) as a sub-dependency uses a node 20 feature.