### PR TITLE
feat(tap): some best practice rules map to RGAA

### DIFF
--- a/build/tasks/validate.js
+++ b/build/tasks/validate.js
@@ -405,7 +405,7 @@ function findTagIssues(tags) {
       standardTag: standardTags[0] ?? null,
       criterionTags
     };
-    if (bestPracticeTags.length !== 0) {
+    if (name !== 'RGAA' && bestPracticeTags.length !== 0) {
       issues.push(`${name} tags cannot be used along side best-practice tag`);
     }
     if (standardTags.length === 0) {
@@ -417,7 +417,7 @@ function findTagIssues(tags) {
       issues.push(`Expected at least one ${name} criterion tag, got 0`);
     }
 
-    if (wcagLevelRegex) {
+    if (wcagLevelRegex && standards.WCAG) {
       const wcagLevel = standards.WCAG.standardTag;
       if (!wcagLevel.match(wcagLevelRegex)) {
         issues.push(`${name} rules not allowed on ${wcagLevel}`);

--- a/lib/rules/focus-order-semantics.json
+++ b/lib/rules/focus-order-semantics.json
@@ -3,7 +3,13 @@
   "impact": "minor",
   "selector": "div, h1, h2, h3, h4, h5, h6, [role=heading], p, span",
   "matches": "inserted-into-focus-order-matches",
-  "tags": ["cat.keyboard", "best-practice", "experimental"],
+  "tags": [
+    "cat.keyboard",
+    "RGAAv4",
+    "RGAA-12.8.1",
+    "best-practice",
+    "experimental"
+  ],
   "metadata": {
     "description": "Ensure elements in the focus order have a role appropriate for interactive content",
     "help": "Elements in the focus order should have an appropriate role"

--- a/lib/rules/focus-order-semantics.json
+++ b/lib/rules/focus-order-semantics.json
@@ -5,9 +5,9 @@
   "matches": "inserted-into-focus-order-matches",
   "tags": [
     "cat.keyboard",
+    "best-practice",
     "RGAAv4",
     "RGAA-12.8.1",
-    "best-practice",
     "experimental"
   ],
   "metadata": {

--- a/lib/rules/region.json
+++ b/lib/rules/region.json
@@ -2,7 +2,7 @@
   "id": "region",
   "impact": "moderate",
   "selector": "body *",
-  "tags": ["cat.keyboard", "best-practice"],
+  "tags": ["cat.keyboard", "RGAAv4", "RGAA-9.2.1", "best-practice"],
   "metadata": {
     "description": "Ensure all page content is contained by landmarks",
     "help": "All page content should be contained by landmarks"

--- a/lib/rules/region.json
+++ b/lib/rules/region.json
@@ -2,7 +2,7 @@
   "id": "region",
   "impact": "moderate",
   "selector": "body *",
-  "tags": ["cat.keyboard", "RGAAv4", "RGAA-9.2.1", "best-practice"],
+  "tags": ["cat.keyboard", "best-practice", "RGAAv4", "RGAA-9.2.1"],
   "metadata": {
     "description": "Ensure all page content is contained by landmarks",
     "help": "All page content should be contained by landmarks"

--- a/lib/rules/skip-link.json
+++ b/lib/rules/skip-link.json
@@ -3,7 +3,7 @@
   "impact": "moderate",
   "selector": "a[href^=\"#\"], a[href^=\"/#\"]",
   "matches": "skip-link-matches",
-  "tags": ["cat.keyboard", "best-practice"],
+  "tags": ["cat.keyboard", "RGAAv4", "RGAA-12.7.1", "best-practice"],
   "metadata": {
     "description": "Ensure all skip links have a focusable target",
     "help": "The skip-link target should exist and be focusable"

--- a/lib/rules/skip-link.json
+++ b/lib/rules/skip-link.json
@@ -3,7 +3,7 @@
   "impact": "moderate",
   "selector": "a[href^=\"#\"], a[href^=\"/#\"]",
   "matches": "skip-link-matches",
-  "tags": ["cat.keyboard", "RGAAv4", "RGAA-12.7.1", "best-practice"],
+  "tags": ["cat.keyboard", "best-practice", "RGAAv4", "RGAA-12.7.1"],
   "metadata": {
     "description": "Ensure all skip links have a focusable target",
     "help": "The skip-link target should exist and be focusable"

--- a/lib/rules/table-duplicate-name.json
+++ b/lib/rules/table-duplicate-name.json
@@ -2,7 +2,7 @@
   "id": "table-duplicate-name",
   "impact": "minor",
   "selector": "table",
-  "tags": ["cat.tables", "RGAAv4", "RGAA-5.2.1", "best-practice"],
+  "tags": ["cat.tables", "best-practice", "RGAAv4", "RGAA-5.2.1"],
   "metadata": {
     "description": "Ensure the <caption> element does not contain the same text as the summary attribute",
     "help": "Tables should not have the same summary and caption"

--- a/lib/rules/table-duplicate-name.json
+++ b/lib/rules/table-duplicate-name.json
@@ -2,7 +2,7 @@
   "id": "table-duplicate-name",
   "impact": "minor",
   "selector": "table",
-  "tags": ["cat.tables", "best-practice"],
+  "tags": ["cat.tables", "RGAAv4", "RGAA-5.2.1", "best-practice"],
   "metadata": {
     "description": "Ensure the <caption> element does not contain the same text as the summary attribute",
     "help": "Tables should not have the same summary and caption"


### PR DESCRIPTION
Mark the following best practice rules as part of RGAA:

- focus-order-semantics (experimental)
- region
- skip-link
- table-duplicate-name