### PR TITLE
test: support with-aria-* attributes on testutils-element

### DIFF
--- a/test/testutils.js
+++ b/test/testutils.js
@@ -38,6 +38,9 @@ var helpers;
 
   // create a custom element that all tests can use
   if (!customElements.get('testutils-element')) {
+    const withAriaRegex = /^with-(aria-.+)$/;
+    const idrefTypes = ['idref', 'idrefs'];
+
     customElements.define(
       'testutils-element',
       class TestutilsElement extends HTMLElement {
@@ -49,6 +52,40 @@ var helpers;
             const role = this.getAttribute('with-role');
             this._internals.role = role ?? 'button';
           }
+
+          // convert with-aria-* attributes to the internals value
+          Array.from(this.attributes).forEach(attr => {
+            const { name, value } = attr;
+            const match = name.match(withAriaRegex);
+            if (!match) {
+              return;
+            }
+
+            const ariaName = match[1];
+            const attrStandard = axe._audit.standards.ariaAttrs[ariaName];
+            if (!attrStandard || !attrStandard.prop) {
+              return;
+            }
+
+            const { type, prop } = attrStandard;
+            if (!idrefTypes.includes(type)) {
+              this._internals[prop] = value;
+              return;
+            }
+
+            const doc = axe.utils.getRootNode(this);
+            // convert idref(s) to DOM node(s)
+            if (type === 'idref') {
+              const node = doc.getElementById(value);
+              this._internals[prop] = node;
+            } else if (type === 'idrefs') {
+              const values = [];
+              for (const id of axe.utils.tokenList(value)) {
+                values.push(doc.getElementById(id));
+              }
+              this._internals[prop] = values;
+            }
+          });
         }
       }
     );


### PR DESCRIPTION
In preparation for https://github.com/dequelabs/axe-core/issues/5044, this will allow us to declaratively set aria prop values on the `testutils-element` using `with-aria-*` attributes (mimicking the `with-role` attribute). It handles converting idref(s) attributes to their DOM nodes.