### PR TITLE
feat(aria/get-aria-idref): resolve ARIA element references to virtual nodes

### DIFF
--- a/lib/commons/aria/get-aria-idref.js
+++ b/lib/commons/aria/get-aria-idref.js
@@ -4,6 +4,10 @@ import getAriaIdrefs from './get-aria-idrefs';
  * Resolve a single ARIA element-reference attribute, property, or
  * `ElementInternals` value to a virtual node. Returns the first connected
  * reference, mirroring how browsers treat element-reference values.
+ *
+ * Note: some `idref`-typed attributes (`aria-errormessage`, `aria-details`)
+ * can reference more than one element and reflect to a plural property. Use
+ * `getAriaIdrefs` for those when you need every referenced node.
  * @method getAriaIdref
  * @memberof axe.commons.aria
  * @instance

--- a/lib/commons/aria/get-aria-idref.js
+++ b/lib/commons/aria/get-aria-idref.js
@@ -1,0 +1,16 @@
+import getAriaIdrefs from './get-aria-idrefs';
+
+/**
+ * Resolve a single ARIA element-reference attribute, property, or
+ * `ElementInternals` value to a virtual node. Returns the first connected
+ * reference, mirroring how browsers treat element-reference values.
+ * @method getAriaIdref
+ * @memberof axe.commons.aria
+ * @instance
+ * @param {Node|Element|VirtualNode} node
+ * @param {String} attrName The ARIA reference attribute name (e.g. `aria-activedescendant`). Use the ARIA attr name even when the value comes from a property or internals.
+ * @return {VirtualNode|null} the resolved virtual node, or `null` when there is no value
+ */
+export default function getAriaIdref(node, attrName) {
+  return getAriaIdrefs(node, attrName)[0] ?? null;
+}

--- a/lib/commons/aria/get-aria-idrefs.js
+++ b/lib/commons/aria/get-aria-idrefs.js
@@ -14,7 +14,7 @@ const refTypes = ['idref', 'idrefs'];
  * @instance
  * @param {Node|Element|VirtualNode} node
  * @param {String} attrName The ARIA reference attribute name (e.g. `aria-labelledby`). Use the ARIA attr name even when the value comes from a property or internals.
