### PR TITLE
chore: prevent update to css-selector-parser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,7 +51,7 @@ updates:
       - dependency-name: '@types/node'
         versions: ['>=5.0.0']
       # Breaking change that we need to handle in its own pr first
-      # See https://github.com/dequelabs/axe-core/pull/4264
+      # @see https://github.com/dequelabs/axe-core/pull/4264
       - dependency-name: 'css-selector-parser'
         versions: ['>=2.0.0']
     groups:


### PR DESCRIPTION
v2 adds a breaking change to the API and export structure that we can't take until we fix how we use it on our end.