### PR TITLE
test: improve reliability on firefox for tests that inject stylesheets

### DIFF
--- a/test/integration/full/preload-cssom/preload-cssom.js
+++ b/test/integration/full/preload-cssom/preload-cssom.js
@@ -40,6 +40,10 @@ describe('preload cssom integration test', function () {
     styleTagWithCyclicCrossOriginImports: {
       id: 'styleTagWithCyclicCrossOriginImports',
       text: '@import "cyclic-cross-origin-import-1.css";'
+    },
+    styleTagWithNonExistentImport: {
+      id: 'styleTagWithNonExistentImport',
+      text: '@import "non-existent-import.css";'
     }
   };
   let stylesForPage;
@@ -141,12 +145,7 @@ describe('preload cssom integration test', function () {
     });
 
     it('throws if cross-origin stylesheet fail to load', done => {
-      stylesForPage = [
-        {
-          id: 'nonExistingStylesheet',
-          text: '@import "import-non-existing-cross-origin.css";'
-        }
-      ];
+      stylesForPage = [styleSheets.styleTagWithNonExistentImport];
       attachStylesheets(
         {
           root: root,
@@ -157,8 +156,12 @@ describe('preload cssom integration test', function () {
             done(err);
           }
           getPreloadCssom(root)
-            .then(() => {
-              done(new Error('Expected getPreload to reject.'));
+            .then(sheets => {
+              done(
+                new Error(
+                  `Expected getPreload to reject, but it resolved with ${JSON.stringify(sheets)}.`
+                )
+              );
             })
             .catch(e => {
               assert.isDefined(e);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -357,7 +357,7 @@ var commons;
         doc.head.appendChild(link);
       });
     } else {
-      q.defer(function (resolve) {
+      q.defer(function (resolve, reject) {
         const style = doc.createElement('style');
         if (data.id) {
           style.id = data.id;
@@ -365,9 +365,25 @@ var commons;
         style.type = 'text/css';
         style.appendChild(doc.createTextNode(data.text));
         doc.head.appendChild(style);
-        setTimeout(function () {
-          resolve();
-        }, 100); // -> note: gives firefox to load (document.stylesheets), other browsers are fine.
+        // In Firefox, there is a delay between adding the element and it appearing in
+        // document.styleSheets, so we poll until we see it there.
+        const timeoutAt = Date.now() + 500;
+        const interval = setInterval(function () {
+          const isLoaded = Array.from(doc.styleSheets).some(
+            sheet => sheet.ownerNode === style
+          );
+          if (isLoaded) {
+            clearInterval(interval);
+            resolve();
+          } else if (Date.now() > timeoutAt) {
+            clearInterval(interval);
+            reject(
+              new Error(
+                'Added <style> element was not reflected in doc.styleSheets within timeout'
+              )
+            );
+          }
+        }, 5);
       });
     }
     return q;


### PR DESCRIPTION
In #4919, we found that the `test_firefox` job was unacceptably flaky in the `preload-cssom` tests. I believe this is because the GHA runners are slightly more resource-constrained than the circleci ones, which broke an assumption in `axe.testUtils.addStyleSheet` that adding a `<style>` element would result in `document.styleSheets` being updated accordingly within 100ms (in Chrome this happens instantly, but in Firefox there is a delay). I updated the test util to poll until it actually *sees* `document.styleSheets` update as expected, and to reject with a more actionable error if a timeout occurs (rather than letting a test run in an unexpected state). This also has a minor side-benefit of making the tests marginally faster on Chrome, since they no longer wait 100ms-per-injected-sheet unnecessarily.

You can see the results of this in https://github.com/dequelabs/axe-core/pull/4936 - the preload-cssom test_firefox case [only passed 6/10 runs without this fix](https://github.com/dequelabs/axe-core/pull/4936/checks?sha=1516bacef0b7e039030adbd4d55c1a627f9899fb) and [passed 10/10 runs with this fix](https://github.com/dequelabs/axe-core/pull/4936/checks?sha=339c2580bb82f2f7833b8e2447bfeff92354350e).

The updates in `preload-cssom.js` turned out to be unnecessary to fix the issue, but they make errors in the test more actionable and make the test more consistent with others, so I left them in.

No QA required.