### PR TITLE
test: fix prototype integration test in dark mode

### DIFF
--- a/test/integration/full/contrast/prototype.html
+++ b/test/integration/full/contrast/prototype.html
@@ -24,7 +24,7 @@
   </head>
 
   <body>
-    <div id="fixture" style="background-color: darkred">Text</div>
+    <div id="fixture" style="background-color: darkred; color: black">Text</div>
     <script src="/test/testutils.js"></script>
     <script src="prototype.js"></script>
     <script src="/test/integration/adapter.js"></script>


### PR DESCRIPTION
This test case was failing when I ran it locally because it relied on the default text `color` having low contrast with a `darkred` background, which is true when the system color preference is light mode but not in dark mode. This updates the test to also pin the foreground color, making it agnostic to the system color mode.

No QA required