### PR TITLE
feat(wcag): add accessible-authentication rule for wcag 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [Unreleased]
+
+### Features
+
+- **new rule:** add WCAG 2.2 accessible-authentication rule (off by default)
+
 ### [4.11.1](https://github.com/dequelabs/axe-core/compare/v4.11.0...v4.11.1) (2026-01-06)
 
 ### Bug Fixes

--- a/doc/rule-descriptions.md
+++ b/doc/rule-descriptions.md
@@ -88,9 +88,10 @@
 
 These rules are disabled by default, until WCAG 2.2 is more widely adopted and required.
 
-| Rule ID                                                                                           | Description                                         | Impact  | Tags                                           | Issue Type                 | [ACT Rules](https://www.w3.org/WAI/standards-guidelines/act/rules/) |
-| :------------------------------------------------------------------------------------------------ | :-------------------------------------------------- | :------ | :--------------------------------------------- | :------------------------- | :------------------------------------------------------------------ |
-| [target-size](https://dequeuniversity.com/rules/axe/4.11/target-size?application=RuleDescription) | Ensure touch targets have sufficient size and space | Serious | cat.sensory-and-visual-cues, wcag22aa, wcag258 | failure, needs&nbsp;review |                                                                     |
+| Rule ID                                                                                                                       | Description                                                | Impact  | Tags                                           | Issue Type                 | [ACT Rules](https://www.w3.org/WAI/standards-guidelines/act/rules/) |
+| :---------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------- | :------ | :--------------------------------------------- | :------------------------- | :------------------------------------------------------------------ |
+| [accessible-authentication](https://dequeuniversity.com/rules/axe/4.11/accessible-authentication?application=RuleDescription) | Ensure password fields have a valid autocomplete attribute | Serious | cat.forms, wcag22aa, wcag337                   | failure, needs&nbsp;review |                                                                     |
+| [target-size](https://dequeuniversity.com/rules/axe/4.11/target-size?application=RuleDescription)                             | Ensure touch targets have sufficient size and space        | Serious | cat.sensory-and-visual-cues, wcag22aa, wcag258 | failure, needs&nbsp;review |                                                                     |
 
 ## Best Practices Rules
 

--- a/lib/checks/forms/accessible-authentication-evaluate.js
+++ b/lib/checks/forms/accessible-authentication-evaluate.js
@@ -23,5 +23,5 @@ export default function accessibleAuthenticationEvaluate(
   if (isValid) {
     return true;
   }
-  return undefined;
+  return false;
 }

--- a/lib/checks/forms/accessible-authentication-evaluate.js
+++ b/lib/checks/forms/accessible-authentication-evaluate.js
@@ -1,0 +1,27 @@
+/**
+ * Evaluates whether password fields have a valid autocomplete attribute for Accessible Authentication.
+ *
+ * @param {HTMLElement} node The current DOM node being evaluated.
+ * @param {Object} options Configuration options for the check.
+ * @param {VirtualNode} virtualNode The internal representation of the element.
+ * @returns {Boolean|undefined} True if the node passes, undefined if manual review is needed.
+ */
+export default function accessibleAuthenticationEvaluate(
+  node,
+  options,
+  virtualNode
+) {
+  const autocomplete = virtualNode.attr('autocomplete');
+  if (!autocomplete) {
+    return undefined;
+  }
+
+  const tokens = String(autocomplete).toLowerCase().split(/\s+/);
+  const isValid =
+    tokens.includes('current-password') || tokens.includes('new-password');
+
+  if (isValid) {
+    return true;
+  }
+  return undefined;
+}

--- a/lib/checks/forms/accessible-authentication.json
+++ b/lib/checks/forms/accessible-authentication.json
@@ -1,0 +1,12 @@
+{
+  "id": "accessible-authentication",
+  "evaluate": "accessible-authentication-evaluate",
+  "metadata": {
+    "impact": "serious",
+    "messages": {
+      "pass": "Password field has a valid autocomplete attribute",
+      "fail": "Password field does not have a valid autocomplete attribute",
+      "incomplete": "Ensure the password field has an alternative method of authentication"
+    }
+  }
+}

--- a/lib/rules/accessible-authentication.json
+++ b/lib/rules/accessible-authentication.json
@@ -1,0 +1,13 @@
+{
+  "id": "accessible-authentication",
+  "impact": "serious",
+  "selector": "input[type=\"password\"]",
+  "tags": ["cat.forms", "wcag22aa", "wcag337"],
+  "metadata": {
+    "description": "Ensure password fields have a valid autocomplete attribute",
+    "help": "Authentication password fields must have a valid autocomplete attribute"
+  },
+  "all": ["accessible-authentication"],
+  "any": [],
+  "none": []
+}

--- a/lib/rules/accessible-authentication.json
+++ b/lib/rules/accessible-authentication.json
@@ -2,6 +2,7 @@
   "id": "accessible-authentication",
   "impact": "serious",
   "selector": "input[type=\"password\"]",
+  "enabled": false,
   "tags": ["cat.forms", "wcag22aa", "wcag337"],
   "metadata": {
     "description": "Ensure password fields have a valid autocomplete attribute",

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -1,6 +1,10 @@
 {
   "lang": "xyz",
   "rules": {
+    "accessible-authentication": {
+      "description": "Ensure password fields have a valid autocomplete attribute",
+      "help": "Authentication password fields must have a valid autocomplete attribute"
+    },
     "accesskeys": {
       "description": "Ensure every accesskey attribute value is unique",
       "help": "accesskey attribute value should be unique"
@@ -688,6 +692,11 @@
         "imgNode": "Element's contrast ratio could not be determined because element contains an image node",
         "bgOverlap": "Element's contrast ratio could not be determined because of element overlap"
       }
+    },
+    "accessible-authentication": {
+      "pass": "Password field has a valid autocomplete attribute",
+      "fail": "Password field does not have a valid autocomplete attribute",
+      "incomplete": "Ensure the password field has an alternative method of authentication"
     },
     "autocomplete-appropriate": {
       "pass": "The autocomplete value is on an appropriate element",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "aria-query": "^5.1.3",
         "chai": "^4.3.7",
         "chalk": "^4.x",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "clean-jsdoc-theme": "^4.2.17",
         "clone": "^2.1.2",
         "colorjs.io": "0.4.3",
@@ -7325,17 +7325,6 @@
         }
       }
     },
-    "node_modules/inquirer/node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
-    },
     "node_modules/inquirer/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -7376,14 +7365,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inquirer/node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/inquirer/node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -18608,17 +18589,6 @@
             "iconv-lite": "^0.6.3"
           }
         },
-        "@types/node": {
-          "version": "24.3.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-          "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "undici-types": "~7.10.0"
-          }
-        },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -18650,14 +18620,6 @@
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
           }
