### PR TITLE
feat(dom/getResolvedRefs): new function to get the resolved virtual nodes of idrefs

### DIFF
--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -30,8 +30,9 @@ export default function getResolvedRefs(node, attr, options = {}) {
       return [];
     }
 
-    // already resolved node refs
     let refs;
+
+    // already resolved node refs
     if (Array.isArray(attrValue) || attrValue instanceof window.NodeList) {
       refs = Array.from(attrValue);
     } else {

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -1,0 +1,76 @@
+import getRootNode from './get-root-node';
+import { tokenList, nodeLookup, getNodeFromTree } from '../../core/utils';
+import standards from '../../standards';
+
+/**
+ * Get elements referenced via a space-separated token attribute or AOM property;
+ * it will insert `null` for any Element that is not found
+ * @method getResolvedRefs
+ * @memberof axe.commons.dom
+ * @instance
+ * @param  {HTMLElement|Node|VirtualNode} node
+ * @param  {String} attr The attribute name to get the value of. Use the ARIA attr name even if getting values from AOM properties.
+ * @return {Array<VirtualNodes|null>} Array of mixed values: Virtual Nodes or `null` if not found
+ *
+ * NOTE: When in a shadow DOM environment: ID refs (even for slotted content)
+ * refer to the document in which the element is considered to be in the
+ * "light DOM". Therefore, we use getElementById on the root node and not QSA
+ * on the flattened tree to dereference idrefs.
+ *
+ */
+export default function getResolvedRefs(node, attr) {
+  const { vNode, domNode } = nodeLookup(node);
+
+  try {
+    const attrValue = getIdrefsValue(vNode, attr);
+    if (!attrValue) {
+      return [];
+    }
+
+    // already resolved node refs
+    if (Array.isArray(attrValue) || attrValue instanceof window.NodeList) {
+      return Array.from(attrValue).map(n => {
+        return getNodeFromTree(n);
+      });
+    }
+
+    const doc = getRootNode(domNode);
+    return tokenList(attrValue).map(value => {
+      const n = doc.getElementById(value);
+      if (!n) {
+        return null;
+      }
+
+      return getNodeFromTree(n);
+    });
+  } catch {
+    throw new TypeError('Cannot resolve id references for non-DOM nodes');
+  }
+}
+
+function getIdrefsValue(vNode, attr) {
+  const { prop } = standards.ariaAttrs[attr] ?? {};
+
+  // get prop value first as setting idrefs can result in empty attribute values
+  // e.g. el.ariaLabelledByElements = [label]; el.getAttribute('aria-labelledby') === ''
+  if (prop && vNode.actualNode) {
+    const propValue = vNode.actualNode[prop];
+    if (propValue !== null) {
+      return propValue;
+    }
+  }
+
+  const attrValue = vNode.attr(attr);
+  if (attrValue !== null) {
+    return attrValue;
+  }
+
+  if (prop && vNode.elementInternals) {
+    const internalsValue = vNode.elementInternals[prop];
+    if (internalsValue !== null) {
+      return internalsValue;
+    }
+  }
+
+  return null;
+}

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -10,6 +10,8 @@ import standards from '../../standards';
  * @instance
  * @param  {HTMLElement|Node|VirtualNode} node
  * @param  {String} attr The attribute name to get the value of. Use the ARIA attr name even if getting values from AOM properties.
+ * @param {Object} [options]
+ * @param {Boolean} [options.self=true] If the resolved refs should include the passed in node if the attr references its own id
  * @return {Array<VirtualNodes|null>} Array of mixed values: Virtual Nodes or `null` if not found
  *
  * NOTE: When in a shadow DOM environment: ID refs (even for slotted content)
@@ -18,7 +20,8 @@ import standards from '../../standards';
  * on the flattened tree to dereference idrefs.
  *
  */
-export default function getResolvedRefs(node, attr) {
+export default function getResolvedRefs(node, attr, options = {}) {
+  const { self = true } = options;
   const { vNode, domNode } = nodeLookup(node);
 
   try {
@@ -29,30 +32,26 @@ export default function getResolvedRefs(node, attr) {
 
     // already resolved node refs
     if (Array.isArray(attrValue) || attrValue instanceof window.NodeList) {
-      return (
-        Array.from(attrValue)
-          // remove self references
-          .filter(n => n !== domNode)
-          .map(n => {
-            return getNodeFromTree(n);
-          })
-      );
+      let refs = Array.from(attrValue);
+      if (!self) {
+        refs = refs.filter(n => n !== domNode);
+      }
+      return refs.map(n => getNodeFromTree(n));
     }
 
     const doc = getRootNode(domNode);
-    return (
-      tokenList(attrValue)
-        // remove self references
-        .filter(value => value !== vNode.props.id)
-        .map(value => {
-          const n = doc.getElementById(value);
-          if (!n) {
-            return null;
-          }
+    let refs = tokenList(attrValue);
+    if (!self) {
+      refs = refs.filter(value => value !== vNode.props.id);
+    }
+    return refs.map(value => {
+      const n = doc.getElementById(value);
+      if (!n) {
+        return null;
+      }
 
-          return getNodeFromTree(n);
-        })
-    );
+      return getNodeFromTree(n);
+    });
   } catch (cause) {
     throw new TypeError('Cannot resolve id references for non-DOM nodes', {
       cause

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -29,20 +29,30 @@ export default function getResolvedRefs(node, attr) {
 
     // already resolved node refs
     if (Array.isArray(attrValue) || attrValue instanceof window.NodeList) {
-      return Array.from(attrValue).map(n => {
-        return getNodeFromTree(n);
-      });
+      return (
+        Array.from(attrValue)
+          // remove self references
+          .filter(n => n !== domNode)
+          .map(n => {
+            return getNodeFromTree(n);
+          })
+      );
     }
 
     const doc = getRootNode(domNode);
-    return tokenList(attrValue).map(value => {
-      const n = doc.getElementById(value);
-      if (!n) {
-        return null;
-      }
+    return (
+      tokenList(attrValue)
+        // remove self references
+        .filter(value => value !== vNode.props.id)
+        .map(value => {
+          const n = doc.getElementById(value);
+          if (!n) {
+            return null;
+          }
 
-      return getNodeFromTree(n);
-    });
+          return getNodeFromTree(n);
+        })
+    );
   } catch (cause) {
     throw new TypeError('Cannot resolve id references for non-DOM nodes', {
       cause
@@ -57,7 +67,8 @@ function getIdrefsValue(vNode, attr) {
   // e.g. el.ariaLabelledByElements = [label]; el.getAttribute('aria-labelledby') === ''
   if (prop && vNode.actualNode) {
     const propValue = vNode.actualNode[prop];
-    if (propValue !== null) {
+    // the prop could be undefined in IE11
+    if (propValue !== null && propValue !== undefined) {
       return propValue;
     }
   }
@@ -69,7 +80,7 @@ function getIdrefsValue(vNode, attr) {
 
   if (prop && vNode.elementInternals) {
     const internalsValue = vNode.elementInternals[prop];
-    if (internalsValue !== null) {
+    if (internalsValue !== null && internalsValue !== undefined) {
       return internalsValue;
     }
   }

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -44,7 +44,9 @@ export default function getResolvedRefs(node, attr) {
       return getNodeFromTree(n);
     });
   } catch (cause) {
-    throw new TypeError('Cannot resolve id references for non-DOM nodes', { cause });
+    throw new TypeError('Cannot resolve id references for non-DOM nodes', {
+      cause
+    });
   }
 }
 

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -43,8 +43,8 @@ export default function getResolvedRefs(node, attr) {
 
       return getNodeFromTree(n);
     });
-  } catch {
-    throw new TypeError('Cannot resolve id references for non-DOM nodes');
+  } catch (cause) {
+    throw new TypeError('Cannot resolve id references for non-DOM nodes', { cause });
   }
 }
 

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -31,26 +31,20 @@ export default function getResolvedRefs(node, attr, options = {}) {
     }
 
     // already resolved node refs
+    let refs;
     if (Array.isArray(attrValue) || attrValue instanceof window.NodeList) {
-      let refs = Array.from(attrValue);
-      if (!self) {
-        refs = refs.filter(n => n !== domNode);
-      }
-      return refs.map(n => getNodeFromTree(n));
+      refs = Array.from(attrValue);
+    } else {
+      const doc = getRootNode(domNode);
+      refs = tokenList(attrValue).map(value => doc.getElementById(value));
     }
 
-    const doc = getRootNode(domNode);
-    let refs = tokenList(attrValue);
     if (!self) {
-      refs = refs.filter(value => value !== vNode.props.id);
+      refs = refs.filter(n => n !== domNode);
     }
-    return refs.map(value => {
-      const n = doc.getElementById(value);
-      if (!n) {
-        return null;
-      }
-
-      return getNodeFromTree(n);
+    return refs.map(n => {
+      const virtualNode = getNodeFromTree(n);
+      return virtualNode ? virtualNode : null;
     });
   } catch (cause) {
     throw new TypeError('Cannot resolve id references for non-DOM nodes', {

--- a/lib/commons/dom/index.js
+++ b/lib/commons/dom/index.js
@@ -18,6 +18,7 @@ export { default as getRootNode } from './get-root-node';
 export { default as getScrollOffset } from './get-scroll-offset';
 export { default as getTabbableElements } from './get-tabbable-elements';
 export { default as getTargetRects } from './get-target-rects';
+export { default as getResolvedRefs } from './get-resolved-refs';
 export { default as getTargetSize } from './get-target-size';
 export { default as getTextElementStack } from './get-text-element-stack';
 export { default as getViewportSize } from './get-viewport-size';

--- a/test/commons/dom/get-resolved-refs.js
+++ b/test/commons/dom/get-resolved-refs.js
@@ -1,0 +1,175 @@
+describe('dom.getResolvedRefs', () => {
+  const { html, queryFixture, queryShadowFixture, fixture } = axe.testUtils;
+  const getResolvedRefs = axe.commons.dom.getResolvedRefs;
+  const getNodeFromTree = axe.utils.getNodeFromTree;
+
+  it('should find referenced nodes by ID', () => {
+    const vNode = queryFixture(html`
+      <div aria-cats="target1 target2" id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2'))
+    ];
+
+    assert.deepEqual(
+      getResolvedRefs(vNode, 'aria-cats'),
+      expected,
+      'Should find it!'
+    );
+  });
+
+  it('should find only referenced nodes within the current root: shadow DOM', () => {
+    const targetVNode = queryShadowFixture(
+      html`<div id="shadow"><div id="target"></div></div>`,
+      html`<div target="target"><div id="target"></div></div>`
+    );
+
+    const node = fixture.querySelector('#shadow').shadowRoot.firstChild;
+    const expected = [targetVNode];
+
+    assert.deepEqual(
+      getResolvedRefs(node, 'target'),
+      expected,
+      'should only find stuff in the shadow DOM'
+    );
+  });
+
+  it('should find only referenced nodes within the current root: document', () => {
+    queryShadowFixture(
+      html`<div target="target" id="shadow"><div id="target"></div></div>`,
+      html`<div target="target"><div id="target"></div></div>`
+    );
+
+    const node = fixture.querySelector('[target]');
+    const expected = [getNodeFromTree(fixture.querySelector('#target'))];
+
+    assert.deepEqual(
+      getResolvedRefs(node, 'target'),
+      expected,
+      'should only find stuff in the document'
+    );
+  });
+
+  it('should insert null if a reference is not found', () => {
+    const vNode = queryFixture(html`
+      <div aria-cats="target1 target2 target3" id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2')),
+      null
+    ];
+
+    assert.deepEqual(
+      getResolvedRefs(vNode, 'aria-cats'),
+      expected,
+      'Should find it!'
+    );
+  });
+
+  it('should not fail when extra whitespace is used', () => {
+    const vNode = queryFixture(html`
+      <div
+        aria-cats="     target1
+  target2  target3
+  "
+        id="target"
+      ></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2')),
+      null
+    ];
+
+    assert.deepEqual(
+      getResolvedRefs(vNode, 'aria-cats'),
+      expected,
+      'Should find it!'
+    );
+  });
+
+  it('should work with idrefs property', () => {
+    const vNode = queryFixture(html`
+      <div id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    vNode.actualNode.ariaControlsElements = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2'))
+    ];
+
+    assert.deepEqual(
+      getResolvedRefs(vNode, 'aria-controls'),
+      expected,
+      'Should find it!'
+    );
+  });
+
+  it('should work with idrefs elementInternals', () => {
+    const vNode = queryFixture(html`
+      <testutils-element id="target"></testutils-element>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    vNode.actualNode._internals.ariaLabelledByElements = [
+      document.getElementById('target1'),
+      document.getElementById('target2')
+    ];
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2'))
+    ];
+
+    assert.deepEqual(
+      getResolvedRefs(vNode, 'aria-labelledby'),
+      expected,
+      'Should find it!'
+    );
+  });
+
+  it('should not insert null if an idrefs property reference is not connected', () => {
+    const vNode = queryFixture(html`
+      <div id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+    const div = document.createElement('div');
+
+    vNode.actualNode.ariaControlsElements = [
+      document.getElementById('target1'),
+      document.getElementById('target2'),
+      div
+    ];
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2'))
+    ];
+
+    assert.deepEqual(
+      getResolvedRefs(vNode, 'aria-controls'),
+      expected,
+      'Should find it!'
+    );
+  });
+});

--- a/test/commons/dom/get-resolved-refs.js
+++ b/test/commons/dom/get-resolved-refs.js
@@ -20,7 +20,8 @@ describe('dom.getResolvedRefs', () => {
 
   it('should find only referenced nodes within the current root: shadow DOM', () => {
     const targetVNode = queryShadowFixture(
-      html`<div id="shadow"><div id="target"></div></div>`,
+      html`<div id="shadow"></div>
+        <div id="target"></div>`,
       html`<div target="target"><div id="target"></div></div>`
     );
 
@@ -32,7 +33,8 @@ describe('dom.getResolvedRefs', () => {
 
   it('should find only referenced nodes within the current root: document', () => {
     queryShadowFixture(
-      html`<div target="target" id="shadow"><div id="target"></div></div>`,
+      html`<div target="target" id="shadow"></div>
+        <div id="target"></div>`,
       html`<div target="target"><div id="target"></div></div>`
     );
 
@@ -40,22 +42,6 @@ describe('dom.getResolvedRefs', () => {
     const expected = [getNodeFromTree(fixture.querySelector('#target'))];
 
     assert.deepEqual(getResolvedRefs(node, 'target'), expected);
-  });
-
-  it('should insert null if a reference is not found', () => {
-    const vNode = queryFixture(html`
-      <div aria-cats="target1 target2 target3" id="target"></div>
-      <div id="target1"></div>
-      <div id="target2"></div>
-    `);
-
-    const expected = [
-      getNodeFromTree(document.getElementById('target1')),
-      getNodeFromTree(document.getElementById('target2')),
-      null
-    ];
-
-    assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
   });
 
   it('should not fail when extra whitespace is used', () => {
@@ -117,6 +103,41 @@ describe('dom.getResolvedRefs', () => {
     ];
 
     assert.deepEqual(getResolvedRefs(vNode, 'aria-labelledby'), expected);
+  });
+
+  it('should insert null if a reference is not found', () => {
+    const vNode = queryFixture(html`
+      <div aria-cats="target1 target2 target3" id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2')),
+      null
+    ];
+
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
+  });
+
+  it('should insert null if a reference is not in the virtual tree', () => {
+    const vNode = queryFixture(html`
+      <div aria-cats="target1 target2 target3" id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+    const div = document.createElement('div');
+    div.id = 'target3';
+    fixture.append(div);
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2')),
+      null
+    ];
+
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
   });
 
   it('should not insert null if an idrefs property reference is not connected', () => {

--- a/test/commons/dom/get-resolved-refs.js
+++ b/test/commons/dom/get-resolved-refs.js
@@ -141,7 +141,7 @@ describe('dom.getResolvedRefs', () => {
     assert.deepEqual(getResolvedRefs(vNode, 'aria-controls'), expected);
   });
 
-  it('should remove self id references from attribute', () => {
+  it('should not remove self id references from attribute', () => {
     const vNode = queryFixture(html`
       <div aria-cats="target1 target target2" id="target"></div>
       <div id="target1"></div>
@@ -150,13 +150,14 @@ describe('dom.getResolvedRefs', () => {
 
     const expected = [
       getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target')),
       getNodeFromTree(document.getElementById('target2'))
     ];
 
     assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
   });
 
-  it('should remove self id references from elementInternals', () => {
+  it('should not remove self id references from elementInternals', () => {
     const vNode = queryFixture(html`
       <testutils-element id="target"></testutils-element>
       <div id="target1"></div>
@@ -171,6 +172,7 @@ describe('dom.getResolvedRefs', () => {
 
     const expected = [
       getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target')),
       getNodeFromTree(document.getElementById('target2'))
     ];
 
@@ -208,5 +210,49 @@ describe('dom.getResolvedRefs', () => {
     ];
 
     assert.deepEqual(getResolvedRefs(vNode, 'aria-labelledby'), expected);
+  });
+
+  describe('options.self=false', () => {
+    it('should remove self id references from attribute', () => {
+      const vNode = queryFixture(html`
+        <div aria-cats="target1 target target2" id="target"></div>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `);
+
+      const expected = [
+        getNodeFromTree(document.getElementById('target1')),
+        getNodeFromTree(document.getElementById('target2'))
+      ];
+
+      assert.deepEqual(
+        getResolvedRefs(vNode, 'aria-cats', { self: false }),
+        expected
+      );
+    });
+
+    it('should remove self id references from elementInternals', () => {
+      const vNode = queryFixture(html`
+        <testutils-element id="target"></testutils-element>
+        <div id="target1"></div>
+        <div id="target2"></div>
+      `);
+
+      vNode.actualNode._internals.ariaLabelledByElements = [
+        document.getElementById('target1'),
+        document.getElementById('target'),
+        document.getElementById('target2')
+      ];
+
+      const expected = [
+        getNodeFromTree(document.getElementById('target1')),
+        getNodeFromTree(document.getElementById('target2'))
+      ];
+
+      assert.deepEqual(
+        getResolvedRefs(vNode, 'aria-labelledby', { self: false }),
+        expected
+      );
+    });
   });
 });

--- a/test/commons/dom/get-resolved-refs.js
+++ b/test/commons/dom/get-resolved-refs.js
@@ -15,11 +15,7 @@ describe('dom.getResolvedRefs', () => {
       getNodeFromTree(document.getElementById('target2'))
     ];
 
-    assert.deepEqual(
-      getResolvedRefs(vNode, 'aria-cats'),
-      expected,
-      'Should find it!'
-    );
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
   });
 
   it('should find only referenced nodes within the current root: shadow DOM', () => {
@@ -31,11 +27,7 @@ describe('dom.getResolvedRefs', () => {
     const node = fixture.querySelector('#shadow').shadowRoot.firstChild;
     const expected = [targetVNode];
 
-    assert.deepEqual(
-      getResolvedRefs(node, 'target'),
-      expected,
-      'should only find stuff in the shadow DOM'
-    );
+    assert.deepEqual(getResolvedRefs(node, 'target'), expected);
   });
 
   it('should find only referenced nodes within the current root: document', () => {
@@ -47,11 +39,7 @@ describe('dom.getResolvedRefs', () => {
     const node = fixture.querySelector('[target]');
     const expected = [getNodeFromTree(fixture.querySelector('#target'))];
 
-    assert.deepEqual(
-      getResolvedRefs(node, 'target'),
-      expected,
-      'should only find stuff in the document'
-    );
+    assert.deepEqual(getResolvedRefs(node, 'target'), expected);
   });
 
   it('should insert null if a reference is not found', () => {
@@ -67,11 +55,7 @@ describe('dom.getResolvedRefs', () => {
       null
     ];
 
-    assert.deepEqual(
-      getResolvedRefs(vNode, 'aria-cats'),
-      expected,
-      'Should find it!'
-    );
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
   });
 
   it('should not fail when extra whitespace is used', () => {
@@ -92,11 +76,7 @@ describe('dom.getResolvedRefs', () => {
       null
     ];
 
-    assert.deepEqual(
-      getResolvedRefs(vNode, 'aria-cats'),
-      expected,
-      'Should find it!'
-    );
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
   });
 
   it('should work with idrefs property', () => {
@@ -116,11 +96,7 @@ describe('dom.getResolvedRefs', () => {
       getNodeFromTree(document.getElementById('target2'))
     ];
 
-    assert.deepEqual(
-      getResolvedRefs(vNode, 'aria-controls'),
-      expected,
-      'Should find it!'
-    );
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-controls'), expected);
   });
 
   it('should work with idrefs elementInternals', () => {
@@ -140,11 +116,7 @@ describe('dom.getResolvedRefs', () => {
       getNodeFromTree(document.getElementById('target2'))
     ];
 
-    assert.deepEqual(
-      getResolvedRefs(vNode, 'aria-labelledby'),
-      expected,
-      'Should find it!'
-    );
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-labelledby'), expected);
   });
 
   it('should not insert null if an idrefs property reference is not connected', () => {
@@ -166,10 +138,75 @@ describe('dom.getResolvedRefs', () => {
       getNodeFromTree(document.getElementById('target2'))
     ];
 
-    assert.deepEqual(
-      getResolvedRefs(vNode, 'aria-controls'),
-      expected,
-      'Should find it!'
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-controls'), expected);
+  });
+
+  it('should remove self id references from attribute', () => {
+    const vNode = queryFixture(html`
+      <div aria-cats="target1 target target2" id="target"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2'))
+    ];
+
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-cats'), expected);
+  });
+
+  it('should remove self id references from elementInternals', () => {
+    const vNode = queryFixture(html`
+      <testutils-element id="target"></testutils-element>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    vNode.actualNode._internals.ariaLabelledByElements = [
+      document.getElementById('target1'),
+      document.getElementById('target'),
+      document.getElementById('target2')
+    ];
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2'))
+    ];
+
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-labelledby'), expected);
+  });
+
+  it('should fallback to attribute if prop is undefined (IE11)', () => {
+    // any AOM property cannot be set to undefined so we'll create a custom element that does override the value
+    customElements.define(
+      'aria-resolved-refs-elm',
+      class AriaResolvedRefsElm extends HTMLElement {
+        constructor() {
+          super();
+        }
+
+        get ariaLabelledByElements() {
+          return undefined;
+        }
+        set ariaLabelledByElements(foo) {}
+      }
     );
+
+    const vNode = queryFixture(html`
+      <aria-resolved-refs-elm
+        aria-labelledby="target1 target2"
+        id="target"
+      ></aria-resolved-refs-elm>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    const expected = [
+      getNodeFromTree(document.getElementById('target1')),
+      getNodeFromTree(document.getElementById('target2'))
+    ];
+
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-labelledby'), expected);
   });
 });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -226,10 +226,10 @@ var helpers;
     // Normalize target, allow it to be the provided string or use '#target' to query composed tree
     let shadowSelector = '#shadow';
     if (typeof targetSelector === 'object') {
-    if (typeof targetSelector === 'object' && targetSelector !== null) {
-      shadowSelector = targetSelector.shadow ?? '#shadow';
-      targetSelector = targetSelector.target ?? '#target';
-    }
+      if (typeof targetSelector === 'object' && targetSelector !== null) {
+        shadowSelector = targetSelector.shadow ?? '#shadow';
+        targetSelector = targetSelector.target ?? '#target';
+      }
     }
 
     const fixtureNode = testUtils.injectIntoFixture(content);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -233,6 +233,7 @@ var helpers;
     const fixtureNode = testUtils.injectIntoFixture(content);
     let container =
       fixtureNode.querySelector(shadowSelector) ||
+      fixtureNode.querySelector(targetSelector) ||
       fixtureNode.firstElementChild;
 
     // attach a shadowRoot with the content provided

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -218,33 +218,35 @@ var helpers;
    * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
    * @return VirtualNode
    */
-  testUtils.queryShadowFixture = (content, shadowContent, targetSelector) => {
+  testUtils.queryShadowFixture = (
+    content,
+    shadowContent,
+    targetSelector = '#target'
+  ) => {
     // Normalize target, allow it to be the provided string or use '#target' to query composed tree
-    if (typeof targetSelector !== 'string') {
-      targetSelector = '#target';
+    let shadowSelector = '#shadow';
+    if (typeof targetSelector === 'object') {
+      targetSelector = targetSelector.target;
+      shadowSelector = targetSelector.shadow;
     }
 
     const fixtureNode = testUtils.injectIntoFixture(content);
-    let targetCandidate = fixtureNode.querySelector(targetSelector);
-    let container = targetCandidate;
-    if (!targetCandidate) {
-      // check if content specifies a shadow container
-      container = fixtureNode.querySelector('#shadow');
-      if (!container) {
-        container = fixtureNode.firstElementChild;
-      }
-    }
+    let container =
+      fixtureNode.querySelector(shadowSelector) ||
+      fixtureNode.firstElementChild;
+
     // attach a shadowRoot with the content provided
     const shadowRoot = container.attachShadow({ mode: 'open' });
     if (typeof shadowContent === 'string') {
       shadowRoot.innerHTML = shadowContent;
-    } else if (content instanceof Node) {
+    } else if (shadowContent instanceof Node) {
       shadowRoot.appendChild(shadowContent);
     }
 
-    if (!targetCandidate) {
-      targetCandidate = shadowRoot.querySelector(targetSelector);
-    }
+    let targetCandidate =
+      shadowRoot.querySelector(targetSelector) ||
+      fixtureNode.querySelector(targetSelector);
+
     if (!targetSelector && !targetCandidate) {
       throw 'shadowCheckSetup requires at least one fragment to have #target, or a provided targetSelector';
     }

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -226,8 +226,10 @@ var helpers;
     // Normalize target, allow it to be the provided string or use '#target' to query composed tree
     let shadowSelector = '#shadow';
     if (typeof targetSelector === 'object') {
-      targetSelector = targetSelector.target;
-      shadowSelector = targetSelector.shadow;
+    if (typeof targetSelector === 'object' && targetSelector !== null) {
+      shadowSelector = targetSelector.shadow ?? '#shadow';
+      targetSelector = targetSelector.target ?? '#target';
+    }
     }
 
     const fixtureNode = testUtils.injectIntoFixture(content);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -225,11 +225,9 @@ var helpers;
   ) => {
     // Normalize target, allow it to be the provided string or use '#target' to query composed tree
     let shadowSelector = '#shadow';
-    if (typeof targetSelector === 'object') {
-      if (typeof targetSelector === 'object' && targetSelector !== null) {
-        shadowSelector = targetSelector.shadow ?? '#shadow';
-        targetSelector = targetSelector.target ?? '#target';
-      }
+    if (typeof targetSelector === 'object' && targetSelector !== null) {
+      shadowSelector = targetSelector.shadow ?? '#shadow';
+      targetSelector = targetSelector.target ?? '#target';
     }
 
     const fixtureNode = testUtils.injectIntoFixture(content);


### PR DESCRIPTION
A new function that is very similar to `commons.dom.idrefs` function, but understands handling ARIA idrefs properties and element internals properties and additionally returns virtual nodes rather than DOM nodes. This was the leftover work from #5109 to handle idrefs being a string (attribute) or array of nodes (property). 

I also update the `queryShadowFixture` function to allow both `#shadow` and `#target` ids to exist in the light DOM. I looked at all uses of `queryShadowFixture` and almost all of them use the `#shadow` in the light DOM and `#target` in the shadow DOM, though a few rely on `#target` in the light DOM (but no `#shadow`). The changes prioritize the order of find things so that `#shadow` is used first as the container, then `#target` (instead of the other way around) and the target selector is found in the shadow DOM first, then in the light DOM after (instead of the other way around). Lastly to support changing either selector I allowed the 3rd parameter to be an object that could define them (no current uses of `queryShadowFixture` pass a 3rd parameter, but I left the option to just pass the target selector as a string).