- * @return {VirtualNode[]} resolved virtual nodes (empty when there is no value)
+ * @return {VirtualNode[]} resolved virtual nodes (empty when there is no value). References not present in the flat tree (e.g. outside the tested context) are omitted.
  */
 export default function getAriaIdrefs(node, attrName) {
   const attrStandard = standards.ariaAttrs[attrName];
@@ -46,9 +46,10 @@ export default function getAriaIdrefs(node, attrName) {
   }
 
   // a property or internals value is already a resolved Element or array of
-  // Elements; drop disconnected references as browsers ignore them (see #5139)
-  const elements =
-    value instanceof window.Element ? [value] : Array.from(value);
+  // Elements; drop disconnected references as browsers ignore them (see #5139).
+  // check `nodeType` to tell a single node from a collection rather than
+  // `instanceof`, which is realm-bound and fails for nodes from other frames
+  const elements = value.nodeType ? [value] : Array.from(value);
   return elements
     .filter(element => element.isConnected)
     .map(element => getNodeFromTree(element))

--- a/lib/commons/aria/get-aria-idrefs.js
+++ b/lib/commons/aria/get-aria-idrefs.js
@@ -31,8 +31,14 @@ export default function getAriaIdrefs(node, attrName) {
   }
 
   // a string value always comes from the HTML attribute; resolve the ids
-  // against the document (idrefs handles shadow roots and DOM clobbering)
+  // against the document (idrefs handles shadow roots and DOM clobbering).
+  // without a real DOM node (e.g. a SerialVirtualNode) there is nothing to
+  // resolve against, so return no references rather than throwing
   if (typeof value === 'string') {
+    if (!vNode.actualNode) {
+      return [];
+    }
+
     return idrefs(vNode, attrName)
       .filter(Boolean)
       .map(refNode => getNodeFromTree(refNode))

--- a/lib/commons/aria/get-aria-idrefs.js
+++ b/lib/commons/aria/get-aria-idrefs.js
@@ -1,0 +1,77 @@
+import { nodeLookup, getNodeFromTree } from '../../core/utils';
+import standards from '../../standards';
+import idrefs from '../dom/idrefs';
+
+const refTypes = ['idref', 'idrefs'];
+
+/**
+ * Resolve an ARIA element-reference attribute, property, or `ElementInternals`
+ * value to an array of virtual nodes. Handles the three value sources (an
+ * attribute id string, a reflected AOM property, or an `ElementInternals`
+ * property) and filters out references that are not connected to the document.
+ * @method getAriaIdrefs
+ * @memberof axe.commons.aria
+ * @instance
+ * @param {Node|Element|VirtualNode} node
+ * @param {String} attrName The ARIA reference attribute name (e.g. `aria-labelledby`). Use the ARIA attr name even when the value comes from a property or internals.
+ * @return {VirtualNode[]} resolved virtual nodes (empty when there is no value)
+ */
+export default function getAriaIdrefs(node, attrName) {
+  const attrStandard = standards.ariaAttrs[attrName];
+  if (!attrStandard || !refTypes.includes(attrStandard.type)) {
+    throw new TypeError(
+      `Attribute ${attrName} is not an ARIA reference attribute`
+    );
+  }
+
+  const { vNode } = nodeLookup(node);
+  const value = getIdrefValue(vNode, attrName, attrStandard.prop);
+  if (value === null) {
+    return [];
+  }
+
+  // a string value always comes from the HTML attribute; resolve the ids
+  // against the document (idrefs handles shadow roots and DOM clobbering)
+  if (typeof value === 'string') {
+    return idrefs(vNode, attrName)
+      .filter(Boolean)
+      .map(refNode => getNodeFromTree(refNode))
+      .filter(Boolean);
+  }
+
+  // a property or internals value is already a resolved Element or array of
+  // Elements; drop disconnected references as browsers ignore them (see #5139)
+  const elements =
+    value instanceof window.Element ? [value] : Array.from(value);
+  return elements
+    .filter(element => element.isConnected)
+    .map(element => getNodeFromTree(element))
+    .filter(Boolean);
+}
+
+function getIdrefValue(vNode, attrName, prop) {
+  // a non-empty HTML attribute takes priority to preserve existing behavior.
+  // setting an idref(s) property empties the attribute, so an empty or absent
+  // attribute falls back to the property and then the ElementInternals value
+  // e.g. el.ariaLabelledByElements = [label]; el.getAttribute('aria-labelledby') === ''
+  const attrValue = vNode.attr(attrName);
+  if (attrValue) {
+    return attrValue;
+  }
+
+  if (prop && vNode.actualNode) {
+    const propValue = vNode.actualNode[prop];
+    if (propValue !== null && propValue !== undefined) {
+      return propValue;
+    }
+  }
+
+  if (prop && vNode.elementInternals) {
+    const internalsValue = vNode.elementInternals[prop];
+    if (internalsValue !== null && internalsValue !== undefined) {
+      return internalsValue;
+    }
+  }
+
+  return null;
+}

--- a/lib/commons/aria/index.js
+++ b/lib/commons/aria/index.js
@@ -7,6 +7,8 @@ export { default as allowedAttr } from './allowed-attr';
 export { default as arialabelText } from './arialabel-text';
 export { default as arialabelledbyText } from './arialabelledby-text';
 export { default as getAccessibleRefs } from './get-accessible-refs';
+export { default as getAriaIdref } from './get-aria-idref';
+export { default as getAriaIdrefs } from './get-aria-idrefs';
 export { default as getAriaValue } from './get-aria-value';
 export { default as getElementUnallowedRoles } from './get-element-unallowed-roles';
 export { default as getExplicitRole } from './get-explicit-role';

--- a/test/commons/aria/get-aria-idref.js
+++ b/test/commons/aria/get-aria-idref.js
@@ -71,4 +71,18 @@ describe('aria.getAriaIdref', () => {
       assert.equal(result.attr('id'), 'child');
     });
   });
+
+  describe('SerialVirtualNode', () => {
+    it('returns null for a non-empty attribute without throwing', () => {
+      // no real DOM node to resolve the id against
+      const vNode = new axe.SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'aria-activedescendant': 'child'
+        }
+      });
+
+      assert.isNull(getAriaIdref(vNode, 'aria-activedescendant'));
+    });
+  });
 });

