### PR TITLE
ci(deploy): setup node internally

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,9 +66,17 @@ jobs:
       packageName: ${{ steps.determine-version.outputs.name }}
     steps:
       - *checkout
-      - &install-deps
-        name: Install Dependencies
-        uses: ./.github/actions/install-deps
+      - &setup-node
+        name: Setup NodeJS
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version-file: .nvmrc
+          cache: npm
+      - &install-project-deps
+        name: Install Project Dependencies
+        shell: bash
+        run: npm ci
       - &build
         name: Build
         run: |
@@ -97,11 +105,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - *checkout
-      - &setup-node
-        name: Setup Node.js
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version-file: .nvmrc
+      - *setup-node
       # In theory since this is a new job now, by the time
       # this would kick off the package should be available.
       # But, to be safe in case of delays in propagation,
@@ -141,7 +145,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - *checkout
-      - *install-deps
+      - *setup-node
+      - *install-project-deps
       - *build
       - *validate-package
       - name: Publish stable version to npm


### PR DESCRIPTION
Setting up Node through a composite workflow does not inherit the environment from the host. Meaning it creates its own token which does not have the correct deployment authorization.

This patch moves setting up node internal with no more use of the composite action for deployment. Which, enables the correct token to be used. It has a side effect of also saving us time in deploy by not installing the browser dependencies that aren't needed for this workflow.

Closes: #4912
