### PR TITLE
chore: add perf timing to runPartial

### DIFF
--- a/lib/core/public/run-partial.js
+++ b/lib/core/public/run-partial.js
@@ -4,7 +4,8 @@ import {
   nodeSerializer,
   getSelectorData,
   assert,
-  getEnvironmentData
+  getEnvironmentData,
+  performanceTimer
 } from '../utils';
 import normalizeRunParams from './run/normalize-run-params';
 
@@ -27,9 +28,17 @@ export default function runPartial(...args) {
 
   return (
     new Promise((res, rej) => {
+      if (options.performanceTimer) {
+        performanceTimer.auditStart();
+      }
+
       axe._audit.run(contextObj, options, res, rej);
     })
       .then(results => {
+        if (options.performanceTimer) {
+          performanceTimer.auditEnd();
+        }
+
         results = nodeSerializer.mapRawResults(results);
         const frames = contextObj.frames.map(({ node }) => {
           return nodeSerializer.toSpec(node);


### PR DESCRIPTION
Just adding the audit start/end perf timings to `runPartial` as I was using it to debug nightly tests, so thought it would be helpful in the code.