### PR TITLE
chore: disable dependabot rebase strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: 'github-actions'
+    rebase-strategy: disabled
     directory: '/'
     schedule:
       interval: 'monthly'
@@ -18,6 +19,7 @@ updates:
       default-days: 7
 
   - package-ecosystem: 'npm'
+    rebase-strategy: disabled
     directory: '/'
     schedule:
       interval: 'monthly'


### PR DESCRIPTION
## Summary
- Add `rebase-strategy: disabled` to every Dependabot ecosystem entry.

## Why
Dependabot's default rebase behavior force-pushes open PRs whenever the base branch moves, re-running CI and disrupting reviewers. Disabling it keeps existing dependency PRs stable until a maintainer is ready to act on them.

No QA Required