### PR TITLE
ci: fix release script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,7 +174,7 @@ jobs:
         run: chmod +x ./node-github-release.sh
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./node-github-release.sh
   validate-deploy:
     name: Validate Deployment


### PR DESCRIPTION
Our first [GHA GitHub release failed](https://github.com/dequelabs/axe-core/actions/runs/20758308118/job/59607316910). Looks like the script expects the env which wasn't set.
