### PR TITLE
fix(utils/getAncestry): escape node name

### DIFF
--- a/lib/core/utils/get-ancestry.js
+++ b/lib/core/utils/get-ancestry.js
@@ -1,7 +1,8 @@
+import escapeSelector from './escape-selector';
 import getShadowSelector from './get-shadow-selector';
 
 function generateAncestry(node) {
-  const nodeName = node.nodeName.toLowerCase();
+  const nodeName = escapeSelector(node.nodeName.toLowerCase());
   const parentElement = node.parentElement;
   const parentNode = node.parentNode;
 

--- a/test/core/utils/get-ancestry.js
+++ b/test/core/utils/get-ancestry.js
@@ -71,4 +71,31 @@ describe('axe.utils.getAncestry', () => {
       'div:nth-child(2)'
     ]);
   });
+
+  it('escapes the node name', () => {
+    fixture.innerHTML = `
+    <div>
+      <hello="world">
+        <button id="target1">button</button>
+      </hello="world">
+    </div>
+    <emoji-👍>
+      <button id="target2">button</button>
+    </emoji-👍>
+    `;
+
+    const sel1 = axe.utils.getAncestry(document.querySelector('#target1'));
+    assert.equal(
+      sel1,
+      'html > body > div:nth-child(1) > div:nth-child(1) > hello\\=\\"world\\" > button'
+    );
+    assert.isNotNull(document.querySelector(sel1));
+
+    const sel2 = axe.utils.getAncestry(document.querySelector('#target2'));
+    assert.equal(
+      sel2,
+      'html > body > div:nth-child(1) > emoji-👍:nth-child(2) > button'
+    );
+    assert.isNotNull(document.querySelector(sel2));
+  });
 });


### PR DESCRIPTION
Closes: #5078 