--- a/test/commons/aria/get-aria-idref.js
+++ b/test/commons/aria/get-aria-idref.js
@@ -1,0 +1,74 @@
+describe('aria.getAriaIdref', () => {
+  const { queryFixture, fixture, html } = axe.testUtils;
+  const getAriaIdref = axe.commons.aria.getAriaIdref;
+
+  it('resolves a single idref attribute to a virtual node', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-activedescendant="child">
+        <div id="child"></div>
+      </div>`
+    );
+
+    const result = getAriaIdref(vNode, 'aria-activedescendant');
+    assert.equal(result.attr('id'), 'child');
+  });
+
+  it('returns the first reference for an idrefs attribute', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-labelledby="label1 label2"></div>
+        <div id="label1"></div>
+        <div id="label2"></div>`
+    );
+
+    const result = getAriaIdref(vNode, 'aria-labelledby');
+    assert.equal(result.attr('id'), 'label1');
+  });
+
+  it('returns null when the attribute is missing', () => {
+    const vNode = queryFixture(html`<div id="target"></div>`);
+    assert.isNull(getAriaIdref(vNode, 'aria-activedescendant'));
+  });
+
+  it('returns null when the reference does not resolve', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-activedescendant="missing"></div>`
+    );
+    assert.isNull(getAriaIdref(vNode, 'aria-activedescendant'));
+  });
+
+  describe('property', () => {
+    it('resolves a reflected element property when the attribute is empty', () => {
+      const vNode = queryFixture(
+        html`<div id="target"></div>
+          <div id="child"></div>`
+      );
+      vNode.actualNode.ariaActiveDescendantElement =
+        fixture.querySelector('#child');
+
+      const result = getAriaIdref(vNode, 'aria-activedescendant');
+      assert.equal(result.attr('id'), 'child');
+    });
+
+    it('returns null when the referenced element is disconnected', () => {
+      const vNode = queryFixture(html`<div id="target"></div>`);
+      vNode.actualNode.ariaActiveDescendantElement =
+        document.createElement('div');
+
+      assert.isNull(getAriaIdref(vNode, 'aria-activedescendant'));
+    });
+  });
+
+  describe('elementInternals', () => {
+    it('resolves an element internals property', () => {
+      const vNode = queryFixture(
+        html`<testutils-element id="target"></testutils-element>
+          <div id="child"></div>`
+      );
+      vNode.actualNode._internals.ariaActiveDescendantElement =
+        fixture.querySelector('#child');
+
+      const result = getAriaIdref(vNode, 'aria-activedescendant');
+      assert.equal(result.attr('id'), 'child');
+    });
+  });
+});

--- a/test/commons/aria/get-aria-idrefs.js
+++ b/test/commons/aria/get-aria-idrefs.js
@@ -1,0 +1,183 @@
+describe('aria.getAriaIdrefs', () => {
+  const { queryFixture, queryShadowFixture, fixture, html } = axe.testUtils;
+  const getAriaIdrefs = axe.commons.aria.getAriaIdrefs;
+  const getNodeFromTree = axe.utils.getNodeFromTree;
+
+  function ids(vNodes) {
+    return vNodes.map(vNode => vNode.attr('id'));
+  }
+
+  it('resolves an idrefs attribute to virtual nodes', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-labelledby="label1 label2"></div>
+        <div id="label1"></div>
+        <div id="label2"></div>`
+    );
+
+    const result = getAriaIdrefs(vNode, 'aria-labelledby');
+    assert.deepEqual(ids(result), ['label1', 'label2']);
+  });
+
+  it('resolves a single idref attribute to virtual nodes', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-activedescendant="child">
+        <div id="child"></div>
+      </div>`
+    );
+
+    const result = getAriaIdrefs(vNode, 'aria-activedescendant');
+    assert.deepEqual(ids(result), ['child']);
+  });
+
+  it('filters out ids that do not resolve to an element', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-labelledby="label1 missing label2"></div>
+        <div id="label1"></div>
+        <div id="label2"></div>`
+    );
+
+    const result = getAriaIdrefs(vNode, 'aria-labelledby');
+    assert.deepEqual(ids(result), ['label1', 'label2']);
+  });
+
+  it('returns an empty array when the attribute is missing', () => {
+    const vNode = queryFixture(html`<div id="target"></div>`);
+    assert.deepEqual(getAriaIdrefs(vNode, 'aria-labelledby'), []);
+  });
+
+  it('returns an empty array when the attribute is empty', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-labelledby=""></div>`
+    );
+    assert.deepEqual(getAriaIdrefs(vNode, 'aria-labelledby'), []);
+  });
+
+  it('resolves references across a shadow boundary', () => {
+    const vNode = queryShadowFixture(
+      html`<div id="shadow"></div>`,
+      html`<div id="target" aria-labelledby="label"></div>
+        <div id="label"></div>`
+    );
+
+    const result = getAriaIdrefs(vNode, 'aria-labelledby');
+    assert.deepEqual(ids(result), ['label']);
+  });
+
+  it('throws for a non-reference ARIA attribute', () => {
+    const vNode = queryFixture(html`<div id="target" aria-label="x"></div>`);
+    assert.throws(() => getAriaIdrefs(vNode, 'aria-label'), TypeError);
+  });
+
+  it('throws for a non-ARIA attribute', () => {
+    const vNode = queryFixture(html`<div id="target"></div>`);
+    assert.throws(() => getAriaIdrefs(vNode, 'id'), TypeError);
+  });
+
+  describe('property', () => {
+    it('resolves a reflected element-array property when the attribute is empty', () => {
+      const vNode = queryFixture(
+        html`<div id="target"></div>
+          <div id="label1"></div>
+          <div id="label2"></div>`
+      );
+      vNode.actualNode.ariaLabelledByElements = [
+        fixture.querySelector('#label1'),
+        fixture.querySelector('#label2')
+      ];
+
+      const result = getAriaIdrefs(vNode, 'aria-labelledby');
+      assert.deepEqual(ids(result), ['label1', 'label2']);
+    });
+
+    it('filters out disconnected referenced elements', () => {
+      const vNode = queryFixture(
+        html`<div id="target"></div>
+          <div id="label1"></div>`
+      );
+      const detached = document.createElement('div');
+      vNode.actualNode.ariaLabelledByElements = [
+        fixture.querySelector('#label1'),
+        detached
+      ];
+
+      const result = getAriaIdrefs(vNode, 'aria-labelledby');
+      assert.deepEqual(ids(result), ['label1']);
+    });
+  });
+
+  describe('elementInternals', () => {
+    it('resolves an element-array internals property', () => {
+      const vNode = queryFixture(
+        html`<testutils-element id="target"></testutils-element>
+          <div id="label1"></div>
+          <div id="label2"></div>`
+      );
+      vNode.actualNode._internals.ariaLabelledByElements = [
+        fixture.querySelector('#label1'),
+        fixture.querySelector('#label2')
+      ];
+
+      const result = getAriaIdrefs(vNode, 'aria-labelledby');
+      assert.deepEqual(ids(result), ['label1', 'label2']);
+    });
+
+    it('prefers the attribute over the internals value', () => {
+      const vNode = queryFixture(
+        html`<testutils-element
+            id="target"
+            aria-labelledby="label1"
+          ></testutils-element>
+          <div id="label1"></div>
+          <div id="label2"></div>`
+      );
+      vNode.actualNode._internals.ariaLabelledByElements = [
+        fixture.querySelector('#label2')
+      ];
+
+      const result = getAriaIdrefs(vNode, 'aria-labelledby');
+      assert.deepEqual(ids(result), ['label1']);
+    });
+
+    it('filters out disconnected referenced elements', () => {
+      const vNode = queryFixture(
+        html`<testutils-element id="target"></testutils-element>
+          <div id="label1"></div>`
+      );
+      const detached = document.createElement('div');
+      vNode.actualNode._internals.ariaLabelledByElements = [
+        fixture.querySelector('#label1'),
+        detached
+      ];
+
+      const result = getAriaIdrefs(vNode, 'aria-labelledby');
+      assert.deepEqual(ids(result), ['label1']);
+    });
+  });
+
+  describe('SerialVirtualNode', () => {
+    it('resolves nothing without a real DOM node', () => {
+      const vNode = new axe.SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'aria-labelledby': ''
+        }
+      });
+
+      assert.deepEqual(getAriaIdrefs(vNode, 'aria-labelledby'), []);
+    });
+  });
+
+  it('accepts a DOM node', () => {
+    const vNode = queryFixture(
+      html`<div id="target" aria-labelledby="label"></div>
+        <div id="label"></div>`
+    );
+
+    const result = getAriaIdrefs(vNode.actualNode, 'aria-labelledby');
+    assert.deepEqual(ids(result), ['label']);
+    assert.strictEqual(
+      result[0],
+      getNodeFromTree(fixture.querySelector('#label'))
+    );
+  });
+});

--- a/test/commons/aria/get-aria-idrefs.js
+++ b/test/commons/aria/get-aria-idrefs.js
@@ -214,11 +214,23 @@ describe('aria.getAriaIdrefs', () => {
   });
 
   describe('SerialVirtualNode', () => {
-    it('resolves nothing without a real DOM node', () => {
+    it('returns an empty array for an empty attribute', () => {
       const vNode = new axe.SerialVirtualNode({
         nodeName: 'div',
         attributes: {
           'aria-labelledby': ''
+        }
+      });
+
+      assert.deepEqual(getAriaIdrefs(vNode, 'aria-labelledby'), []);
+    });
+
+    it('returns an empty array for a non-empty attribute without throwing', () => {
+      // no real DOM node to resolve the ids against
+      const vNode = new axe.SerialVirtualNode({
+        nodeName: 'div',
+        attributes: {
+          'aria-labelledby': 'label'
         }
       });
 

--- a/test/commons/aria/get-aria-idrefs.js
+++ b/test/commons/aria/get-aria-idrefs.js
@@ -29,6 +29,19 @@ describe('aria.getAriaIdrefs', () => {
     assert.deepEqual(ids(result), ['child']);
   });
 
+  it('resolves multiple refs for an idref-typed attribute with an element-array property', () => {
+    // aria-errormessage is type `idref` but reflects to a *plural* property
+    // (ariaErrorMessageElements), so the resolver must stay value-shape driven
+    const vNode = queryFixture(
+      html`<div id="target" aria-errormessage="err1 err2"></div>
+        <div id="err1"></div>
+        <div id="err2"></div>`
+    );
+
+    const result = getAriaIdrefs(vNode, 'aria-errormessage');
+    assert.deepEqual(ids(result), ['err1', 'err2']);
+  });
+
   it('filters out ids that do not resolve to an element', () => {
     const vNode = queryFixture(
       html`<div id="target" aria-labelledby="label1 missing label2"></div>
@@ -151,6 +164,52 @@ describe('aria.getAriaIdrefs', () => {
 
       const result = getAriaIdrefs(vNode, 'aria-labelledby');
       assert.deepEqual(ids(result), ['label1']);
+    });
+
+    describe('global internals map', () => {
+      afterEach(() => {
+        delete globalThis._elementInternals;
+      });
+
+      it('resolves an element-array value from the global map', () => {
+        const vNode = queryFixture(
+          html`<testutils-element id="target"></testutils-element>
+            <div id="label1"></div>
+            <div id="label2"></div>`
+        );
+        const node = vNode.actualNode;
+        node._internals.ariaLabelledByElements = [
+          fixture.querySelector('#label1'),
+          fixture.querySelector('#label2')
+        ];
+        globalThis._elementInternals = new WeakMap();
+        globalThis._elementInternals.set(node, node._internals);
+
+        const result = getAriaIdrefs(vNode, 'aria-labelledby');
+        assert.deepEqual(ids(result), ['label1', 'label2']);
+      });
+
+      it('uses the global map internals over the _internals property', () => {
+        const vNode = queryFixture(
+          html`<testutils-element id="target"></testutils-element>
+            <div id="label1"></div>
+            <div id="label2"></div>`
+        );
+        const node = vNode.actualNode;
+        node._internals.ariaLabelledByElements = [
+          fixture.querySelector('#label1')
+        ];
+        // can't attach internals twice, so fake an ElementInternals object
+        const mapInternals = {
+          ariaLabelledByElements: [fixture.querySelector('#label2')]
+        };
+        Object.setPrototypeOf(mapInternals, window.ElementInternals.prototype);
+        globalThis._elementInternals = new WeakMap();
+        globalThis._elementInternals.set(node, mapInternals);
+
+        const result = getAriaIdrefs(vNode, 'aria-labelledby');
+        assert.deepEqual(ids(result), ['label2']);
+      });
     });
   });
 

