### PR TITLE
fix(commons/text): exclude natively hidden elements from aria-labelledby accessible name

### DIFF
--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -7,6 +7,7 @@ import titleText from './title-text';
 import sanitize from './sanitize';
 import isVisibleToScreenReaders from '../dom/is-visible-to-screenreader';
 import isIconLigature from '../text/is-icon-ligature';
+import { nativelyHidden } from '../dom/visibility-methods';
 
 /**
  * Finds virtual node and calls accessibleTextVirtual()
@@ -84,11 +85,14 @@ function shouldIgnoreHidden(virtualNode, context) {
     return false;
   }
 
+  // When traversing aria-labelledby references, include hidden nodes except natively hidden elements
+  if (context.includeHidden && !nativelyHidden(virtualNode)) {
+    return false;
+  }
+
   if (
     // If the parent isn't ignored, the text node should not be either
-    virtualNode.props.nodeType !== 1 ||
-    // If the target of aria-labelledby is hidden, ignore all descendents
-    context.includeHidden
+    virtualNode.props.nodeType !== 1
   ) {
     return false;
   }

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -1649,6 +1649,38 @@ describe('text.accessibleTextVirtual', () => {
     });
   });
 
+  describe('natively hidden elements', () => {
+    const tags = ['style', 'script', 'noscript', 'template'];
+
+    it('should not use content as accessible name when directly referenced by aria-labelledby', () => {
+      tags.forEach(tag => {
+        fixture.innerHTML = `<div id="t1" aria-labelledby="el-id"></div><${tag} id="el-id">content</${tag}>`;
+        axe.testUtils.flatTreeSetup(fixture);
+        const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+        assert.equal(axe.commons.text.accessibleTextVirtual(target), '', tag);
+      });
+    });
+
+    it('should not use content when inside a hidden container referenced by aria-labelledby', () => {
+      tags.forEach(tag => {
+        fixture.innerHTML = `
+          <div id="t1" aria-labelledby="hidden-container"></div>
+          <div id="hidden-container" aria-hidden="true">
+            <${tag}>content</${tag}>
+            Expected label
+          </div>
+        `;
+        axe.testUtils.flatTreeSetup(fixture);
+        const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+        assert.equal(
+          axe.commons.text.accessibleTextVirtual(target),
+          'Expected label',
+          tag
+        );
+      });
+    });
+  });
+
   describe('text.accessibleText acceptance tests', () => {
     'use strict';
     // Tests borrowed from the AccName 1.1 testing docs

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -1679,6 +1679,15 @@ describe('text.accessibleTextVirtual', () => {
         );
       });
     });
+
+    it('should ignore aria-label as accessible name when directly referenced by aria-labelledby', () => {
+      tags.forEach(tag => {
+        fixture.innerHTML = `<div id="t1" aria-labelledby="el-id"></div><${tag} id="el-id" aria-label="aria-label"></${tag}>`;
+        axe.testUtils.flatTreeSetup(fixture);
+        const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+        assert.equal(axe.commons.text.accessibleTextVirtual(target), '', tag);
+      });
+    });
   });
 
   describe('text.accessibleText acceptance tests', () => {


### PR DESCRIPTION
Fixes accessible name calculation to correctly exclude `<style>` contents, as well as `<script>`, `<noscript>`, and `<template>`, when referenced via `aria-labelledby`.

Closes #4704