### PR TITLE
docs(check-options): fix duplicate "the" (passLength/failLength rows)

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -517,7 +517,7 @@ h6:not([role]),
       <td align="left">
         <pre lang=js><code>"passLength": 1</code></pre>
         </td>
-      <td align="left">Relative length, if the the candidate heading is X times or greater the length of the candidate paragraph, it will pass.</td>
+      <td align="left">Relative length, if the candidate heading is X times or greater the length of the candidate paragraph, it will pass.</td>
       </tr>
        <tr>
      <td>
@@ -526,7 +526,7 @@ h6:not([role]),
       <td align="left">
         <pre lang=js><code>"failLength": 0.5</code></pre>
         </td>
-      <td align="left">Relative length, if the the candidate heading is X times or less the length of the candidate paragraph, it can fail.</td>
+      <td align="left">Relative length, if the candidate heading is X times or less the length of the candidate paragraph, it can fail.</td>
       </tr>
   </tbody>
 </table>


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate `the` that appears twice in `doc/check-options.md` (lines 520 and 529, in adjacent `passLength` / `failLength` rows of the heading-order check table). Both reads `if the the candidate heading…` → `if the candidate heading…`.

## Why

Small docs cleanup — two adjacent sentences with the same typo.

## How verified

Single-file edit in a docs-only file (`doc/check-options.md`). No runtime/check behavior touched.

## Maintainer note

Feel free to close if not worth the review cycle.
