### PR TITLE
fix(scrollable-region-focusable): clarify the issue is in safari

### DIFF
--- a/lib/rules/scrollable-region-focusable.json
+++ b/lib/rules/scrollable-region-focusable.json
@@ -18,7 +18,7 @@
   ],
   "actIds": ["0ssw9k"],
   "metadata": {
-    "description": "Ensure elements that have scrollable content are accessible by keyboard",
+    "description": "Ensure elements that have scrollable content are accessible by keyboard in Safari",
     "help": "Scrollable region must have keyboard access"
   },
   "all": [],


### PR DESCRIPTION
Part of https://github.com/dequelabs/axe-core/issues/4830

Doesn't close the issue, but people keep reporting this as a false positive because we don't make it clear this is a Safari-only issue. Axe-core explicitly calling out a browser or screen reader is unusual, but I think the problem not doing this creates here is bigger than the overhead it would be for us to keep an eye on this and pull this out. If Safari ever addresses this the rule can be deprecated completely.

See related Webkit bugs:

- [WebKit#190870: Make scrollable element focusable](https://bugs.webkit.org/show_bug.cgi?id=190870)
- [WebKit#277290: AX: Scrolling containers inoperable with keyboard](https://bugs.webkit.org/show_bug.cgi?id=277290)