### PR TITLE
ci(tests): port to github actions

### DIFF
--- a/test/integration/full/contrast/prototype.html
+++ b/test/integration/full/contrast/prototype.html
@@ -24,7 +24,7 @@
   </head>
 
   <body>
-    <div id="fixture" style="background-color: darkred">Text</div>
+    <div id="fixture" style="background-color: darkred; color: black">Text</div>
     <script src="/test/testutils.js"></script>
     <script src="prototype.js"></script>
     <script src="/test/integration/adapter.js"></script>

--- a/test/integration/full/preload-cssom/preload-cssom.js
+++ b/test/integration/full/preload-cssom/preload-cssom.js
@@ -40,6 +40,10 @@ describe('preload cssom integration test', function () {
     styleTagWithCyclicCrossOriginImports: {
       id: 'styleTagWithCyclicCrossOriginImports',
       text: '@import "cyclic-cross-origin-import-1.css";'
+    },
+    styleTagWithNonExistentImport: {
+      id: 'styleTagWithNonExistentImport',
+      text: '@import "non-existent-import.css";'
     }
   };
   let stylesForPage;
@@ -141,12 +145,7 @@ describe('preload cssom integration test', function () {
     });
 
     it('throws if cross-origin stylesheet fail to load', done => {
-      stylesForPage = [
-        {
-          id: 'nonExistingStylesheet',
-          text: '@import "import-non-existing-cross-origin.css";'
-        }
-      ];
+      stylesForPage = [styleSheets.styleTagWithNonExistentImport];
       attachStylesheets(
         {
           root: root,
@@ -157,8 +156,12 @@ describe('preload cssom integration test', function () {
             done(err);
           }
           getPreloadCssom(root)
-            .then(() => {
-              done(new Error('Expected getPreload to reject.'));
+            .then(sheets => {
+              done(
+                new Error(
+                  `Expected getPreload to reject, but it resolved with ${JSON.stringify(sheets)}.`
+                )
+              );
             })
             .catch(e => {
               assert.isDefined(e);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -357,7 +357,7 @@ var commons;
         doc.head.appendChild(link);
       });
     } else {
-      q.defer(function (resolve) {
+      q.defer(function (resolve, reject) {
         const style = doc.createElement('style');
         if (data.id) {
           style.id = data.id;
@@ -365,9 +365,25 @@ var commons;
         style.type = 'text/css';
         style.appendChild(doc.createTextNode(data.text));
         doc.head.appendChild(style);
-        setTimeout(function () {
-          resolve();
-        }, 100); // -> note: gives firefox to load (document.stylesheets), other browsers are fine.
+        // In Firefox, there is a delay between adding the element and it appearing in
+        // document.styleSheets, so we poll until we see it there.
+        const timeoutAt = Date.now() + 500;
+        const interval = setInterval(function () {
+          const isLoaded = Array.from(doc.styleSheets).some(
+            sheet => sheet.ownerNode === style
+          );
+          if (isLoaded) {
+            clearInterval(interval);
+            resolve();
+          } else if (Date.now() > timeoutAt) {
+            clearInterval(interval);
+            reject(
+              new Error(
+                'Added <style> element was not reflected in doc.styleSheets within timeout'
+              )
+            );
+          }
+        }, 5);
       });
     }
     return q;


### PR DESCRIPTION
This patch ports the main test workflow over to GHA. This is not removing Circle CI configuration as we need to convert required checks over. As well as only removing that after the publishing is ported over to GitHub.

One key change in the patterns from the CircleCI system, is the browser tests and the examples have to do the build internally instead of using the build artifact. I have not had the time to fully investigate what is going on with the differences. I _believe_ it fails in re-use now because of some slight difference in the way the caches were done before vs how they are done in GitHub Actions.

As an aside, I realized in the previous nightly PR I did mess up one aspect. Since the browsers are individual steps now, if the first running fails it was blocking the second from proceeding. For that situation, I added an instruction to always run the second browser. This is good enough for now and we can further optimize later when we setup better failure reporting.

Refs: #4912 
