### PR TITLE
ci: fix isolated-env test

### DIFF
--- a/test/integration/full/isolated-env/isolated-env.html
+++ b/test/integration/full/isolated-env/isolated-env.html
@@ -116,6 +116,9 @@
       </main>
       <footer></footer>
 
+      <script src="/test/testutils.js"></script>
+      <script src="isolated-env.js"></script>
+
       <iframe
         id="isolated-frame"
         title="foo"
@@ -130,8 +133,6 @@
       <p>Paragraph with a <a href="#">link</a>.</p>
     </div>
     <div id="mocha"></div>
-    <script src="/test/testutils.js"></script>
-    <script src="isolated-env.js"></script>
     <script src="/test/integration/adapter.js"></script>
   </body>
 </html>

--- a/test/integration/full/isolated-env/isolated-env.js
+++ b/test/integration/full/isolated-env/isolated-env.js
@@ -1,4 +1,8 @@
 /* global chai */
+var messages = [];
+window.addEventListener('message', function (msg) {
+  messages.push(msg.data);
+});
 
 describe('isolated-env test', function () {
   'use strict';
@@ -40,11 +44,16 @@ describe('isolated-env test', function () {
     });
 
     var isloadedPromise = new Promise(function (resolve, reject) {
-      window.addEventListener('message', function (msg) {
-        if (msg.data === 'axe-loaded') {
-          resolve();
-        }
-      });
+      if (messages.includes('axe-loaded')) {
+        resolve();
+      } else {
+        window.addEventListener('message', function (msg) {
+          if (msg.data === 'axe-loaded') {
+            resolve();
+          }
+        });
+      }
+
       setTimeout(function () {
         reject(new Error('axe-loaded message not called'));
       }, 5000);


### PR DESCRIPTION
This test in firefox started to fail all of a sudden, and [almost consistently](https://github.com/dequelabs/axe-core/pull/4881). I couldn't figure out why the test kept failing, so after playing around with the order of operations I figured out that the iframe is loading axe and calling the `axe-loaded` event [_before_ mocha runs the `before`](https://app.circleci.com/pipelines/github/dequelabs/axe-core/7369/workflows/8fa125f3-2a32-43d9-8ec9-d5a9ccd172df/jobs/79258) where we look for the event. So to fix it I changed up the loading order so the script runs first and adds the event tracking, and now the event tracking now happens outside the `before` function and keeps track of the logs. Then inside the `before` we see if the message has already been fired, otherwise we listen to the event as we were doing before.
