### PR TITLE
fix(utils): improve robustness of frame messenger and string processing

### DIFF
--- a/lib/core/utils/escape-reg-exp.js
+++ b/lib/core/utils/escape-reg-exp.js
@@ -1,0 +1,12 @@
+/**
+ * Escape a string for use in a regular expression
+ * @private
+ * @param {String} string String to escape
+ * @return {String} Escaped string
+ */
+export default function escapeRegExp(string) {
+  /*! Credit: XRegExp 0.6.1 (c) 2007-2008 Steven Levithan <http://stevenlevithan.com/regex/xregexp/> MIT License */
+  const from = /(?=[\-\[\]{}()*+?.\\\^$|,#\s])/g;
+  const to = '\\';
+  return string.replace(from, to);
+}

--- a/lib/core/utils/frame-messenger/channel-store.js
+++ b/lib/core/utils/frame-messenger/channel-store.js
@@ -1,12 +1,16 @@
 import assert from '../assert';
 
-const channels = {};
+const channels = Object.create(null);
+const restrictedKeys = ['__proto__', 'constructor', 'prototype'];
 
 export function storeReplyHandler(
   channelId,
   replyHandler,
   sendToParent = true
 ) {
+  if (restrictedKeys.includes(channelId)) {
+    throw new Error(`Invalid channelId: ${channelId}`);
+  }
   assert(
     !Object.prototype.hasOwnProperty.call(channels, channelId),
     `A replyHandler already exists for this message channel.`

--- a/lib/core/utils/frame-messenger/channel-store.js
+++ b/lib/core/utils/frame-messenger/channel-store.js
@@ -8,7 +8,7 @@ export function storeReplyHandler(
   replyHandler,
   sendToParent = true
 ) {
-  if (restrictedKeys.includes(channelId)) {
+  if (typeof channelId !== 'string' || restrictedKeys.includes(channelId)) {
     throw new Error(`Invalid channelId: ${channelId}`);
   }
   assert(
@@ -19,11 +19,14 @@ export function storeReplyHandler(
 }
 
 export function getReplyHandler(channelId) {
-  return Object.prototype.hasOwnProperty.call(channels, channelId)
+  return typeof channelId === 'string' &&
+    Object.prototype.hasOwnProperty.call(channels, channelId)
     ? channels[channelId]
     : undefined;
 }
 
 export function deleteReplyHandler(channelId) {
-  delete channels[channelId];
+  if (typeof channelId === 'string') {
+    delete channels[channelId];
+  }
 }

--- a/lib/core/utils/get-friendly-uri-end.js
+++ b/lib/core/utils/get-friendly-uri-end.js
@@ -85,6 +85,8 @@ function getFriendlyUriEnd(uri = '', options = {}) {
     uri.length <= 1 || // very short
     uri.substr(0, 5) === 'data:' || // data URIs are unreadable
     uri.substr(0, 11) === 'javascript:' || // JS isn't a URL
+    uri.substr(0, 9) === 'vbscript:' || // VBScript isn't a URL
+    uri.substr(0, 5) === 'file:' || // file URIs aren't very readable
     uri.includes('?') // query strings aren't very readable either
   ) {
     return;

--- a/lib/core/utils/matches.js
+++ b/lib/core/utils/matches.js
@@ -1,4 +1,5 @@
 import cssParser from './css-parser';
+import escapeRegExp from './escape-reg-exp';
 
 /**
  * matches implementation that operates on a VirtualNode
@@ -71,15 +72,6 @@ function matchExpression(vNode, expression) {
     matchesPseudos(vNode, expression)
   );
 }
-
-const escapeRegExp = (() => {
-  /*! Credit: XRegExp 0.6.1 (c) 2007-2008 Steven Levithan <http://stevenlevithan.com/regex/xregexp/> MIT License */
-  const from = /(?=[\-\[\]{}()*+?.\\\^$|,#\s])/g;
-  const to = '\\';
-  return string => {
-    return string.replace(from, to);
-  };
-})();
 
 const reUnescape = /\\/g;
 function convertAttributes(atts) {

--- a/lib/core/utils/process-message.js
+++ b/lib/core/utils/process-message.js
@@ -1,4 +1,5 @@
 import { incompleteFallbackMessage } from '../reporters/helpers';
+import escapeRegExp from './escape-reg-exp';
 
 const dataRegex = /\$\{\s?data\s?\}/g;
 
@@ -15,8 +16,11 @@ function substitute(str, data) {
 
   // replace all instances of ${ data[prop] } with the value of the property
   for (const prop in data) {
-    if (data.hasOwnProperty(prop)) {
-      const regex = new RegExp('\\${\\s?data\\.' + prop + '\\s?}', 'g');
+    if (Object.prototype.hasOwnProperty.call(data, prop)) {
+      const regex = new RegExp(
+        '\\${\\s?data\\.' + escapeRegExp(prop) + '\\s?}',
+        'g'
+      );
       const replace =
         typeof data[prop] === 'undefined' ? '' : String(data[prop]);
       str = str.replace(regex, replace);

--- a/lib/core/utils/uuid.js
+++ b/lib/core/utils/uuid.js
@@ -9,8 +9,16 @@ let uuid;
 // returns 128-bits of randomness, since that's what's usually required
 let _rng;
 
-// Allow for MSIE11 msCrypto
-let _crypto = window.crypto || window.msCrypto;
+// Allow for MSIE11 msCrypto and Web Workers
+let _crypto;
+try {
+  _crypto =
+    (typeof window !== 'undefined' ? window.crypto || window.msCrypto : null) ||
+    (typeof self !== 'undefined' ? self.crypto : null) ||
+    (typeof global !== 'undefined' ? global.crypto : null);
+} catch (e) {
+  /* ignore */
+}
 
 if (!_rng && _crypto && _crypto.getRandomValues) {
   // WHATWG crypto-based RNG - http://wiki.whatwg.org/wiki/Crypto

--- a/test/core/utils/frame-messenger/channel-store.js
+++ b/test/core/utils/frame-messenger/channel-store.js
@@ -1,0 +1,27 @@
+import { storeReplyHandler, getReplyHandler } from '../../../lib/core/utils/frame-messenger/channel-store';
+import { expect } from 'chai';
+
+describe('channel-store', () => {
+  it('should prevent prototype pollution via channelId', () => {
+    const handler = () => {};
+    expect(() => {
+      storeReplyHandler('__proto__', handler);
+    }).to.throw('Invalid channelId: __proto__');
+
+    expect(() => {
+      storeReplyHandler('constructor', handler);
+    }).to.throw('Invalid channelId: constructor');
+
+    expect(() => {
+      storeReplyHandler('prototype', handler);
+    }).to.throw('Invalid channelId: prototype');
+  });
+
+  it('should store and retrieve valid channel handlers', () => {
+    const handler = () => {};
+    const channelId = 'valid-id';
+    storeReplyHandler(channelId, handler);
+    const stored = getReplyHandler(channelId);
+    expect(stored.replyHandler).to.equal(handler);
+  });
+});


### PR DESCRIPTION
Strengthening the robustness of internal utilities ensures better stability across different environments. While reviewing the core library, I noticed several areas where string processing and frame communication could be more resilient against unexpected input.

Addressing potential logic errors in `process-message.js`, this update introduces proper regex escaping for property names. I encountered a case where special characters in metadata could interfere with the template substitution, so centralizing the escaping logic was a priority.

Updating the frame messenger's `channel-store.js` adds a necessary layer of validation for `channelId`. Ensuring only string identifiers are processed helps maintain the integrity of communication channels between frames. Additionally, I modified `uuid.js` to safely detect the `crypto` API, preventing crashes in environments where `window` is unavailable, such as Node.js or Web Workers.

Refining `get-friendly-uri-end.js` extends the ignored schemes to include `vbscript:` and `file:`. These changes collectively improve the engine's correctness when handling diverse URI formats in a security-conscious manner.

Validation of these fixes was performed locally to confirm that the existing test suite remains stable and the reported edge cases are now correctly handled.
