### PR TITLE
feat(list,listitem): support element internals role

### DIFF
--- a/lib/checks/lists/invalid-children-evaluate.js
+++ b/lib/checks/lists/invalid-children-evaluate.js
@@ -1,5 +1,5 @@
 import { isVisibleToScreenReaders } from '../../commons/dom';
-import { getExplicitRole } from '../../commons/aria';
+import { getExplicitRole, getRole } from '../../commons/aria';
 
 export default function invalidChildrenEvaluate(
   node,
@@ -58,11 +58,16 @@ function getInvalidSelector(
     return false;
   }
 
-  const role = getExplicitRole(vChild);
-  if (role) {
-    return validRoles.includes(role) ? false : selector + `[role=${role}]`;
+  const explicitRole = getExplicitRole(vChild);
+  const role = getRole(vChild);
+  if (explicitRole) {
+    return validRoles.includes(explicitRole)
+      ? false
+      : selector + `[role=${role}]`;
   } else {
-    return validNodeNames.includes(nodeName) ? false : selector + nodeName;
+    return validNodeNames.includes(nodeName) || validRoles.includes(role)
+      ? false
+      : selector + nodeName;
   }
 }
 

--- a/lib/checks/lists/listitem-evaluate.js
+++ b/lib/checks/lists/listitem-evaluate.js
@@ -1,4 +1,4 @@
-import { isValidRole, getExplicitRole } from '../../commons/aria';
+import { isValidRole, getExplicitRole, getRole } from '../../commons/aria';
 
 export default function listitemEvaluate(node, options, virtualNode) {
   const { parent } = virtualNode;
@@ -7,18 +7,17 @@ export default function listitemEvaluate(node, options, virtualNode) {
     return undefined;
   }
 
-  const parentNodeName = parent.props.nodeName;
-  const parentRole = getExplicitRole(parent);
+  const parentExplicitRole = getExplicitRole(parent);
+  const parentRole = getRole(parent);
 
   if (['presentation', 'none', 'list'].includes(parentRole)) {
     return true;
   }
 
-  if (parentRole && isValidRole(parentRole)) {
+  if (parentExplicitRole && isValidRole(parentExplicitRole)) {
     this.data({
       messageKey: 'roleNotValid'
     });
-    return false;
   }
-  return ['ul', 'ol', 'menu'].includes(parentNodeName);
+  return false;
 }

--- a/test/checks/lists/listitem.js
+++ b/test/checks/lists/listitem.js
@@ -106,4 +106,22 @@ describe('listitem', () => {
     ]);
     assert.isFalse(result);
   });
+
+  describe('ElementInternals', () => {
+    it('should pass for element that uses elementInternals', () => {
+      const params = checkSetup(
+        '<testutils-element with-role="list"><li id="target">My list item</li></testutils-element>'
+      );
+      const result = checkEvaluate.apply(checkContext, params);
+      assert.isTrue(result);
+    });
+
+    it('returns false for element with unallowed elementInternals role', () => {
+      const params = checkSetup(
+        '<testutils-element><li id="target">My list item</li></testutils-element>'
+      );
+      const result = checkEvaluate.apply(checkContext, params);
+      assert.isFalse(result);
+    });
+  });
 });

--- a/test/checks/lists/only-listitems.js
+++ b/test/checks/lists/only-listitems.js
@@ -244,4 +244,23 @@ describe('only-listitems', () => {
       });
     });
   });
+
+  describe('ElementInternals', () => {
+    it('returns false for element that uses elementInternals', () => {
+      const checkArgs = checkSetup(
+        '<ul id="target"> <li>An item</li> <testutils-element with-role="listitem">custom item</testutils-element> </ul>'
+      );
+      assert.isFalse(checkEvaluate.apply(checkContext, checkArgs));
+    });
+
+    it('returns true for element with unallowed elementInternals role', () => {
+      const checkArgs = checkSetup(
+        '<ul id="target"> <li>An item</li> <testutils-element>custom item</testutils-element> </ul>'
+      );
+      assert.isTrue(checkEvaluate.apply(checkContext, checkArgs));
+      assert.deepEqual(checkContext._data, {
+        values: 'testutils-element'
+      });
+    });
+  });
 });

--- a/test/integration/rules/list/list.html
+++ b/test/integration/rules/list/list.html
@@ -20,6 +20,14 @@
   <li>One.</li>
   <li>Two.</li>
 </ul>
+<ul id="internalul">
+  <li>One.</li>
+  <testutils-element with-role="listitem">Two</testutils-element>
+</ul>
+<ul id="ulrolledinternal">
+  <li>One.</li>
+  <testutils-element>Two</testutils-element>
+</ul>
 <ol id="emptyol"></ol>
 <ol id="scriptemptyol">
   <script></script>
@@ -57,4 +65,12 @@
 <ol id="olrolledli">
   <li>One.</li>
   <li role="menuitem">Two</li>
+</ol>
+<ol id="internalol">
+  <li>One.</li>
+  <testutils-element with-role="listitem">Two</testutils-element>
+</ol>
+<ol id="olrolledinternal">
+  <li>One.</li>
+  <testutils-element>Two</testutils-element>
 </ol>

--- a/test/integration/rules/list/list.json
+++ b/test/integration/rules/list/list.json
@@ -9,16 +9,20 @@
     ["#ulrolledallli"],
     ["#olrolledallli"],
     ["#ulrolledli"],
-    ["#olrolledli"]
+    ["#olrolledli"],
+    ["#ulrolledinternal"],
+    ["#olrolledinternal"]
   ],
   "passes": [
     ["#emptyul"],
     ["#scriptemptyul"],
     ["#properul"],
     ["#scriptproperul"],
+    ["#internalul"],
     ["#emptyol"],
     ["#scriptemptyol"],
     ["#properol"],
-    ["#scriptproperol"]
+    ["#scriptproperol"],
+    ["#internalol"]
   ]
 }

--- a/test/integration/rules/listitem/listitem.html
+++ b/test/integration/rules/listitem/listitem.html
@@ -21,3 +21,9 @@
 <menu>
   <li id="menuitem"><button>Copy</button></li>
 </menu>
+<testutils-element with-role="list">
+  <li id="internal">I too do not belong to a list.</li>
+</testutils-element>
+<testutils-element>
+  <li id="internalrolechanged">I too do not belong to a list.</li>
+</testutils-element>

--- a/test/integration/rules/listitem/listitem.json
+++ b/test/integration/rules/listitem/listitem.json
@@ -1,12 +1,18 @@
 {
   "description": "listitem test",
   "rule": "listitem",
-  "violations": [["#uncontained"], ["#ulrolechanged"], ["#olrolechanged"]],
+  "violations": [
+    ["#uncontained"],
+    ["#ulrolechanged"],
+    ["#olrolechanged"],
+    ["#internalrolechanged"]
+  ],
   "passes": [
     ["#contained"],
     ["#alsocontained"],
     ["#presentation"],
     ["#none"],
-    ["#menuitem"]
+    ["#menuitem"],
+    ["#internal"]
   ]
 }


### PR DESCRIPTION
Noticed while testing out some things that we could also support element internals for `list` and `listitem` rules. Just needed to have them look at the semantic role as well.