### PR TITLE
fix(label-content-name-mismatch): match visible text with aria-label and exclude invisible text

### DIFF
--- a/lib/checks/label/label-content-name-mismatch-evaluate.js
+++ b/lib/checks/label/label-content-name-mismatch-evaluate.js
@@ -1,9 +1,9 @@
 import {
   accessibleText,
   isHumanInterpretable,
-  subtreeText,
+  removeUnicode,
   sanitize,
-  removeUnicode
+  visibleVirtual
 } from '../../commons/text';
 
 /**
@@ -42,14 +42,11 @@ function labelContentNameMismatchEvaluate(node, options, virtualNode) {
   const occurrenceThreshold =
     options?.occurrenceThreshold ?? options?.occuranceThreshold;
   const accText = accessibleText(node).toLowerCase();
-  const visibleText = sanitize(
-    subtreeText(virtualNode, {
-      subtreeDescendant: true,
-      ignoreIconLigature: true,
-      pixelThreshold,
-      occurrenceThreshold
-    })
-  ).toLowerCase();
+  const visibleText = visibleVirtual(virtualNode, false, false, {
+    ignoreIconLigature: true,
+    pixelThreshold,
+    occurrenceThreshold
+  }).toLowerCase();
 
   if (!visibleText) {
     return true;

--- a/lib/commons/text/visible-virtual.js
+++ b/lib/commons/text/visible-virtual.js
@@ -1,7 +1,8 @@
-import sanitize from './sanitize';
+import { nodeLookup } from '../../core/utils';
 import isVisibleOnScreen from '../dom/is-visible-on-screen';
 import isVisibleToScreenReaders from '../dom/is-visible-to-screenreader';
-import { nodeLookup } from '../../core/utils';
+import isIconLigature from './is-icon-ligature';
+import sanitize from './sanitize';
 
 /**
  * Returns the visible text of the virtual node
@@ -15,9 +16,13 @@ import { nodeLookup } from '../../core/utils';
  * @param  {Boolean} screenReader When provided, will evaluate visibility from the perspective of a screen reader
  * @param  {Boolean} noRecursing When False, the result will contain text from the element and it's children.
  * When True, the result will only contain text from the element
+ * @param  {Object} [options]
+ * @param  {Boolean} [options.ignoreIconLigature] When true, icon ligature text nodes are excluded
+ * @param  {number} [options.pixelThreshold] Pixel threshold for icon ligature detection
+ * @param  {number} [options.occurrenceThreshold] Occurrence threshold for icon ligature detection
  * @return {String}
  */
