### PR TITLE
fix(core): prevent ping timeout during long gather steps

### DIFF
--- a/lib/core/base/audit.js
+++ b/lib/core/base/audit.js
@@ -281,8 +281,11 @@ export default class Audit {
     const allRulesToRun = getRulesToRun(this.rules, context, options);
     const runNowRules = allRulesToRun.now;
     const runLaterRules = allRulesToRun.later;
-    // init a NOW queue for rules to run immediately
-    const nowRulesQueue = queue();
+    // init a NOW queue for rules to run immediately.
+    // Use a time budget to yield to the event loop periodically,
+    // preventing long gather steps from blocking iframe communication.
+    // See: #4831
+    const nowRulesQueue = queue({ timeBudget: 50 });
     // construct can run NOW rules into NOW queue
     runNowRules.forEach(rule => {
       nowRulesQueue.defer(getDefferedRule(rule, context, options));
@@ -341,7 +344,7 @@ export default class Audit {
           return;
         }
         // init a LATER queue for rules that are dependant on preloaded assets
-        const laterRulesQueue = queue();
+        const laterRulesQueue = queue({ timeBudget: 50 });
         runLaterRules.forEach(rule => {
           const deferredRule = getDefferedRule(rule, context, options);
           laterRulesQueue.defer(deferredRule);

--- a/lib/core/public/run-rules.js
+++ b/lib/core/public/run-rules.js
@@ -40,10 +40,21 @@ export default function runRules(context, options, resolve, reject) {
     q.defer((res, rej) => {
       collectResultsFromFrames(context, options, 'rules', null, res, rej);
     });
+
+    q.defer((res, rej) => {
+      // Yield to the event loop before starting the audit. This allows
+      // pending postMessage events (e.g. iframe ping responses from
+      // collectResultsFromFrames) to be processed before the synchronous
+      // gather step blocks the thread. See: #4831
+      setTimeout(() => {
+        audit.run(context, options, res, rej);
+      }, 0);
+    });
+  } else {
+    q.defer((res, rej) => {
+      audit.run(context, options, res, rej);
+    });
   }
-  q.defer((res, rej) => {
-    audit.run(context, options, res, rej);
-  });
   q.then(data => {
     try {
       if (options.performanceTimer) {

--- a/lib/core/utils/queue.js
+++ b/lib/core/utils/queue.js
@@ -9,15 +9,22 @@ function funcGuard(f) {
 
 /**
  * Create an asynchronous "queue", list of functions to be invoked in parallel, but not necessarily returned in order
+ * @param {Object} [options] Optional configuration
+ * @param {number} [options.timeBudget] Maximum synchronous execution time (ms) before yielding to the event loop
  * @return {Queue} The newly generated "queue"
  */
-function queue() {
+function queue(options) {
+  const timeBudget =
+    options && typeof options.timeBudget === 'number' ? options.timeBudget : 0;
   const tasks = [];
   let started = 0;
   let remaining = 0; // number of tasks not yet finished
   let completeQueue = noop;
   let complete = false;
   let err;
+  let budgetStart = 0;
+  let pendingYield = false;
+  let aborted = false;
 
   // By default, wait until the next tick,
   // if no catch was set, throw to console.
@@ -45,6 +52,7 @@ function queue() {
   function abort(msg) {
     // reset tasks
     completeQueue = noop;
+    aborted = true;
 
     // notify catch
     failed(msg);
@@ -53,8 +61,25 @@ function queue() {
   }
 
   function pop() {
+    pendingYield = false;
+
+    if (err !== undefined || aborted) {
+      return;
+    }
+
+    if (timeBudget && !budgetStart) {
+      budgetStart = Date.now();
+    }
+
     const length = tasks.length;
     for (; started < length; started++) {
+      if (timeBudget && budgetStart && Date.now() - budgetStart > timeBudget) {
+        budgetStart = 0;
+        pendingYield = true;
+        setTimeout(pop, 0);
+        return;
+      }
+
       const task = tasks[started];
 
       try {
@@ -88,7 +113,9 @@ function queue() {
 
       tasks.push(fn);
       ++remaining;
-      pop();
+      if (!pendingYield) {
+        pop();
+      }
       return q;
     },
 

--- a/test/core/utils/queue.js
+++ b/test/core/utils/queue.js
@@ -171,6 +171,151 @@ describe('axe.utils.queue', function () {
     });
   });
 
+  describe('timeBudget', function () {
+    it('should preserve default behavior when no timeBudget is set', function () {
+      var q = axe.utils.queue();
+      var complete = false;
+
+      q.defer(function (resolve) {
+        resolve(1);
+      });
+
+      q.defer(function (resolve) {
+        resolve(2);
+      });
+
+      q.then(function (data) {
+        complete = true;
+        assert.deepEqual(data, [1, 2]);
+      });
+
+      assert.isTrue(complete);
+    });
+
+    it('should complete all deferred tasks with a timeBudget', function (done) {
+      var q = axe.utils.queue({ timeBudget: 1 });
+
+      q.defer(function (resolve) {
+        var start = Date.now();
+        while (Date.now() - start < 10) {
+          // busy-wait to exceed budget
+        }
+        resolve(1);
+      });
+
+      q.defer(function (resolve) {
+        resolve(2);
+      });
+
+      q.defer(function (resolve) {
+        resolve(3);
+      });
+
+      q.then(function (data) {
+        assert.deepEqual(data, [1, 2, 3]);
+        done();
+      });
+    });
+
+    it('should not complete synchronously when budget is exceeded', function (done) {
+      var q = axe.utils.queue({ timeBudget: 1 });
+      var complete = false;
+
+      q.defer(function (resolve) {
+        var start = Date.now();
+        while (Date.now() - start < 10) {
+          // busy-wait to exceed budget
+        }
+        resolve(1);
+      });
+
+      q.defer(function (resolve) {
+        resolve(2);
+      });
+
+      q.then(function (data) {
+        complete = true;
+        assert.deepEqual(data, [1, 2]);
+        done();
+      });
+
+      assert.isFalse(
+        complete,
+        'queue should not complete synchronously when yielding'
+      );
+    });
+
+    it('should complete synchronously when budget is not exceeded', function () {
+      var q = axe.utils.queue({ timeBudget: 5000 });
+      var complete = false;
+
+      q.defer(function (resolve) {
+        resolve(1);
+      });
+
+      q.defer(function (resolve) {
+        resolve(2);
+      });
+
+      q.then(function (data) {
+        complete = true;
+        assert.deepEqual(data, [1, 2]);
+      });
+
+      assert.isTrue(complete);
+    });
+
+    it('should handle errors during yielded execution', function (done) {
+      var q = axe.utils.queue({ timeBudget: 1 });
+
+      q.defer(function (resolve) {
+        var start = Date.now();
+        while (Date.now() - start < 10) {
+          // busy-wait to exceed budget
+        }
+        resolve(1);
+      });
+
+      q.defer(function () {
+        throw 'error during yield';
+      });
+
+      q.catch(function (e) {
+        assert.equal(e, 'error during yield');
+        done();
+      });
+    });
+
+    it('should not run yielded tasks after abort', function (done) {
+      var q = axe.utils.queue({ timeBudget: 1 });
+      var taskRan = false;
+
+      q.defer(function (resolve) {
+        var start = Date.now();
+        while (Date.now() - start < 10) {
+          // busy-wait to exceed budget
+        }
+        resolve(1);
+      });
+
+      q.defer(function () {
+        taskRan = true;
+      });
+
+      q.then(function () {
+        assert.ok(false, 'should not execute');
+      });
+
+      q.catch(function () {});
+      q.abort('aborted');
+
+      setTimeout(function () {
+        assert.isFalse(taskRan, 'task should not run after abort');
+        done();
+      }, 50);
+    });
+  });
+
   describe('catch', function () {
     it('is called when defer throws an error', function (done) {
       var q = axe.utils.queue();


### PR DESCRIPTION
## Summary

Fixes the cross-frame ping timeout that occurs on large pages when the synchronous gather step blocks the event loop for multiple seconds, preventing iframe ping responses from being processed.

Two complementary changes:

- **Time-budgeted queue yielding**: Enhanced `queue()` to accept an optional `{ timeBudget }` parameter. When cumulative synchronous execution time exceeds the budget (50ms), the queue yields to the event loop via `setTimeout(0)` before running the next task. Applied to rule execution queues in `audit.run()`, this allows pending `postMessage` events (including iframe ping responses) to be processed between rule gather steps.

- **Yield before `audit.run()` when iframes are present**: Wraps the `audit.run()` call in `setTimeout(0)` when cross-frame testing is active, giving the event loop a tick to process pending ping responses before heavy gather work begins. No yield overhead when iframes are absent.

### Implementation details

- `queue.js`: Added `timeBudget` option, `pendingYield` flag to prevent duplicate `pop()` calls during yield, `aborted` flag to prevent yielded tasks from running after `abort()`. Uses `Date.now()` for universal compatibility.
- `run-rules.js`: Conditional `setTimeout(0)` only when `context.frames.length > 0`.
- `audit.js`: `nowRulesQueue` and `laterRulesQueue` use `{ timeBudget: 50 }`.
- 6 new tests covering: default behavior preservation, async completion, synchronous completion when budget not exceeded, error handling during yield, and abort during yield.

Closes: https://github.com/dequelabs/axe-core/issues/4831