### PR TITLE
test: fix test:unit

### DIFF
--- a/test/core/utils/memoize.js
+++ b/test/core/utils/memoize.js
@@ -2,9 +2,9 @@ describe('axe.utils.memoize', function () {
   'use strict';
 
   it('should add the function to axe._memoizedFns', function () {
-    axe._memoizedFns.length = 0;
+    const length = axe._memoizedFns.length;
 
     axe.utils.memoize(function myFn() {});
-    assert.equal(axe._memoizedFns.length, 1);
+    assert.equal(axe._memoizedFns.length, length + 1);
   });
 });


### PR DESCRIPTION
Running `npm run test:unit` results in loads of failures. After racking my brain about why, I remembered I had a similar problem in my [fixing `npm run test:debug` pr](https://github.com/dequelabs/axe-core/pull/4769) where resetting the memoize functions results in them not being able to clear the cache between tests. Turns out that was the issue here.

Note: this isn't a problem in our pr runs or nightly tests because we either call `npm run: test:unit:<name>` directly or run `npm test` which runs all the tests in turn. This only happens when running `npm run test:unit` since the browser doesn't close between test types.