-function visibleVirtual(element, screenReader, noRecursing) {
+function visibleVirtual(element, screenReader, noRecursing, options = {}) {
   const { vNode } = nodeLookup(element);
   const visibleMethod = screenReader
     ? isVisibleToScreenReaders
@@ -28,16 +33,29 @@ function visibleVirtual(element, screenReader, noRecursing) {
   const visible =
     !element.actualNode || (element.actualNode && visibleMethod(element));
 
+  const { ignoreIconLigature, pixelThreshold, occurrenceThreshold } = options;
+
   const result = vNode.children
     .map(child => {
-      const { nodeType, nodeValue } = child.props;
+      const { nodeType, nodeValue, nodeName } = child.props;
       if (nodeType === 3) {
         // filter on text nodes
-        if (nodeValue && visible) {
-          return nodeValue;
+        if (!nodeValue || !visible) {
+          return '';
         }
-      } else if (!noRecursing) {
-        return visibleVirtual(child, screenReader);
+        if (
+          ignoreIconLigature &&
+          isIconLigature(child, pixelThreshold, occurrenceThreshold)
+        ) {
+          return '';
+        }
+        return nodeValue;
+      }
+      if (nodeName === 'br') {
+        return ' ';
+      }
+      if (!noRecursing) {
+        return visibleVirtual(child, screenReader, false, options);
       }
     })
     .join('');

--- a/test/checks/label/label-content-name-mismatch.js
+++ b/test/checks/label/label-content-name-mismatch.js
@@ -194,4 +194,34 @@ describe('label-content-name-mismatch tests', () => {
     var actual = check.evaluate(vNode.actualNode, options, vNode);
     assert.isTrue(actual);
   });
+
+  it('returns false when aria-label and visible text do not match even though there is an image with alt text', function () {
+    var vNode = queryFixture(
+      '<button id="target" aria-label="button label"><img alt="button icon" src="button.png" />this is a button label</button>'
+    );
+    var actual = check.evaluate(vNode.actualNode, options, vNode);
+    assert.isFalse(actual);
+  });
+
+  (fontApiSupport ? it : it.skip)(
+    'returns true when aria-label and visible text match even though there is a ligature icon',
+    function () {
+      var vNode = queryFixture(
+        '<button id="target" aria-label="button label"><span style="font-family: \'Material Icons\'">delete</span>button label</button>'
+      );
+      var actual = check.evaluate(vNode.actualNode, options, vNode);
+      assert.isTrue(actual);
+    }
+  );
+
+  (fontApiSupport ? it : it.skip)(
+    'returns false when aria-label and visible text do not match even though there is a ligature icon',
+    function () {
+      var vNode = queryFixture(
+        '<button id="target" aria-label="button label"><span style="font-family: \'Material Icons\'">delete</span>this is a button label</button>'
+      );
+      var actual = check.evaluate(vNode.actualNode, options, vNode);
+      assert.isFalse(actual);
+    }
+  );
 });

--- a/test/checks/label/label-content-name-mismatch.js
+++ b/test/checks/label/label-content-name-mismatch.js
@@ -186,4 +186,12 @@ describe('label-content-name-mismatch tests', () => {
     const actual = check.evaluate(vNode.actualNode, options, vNode);
     assert.isTrue(actual);
   });
+
+  it('returns true when aria-label and visible text match even though there is an image with alt text', function () {
+    var vNode = queryFixture(
+      '<button id="target" aria-label="button label"><img alt="button icon" src="button.png" />button label</button>'
+    );
+    var actual = check.evaluate(vNode.actualNode, options, vNode);
+    assert.isTrue(actual);
+  });
 });