-        },
-        "undici-types": {
-          "version": "7.10.0",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-          "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "wrap-ansi": {
           "version": "6.2.0",

--- a/test/checks/forms/accessible-authentication.js
+++ b/test/checks/forms/accessible-authentication.js
@@ -26,11 +26,11 @@ describe('accessible-authentication tests', () => {
     assert.isTrue(checkEvaluate.apply(checkContext, params));
   });
 
-  it('returns undefined for invalid autocomplete values', () => {
+  it('returns false for invalid autocomplete values', () => {
     const params = checkSetup(
       '<input type="password" autocomplete="username" id="target" />'
     );
-    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    assert.isFalse(checkEvaluate.apply(checkContext, params));
   });
 
   it('returns true for password field in an open shadow root', () => {

--- a/test/checks/forms/accessible-authentication.js
+++ b/test/checks/forms/accessible-authentication.js
@@ -1,0 +1,46 @@
+describe('accessible-authentication tests', () => {
+  const { checkSetup, fixtureSetup, getCheckEvaluate } = axe.testUtils;
+  const checkContext = axe.testUtils.MockCheckContext();
+  const checkEvaluate = getCheckEvaluate('accessible-authentication');
+
+  afterEach(() => {
+    checkContext.reset();
+  });
+
+  it('returns undefined when input has no autocomplete', () => {
+    const params = checkSetup('<input type="password" id="target" />');
+    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+  });
+
+  it('returns true when input has correct autocomplete', () => {
+    const params = checkSetup(
+      '<input type="password" autocomplete="current-password" id="target" />'
+    );
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
+  });
+
+  it('returns true when autocomplete has multiple tokens', () => {
+    const params = checkSetup(
+      '<input type="password" autocomplete="section-login current-password" id="target" />'
+    );
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
+  });
+
+  it('returns undefined for invalid autocomplete values', () => {
+    const params = checkSetup(
+      '<input type="password" autocomplete="username" id="target" />'
+    );
+    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+  });
+
+  it('returns true for password field in an open shadow root', () => {
+    const root = document.createElement('div');
+    const shadow = root.attachShadow({ mode: 'open' });
+    shadow.innerHTML =
+      '<input type="password" autocomplete="new-password" id="target" />';
+    fixtureSetup(root);
+
+    const vNode = axe.utils.getNodeFromTree(shadow.querySelector('#target'));
+    assert.isTrue(checkEvaluate.call(checkContext, null, {}, vNode));
+  });
+});

--- a/test/integration/rules/accessible-authentication/accessible-authentication.html
+++ b/test/integration/rules/accessible-authentication/accessible-authentication.html
@@ -1,0 +1,20 @@
+<input type="password" autocomplete="current-password" id="pass1" />
+<input type="password" autocomplete="new-password" id="pass2" />
+<input
+  type="password"
+  autocomplete="section-login current-password"
+  id="pass3"
+/>
+
+<input type="password" id="incomplete1" />
+<input type="password" autocomplete="off" id="incomplete2" />
+<input type="password" autocomplete="username" id="incomplete3" />
+<input type="text" id="inapplicable1" />
+
+<div id="shadow-host"></div>
+<script>
+  const host = document.querySelector('#shadow-host');
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  shadowRoot.innerHTML =
+    '<input type="password" autocomplete="current-password" id="pass-shadow" />';
+</script>

--- a/test/integration/rules/accessible-authentication/accessible-authentication.json
+++ b/test/integration/rules/accessible-authentication/accessible-authentication.json
@@ -1,0 +1,7 @@
+{
+  "description": "accessible-authentication tests",
+  "rule": "accessible-authentication",
+  "violations": [],
+  "passes": [["#pass1"], ["#pass2"], ["#pass3"]],
+  "incomplete": [["#incomplete1"], ["#incomplete2"], ["#incomplete3"]]
+}

--- a/test/integration/rules/accessible-authentication/accessible-authentication.json
+++ b/test/integration/rules/accessible-authentication/accessible-authentication.json
@@ -1,7 +1,7 @@
 {
   "description": "accessible-authentication tests",
   "rule": "accessible-authentication",
-  "violations": [],
+  "violations": [["#incomplete2"], ["#incomplete3"]],
   "passes": [["#pass1"], ["#pass2"], ["#pass3"]],
-  "incomplete": [["#incomplete1"], ["#incomplete2"], ["#incomplete3"]]
+  "incomplete": [["#incomplete1"]]
 }


### PR DESCRIPTION
## Summary

Add a new WCAG 2.2 rule, `accessible-authentication`, for password inputs with valid `autocomplete` tokens.

## Changes

- Add new rule/check: `accessible-authentication`
- Add evaluate logic for `current-password` / `new-password`
- Add unit tests (including Shadow DOM and multi-token cases)
- Add integration test HTML/JSON fixtures
- Update `locales/_template.json`, `doc/rule-descriptions.md`, and `CHANGELOG.md`

## Testing

- `npm run fmt`
- `npm run eslint`
- `npm run build`
- `npm run test:unit -- testFiles=lib/checks/forms/accessible-authentication-evaluate.js,test/integration/rules/accessible-authentication/accessible-authentication.json`

## Notes

- Rule is part of WCAG 2.2 set and is disabled by default.
- Existing unrelated baseline failure remains in full `npm test` (`color-contrast`).
