### PR TITLE
feat(aria/has-attr-value): new function to check if node has aria value

### DIFF
--- a/lib/commons/aria/has-aria-value.js
+++ b/lib/commons/aria/has-aria-value.js
@@ -11,13 +11,9 @@ import standards from '../../standards';
  * @return {Boolean}
  */
 export default function hasAriaValue(node, attrName) {
-  const attrStandard = standards.ariaAttrs[attrName]
-    ? standards.ariaAttrs[attrName]
-    : attrName === 'role'
-      ? { prop: 'role' }
-      : null;
+  const attrStandard = standards.ariaAttrs[attrName];
   if (!attrStandard) {
-    return false;
+    throw new TypeError(`Attribute ${attrName} is not an ARIA attribute`);
   }
 
   const { vNode } = nodeLookup(node);

--- a/lib/commons/aria/has-aria-value.js
+++ b/lib/commons/aria/has-aria-value.js
@@ -1,0 +1,49 @@
+import { nodeLookup } from '../../core/utils';
+import standards from '../../standards';
+
+/**
+ * Test if the element has an ARIA attribute, property, or ElementInternal key
+ * @method hasAriaValue
+ * @memberof axe.commons.aria
+ * @instance
+ * @param {Node|Element|VirtualNode} node
+ * @param {String} attrName The ARIA attribute name to get the value of. Use the ARIA attr name even if getting values from properties.
+ * @return {Boolean}
+ */
+export default function hasAriaValue(node, attrName) {
+  const attrStandard = standards.ariaAttrs[attrName]
+    ? standards.ariaAttrs[attrName]
+    : attrName === 'role'
+      ? { prop: 'role' }
+      : null;
+  if (!attrStandard) {
+    return false;
+  }
+
+  const { vNode } = nodeLookup(node);
+  return (
+    hasAttributeValue(vNode, attrName) ||
+    hasPropertyValue(vNode, attrStandard) ||
+    hasInternalValue(vNode, attrStandard)
+  );
+}
+
+function hasAttributeValue(vNode, attrName) {
+  return vNode.hasAttr(attrName);
+}
+
+function hasPropertyValue(vNode, attrStandard) {
+  const { prop } = attrStandard;
+  if (prop && vNode.actualNode) {
+    return vNode.actualNode[prop] !== null;
+  }
+  return false;
+}
+
+function hasInternalValue(vNode, attrStandard) {
+  const { prop } = attrStandard;
+  if (prop && vNode.elementInternals) {
+    return vNode.elementInternals[prop] !== null;
+  }
+  return false;
+}

--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -16,6 +16,7 @@ export { default as getRoleType } from './get-role-type';
 export { default as getRole } from './get-role';
 export { default as getRolesByType } from './get-roles-by-type';
 export { default as getRolesWithNameFromContents } from './get-roles-with-name-from-contents';
+export { default as hasAriaValue } from './has-aria-value';
 export { default as implicitNodes } from './implicit-nodes';
 export { default as implicitRole } from './implicit-role';
 export { default as isAccessibleRef } from './is-accessible-ref';

--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -1,0 +1,106 @@
+describe('aria.hasAriaValue', () => {
+  const { queryFixture, html } = axe.testUtils;
+  const hasAriaValue = axe.commons.aria.hasAriaValue;
+  const SerialVirtualNode = axe.SerialVirtualNode;
+
+  it('returns true if element has attribute', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-label="hello"></div>`
+    );
+
+    assert.isTrue(hasAriaValue(vNode, 'aria-label'));
+  });
+
+  it('returns true if element has elementInternals', () => {
+    const vNode = queryFixture(
+      html`<testutils-element id="target"></testutils-element>`
+    );
+    const node = vNode.actualNode;
+    node._internals.ariaLabel = 'hello';
+
+    assert.isTrue(hasAriaValue(vNode, 'aria-label'));
+  });
+
+  it('returns true if attribute is empty', () => {
+    const vNode = queryFixture(html`<div id="target" aria-label=""></div>`);
+
+    assert.isTrue(hasAriaValue(vNode, 'aria-label'));
+  });
+
+  it('returns true if elementInternals is empty', () => {
+    const vNode = queryFixture(
+      html`<testutils-element id="target"></testutils-element>`
+    );
+    const node = vNode.actualNode;
+    node._internals.ariaLabel = '';
+
+    assert.isTrue(hasAriaValue(vNode, 'aria-label'));
+  });
+
+  it('returns true if elementInternals idrefs is empty', () => {
+    const vNode = queryFixture(
+      html`<testutils-element id="target"></testutils-element>`
+    );
+    const node = vNode.actualNode;
+    node._internals.ariaLabelledByElements = [];
+
+    assert.isTrue(hasAriaValue(vNode, 'aria-labelledby'));
+  });
+
+  it('returns false if missing attribute', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-label="hello"></div>`
+    );
+
+    assert.isFalse(hasAriaValue(vNode, 'aria-sort'));
+  });
+
+  it('returns false for non-aria value', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-label="hello"></div>`
+    );
+
+    assert.isFalse(hasAriaValue(vNode, 'id'));
+  });
+
+  it('returns `role` attribute', () => {
+    const vNode = queryFixture(html`<div id="target" role="button"></div>`);
+
+    assert.isTrue(hasAriaValue(vNode, 'role'));
+  });
+
+  it('returns `role` elementInternals', () => {
+    const vNode = queryFixture(
+      html`<testutils-element id="target"></testutils-element>`
+    );
+    const node = vNode.actualNode;
+    node._internals.role = 'button';
+
+    assert.isTrue(hasAriaValue(vNode, 'role'));
+  });
+
+  describe('SerialVirtualNode', () => {
+    it('returns true if element has attribute', () => {
+      // SerialVirtualNode will not support `props` or `elementInternals` so everything must be part of the `attributes` property
+      const vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'aria-label': 'hello'
+        }
+      });
+
+      assert.isTrue(hasAriaValue(vNode, 'aria-label'));
+    });
+
+    it('returns false if missing attribute', () => {
+      const vNode = new SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'aria-label': 'hello'
+        }
+      });
+
+      assert.isFalse(hasAriaValue(vNode, 'aria-sort'));
+    });
+  });
+});

--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -37,15 +37,21 @@ describe('aria.hasAriaValue', () => {
     assert.isTrue(hasAriaValue(vNode, 'aria-label'));
   });
 
-  it('returns true if elementInternals idrefs is empty', () => {
-    const vNode = queryFixture(
-      html`<testutils-element id="target"></testutils-element>`
-    );
-    const node = vNode.actualNode;
-    node._internals.ariaLabelledByElements = [];
+  // TODO: remove when we resolve https://github.com/dequelabs/axe-core/issues/5139
+  // accessing empty idrefs element internal values crashes firefox
+  // @see https://bugzilla.mozilla.org/show_bug.cgi?id=2045887
+  (navigator.userAgent.indexOf('Firefox') > 0 ? it.skip : it)(
+    'returns true if elementInternals idrefs is empty',
+    () => {
+      const vNode = queryFixture(
+        html`<testutils-element id="target"></testutils-element>`
+      );
+      const node = vNode.actualNode;
+      node._internals.ariaLabelledByElements = [];
 
-    assert.isTrue(hasAriaValue(vNode, 'aria-labelledby'));
-  });
+      assert.isTrue(hasAriaValue(vNode, 'aria-labelledby'));
+    }
+  );
 
   it('returns false if missing attribute', () => {
     const vNode = queryFixture(

--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -61,28 +61,12 @@ describe('aria.hasAriaValue', () => {
     assert.isFalse(hasAriaValue(vNode, 'aria-sort'));
   });
 
-  it('returns false for non-aria value', () => {
+  it('throws for non-aria value', () => {
     const vNode = queryFixture(
       html`<div id="target" aria-label="hello"></div>`
     );
 
-    assert.isFalse(hasAriaValue(vNode, 'id'));
-  });
-
-  it('returns `role` attribute', () => {
-    const vNode = queryFixture(html`<div id="target" role="button"></div>`);
-
-    assert.isTrue(hasAriaValue(vNode, 'role'));
-  });
-
-  it('returns `role` elementInternals', () => {
-    const vNode = queryFixture(
-      html`<testutils-element id="target"></testutils-element>`
-    );
-    const node = vNode.actualNode;
-    node._internals.role = 'button';
-
-    assert.isTrue(hasAriaValue(vNode, 'role'));
+    assert.throws(() => hasAriaValue(vNode, 'id'));
   });
 
   describe('SerialVirtualNode', () => {


### PR DESCRIPTION
Companion to #5109 but replaces `vNode.hasAttr`.

This resulted in finding a bug in Firefox which crashes the browser when trying to access an empty array set to an idrefs property in element internals. This is why the Firefox tests are failing (technically crashing). Filled here https://bugzilla.mozilla.org/show_bug.cgi?id=2045887.