### PR TITLE
ci: ignore gather-internals.js from import deploy validation

### DIFF
--- a/.github/bin/validate-package.mjs
+++ b/.github/bin/validate-package.mjs
@@ -210,7 +210,13 @@ defined files in the \`files\` array of \`package.json\`.
 | File | Status | Version |\n|------|--------|--------|
 `;
 
-  const importTargets = [...pkg.files.map(file => `${pkg.name}/${file}`)];
+  // these files are not part of the importable api
+  const nonImportableFiles = ['gather-internals.js'];
+  const importTargets = [
+    ...pkg.files
+      .filter(file => !nonImportableFiles.includes(file))
+      .map(file => `${pkg.name}/${file}`)
+  ];
   let anyCaught = false;
 
   console.log('Validating package files are importable:');

--- a/.github/bin/validate-package.mjs
+++ b/.github/bin/validate-package.mjs
@@ -290,6 +290,27 @@ defined files in the \`files\` array of \`package.json\`.
     }
   }
 
+  // check that the non-importable files are parsable
+  for (const file of nonImportableFiles) {
+    const target = `${pkg.name}/${file}`;
+    try {
+      const resolved = import.meta.resolve(target);
+      if (resolved.includes('node_modules')) {
+        console.error(`✗ ${target} resolves to node_modules`);
+        summary += `| \`${target}\` | ✗ Resolves to node_modules |\n`;
+        exitCode++;
+        continue;
+      }
+      execSync(`node --check "${fileURLToPath(resolved)}"`, { stdio: 'pipe' });
+      console.info(`✓ ${target} (parse-only, browser-only)`);
+      summary += `| \`${target}\` | ✓ Parse OK (browser-only) | n/a |\n`;
+    } catch (error) {
+      console.error(`✗ ${target}: ${error.message}`);
+      summary += `| \`${target}\` | ✗ Parse failed (browser-only) | n/a |\n`;
+      exitCode++;
+    }
+  }
+
   if (anyCaught) {
     exitCode++;
   }


### PR DESCRIPTION
`@next` [failed to deploy](https://github.com/dequelabs/axe-core/actions/runs/26101303110/job/76753975655#step:8:32) with the new `gather-internals.js` export script as it's not an importable file. Fixed to ignore that file from the check as it is not suppose to be imported.