### PR TITLE
ci: fix update-generated-files workflow

### DIFF
--- a/locales/_template.json
+++ b/locales/_template.json
@@ -358,7 +358,7 @@
       "help": "scope attribute should be used correctly"
     },
     "scrollable-region-focusable": {
-      "description": "Ensure elements that have scrollable content are accessible by keyboard in Safari",
+      "description": "Ensure elements that have scrollable content are accessible by keyboard",
       "help": "Scrollable region must have keyboard access"
     },
     "select-name": {


### PR DESCRIPTION
It would seem that the `GITHUB_OUTPUT` syntax [does not allow line breaks](https://github.com/orgs/community/discussions/106666). Since the output to `git status --porcelain` produces a line with 2 changes

```
 M doc/rule-descriptions.md
 M locales/_template.json
```

removing the line breaks from the variable should fix the problem.