### PR TITLE
fix(aria/get-aria-value): allow getting role value

### DIFF
--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -33,7 +33,7 @@ export default function getAriaValue(node, attrName, options = {}) {
   const attrStandard = standards.ariaAttrs[attrName]
     ? standards.ariaAttrs[attrName]
     : attrName === 'role'
-      ? { type: 'string', prop: 'roll' }
+      ? { type: 'string', prop: 'role' }
       : null;
   if (!attrStandard) {
     return null;

--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -30,7 +30,11 @@ const sources = [
  * @return {{value: String, source: String}|null} value
  */
 export default function getAriaValue(node, attrName, options = {}) {
-  const attrStandard = standards.ariaAttrs[attrName];
+  const attrStandard = standards.ariaAttrs[attrName]
+    ? standards.ariaAttrs[attrName]
+    : attrName === 'role'
+      ? { type: 'string', prop: 'roll' }
+      : null;
   if (!attrStandard) {
     return null;
   }

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -45,13 +45,31 @@ describe('aria.getAriaValue', () => {
     assert.isNull(getAriaValue(vNode, 'id'));
   });
 
-  it('returns `role` value', () => {
+  it('returns `role` attribute value', () => {
     const vNode = queryFixture(
       html`<div id="target" role="fallback button"></div>`
     );
 
-    const { value } = getAriaValue(vNode, 'role');
-    assert.equal(value, 'fallback button');
+    const result = getAriaValue(vNode, 'role');
+    assert.deepEqual(result, {
+      value: 'fallback button',
+      source: 'attribute'
+    });
+  });
+
+  it('returns `role` elementInternals value', () => {
+    const vNode = queryFixture(
+      html`<testutils-element
+        id="target"
+        with-role="fallback button"
+      ></testutils-element>`
+    );
+
+    const result = getAriaValue(vNode, 'role');
+    assert.deepEqual(result, {
+      value: 'fallback button',
+      source: 'internals'
+    });
   });
 
   it('trims non-string values', () => {

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -45,6 +45,15 @@ describe('aria.getAriaValue', () => {
     assert.isNull(getAriaValue(vNode, 'id'));
   });
 
+  it('returns `role` value', () => {
+    const vNode = queryFixture(
+      html`<div id="target" role="fallback button"></div>`
+    );
+
+    const { value } = getAriaValue(vNode, 'role');
+    assert.equal(value, 'fallback button');
+  });
+
   it('trims non-string values', () => {
     const vNode = queryFixture(
       html`<div


### PR DESCRIPTION
While reviewing code in preparation for https://github.com/dequelabs/axe-core/issues/5044, I realized that we'll need to be able to look at the `role` value (and not use `getExplicitRole` like I was thinking). So fixed the code in order to allow that. Alternatively, if we wanted to not have to special case `role` we could add `role` into the `ariaAttrs` standard since we'll also need to do this for the [`hasAttrValue` function](https://github.com/dequelabs/axe-core/pull/5136) as well.