### PR TITLE
feat(dom/idrefs): support ARIA idrefs properties and element internals

### DIFF
--- a/lib/commons/dom/idrefs.js
+++ b/lib/commons/dom/idrefs.js
@@ -1,5 +1,6 @@
 import getRootNode from './get-root-node';
-import { tokenList } from '../../core/utils';
+import { tokenList, nodeLookup } from '../../core/utils';
+import standards from '../../standards';
 
 /**
  * Get elements referenced via a space-separated token attribute;
@@ -17,18 +18,23 @@ import { tokenList } from '../../core/utils';
  * on the flattened tree to dereference idrefs.
  *
  */
-function idrefs(node, attr) {
-  node = node.actualNode || node;
+export default function idrefs(node, attr) {
+  const { vNode, domNode } = nodeLookup(node);
 
   try {
-    const doc = getRootNode(node);
+    const doc = getRootNode(domNode);
     const result = [];
-    let attrValue = node.getAttribute(attr);
+    let attrValue = getIdrefsValue(vNode, attr);
 
     if (attrValue) {
+      // already resolved idrefs
+      if (Array.isArray(attrValue) || attrValue instanceof window.NodeList) {
+        return Array.from(attrValue);
+      }
+
       attrValue = tokenList(attrValue);
-      for (let index = 0; index < attrValue.length; index++) {
-        result.push(doc.getElementById(attrValue[index]));
+      for (const value of attrValue) {
+        result.push(doc.getElementById(value));
       }
     }
 
@@ -38,4 +44,29 @@ function idrefs(node, attr) {
   }
 }
 
-export default idrefs;
+function getIdrefsValue(vNode, attr) {
+  const { prop } = standards.ariaAttrs[attr] ?? {};
+
+  // get prop value first as setting idrefs can result in empty attribute values
+  // e.g. el.ariaLabelledByElements = [label]; el.getAttribute('aria-labelledby') === ''
+  if (prop && vNode.actualNode) {
+    const propValue = vNode.actualNode[prop];
+    if (propValue !== null) {
+      return propValue;
+    }
+  }
+
+  const attrValue = vNode.attr(attr);
+  if (attrValue !== null) {
+    return attrValue;
+  }
+
+  if (prop && vNode.elementInternals) {
+    const internalsValue = vNode.elementInternals[prop];
+    if (internalsValue !== null) {
+      return internalsValue;
+    }
+  }
+
+  return null;
+}

--- a/test/commons/dom/idrefs.js
+++ b/test/commons/dom/idrefs.js
@@ -18,11 +18,14 @@ describe('dom.idrefs', () => {
   const idrefs = axe.commons.dom.idrefs;
 
   it('should find referenced nodes by ID', () => {
-    const vNode = queryFixture(html`
-      <div aria-cats="target1 target2" id="target"></div>
-      <div id="target1"></div>
-      <div id="target2"></div>
-    `);
+    const vNode = queryFixture(
+      html`
+        <div aria-cats="target1 target2" id="start"></div>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `,
+      '#start'
+    );
 
     const expected = [
       document.getElementById('target1'),
@@ -66,11 +69,14 @@ describe('dom.idrefs', () => {
   });
 
   it('should insert null if a reference is not found', () => {
-    const vNode = queryFixture(html`
-      <div aria-cats="target1 target2 target3" id="target"></div>
-      <div id="target1"></div>
-      <div id="target2"></div>
-    `);
+    const vNode = queryFixture(
+      html`
+        <div aria-cats="target1 target2 target3" id="start"></div>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `,
+      '#start'
+    );
 
     const expected = [
       document.getElementById('target1'),
@@ -82,16 +88,19 @@ describe('dom.idrefs', () => {
   });
 
   it('should not fail when extra whitespace is used', () => {
-    const vNode = queryFixture(html`
-      <div
-        aria-cats="     target1
+    const vNode = queryFixture(
+      html`
+        <div
+          aria-cats="     target1
   target2  target3
   "
-        id="target"
-      ></div>
-      <div id="target1"></div>
-      <div id="target2"></div>
-    `);
+          id="start"
+        ></div>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `,
+      '#start'
+    );
 
     const expected = [
       document.getElementById('target1'),
@@ -103,11 +112,14 @@ describe('dom.idrefs', () => {
   });
 
   it('should work with idrefs property', () => {
-    const vNode = queryFixture(html`
-      <div id="target"></div>
-      <div id="target1"></div>
-      <div id="target2"></div>
-    `);
+    const vNode = queryFixture(
+      html`
+        <div id="start"></div>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `,
+      '#start'
+    );
 
     vNode.actualNode.ariaControlsElements = [
       document.getElementById('target1'),
@@ -127,11 +139,14 @@ describe('dom.idrefs', () => {
   });
 
   it('should work with idrefs elementInternals', () => {
-    const vNode = queryFixture(html`
-      <testutils-element id="target"></testutils-element>
-      <div id="target1"></div>
-      <div id="target2"></div>
-    `);
+    const vNode = queryFixture(
+      html`
+        <testutils-element id="start"></testutils-element>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `,
+      '#start'
+    );
 
     vNode.actualNode._internals.ariaLabelledByElements = [
       document.getElementById('target1'),
@@ -151,11 +166,14 @@ describe('dom.idrefs', () => {
   });
 
   it('should not insert null if an idrefs property reference is not connected', () => {
-    const vNode = queryFixture(html`
-      <div id="target"></div>
-      <div id="target1"></div>
-      <div id="target2"></div>
-    `);
+    const vNode = queryFixture(
+      html`
+        <div id="start"></div>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `,
+      '#start'
+    );
     const div = document.createElement('div');
 
     vNode.actualNode.ariaControlsElements = [

--- a/test/commons/dom/idrefs.js
+++ b/test/commons/dom/idrefs.js
@@ -14,32 +14,22 @@ function makeShadowTreeIDR(node) {
 }
 
 describe('dom.idrefs', () => {
-  const html = axe.testUtils.html;
-
-  const fixture = document.getElementById('fixture');
-
-  afterEach(() => {
-    fixture.innerHTML = '';
-  });
+  const { html, queryFixture, fixture, flatTreeSetup } = axe.testUtils;
+  const idrefs = axe.commons.dom.idrefs;
 
   it('should find referenced nodes by ID', () => {
-    fixture.innerHTML = html`
-      <div aria-cats="target1 target2" id="start"></div>
+    const vNode = queryFixture(html`
+      <div aria-cats="target1 target2" id="target"></div>
       <div id="target1"></div>
       <div id="target2"></div>
-    `;
+    `);
 
-    const start = document.getElementById('start'),
-      expected = [
-        document.getElementById('target1'),
-        document.getElementById('target2')
-      ];
+    const expected = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
 
-    assert.deepEqual(
-      axe.commons.dom.idrefs(start, 'aria-cats'),
-      expected,
-      'Should find it!'
-    );
+    assert.deepEqual(idrefs(vNode, 'aria-cats'), expected, 'Should find it!');
   });
 
   it('should find only referenced nodes within the current root: shadow DOM', () => {
@@ -47,11 +37,12 @@ describe('dom.idrefs', () => {
     // to specifically test this
     fixture.innerHTML = '<div target="target"><div id="target"></div></div>';
     makeShadowTreeIDR(fixture.firstChild);
+    flatTreeSetup(fixture);
     const start = fixture.firstChild.shadowRoot.querySelector('.parent');
     const expected = [fixture.firstChild.shadowRoot.getElementById('target')];
 
     assert.deepEqual(
-      axe.commons.dom.idrefs(start, 'target'),
+      idrefs(start, 'target'),
       expected,
       'should only find stuff in the shadow DOM'
     );
@@ -63,58 +54,123 @@ describe('dom.idrefs', () => {
     fixture.innerHTML =
       '<div target="target" class="parent"><div id="target"></div></div>';
     makeShadowTreeIDR(fixture.firstChild);
+    flatTreeSetup(fixture);
     const start = fixture.querySelector('.parent');
     const expected = [document.getElementById('target')];
 
     assert.deepEqual(
-      axe.commons.dom.idrefs(start, 'target'),
+      idrefs(start, 'target'),
       expected,
       'should only find stuff in the document'
     );
   });
 
   it('should insert null if a reference is not found', () => {
-    fixture.innerHTML = html`
-      <div aria-cats="target1 target2 target3" id="start"></div>
+    const vNode = queryFixture(html`
+      <div aria-cats="target1 target2 target3" id="target"></div>
       <div id="target1"></div>
       <div id="target2"></div>
-    `;
+    `);
 
-    const start = document.getElementById('start'),
-      expected = [
-        document.getElementById('target1'),
-        document.getElementById('target2'),
-        null
-      ];
+    const expected = [
+      document.getElementById('target1'),
+      document.getElementById('target2'),
+      null
+    ];
+
+    assert.deepEqual(idrefs(vNode, 'aria-cats'), expected, 'Should find it!');
+  });
+
+  it('should not fail when extra whitespace is used', () => {
+    const vNode = queryFixture(html`
+      <div
+        aria-cats="     target1
+  target2  target3
+  "
+        id="target"
+      ></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    const expected = [
+      document.getElementById('target1'),
+      document.getElementById('target2'),
+      null
+    ];
+
+    assert.deepEqual(idrefs(vNode, 'aria-cats'), expected, 'Should find it!');
+  });
+
+  it('should work with idrefs property', () => {
+    const vNode = queryFixture(html`
+      <div id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    vNode.actualNode.ariaControlsElements = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
+
+    const expected = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
 
     assert.deepEqual(
-      axe.commons.dom.idrefs(start, 'aria-cats'),
+      idrefs(vNode, 'aria-controls'),
       expected,
       'Should find it!'
     );
   });
 
-  it('should not fail when extra whitespace is used', () => {
-    fixture.innerHTML = html`
-      <div
-        aria-cats="    	target1 
-  target2  target3 
-  "
-        id="start"
-      ></div>
+  it('should work with idrefs elementInternals', () => {
+    const vNode = queryFixture(html`
+      <testutils-element id="target"></testutils-element>
       <div id="target1"></div>
       <div id="target2"></div>
-    `;
+    `);
 
-    const start = document.getElementById('start'),
-      expected = [
-        document.getElementById('target1'),
-        document.getElementById('target2'),
-        null
-      ];
+    vNode.actualNode._internals.ariaLabelledByElements = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
+
+    const expected = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
 
     assert.deepEqual(
-      axe.commons.dom.idrefs(start, 'aria-cats'),
+      idrefs(vNode, 'aria-labelledby'),
+      expected,
+      'Should find it!'
+    );
+  });
+
+  it('should not insert null if an idrefs property reference is not connected', () => {
+    const vNode = queryFixture(html`
+      <div id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+    const div = document.createElement('div');
+
+    vNode.actualNode.ariaControlsElements = [
+      document.getElementById('target1'),
+      document.getElementById('target2'),
+      div
+    ];
+
+    const expected = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
+
+    assert.deepEqual(
+      idrefs(vNode, 'aria-controls'),
       expected,
       'Should find it!'
     );


### PR DESCRIPTION
Update `idrefs` function to understand handling ARIA idrefs properties and element internals properties. This was the leftover work from #5109 to handle idrefs being a string (attribute) or array of nodes (property). This should seemlessly allow all function calls to `idrefs` to handle element internals.