### PR TITLE
chore: Release 4.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.11.4](https://github.com/dequelabs/axe-core/compare/v4.11.3...v4.11.4) (2026-04-23)
+
+### Bug Fixes
+
+- **commons/text:** exclude natively hidden elements from aria-labelledby accessible name ([#5076](https://github.com/dequelabs/axe-core/issues/5076)) ([df34adf](https://github.com/dequelabs/axe-core/commit/df34adfc1967919d667d40a76ab5c85b6e47ddfe)), closes [#4704](https://github.com/dequelabs/axe-core/issues/4704)
+- **utils/getAncestry:** escape node name ([#5079](https://github.com/dequelabs/axe-core/issues/5079)) ([6e68d0a](https://github.com/dequelabs/axe-core/commit/6e68d0a5d26999b996152df82238bc3f3a041cb3)), closes [#5078](https://github.com/dequelabs/axe-core/issues/5078)
+
 ### [4.11.3](https://github.com/dequelabs/axe-core/compare/v4.11.2...v4.11.3) (2026-04-13)
 
 ### Bug Fixes

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "axe-core",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "deprecated": true,
   "contributors": [
     {

--- a/build/cherry-pick.js
+++ b/build/cherry-pick.js
@@ -5,6 +5,9 @@ const conventionalCommitsParser = require('conventional-commits-parser');
 const chalk = require('chalk');
 const { version } = require('../package.json');
 
+// Node's default execSync buffer (~1 MiB) is too small for `git log` on long histories.
+const GIT_LOG_EXEC_OPTS = { maxBuffer: 50 * 1024 * 1024 };
+
 const releaseType = process.argv[2];
 let ignoreCommits = process.argv[3];
 
@@ -50,7 +53,8 @@ function getCommits(branch) {
   // all commits are too large for execSync buffer size so we'll just get since the last 3 years
   const date = new Date(new Date().setFullYear(new Date().getFullYear() - 3));
   const stdout = execSync(
-    `git log ${branch || ''} --abbrev-commit --since=${date.getFullYear()}`
+    `git log ${branch || ''} --no-merges --abbrev-commit --since=${date.getFullYear()}`,
+    GIT_LOG_EXEC_OPTS
   ).toString();
   const allCommits = stdout
     .split(/commit (?=[\w\d]{8}[\n\r])/)

--- a/lib/commons/text/accessible-text-virtual.js
+++ b/lib/commons/text/accessible-text-virtual.js
@@ -7,6 +7,7 @@ import titleText from './title-text';
 import sanitize from './sanitize';
 import isVisibleToScreenReaders from '../dom/is-visible-to-screenreader';
 import isIconLigature from '../text/is-icon-ligature';
+import { nativelyHidden } from '../dom/visibility-methods';
 
 /**
  * Finds virtual node and calls accessibleTextVirtual()
@@ -84,11 +85,14 @@ function shouldIgnoreHidden(virtualNode, context) {
     return false;
   }
 
+  // When traversing aria-labelledby references, include hidden nodes except natively hidden elements
+  if (context.includeHidden && !nativelyHidden(virtualNode)) {
+    return false;
+  }
+
   if (
     // If the parent isn't ignored, the text node should not be either
-    virtualNode.props.nodeType !== 1 ||
-    // If the target of aria-labelledby is hidden, ignore all descendents
-    context.includeHidden
+    virtualNode.props.nodeType !== 1
   ) {
     return false;
   }

--- a/lib/core/utils/get-ancestry.js
+++ b/lib/core/utils/get-ancestry.js
@@ -1,7 +1,8 @@
+import escapeSelector from './escape-selector';
 import getShadowSelector from './get-shadow-selector';
 
 function generateAncestry(node) {
-  const nodeName = node.nodeName.toLowerCase();
+  const nodeName = escapeSelector(node.nodeName.toLowerCase());
   const parentElement = node.parentElement;
   const parentNode = node.parentNode;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axe-core",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "axe-core",
-      "version": "4.11.3",
+      "version": "4.11.4",
       "license": "MPL-2.0",
       "devDependencies": {
         "@axe-core/webdriverjs": "^4.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axe-core",
   "description": "Accessibility engine for automated Web UI testing",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "license": "MPL-2.0",
   "engines": {
     "node": ">=4"

--- a/sri-history.json
+++ b/sri-history.json
@@ -410,5 +410,9 @@
   "4.11.3": {
     "axe.js": "sha256-MgD9sqZmQpnqTg+i7glZ32Zo9TQZ81mOpgg0HABdwoE=",
     "axe.min.js": "sha256-BWVH7wRf9Q7eSaVMmaNWiQ/4lAxUFqVKnJEAhsVFM90="
+  },
+  "4.11.4": {
+    "axe.js": "sha256-z6N/Bsu4JMKvDv5G+M9oJcriL2ZREr2InHeS3lRWRa8=",
+    "axe.min.js": "sha256-+4OkN42Xjst9La5Io6N3ioTJcaxpLzr9RdcU+6icDw0="
   }
 }

--- a/sri-history.json
+++ b/sri-history.json
@@ -412,7 +412,7 @@
     "axe.min.js": "sha256-BWVH7wRf9Q7eSaVMmaNWiQ/4lAxUFqVKnJEAhsVFM90="
   },
   "4.11.4": {
-    "axe.js": "sha256-z6N/Bsu4JMKvDv5G+M9oJcriL2ZREr2InHeS3lRWRa8=",
+    "axe.js": "sha256-MFYbxYKg+pR6osY47p1hwmvMOb7f5kMTHtPU7APqp/A=",
     "axe.min.js": "sha256-+4OkN42Xjst9La5Io6N3ioTJcaxpLzr9RdcU+6icDw0="
   }
 }

--- a/test/commons/text/accessible-text.js
+++ b/test/commons/text/accessible-text.js
@@ -1649,6 +1649,47 @@ describe('text.accessibleTextVirtual', () => {
     });
   });
 
+  describe('natively hidden elements', () => {
+    const tags = ['style', 'script', 'noscript', 'template'];
+
+    it('should not use content as accessible name when directly referenced by aria-labelledby', () => {
+      tags.forEach(tag => {
+        fixture.innerHTML = `<div id="t1" aria-labelledby="el-id"></div><${tag} id="el-id">content</${tag}>`;
+        axe.testUtils.flatTreeSetup(fixture);
+        const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+        assert.equal(axe.commons.text.accessibleTextVirtual(target), '', tag);
+      });
+    });
+
+    it('should not use content when inside a hidden container referenced by aria-labelledby', () => {
+      tags.forEach(tag => {
+        fixture.innerHTML = `
+          <div id="t1" aria-labelledby="hidden-container"></div>
+          <div id="hidden-container" aria-hidden="true">
+            <${tag}>content</${tag}>
+            Expected label
+          </div>
+        `;
+        axe.testUtils.flatTreeSetup(fixture);
+        const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+        assert.equal(
+          axe.commons.text.accessibleTextVirtual(target),
+          'Expected label',
+          tag
+        );
+      });
+    });
+
+    it('should ignore aria-label as accessible name when directly referenced by aria-labelledby', () => {
+      tags.forEach(tag => {
+        fixture.innerHTML = `<div id="t1" aria-labelledby="el-id"></div><${tag} id="el-id" aria-label="aria-label"></${tag}>`;
+        axe.testUtils.flatTreeSetup(fixture);
+        const target = axe.utils.querySelectorAll(axe._tree, '#t1')[0];
+        assert.equal(axe.commons.text.accessibleTextVirtual(target), '', tag);
+      });
+    });
+  });
+
   describe('text.accessibleText acceptance tests', () => {
     'use strict';
     // Tests borrowed from the AccName 1.1 testing docs

--- a/test/core/utils/get-ancestry.js
+++ b/test/core/utils/get-ancestry.js
@@ -71,4 +71,31 @@ describe('axe.utils.getAncestry', () => {
       'div:nth-child(2)'
     ]);
   });
+
+  it('escapes the node name', () => {
+    fixture.innerHTML = `
+    <div>
+      <hello="world">
+        <button id="target1">button</button>
+      </hello="world">
+    </div>
+    <emoji-👍>
+      <button id="target2">button</button>
+    </emoji-👍>
+    `;
+
+    const sel1 = axe.utils.getAncestry(document.querySelector('#target1'));
+    assert.equal(
+      sel1,
+      'html > body > div:nth-child(1) > div:nth-child(1) > hello\\=\\"world\\" > button'
+    );
+    assert.isNotNull(document.querySelector(sel1));
+
+    const sel2 = axe.utils.getAncestry(document.querySelector('#target2'));
+    assert.equal(
+      sel2,
+      'html > body > div:nth-child(1) > emoji-👍:nth-child(2) > button'
+    );
+    assert.isNotNull(document.querySelector(sel2));
+  });
 });


### PR DESCRIPTION
### Bug Fixes

- **commons/text:** exclude natively hidden elements from aria-labelledby accessible name ([#5076](https://github.com/dequelabs/axe-core/issues/5076)) ([df34adf](https://github.com/dequelabs/axe-core/commit/df34adfc1967919d667d40a76ab5c85b6e47ddfe)), closes [#4704](https://github.com/dequelabs/axe-core/issues/4704)
- **utils/getAncestry:** escape node name ([#5079](https://github.com/dequelabs/axe-core/issues/5079)) ([6e68d0a](https://github.com/dequelabs/axe-core/commit/6e68d0a5d26999b996152df82238bc3f3a041cb3)), closes [#5078](https://github.com/dequelabs/axe-core/issues/5078)