--- a/test/commons/aria/get-aria-idrefs.js
+++ b/test/commons/aria/get-aria-idrefs.js
@@ -166,6 +166,21 @@ describe('aria.getAriaIdrefs', () => {
       assert.deepEqual(ids(result), ['label1']);
     });
 
+    it('resolves an internals reference across a shadow boundary', () => {
+      // internals element references may point at nodes in another tree scope
+      const vNode = queryShadowFixture(
+        html`<div id="shadow"></div>
+          <div id="label"></div>`,
+        html`<testutils-element id="target"></testutils-element>`
+      );
+      vNode.actualNode._internals.ariaLabelledByElements = [
+        fixture.querySelector('#label')
+      ];
+
+      const result = getAriaIdrefs(vNode, 'aria-labelledby');
+      assert.deepEqual(ids(result), ['label']);
+    });
+
     describe('global internals map', () => {
       afterEach(() => {
         delete globalThis._elementInternals;


### PR DESCRIPTION
Part of #5044. Adds the dedicated idref→virtual-node resolvers that #5109 deferred (`getAriaValue` returns a string for reporting; these return resolved nodes for consumers to use 99% of the time).

This was previously attempted in #5138 by making `idrefs` itself internals-aware. That PR was closed in favor of **new dedicated functions** so existing `idrefs` callers are unaffected — this PR takes that approach.

## What

- `getAriaIdrefs(node, attrName)` → `VirtualNode[]`
- `getAriaIdref(node, attrName)` → `VirtualNode | null` (first resolved reference)

Both resolve an ARIA element-reference from any of the three sources and normalize to virtual nodes.

## Behavior

- **Source precedence:** non-empty HTML attribute → reflected AOM property → `ElementInternals` property. An explicit attribute overrides internals (per the [element-internals proposal](https://github.com/dequelabs/ocarina-team/blob/main/proposals/axe-core/element-internals.md)); and because setting an idref(s) *property* empties the HTML attribute, the empty-attribute fallback to property/internals is the real path.
- **Already-resolved references** (property/internals return `Element`s or arrays of them) are used directly; **disconnected references are filtered** via `isConnected`, since browsers ignore them ([#5139](https://github.com/dequelabs/axe-core/issues/5139)).
- **Type-agnostic** across `idref`/`idrefs`: `aria-errormessage` and `aria-details` are type `idref` but reflect to *array* properties (`ariaErrorMessageElements`), so `getAriaIdrefs` handles both and `getAriaIdref` returns the first.
- **`elementInternals` flag only gates the internals source:** the `ElementInternals` value is read through the flag-gated `vNode.elementInternals` getter, so it is skipped when the flag is off. The reflected AOM **property** is read ungated (consistent with `getAriaValue`/`hasAriaValue`). Either way nothing yet calls these functions — consuming subdirectories adopt them in later #5044 sub-issues.

## Scope / out of scope

- In: the two resolver functions + unit tests (attribute, property, internals, disconnected, shadow-DOM, `SerialVirtualNode`, throw cases).
- Out (deliberately, per the resolver-only scope): `idrefs`, `get-accessible-refs` (reverse lookup), `get-element-by-reference` (href/for, no internals equivalent), and `get-node-attributes`. Per Wilco, value-*validating* checks keep reading the literal attribute on purpose.

## Known limitation

Firefox crashes when *accessing* an empty idrefs array set on `ElementInternals` (upstream bug [bugzilla 2045887](https://bugzilla.mozilla.org/show_bug.cgi?id=2045887), same one affecting #5136). Not fixable in JS; fixtures avoid empty internals arrays.

## Testing

- `npm run build`
- New suites green in Chrome (22 tests); full `commons/aria` suite green (432); `eslint` + `tsc` clean.

Part of #5149 — this PR delivers the resolver only (and leaves `idrefs` in place per #5138). The `get-accessible-refs` reverse-lookup internals-awareness, also owned by #5149, lands in a follow-up PR; `get-element-by-reference` and `get-node-attributes` carry no ARIA/internals relevance (N/A).