### PR TITLE
ci(deploy): install npm version 11

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version-file: .nvmrc
           cache: npm
+      - &install-npm
+        name: Install npm
+        run: npm install -g npm@11
       - &install-project-deps
         name: Install Project Dependencies
         shell: bash
@@ -146,6 +149,7 @@ jobs:
     steps:
       - *checkout
       - *setup-node
+      - *install-npm
       - *install-project-deps
       - *build
       - *validate-package


### PR DESCRIPTION
The other part that I forgot with deploy. We run on Node 22 by the `.nvmrc` version, which uses npm@10 as the default version. To use OIDC publishing at all, npm must be at 11.5.1 or higher. So dual combo of the token being off before combined with this version issue is why deployment was failing.

Closes: #4912
