### PR TITLE
fix: replaced luminance threshold constant 0.03928 with 0.04045

### DIFF
--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -230,11 +230,11 @@ export default class Color {
     const { r: rSRGB, g: gSRGB, b: bSRGB } = this;
 
     const r =
-      rSRGB <= 0.03928 ? rSRGB / 12.92 : Math.pow((rSRGB + 0.055) / 1.055, 2.4);
+      rSRGB <= 0.04045 ? rSRGB / 12.92 : Math.pow((rSRGB + 0.055) / 1.055, 2.4);
     const g =
-      gSRGB <= 0.03928 ? gSRGB / 12.92 : Math.pow((gSRGB + 0.055) / 1.055, 2.4);
+      gSRGB <= 0.04045 ? gSRGB / 12.92 : Math.pow((gSRGB + 0.055) / 1.055, 2.4);
     const b =
-      bSRGB <= 0.03928 ? bSRGB / 12.92 : Math.pow((bSRGB + 0.055) / 1.055, 2.4);
+      bSRGB <= 0.04045 ? bSRGB / 12.92 : Math.pow((bSRGB + 0.055) / 1.055, 2.4);
 
     return 0.2126 * r + 0.7152 * g + 0.0722 * b;
   }


### PR DESCRIPTION
Closes: #4933 

Updates the luminance calculation constant from 0.03928 to 0.04045 in lib/commons/color/get-contrast.js to align with the corrected WCAG 2.2 standard. While the practical impact on contrast ratios is minimal, this change ensures standards compliance with the current WCAG guidelines.
