### PR TITLE
fix(utils): update isShadowRoot to use spec-compliant custom element regex

### DIFF
--- a/lib/core/utils/is-shadow-root.js
+++ b/lib/core/utils/is-shadow-root.js
@@ -18,6 +18,26 @@ const possibleShadowRoots = [
   'section',
   'span'
 ];
+
+// Reserved names that match the custom element regex but are not valid custom elements.
+// https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+const reservedNames = [
+  'annotation-xml',
+  'color-profile',
+  'font-face',
+  'font-face-src',
+  'font-face-uri',
+  'font-face-format',
+  'font-face-name',
+  'missing-glyph'
+];
+
+// Spec-compliant PCEN (Potential Custom Element Name) regex.
+// Extends the ASCII-only regex to include Unicode characters permitted by the spec.
+// https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+const customElementRegex =
+  /^[a-z](?:[a-z0-9._-]|[\u00B7\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u037D\u037F-\u1FFF\u200C-\u200D\u203F-\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD])*-(?:[a-z0-9._-]|[\u00B7\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u037D\u037F-\u1FFF\u200C-\u200D\u203F-\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD])*$/;
+
 /**
  * Test a node to see if it has a spec-conforming shadow root
  *
@@ -29,7 +49,7 @@ function isShadowRoot(node) {
     const nodeName = node.nodeName.toLowerCase();
     if (
       possibleShadowRoots.includes(nodeName) ||
-      /^[a-z][a-z0-9_.-]*-[a-z0-9_.-]*$/.test(nodeName)
+      (!reservedNames.includes(nodeName) && customElementRegex.test(nodeName))
     ) {
       return true;
     }

--- a/lib/core/utils/is-shadow-root.js
+++ b/lib/core/utils/is-shadow-root.js
@@ -1,3 +1,5 @@
+import isValidCustomElementName from './is-valid-custom-element-name';
+
 const possibleShadowRoots = [
   'article',
   'aside',
@@ -18,6 +20,7 @@ const possibleShadowRoots = [
   'section',
   'span'
 ];
+
 /**
  * Test a node to see if it has a spec-conforming shadow root
  *
@@ -29,7 +32,7 @@ function isShadowRoot(node) {
     const nodeName = node.nodeName.toLowerCase();
     if (
       possibleShadowRoots.includes(nodeName) ||
-      /^[a-z][a-z0-9_.-]*-[a-z0-9_.-]*$/.test(nodeName)
+      isValidCustomElementName(nodeName)
     ) {
       return true;
     }

--- a/test/core/utils/is-shadow-root.js
+++ b/test/core/utils/is-shadow-root.js
@@ -33,6 +33,18 @@ describe('axe.utils.isShadowRoot', function () {
     assert.isFalse(isShadowRoot({ nodeName: '0-BUZZ', shadowRoot: {} }));
     assert.isFalse(isShadowRoot({ nodeName: '--ELM--', shadowRoot: {} }));
   });
+  it('returns false for reserved custom element names', function () {
+    assert.isFalse(
+      isShadowRoot({ nodeName: 'ANNOTATION-XML', shadowRoot: {} })
+    );
+    assert.isFalse(isShadowRoot({ nodeName: 'COLOR-PROFILE', shadowRoot: {} }));
+    assert.isFalse(isShadowRoot({ nodeName: 'FONT-FACE', shadowRoot: {} }));
+    assert.isFalse(isShadowRoot({ nodeName: 'MISSING-GLYPH', shadowRoot: {} }));
+  });
+  it('returns true for Unicode custom element names', function () {
+    assert.isTrue(isShadowRoot({ nodeName: 'CAF\u00C9-MENU', shadowRoot: {} }));
+    assert.isTrue(isShadowRoot({ nodeName: 'MATH-\u03A0', shadowRoot: {} }));
+  });
   it('returns false if the native element does not allow shadow DOM', function () {
     assert.isFalse(isShadowRoot({ nodeName: 'IFRAME', shadowRoot: {} }));
     assert.isFalse(isShadowRoot({ nodeName: 'STRONG', shadowRoot: {} }));

--- a/test/core/utils/is-shadow-root.js
+++ b/test/core/utils/is-shadow-root.js
@@ -30,6 +30,18 @@ describe('axe.utils.isShadowRoot', () => {
     assert.isFalse(isShadowRoot({ nodeName: '0-BUZZ', shadowRoot: {} }));
     assert.isFalse(isShadowRoot({ nodeName: '--ELM--', shadowRoot: {} }));
   });
+  it('returns false for reserved custom element names', () => {
+    assert.isFalse(
+      isShadowRoot({ nodeName: 'ANNOTATION-XML', shadowRoot: {} })
+    );
+    assert.isFalse(isShadowRoot({ nodeName: 'COLOR-PROFILE', shadowRoot: {} }));
+    assert.isFalse(isShadowRoot({ nodeName: 'FONT-FACE', shadowRoot: {} }));
+    assert.isFalse(isShadowRoot({ nodeName: 'MISSING-GLYPH', shadowRoot: {} }));
+  });
+  it('returns true for Unicode custom element names', () => {
+    assert.isTrue(isShadowRoot({ nodeName: 'CAFÉ-MENU', shadowRoot: {} }));
+    assert.isTrue(isShadowRoot({ nodeName: 'MATH-Π', shadowRoot: {} }));
+  });
   it('returns false if the native element does not allow shadow DOM', () => {
     assert.isFalse(isShadowRoot({ nodeName: 'IFRAME', shadowRoot: {} }));
     assert.isFalse(isShadowRoot({ nodeName: 'STRONG', shadowRoot: {} }));


### PR DESCRIPTION
The custom element name regex in `isShadowRoot` only matches ASCII characters. The HTML spec allows a broader set of Unicode characters in Potential Custom Element Names (PCEN), so valid elements like `<café-menu>` and `<math-π>` were being rejected as shadow root candidates.

Two changes:
- Replace the ASCII-only regex with the spec-compliant PCEN character ranges
- Add an explicit reserved names check (`annotation-xml`, `color-profile`, `font-face`, etc.): these match the pattern but are explicitly excluded by the spec

Tests added for both cases.

Closes #5030