### PR TITLE
fix(commons/color): Match browser behavior for out-of-gamut oklch colors

### DIFF
--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -154,7 +154,12 @@ export default class Color {
       }
 
       // srgb values are between 0 and 1
-      const color = new Colorjs(colorString).to('srgb');
+      const color = new Colorjs(colorString)
+        .toGamut({
+          space: 'srgb',
+          method: 'clip'
+        })
+        .to('srgb');
 
       if (prototypeArrayFrom) {
         Array.from = prototypeArrayFrom;

--- a/test/commons/color/color.js
+++ b/test/commons/color/color.js
@@ -301,6 +301,19 @@ describe('color.Color', () => {
         assert.equal(c.blue, 144);
         assert.equal(c.alpha, 0.5);
       });
+
+      it('clips out of gamut values', () => {
+        const c = new Color();
+        c.parseColorFnString('oklch(25% 0.75 345)');
+        assert.equal(c.red, 186);
+        assert.equal(c.green, 0);
+        assert.equal(c.blue, 103);
+        assert.equal(c.alpha, 1);
+
+        assert.equal(c.red, Math.round(c.r * 255));
+        assert.equal(c.green, Math.round(c.g * 255));
+        assert.equal(c.blue, Math.round(c.b * 255));
+      });
     });
   });
 


### PR DESCRIPTION
While working on color-contrast accessibility in our own app we noticed that the contrasts calculated by axe-core were different from the ones we calculated ourselves, despite using the same colors that axe gave us in the data (fgColor, bgColor) for the color-contrast check results. The difference came from how out-of-gamut colors were handled.

As an example, for color oklch(25% 0.75, 345) we got a color parsed to (roughly)
r: 0.73
g: -0.44
b: 0.4

The negative green value here threw getContrast off. When troubleshooting we found that the `red`, `green` and `blue` values were the same ones the browser would give us for the same oklch input (186, 0, 103).

To fix this, we can make use of the `toGamut` function of colorjs.io and ask for it to clip any out-of-gamut colors. This seems to be what browsers do as well, so this fix should make things align better with what developers see when working in a browser.

Related issue for color.js: https://github.com/color-js/color.js/issues/301

