### PR TITLE
test: fix puppeteer example failure

### DIFF
--- a/doc/examples/puppeteer/axe-puppeteer.js
+++ b/doc/examples/puppeteer/axe-puppeteer.js
@@ -1,12 +1,15 @@
 const puppeteer = require('puppeteer');
 const axeCore = require('axe-core');
-const { parse: parseURL } = require('url');
 const assert = require('assert');
 
 // Cheap URL validation
 const isValidURL = input => {
-  const u = parseURL(input);
-  return u.protocol && u.host;
+  try {
+    const u = new URL(input);
+    return u.protocol && u.host;
+  } catch {
+    return false;
+  }
 };
 
 (async () => {
@@ -18,7 +21,15 @@ const isValidURL = input => {
   let results;
   try {
     // Setup Puppeteer
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-gpu'
+      ]
+    });
 
     // Get new page
     const page = await browser.newPage();
@@ -26,11 +37,11 @@ const isValidURL = input => {
 
     // Inject and run axe-core
     const handle = await page.evaluateHandle(`
-			// Inject axe source code
-			${axeCore.source}
-			// Run axe
-			axe.run()
-		`);
+      // Inject axe source code
+      ${axeCore.source}
+      // Run axe
+      axe.run()
+    `);
 
     // Get the results from `axe.run()`.
     results = await handle.jsonValue();

--- a/doc/examples/puppeteer/set-content.js
+++ b/doc/examples/puppeteer/set-content.js
@@ -3,7 +3,15 @@ const puppeteer = require('puppeteer');
 const axe = require('axe-core');
 
 (async () => {
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu'
+    ]
+  });
   const page = await browser.newPage();
 
   await page.setContent(`


### PR DESCRIPTION
Fixes the failing puppeteer example failure and the deprecation warning for `url.parse`.