### PR TITLE
ci(deploy): use gh cli to create github release

### DIFF
--- a/.github/bin/extract-release-notes.sh
+++ b/.github/bin/extract-release-notes.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Extracts the body of the most recent release section from CHANGELOG.md —
+# everything between the latest version header and the previous one. The
+# version header itself is not included. The result is written as a
+# multiline `notes` step output to $GITHUB_OUTPUT when set (GitHub
+# Actions), otherwise to stdout.
+#
+# The awk pattern /# \[?[0-9]/ matches version-header lines (`#`, space,
+# optional `[`, digit), e.g. `### [4.11.4](...) (2026-04-23)`. The pattern
+# is not anchored, so it matches the `# [4` substring inside `###`. On the
+# first match it sets `found=1` and skips the line (so the header itself
+# is not printed); on the next match (the previous release's header) it
+# exits. `found{print}` prints every line in between.
+#
+# Walking through a typical CHANGELOG.md:
+#
+#   Line                              v-header?  found    Action
+#   --------------------------------  ---------  ------   -------
+#   # Changelog                       no         0        nothing
+#   All notable changes...            no         0        nothing
+#   ### [4.11.4](...) (2026-04-23)    yes        0 -> 1   skip
+#   (blank)                           no         1        print
+#   ### Bug Fixes                     no         1        print
+#   - **commons/text:** ...           no         1        print
+#   - **utils/getAncestry:** ...      no         1        print
+#   ### [4.11.3](...) (2026-04-13)    yes        1        exit
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+{
+  echo 'notes<<EOF'
+  awk '/# \[?[0-9]/{if(found) exit; found=1; next} found{print}' "$repo_root/CHANGELOG.md"
+  echo 'EOF'
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,12 +168,7 @@ jobs:
       - *checkout
       - name: Extract release notes
         id: release-notes
-        run: |
-          {
-            echo 'notes<<EOF'
-            awk '/# \[?[0-9]/{if(found) exit; found=1; next} found{print}' CHANGELOG.md
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+        run: ./.github/bin/extract-release-notes.sh
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,6 +177,7 @@ jobs:
         run: |
           gh release create "v${VERSION}" \
             --title "Release ${VERSION}" \
+            --target ${{ github.sha }} \
             --notes "$NOTES"
   validate-deploy:
     name: Validate Deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,16 +166,23 @@ jobs:
       contents: write # Required to create releases
     steps:
       - *checkout
-      - name: Install Release Helper
-        run: go install gopkg.in/aktau/github-release.v0@latest
-      - name: Download Release Script
-        run: curl https://raw.githubusercontent.com/dequelabs/attest-release-scripts/develop/src/node-github-release.sh -s -o ./node-github-release.sh
-      - name: Make Release Script Executable
-        run: chmod +x ./node-github-release.sh
+      - name: Extract release notes
+        id: release-notes
+        run: |
+          {
+            echo 'notes<<EOF'
+            awk '/# \[?[0-9]/{if(found) exit; found=1; next} found{print}' CHANGELOG.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./node-github-release.sh
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prod-deploy.outputs.version }}
+          NOTES: ${{ steps.release-notes.outputs.notes }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "Release ${VERSION}" \
+            --notes "$NOTES"
   validate-deploy:
     name: Validate Deployment
     needs: prod-deploy


### PR DESCRIPTION
Replaces the Go-based `github-release` tool and the externally fetched `node-github-release.sh` script in the `create-github-release` job with a single step that uses the `gh` CLI (pre-installed on GitHub-hosted runners).

### What changed

- **Dropped:** `go install gopkg.in/aktau/github-release.v0@latest`, the `curl` of `dequelabs/attest-release-scripts/.../node-github-release.sh`, the `chmod +x` step.
- **Added:** an `Extract release notes` step that runs the same changelog-section `awk` as the original script and writes the result to a multiline `notes` step output.
- **Added:** a `Create GitHub Release` step that calls `gh release create "v${VERSION}" --title "Release ${VERSION}" --notes "$NOTES"`, taking the version from `prod-deploy`'s job output and the notes from the previous step's output (passed via `NOTES` env var so shell metacharacters in the changelog aren't re-evaluated).
- Switched the auth env var from `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to `GH_TOKEN: ${{ github.token }}` to match the rest of the workflow and the `gh` CLI's preferred env var.

### Why

- Removes two external dependencies (a Go binary install and a remote shell script fetched at job runtime) in favor of a tool already on the runner image.
- Keeps the entire release-creation flow visible in `deploy.yml` instead of being hidden in a fetched script from another repo.

<details>
<summary>How the <code>awk</code> changelog extraction works</summary>

```
awk '/# \[?[0-9]/{if(found) exit; found=1; next} found{print}' CHANGELOG.md
```

awk walks `CHANGELOG.md` line by line and runs two `pattern { action }` blocks:

1. `/# \[?[0-9]/` matches a version-header line — `#`, a space, an optional `[`, a digit. In our CHANGELOG that hits lines like `### [4.11.4](...) (2026-04-23)` (the pattern isn't anchored, so it matches the `# [4` substring inside `###`).
    - On the **first** match: set `found=1` and `next` past the line (so the header itself isn't printed).
    - On the **next** match (the previous release's header): `exit`.
2. `found{print}` — for every line where `found` is non-zero, print it.

Net effect: prints everything between the latest version header and the previous one — i.e. the body of the most recent release section, which becomes the GitHub release notes.

Walking through the current `CHANGELOG.md`:

| Line | Matches v-header? | `found` | Action |
| --- | --- | --- | --- |
| `# Changelog` | no | 0 | nothing (`found` is 0) |
| (blank) | no | 0 | nothing |
| `All notable changes...` | no | 0 | nothing |
| (blank) | no | 0 | nothing |
| `### [4.11.4](...) (2026-04-23)` | **yes** | 0 → 1 | set `found=1`, skip line |
| (blank) | no | 1 | print |
| `### Bug Fixes` | no | 1 | print |
| (blank) | no | 1 | print |
| `- **commons/text:** ...` | no | 1 | print |
| `- **utils/getAncestry:** ...` | no | 1 | print |
| (blank) | no | 1 | print |
| `### [4.11.3](...) (2026-04-13)` | **yes** | 1 | `exit` |

</details>

Closes: #5052