### PR TITLE
test: allow declarative shadow dom

### DIFF
--- a/test/checks/aria/errormessage.js
+++ b/test/checks/aria/errormessage.js
@@ -1,9 +1,6 @@
 describe('aria-errormessage', () => {
-  const html = axe.testUtils.html;
-
-  const queryFixture = axe.testUtils.queryFixture;
-  const shadowCheckSetup = axe.testUtils.shadowCheckSetup;
-  const checkContext = axe.testUtils.MockCheckContext();
+  const { html, queryFixture, checkSetup, MockCheckContext } = axe.testUtils;
+  const checkContext = MockCheckContext();
 
   afterEach(() => {
     checkContext.reset();
@@ -350,9 +347,12 @@ describe('aria-errormessage', () => {
   });
 
   it('should return undefined if aria-errormessage value crosses shadow boundary', () => {
-    const params = shadowCheckSetup(
-      '<div id="target" aria-errormessage="live" aria-invalid="true"></div>',
-      '<div id="live" aria-live="assertive"></div>'
+    const params = checkSetup(
+      html`<div id="target" aria-errormessage="live" aria-invalid="true">
+        <template shadowrootmode="open">
+          <div id="live" aria-live="assertive"></div>
+        </template>
+      </div>`
     );
     assert.isUndefined(
       axe.testUtils
@@ -362,12 +362,13 @@ describe('aria-errormessage', () => {
   });
 
   it('should return false if aria-errormessage and invalid reference are both inside shadow dom', () => {
-    const params = shadowCheckSetup(
-      '<div></div>',
-      html`
-        <div id="target" aria-errormessage="live" aria-invalid="true"></div>
-        <div id="live"></div>
-      `
+    const params = checkSetup(
+      html`<div>
+        <template shadowrootmode="open">
+          <div id="target" aria-errormessage="live" aria-invalid="true"></div>
+          <div id="live"></div>
+        </template>
+      </div>`
     );
     assert.isFalse(
       axe.testUtils
@@ -377,12 +378,13 @@ describe('aria-errormessage', () => {
   });
 
   it('should return true if aria-errormessage and valid reference are both inside shadow dom', () => {
-    const params = shadowCheckSetup(
-      '<div></div>',
-      html`
-        <div id="target" aria-errormessage="live" aria-invalid="true"></div>
-        <div id="live" aria-live="assertive"></div>
-      `
+    const params = checkSetup(
+      html`<div>
+        <template shadowrootmode="open">
+          <div id="target" aria-errormessage="live" aria-invalid="true"></div>
+          <div id="live" aria-live="assertive"></div>
+        </template>
+      </div>`
     );
     assert.isTrue(
       axe.testUtils

--- a/test/commons/dom/get-resolved-refs.js
+++ b/test/commons/dom/get-resolved-refs.js
@@ -1,5 +1,5 @@
 describe('dom.getResolvedRefs', () => {
-  const { html, queryFixture, queryShadowFixture, fixture } = axe.testUtils;
+  const { html, queryFixture, fixture } = axe.testUtils;
   const getResolvedRefs = axe.commons.dom.getResolvedRefs;
   const getNodeFromTree = axe.utils.getNodeFromTree;
 
@@ -19,23 +19,33 @@ describe('dom.getResolvedRefs', () => {
   });
 
   it('should find only referenced nodes within the current root: shadow DOM', () => {
-    const targetVNode = queryShadowFixture(
-      html`<div id="shadow"></div>
-        <div id="target"></div>`,
-      html`<div target="target"><div id="target"></div></div>`
+    const vNode = queryFixture(
+      html`<div id="shadow">
+          <template shadowrootmode="open">
+            <div target="target">
+              <div id="target"></div>
+            </div>
+          </template>
+        </div>
+        <div id="target"></div>`
     );
 
-    const node = fixture.querySelector('#shadow').shadowRoot.firstChild;
-    const expected = [targetVNode];
+    const node = fixture.querySelector('#shadow').shadowRoot.firstElementChild;
+    const expected = [vNode];
 
     assert.deepEqual(getResolvedRefs(node, 'target'), expected);
   });
 
   it('should find only referenced nodes within the current root: document', () => {
-    queryShadowFixture(
-      html`<div target="target" id="shadow"></div>
-        <div id="target"></div>`,
-      html`<div target="target"><div id="target"></div></div>`
+    queryFixture(
+      html`<div target="target" id="shadow">
+          <template shadowrootmode="open">
+            <div target="target">
+              <div id="target"></div>
+            </div>
+          </template>
+        </div>
+        <div id="target"></div>`
     );
 
     const node = fixture.querySelector('[target]');

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -576,7 +576,9 @@ const declarativeShadowDOMRegex =
     let ret = root.shadowRoot ? [root.shadowRoot] : [];
     ret.push(
       ...[...root.querySelectorAll('*')].flatMap(element => {
-        if (!element.shadowRoot) {return [];}
+        if (!element.shadowRoot) {
+          return [];
+        }
 
         let rets = [element.shadowRoot];
         if (recursive) {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -189,6 +189,8 @@ const declarativeShadowDOMRegex =
   /**
    * Method for injecting content into a fixture
    * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
+   * @param {Object} [options]
+   * @param {Boolean} [options.shadow] True if using declarative shadow DOM
    * @return HTMLElement
    */
   testUtils.injectIntoFixture = (content, options = {}) => {
@@ -198,7 +200,7 @@ const declarativeShadowDOMRegex =
 
     if (typeof content === 'string') {
       if (options.shadow) {
-        // allow declarative shadow DOM which requires using setUnsafeHTML to parse
+        // allow declarative shadow DOM which requires using setHTMLUnsafe to parse
         fixture.setHTMLUnsafe(content);
       } else {
         fixture.innerHTML = content;
@@ -219,6 +221,8 @@ const declarativeShadowDOMRegex =
    * the flattened DOM tree (light and Shadow DOM together)
    *
    * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
+   * @param {Object} [options]
+   * @param {Boolean} [options.shadow] True if using declarative shadow DOM
    * @return HTMLElement
    */
   testUtils.fixtureSetup = (content, options = {}) => {
@@ -243,11 +247,21 @@ const declarativeShadowDOMRegex =
     }
     // Normalize target, allow it to be the inserted node or '#target'
     target = target || (content instanceof Node ? content : '#target');
-    const rootNode = testUtils.fixtureSetup(content);
+
+    // Automatically detect declarative shadow DOM
+    let fixtureOptions = {};
+    if (
+      typeof content === 'string' &&
+      declarativeShadowDOMRegex.test(content)
+    ) {
+      fixtureOptions.shadow = true;
+    }
+
+    const rootNode = testUtils.fixtureSetup(content, fixtureOptions);
 
     let node;
     if (typeof target === 'string') {
-      node = axe.utils.querySelectorAll(rootNode, target)[0];
+      node = findTarget(rootNode, target, fixtureOptions);
     } else if (target instanceof Node) {
       node = axe.utils.getNodeFromTree(target);
     } else {
@@ -311,6 +325,7 @@ const declarativeShadowDOMRegex =
    * @param Node|String 	Stuff to go into the shadow boundary (html or node)
    * @param Object				Options argument for the check (optional, default: {})
    * @param String				Target selector for the check, can be inside or outside of Shadow DOM (optional, default: '#target')
+   * @deprecated use checkSetup with declarative shadow DOM
    * @return Array
    */
   testUtils.shadowCheckSetup = (
@@ -544,23 +559,7 @@ const declarativeShadowDOMRegex =
     }
 
     const rootNode = testUtils.fixtureSetup(html, options);
-
-    let vNode;
-    if (!options.shadow) {
-      vNode = axe.utils.querySelectorAll(rootNode, query)[0];
-    } else {
-      // find target in deepest to shallowest root order first
-      const roots = [
-        rootNode.actualNode,
-        ...getShadowRootsUnder(rootNode.actualNode)
-      ].reverse();
-      for (const root of roots) {
-        vNode = axe.utils.getNodeFromTree(root.querySelector(query));
-        if (vNode) {
-          break;
-        }
-      }
-    }
+    const vNode = findTarget(rootNode, query, options);
 
     // find the target in the shadow tree first
     assert.exists(
@@ -569,6 +568,33 @@ const declarativeShadowDOMRegex =
     );
     return vNode;
   };
+
+  /**
+   * Find the target selector in the root
+   *
+   * @param {Node} rootNode
+   * @param {String} target - the CSS selector query to find target DOM node
+   * @param {Object} [options]
+   * @param {Boolean} [options.shadow] True if using declarative shadow DOM
+   * @return {VirtualNode}
+   */
+  function findTarget(rootNode, target, options = {}) {
+    if (!options.shadow) {
+      return axe.utils.querySelectorAll(rootNode, target)[0];
+    }
+
+    // find target in deepest to shallowest root order first
+    const roots = [
+      rootNode.actualNode,
+      ...getShadowRootsUnder(rootNode.actualNode)
+    ].reverse();
+    for (const root of roots) {
+      const vNode = axe.utils.getNodeFromTree(root.querySelector(target));
+      if (vNode) {
+        return vNode;
+      }
+    }
+  }
 
   /**
    * Find all shadow roots in a tree.
@@ -793,6 +819,9 @@ const declarativeShadowDOMRegex =
     return promiseResults;
   };
 
+  /**
+   * @deprecated use queryFixture with declarative shadow DOM
+   */
   testUtils.shadowQuerySelector = function shadowQuerySelector(
     axeSelector,
     doc
@@ -807,6 +836,9 @@ const declarativeShadowDOMRegex =
     return elm;
   };
 
+  /**
+   * @deprecated use queryFixture with declarative shadow DOM
+   */
   testUtils.createNestedShadowDom = function createFixtureShadowTree(
     fixtureNode,
     ...htmlCodes

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -6,6 +6,10 @@ var checks;
 var commons;
 var helpers;
 
+// find a "<template" tag with the first attribute being "shadowrootmode" followed by an equal sign and the value "open". allows any amount of whitespace in between everything and either quotes (" or ') or no quotes for the value
+const declarativeShadowDOMRegex =
+  /<template\s+shadowrootmode\s*=\s*(['"]?)open\1/;
+
 (() => {
   // Let the user know they need to disable their axe/attest extension before running the tests.
   if (window.__AXE_EXTENSION__) {
@@ -187,13 +191,18 @@ var helpers;
    * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
    * @return HTMLElement
    */
-  testUtils.injectIntoFixture = content => {
+  testUtils.injectIntoFixture = (content, options = {}) => {
     if (typeof content !== 'undefined') {
       fixture.innerHTML = '';
     }
 
     if (typeof content === 'string') {
-      fixture.innerHTML = content;
+      if (options.shadow) {
+        // allow declarative shadow DOM which requires using setUnsafeHTML to parse
+        fixture.setHTMLUnsafe(content);
+      } else {
+        fixture.innerHTML = content;
+      }
     } else if (content instanceof Node) {
       fixture.appendChild(content);
     } else if (Array.isArray(content)) {
@@ -212,8 +221,8 @@ var helpers;
    * @param {String|Node} content Stuff to go into the fixture (html or DOM node)
    * @return HTMLElement
    */
-  testUtils.fixtureSetup = content => {
-    testUtils.injectIntoFixture(content);
+  testUtils.fixtureSetup = (content, options = {}) => {
+    testUtils.injectIntoFixture(content, options);
     axe.teardown();
     return axe.setup(fixture);
   };
@@ -524,14 +533,60 @@ var helpers;
    */
   testUtils.queryFixture = function queryFixture(html, query) {
     query = query || '#target';
-    const rootNode = testUtils.fixtureSetup(html);
-    const vNode = axe.utils.querySelectorAll(rootNode, query)[0];
+    const options = {};
+
+    // automatically detect declarative shadow DOM
+    if (declarativeShadowDOMRegex.test(html)) {
+      options.shadow = true;
+    }
+
+    const rootNode = testUtils.fixtureSetup(html, options);
+
+    let vNode;
+    if (!options.shadow) {
+      vNode = axe.utils.querySelectorAll(rootNode, query)[0];
+    } else {
+      // find target in deepest to shallowest root order first
+      const roots = [
+        rootNode.actualNode,
+        ...getShadowRootsUnder(rootNode.actualNode)
+      ].reverse();
+      for (const root of roots) {
+        vNode = axe.utils.getNodeFromTree(root.querySelector(query));
+        if (vNode) {
+          break;
+        }
+      }
+    }
+
+    // find the target in the shadow tree first
     assert.exists(
       vNode,
       `Node does not exist in query \`${query}\`. This is usually fixed by adding the default target (\`id="target"\`) to your html parameter. If you do not intend on querying the fixture for #target, consider using \`axe.testUtils.fixtureSetup()\` instead.`
     );
     return vNode;
   };
+
+  /**
+   * Find all shadow roots in a tree.
+   * @param {HTMLElement|Node} root
+   * @see https://github.com/whatwg/dom/issues/1422
+   */
+  function getShadowRootsUnder(root = document, recursive = true) {
+    let ret = root.shadowRoot ? [root.shadowRoot] : [];
+    ret.push(
+      ...[...root.querySelectorAll('*')].flatMap(element => {
+        if (!element.shadowRoot) {return [];}
+
+        let rets = [element.shadowRoot];
+        if (recursive) {
+          rets.push(...getShadowRootsUnder(element.shadowRoot));
+        }
+        return rets;
+      })
+    );
+    return ret;
+  }
 
   /**
    * Return the checks evaluate method and apply default options


### PR DESCRIPTION
This allows `queryFixture` to now support declarative shadow DOM, replacing the need for `queryShadowFixture` and `createNestedShadowDom`. I wanted the detection to be conditional so we didn't need to do the expensive calls of `setHTMLUnsafe` and querying for every shadow on every test. So the code only does the expensive operations when it detects a declarative shadow DOM. Alternatively if we don't like the regex we could just have the `options.shadow` be passed into the `queryFixture`, but that would be a bit odd when the 2nd param is the query, but would be fine for the few times we actually use the functions: `queryFixture('<div>', '#target', { shadow: true });`