### PR TITLE
fix(landmark-unique): correct form/section landmark calculation

### DIFF
--- a/lib/rules/landmark-unique-matches.js
+++ b/lib/rules/landmark-unique-matches.js
@@ -1,27 +1,9 @@
 import { isVisibleToScreenReaders } from '../commons/dom';
-import { getRole } from '../commons/aria';
-import { getAriaRolesByType } from '../commons/standards';
-import { accessibleTextVirtual } from '../commons/text';
+import { getRoleType } from '../commons/aria';
 
 export default function landmarkUniqueMatches(node, virtualNode) {
   return (
-    isLandmarkVirtual(virtualNode) && isVisibleToScreenReaders(virtualNode)
+    getRoleType(virtualNode) === 'landmark' &&
+    isVisibleToScreenReaders(virtualNode)
   );
-}
-
-function isLandmarkVirtual(vNode) {
-  const landmarkRoles = getAriaRolesByType('landmark');
-  const role = getRole(vNode);
-  if (!role) {
-    return false;
-  }
-
-  const { nodeName } = vNode.props;
-
-  if (nodeName === 'section' || nodeName === 'form') {
-    const accessibleText = accessibleTextVirtual(vNode);
-    return !!accessibleText;
-  }
-
-  return landmarkRoles.indexOf(role) >= 0 || role === 'region';
 }

--- a/test/rule-matches/landmark-unique-matches.js
+++ b/test/rule-matches/landmark-unique-matches.js
@@ -39,47 +39,44 @@ describe('landmark-unique-matches', function () {
     assert.isFalse(rule.matches(node, virtualNode));
   });
 
-  describe('form and section elements must have accessible names to be matched', function () {
-    const sectionFormElements = ['section', 'form'];
+  const sectionFormElements = ['section', 'form'];
+  for (const elementType of sectionFormElements) {
+    describe(`${elementType} must have accessible names to be matched`, () => {
+      it(`should match with a label`, () => {
+        axeFixtureSetup(
+          `<${elementType} aria-label="sample label">some ${elementType}</${elementType}>`
+        );
+        const node = fixture.querySelector(elementType);
+        const virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
+        assert.isTrue(rule.matches(node, virtualNode));
+      });
 
-    sectionFormElements.forEach(function (elementType) {
-      it(
-        'should match because it is a ' + elementType + ' with a label',
-        function () {
-          axeFixtureSetup(
-            '<' +
-              elementType +
-              ' aria-label="sample label">some ' +
-              elementType +
-              '</' +
-              elementType +
-              '>'
-          );
-          const node = fixture.querySelector(elementType);
-          const virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-          assert.isTrue(rule.matches(node, virtualNode));
-        }
-      );
+      it(`should not match without a label`, () => {
+        axeFixtureSetup(`<${elementType}>some ${elementType}</${elementType}>`);
+        const node = fixture.querySelector(elementType);
+        const virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
+        assert.isFalse(rule.matches(node, virtualNode));
+      });
 
-      it(
-        'should not match because it is a ' + elementType + ' without a label',
-        function () {
-          axeFixtureSetup(
-            '<' +
-              elementType +
-              '>some ' +
-              elementType +
-              '</' +
-              elementType +
-              '>'
-          );
-          const node = fixture.querySelector(elementType);
-          const virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
-          assert.isFalse(rule.matches(node, virtualNode));
-        }
-      );
+      it('should match without label if given a landmark role', () => {
+        axeFixtureSetup(
+          `<${elementType} role="banner">some ${elementType}</${elementType}>`
+        );
+        const node = fixture.querySelector(elementType);
+        const virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
+        assert.isTrue(rule.matches(node, virtualNode));
+      });
+
+      it('should not match with a label if given a non-landmark role', () => {
+        axeFixtureSetup(
+          `<${elementType} aria-label="sample label" role="tabpanel">some ${elementType}</${elementType}>`
+        );
+        const node = fixture.querySelector(elementType);
+        const virtualNode = axe.utils.getNodeFromTree(axe._tree[0], node);
+        assert.isFalse(rule.matches(node, virtualNode));
+      });
     });
-  });
+  }
 
   describe('header/footers should only match when not inside the excluded descendants', function () {
     headerFooterElements.forEach(function (elementType) {


### PR DESCRIPTION
The landmark-unique-matches function used an outdated approach to finding landmarks. I noticed that looking at https://github.com/dequelabs/axe-core/pull/5085, which tried to patch the problem. The better solve is to use the existing code for finding larndmarks. 

Closes: https://github.com/dequelabs/axe-core/issues/4722, closes https://github.com/dequelabs/axe-core/issues/5064


