### PR TITLE
feat(getRules): include rule enabled state in returned objects

### DIFF
--- a/axe.d.ts
+++ b/axe.d.ts
@@ -390,8 +390,10 @@ declare namespace axe {
     frameContext: FrameContextObject;
   }
 
-  interface RawCheckResult
-    extends Omit<CheckResult, 'relatedNodes' | 'impact'> {
+  interface RawCheckResult extends Omit<
+    CheckResult,
+    'relatedNodes' | 'impact'
+  > {
     relatedNodes?: Array<SerialDqElement | DqElement>;
     impact?: ImpactValue;
   }

--- a/axe.d.ts
+++ b/axe.d.ts
@@ -334,7 +334,7 @@ declare namespace axe {
     matches?: string | ((node: Element, virtualNode: VirtualNode) => boolean);
     reviewOnFail?: boolean;
     actIds?: string[];
-    metadata?: Omit<RuleMetadata, 'ruleId' | 'tags' | 'actIds'>;
+    metadata?: Omit<RuleMetadata, 'ruleId' | 'tags' | 'actIds' | 'enabled'>;
   }
   interface AxePlugin {
     id: string;
@@ -352,6 +352,7 @@ declare namespace axe {
     helpUrl: string;
     tags: string[];
     actIds?: string[];
+    enabled: boolean;
   }
   interface SerialDqElement {
     source: string;
@@ -389,10 +390,8 @@ declare namespace axe {
     frameContext: FrameContextObject;
   }
 
-  interface RawCheckResult extends Omit<
-    CheckResult,
-    'relatedNodes' | 'impact'
-  > {
+  interface RawCheckResult
+    extends Omit<CheckResult, 'relatedNodes' | 'impact'> {
     relatedNodes?: Array<SerialDqElement | DqElement>;
     impact?: ImpactValue;
   }

--- a/doc/API.md
+++ b/doc/API.md
@@ -734,7 +734,6 @@ axe.run(document, function (err, results) {
 
 - `passes[0]`
   ...
-
   - `help` - `"Elements must have sufficient color contrast"`
   - `helpUrl` - `"https://dequeuniversity.com/courses/html-css/visual-layout/color-contrast"`
   - `id` - `"color-contrast"`
@@ -747,7 +746,6 @@ axe.run(document, function (err, results) {
 ###### `violations`
 
 - `violations[0]`
-
   - `help` - `"<button> elements must have alternate text"`
   - `helpUrl` - `"https://dequeuniversity.com/courses/html-css/forms/form-labels#id84_example_button"`
   - `id` - `"button-name"`

--- a/doc/API.md
+++ b/doc/API.md
@@ -137,7 +137,7 @@ Returns a list of all rules with their ID and description
 
 - `tags` - **optional** Array of tags used to filter returned rules. If omitted, it will return all rules. See [axe-core tags](#axe-core-tags).
 
-**Returns:** Array of rules that match the input filter with each entry having a format of `{ruleId: <id>, description: <desc>, helpUrl: <url>, help: <help>, tags: <tags>}`
+**Returns:** Array of rules that match the input filter with each entry having a format of `{ruleId: <id>, description: <desc>, helpUrl: <url>, help: <help>, tags: <tags>, enabled: <boolean>}`. `enabled` is `true` for rules that run by default when `axe.run()` is called with no options, and `false` for rules that are disabled by default.
 
 #### Example 1
 
@@ -163,7 +163,8 @@ In this example, we pass in the WCAG 2 A and AA tags into `axe.getRules` to retr
       "section508",
       "section508.22.a"
     ],
-    actIds: ['c487ae']
+    actIds: ['c487ae'],
+    enabled: true
   },
   {
     description: "Ensure ARIA attributes are allowed for an element's role",
@@ -174,7 +175,8 @@ In this example, we pass in the WCAG 2 A and AA tags into `axe.getRules` to retr
       "cat.aria",
       "wcag2a",
       "wcag412"
-    ]
+    ],
+    enabled: true
   }
   …
 ]
@@ -732,6 +734,7 @@ axe.run(document, function (err, results) {
 
 - `passes[0]`
   ...
+
   - `help` - `"Elements must have sufficient color contrast"`
   - `helpUrl` - `"https://dequeuniversity.com/courses/html-css/visual-layout/color-contrast"`
   - `id` - `"color-contrast"`
@@ -744,6 +747,7 @@ axe.run(document, function (err, results) {
 ###### `violations`
 
 - `violations[0]`
+
   - `help` - `"<button> elements must have alternate text"`
   - `helpUrl` - `"https://dequeuniversity.com/courses/html-css/forms/form-labels#id84_example_button"`
   - `id` - `"button-name"`

--- a/lib/core/public/get-rules.js
+++ b/lib/core/public/get-rules.js
@@ -22,7 +22,8 @@ function getRules(tags) {
       help: rd.help,
       helpUrl: rd.helpUrl,
       tags: matchingRule.tags,
-      actIds: matchingRule.actIds
+      actIds: matchingRule.actIds,
+      enabled: matchingRule.enabled
     };
   });
 }

--- a/test/core/public/get-rules.js
+++ b/test/core/public/get-rules.js
@@ -16,7 +16,8 @@ describe('axe.getRules', () => {
           id: 'awesomeRule2',
           any: [],
           tags: ['tag1', 'tag2'],
-          actIds: ['abc123', 'xyz789']
+          actIds: ['abc123', 'xyz789'],
+          enabled: false
         }
       ],
       data: {
@@ -101,6 +102,13 @@ describe('axe.getRules', () => {
     );
     assert.deepEqual(retValue[1].tags, ['tag1', 'tag2']);
     assert.deepEqual(retValue[1].actIds, ['abc123', 'xyz789']);
+  });
+
+  it('should return the enabled state of each rule', () => {
+    const retValue = axe.getRules();
+    assert.lengthOf(retValue, 2);
+    assert.equal(retValue[0].enabled, true);
+    assert.equal(retValue[1].enabled, false);
   });
 
   it('should return all rules if given empty array', () => {


### PR DESCRIPTION
Adds an `enabled` boolean to each rule object returned by `axe.getRules()`, exposing whether the rule runs by default when `axe.run()` is called without options. Previously the only way to determine this was via the undocumented `axe._audit.rules` field.

Closes: #5116
