### PR TITLE
chore: fix cherry-pick script buffer size error for large git logs

### DIFF
--- a/build/cherry-pick.js
+++ b/build/cherry-pick.js
@@ -5,6 +5,9 @@ const conventionalCommitsParser = require('conventional-commits-parser');
 const chalk = require('chalk');
 const { version } = require('../package.json');
 
+// Node's default execSync buffer (~1 MiB) is too small for `git log` on long histories.
+const GIT_LOG_EXEC_OPTS = { maxBuffer: 50 * 1024 * 1024 };
+
 const releaseType = process.argv[2];
 let ignoreCommits = process.argv[3];
 
@@ -50,7 +53,8 @@ function getCommits(branch) {
   // all commits are too large for execSync buffer size so we'll just get since the last 3 years
   const date = new Date(new Date().setFullYear(new Date().getFullYear() - 3));
   const stdout = execSync(
-    `git log ${branch || ''} --abbrev-commit --since=${date.getFullYear()}`
+    `git log ${branch || ''} --no-merges --abbrev-commit --since=${date.getFullYear()}`,
+    GIT_LOG_EXEC_OPTS
   ).toString();
   const allCommits = stdout
     .split(/commit (?=[\w\d]{8}[\n\r])/)


### PR DESCRIPTION
This fixes the cherry-pick script's problem of trying to read git log information now that we have too many for the current buffer size. Originally done in https://github.com/dequelabs/axe-core/pull/5048 but porting to it's own pr since that one was closed.