--- a/test/commons/text/visible-virtual.js
+++ b/test/commons/text/visible-virtual.js
@@ -5,7 +5,7 @@ describe('text.visible', () => {
   const visibleVirtual = axe.commons.text.visibleVirtual;
   const fontApiSupport = !!document.fonts;
 
-  before((done) => {
+  before(done => {
     if (!fontApiSupport) {
       done();
       return;

--- a/test/commons/text/visible-virtual.js
+++ b/test/commons/text/visible-virtual.js
@@ -3,6 +3,22 @@ describe('text.visible', () => {
 
   const fixture = document.getElementById('fixture');
   const visibleVirtual = axe.commons.text.visibleVirtual;
+  const fontApiSupport = !!document.fonts;
+
+  before((done) => {
+    if (!fontApiSupport) {
+      done();
+      return;
+    }
+    const materialFont = new FontFace(
+      'Material Icons',
+      'url(https://fonts.gstatic.com/s/materialicons/v48/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2)'
+    );
+    materialFont.load().then(() => {
+      document.fonts.add(materialFont);
+      done();
+    });
+  });
 
   afterEach(() => {
     document.getElementById('fixture').innerHTML = '';
@@ -103,6 +119,12 @@ describe('text.visible', () => {
       const tree = axe.utils.getFlattenedTree(fixture.firstChild);
       assert.equal(visibleVirtual(tree[0]), 'Stuffhello');
     });
+
+    it('should treat <br> elements as a space', () => {
+      fixture.innerHTML = '<button>button<br>label</button>';
+      const tree = axe.utils.getFlattenedTree(fixture);
+      assert.equal(visibleVirtual(tree[0]), 'button label');
+    });
   });
 
   describe('screen reader', () => {
@@ -174,5 +196,41 @@ describe('text.visible', () => {
       const tree = axe.utils.getFlattenedTree(fixture);
       assert.equal(visibleVirtual(tree[0], true), 'Hello');
     });
+  });
+
+  describe('options', () => {
+    (fontApiSupport ? it : it.skip)(
+      'should exclude icon ligature text when ignoreIconLigature is true',
+      () => {
+        fixture.innerHTML =
+          '<button>next page <span style="font-family: \'Material Icons\'">delete</span></button>';
+        const tree = axe.utils.getFlattenedTree(fixture);
+        assert.equal(
+          visibleVirtual(tree[0], false, false, {
+            ignoreIconLigature: true,
+            pixelThreshold: 0.1,
+            occurrenceThreshold: 3
+          }),
+          'next page'
+        );
+      }
+    );
+
+    (fontApiSupport ? it : it.skip)(
+      'should not exclude icon ligature text when ignoreIconLigature is false',
+      () => {
+        fixture.innerHTML =
+          '<button>next page <span style="font-family: \'Material Icons\'">delete</span></button>';
+        const tree = axe.utils.getFlattenedTree(fixture);
+        assert.equal(
+          visibleVirtual(tree[0], false, false, {
+            ignoreIconLigature: false,
+            pixelThreshold: 0.1,
+            occurrenceThreshold: 3
+          }),
+          'next page delete'
+        );
+      }
+    );
   });
 });

--- a/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.html
+++ b/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.html
@@ -15,6 +15,18 @@
   Next Page
 </button>
 
+<a id="pass8" aria-label="Deque" href="#">
+  <img alt="Logo" width="100" src="logo.svg" />
+  <span>Deque</span>
+</a>
+<a id="pass9" href="#" aria-label="Hello world">
+  <svg width="14" height="14" viewBox="0 0 100 100">
+    <title>Circle</title>
+    <circle cx="50" cy="50" r="50" />
+  </svg>
+  Hello World
+</a>
+
 <!-- Fail -->
 <div id="fail1" role="link" aria-label="OK">Next</div>
 <button id="fail2" name="link" aria-label="the full">The full label</button>
@@ -22,6 +34,18 @@
 <button id="fail4" name="link" aria-label="the full">The full label</button>
 <div id="labelForFail5">123</div>
 <div role="button" id="fail5" aria-labelledby="labelForFail5">some content</div>
+
+<a id="fail6" aria-label="Deque" href="#">
+  <img alt="Logo" width="100" src="logo.svg" />
+  <span>Deque Systems</span>
+</a>
+<a id="fail7" href="#" aria-label="Hello world">
+  <svg width="14" height="14" viewBox="0 0 100 100">
+    <title>Circle</title>
+    <circle cx="50" cy="50" r="50" />
+  </svg>
+  Hello Deque Systems
+</a>
 
 <!-- incomplete -->
 <button id="incomplete1" aria-label="comet">☄️</button>

--- a/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.json
+++ b/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.json
@@ -1,7 +1,15 @@
 {
   "description": "label-content-name-mismatch tests",
   "rule": "label-content-name-mismatch",
-  "violations": [["#fail1"], ["#fail2"], ["#fail3"], ["#fail4"], ["#fail5"]],
+  "violations": [
+    ["#fail1"],
+    ["#fail2"],
+    ["#fail3"],
+    ["#fail4"],
+    ["#fail5"],
+    ["#fail6"],
+    ["#fail7"]
+  ],
   "passes": [
     ["#pass1"],
     ["#pass2"],
@@ -9,7 +17,9 @@
     ["#pass4"],
     ["#pass5"],
     ["#pass6"],
-    ["#pass7"]
+    ["#pass7"],
+    ["#pass8"],
+    ["#pass9"]
   ],
   "incomplete": [
     ["#incomplete1"],


### PR DESCRIPTION
Using `visibleVirtual` instead of `subtreeText`, I resolved issue.
Because if I simple replace it and use `isIconLigature` existing two tests failed (`'returns true when visible text excluding ligature icon is part of accessible name'` and `'returns true when text contains <br/>'`), I changed `visible-virtual.js`, but I'm not sure this is proper changes (this is the first PR for me to axe-core).

Closes: https://github.com/dequelabs/axe-core/issues/5063