### PR TITLE
feat(commons/dom): support ARIA element internals properties

### DIFF
--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -45,12 +45,16 @@ export default function getAriaValue(node, attrName, options = {}) {
       continue;
     }
 
-    if ('Node' in window && value instanceof window.Node) {
+    if (typeof value === 'string') {
+      // string types (like aria-label) should not be trimmed
+      if (type !== 'string') {
+        value = value.trim();
+      }
+      value = lowercase ? value.toLowerCase() : value;
+    } else if (value instanceof window.Node) {
       value = value.nodeName;
-    } else if (
-      Array.isArray(value) ||
-      ('NodeList' in window && value instanceof window.NodeList)
-    ) {
+    } else {
+      // already resolved node refs
       value =
         '[' +
         Array.from(value)
@@ -59,15 +63,7 @@ export default function getAriaValue(node, attrName, options = {}) {
         ']';
     }
 
-    // string types (like aria-label) should not be trimmed
-    if (type !== 'string') {
-      value = value.trim();
-    }
-
-    return {
-      value: lowercase ? value.toLowerCase() : value,
-      source
-    };
+    return { value, source };
   }
 
   return null;

--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -45,9 +45,12 @@ export default function getAriaValue(node, attrName, options = {}) {
       continue;
     }
 
-    if (value instanceof window.Node) {
+    if ('Node' in window && value instanceof window.Node) {
       value = value.nodeName;
-    } else if (Array.isArray(value) || value instanceof window.NodeList) {
+    } else if (
+      Array.isArray(value) ||
+      ('NodeList' in window && value instanceof window.NodeList)
+    ) {
       value =
         '[' +
         Array.from(value)

--- a/lib/commons/dom/get-element-by-reference.js
+++ b/lib/commons/dom/get-element-by-reference.js
@@ -1,16 +1,18 @@
 import isCurrentPageLink from './is-current-page-link';
+import { nodeLookup } from '../../core/utils';
 
 /**
  * Returns a reference to the element matching the attr URL fragment value
  * @method getElementByReference
  * @memberof axe.commons.dom
  * @instance
- * @param {Element} node
+ * @param {Element|VirtualNode} node
  * @param {String} attr Attribute name (href)
  * @return {Element}
  */
-function getElementByReference(node, attr) {
-  let fragment = node.getAttribute(attr);
+export default function getElementByReference(node, attr) {
+  const { vNode } = nodeLookup(node);
+  let fragment = vNode.attr(attr);
   if (!fragment) {
     return null;
   }
@@ -34,5 +36,3 @@ function getElementByReference(node, attr) {
   }
   return null;
 }
-
-export default getElementByReference;

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -33,7 +33,10 @@ export default function getResolvedRefs(node, attr, options = {}) {
     let refs;
 
     // already resolved node refs
-    if (Array.isArray(attrValue) || attrValue instanceof window.NodeList) {
+    if (
+      Array.isArray(attrValue) ||
+      ('NodeList' in window && attrValue instanceof window.NodeList)
+    ) {
       refs = Array.from(attrValue);
     } else {
       const doc = getRootNode(domNode);

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -32,15 +32,12 @@ export default function getResolvedRefs(node, attr, options = {}) {
 
     let refs;
 
-    // already resolved node refs
-    if (
-      Array.isArray(attrValue) ||
-      ('NodeList' in window && attrValue instanceof window.NodeList)
-    ) {
-      refs = Array.from(attrValue);
-    } else {
+    if (typeof attrValue === 'string') {
       const doc = getRootNode(domNode);
       refs = tokenList(attrValue).map(value => doc.getElementById(value));
+    } else {
+      // already resolved node refs
+      refs = Array.from(attrValue);
     }
 
     if (!self) {

--- a/lib/commons/dom/get-tabbable-elements.js
+++ b/lib/commons/dom/get-tabbable-elements.js
@@ -9,17 +9,15 @@ import { parseTabindex } from '../../core/utils';
  * @param  {Object} virtualNode The virtualNode to assess
  * @return {Boolean}
  */
-function getTabbableElements(virtualNode) {
+export default function getTabbableElements(virtualNode) {
   const nodeAndDescendents = querySelectorAll(virtualNode, '*');
 
   const tabbableElements = nodeAndDescendents.filter(vNode => {
     const isFocusable = vNode.isFocusable;
-    const tabIndex = parseTabindex(vNode.actualNode.getAttribute('tabindex'));
+    const tabIndex = parseTabindex(vNode.attr('tabindex'));
 
     return tabIndex !== null ? isFocusable && tabIndex >= 0 : isFocusable;
   });
 
   return tabbableElements;
 }
-
-export default getTabbableElements;

--- a/lib/commons/dom/inserted-into-focus-order.js
+++ b/lib/commons/dom/inserted-into-focus-order.js
@@ -1,6 +1,6 @@
 import isFocusable from './is-focusable';
 import isNativelyFocusable from './is-natively-focusable';
-import { parseTabindex } from '../../core/utils';
+import { parseTabindex, nodeLookup } from '../../core/utils';
 
 /**
  * Determines if an element is in the focus order, but would not be if its
@@ -8,18 +8,17 @@ import { parseTabindex } from '../../core/utils';
  * @method insertedIntoFocusOrder
  * @memberof axe.commons.dom
  * @instance
- * @param {HTMLElement} el The HTMLElement
+ * @param {Element|VirtualNode} node
  * @return {Boolean} True if the element is in the focus order but wouldn't be
  * if its tabindex were removed. Else, false.
  */
-function insertedIntoFocusOrder(el) {
-  const tabIndex = parseTabindex(el.getAttribute('tabindex'));
+export default function insertedIntoFocusOrder(node) {
+  const { vNode } = nodeLookup(node);
+  const tabIndex = parseTabindex(vNode.attr('tabindex'));
 
   // an element that has an invalid tabindex will return 0 or -1 based on
   // if it is natively focusable or not, which will always be false for this
   // check as NaN is not > 1
   // @see https://www.w3.org/TR/html51/editing.html#the-tabindex-attribute
-  return tabIndex > -1 && isFocusable(el) && !isNativelyFocusable(el);
+  return tabIndex > -1 && isFocusable(node) && !isNativelyFocusable(node);
 }
-
-export default insertedIntoFocusOrder;

--- a/lib/commons/dom/visibility-methods.js
+++ b/lib/commons/dom/visibility-methods.js
@@ -7,6 +7,7 @@ import {
 } from '../../core/utils';
 import rectsOverlap from '../math/rects-overlap';
 import getOverflowHiddenAncestors from './get-overflow-hidden-ancestors';
+import getAriaValue from '../aria/get-aria-value';
 
 const clipRegex =
   /rect\s*\(([0-9]+)px,?\s*([0-9]+)px,?\s*([0-9]+)px,?\s*([0-9]+)px\s*\)/;
@@ -78,7 +79,9 @@ export function contentVisibiltyHidden(vNode, { isAncestor } = {}) {
  * @return {Boolean}
  */
 export function ariaHidden(vNode) {
-  return vNode.attr('aria-hidden') === 'true';
+  return (
+    getAriaValue(vNode, 'aria-hidden', { lowercase: true })?.value === 'true'
+  );
 }
 
 /**

--- a/test/commons/dom/get-element-by-reference.js
+++ b/test/commons/dom/get-element-by-reference.js
@@ -1,14 +1,8 @@
 describe('dom.getElementByReference', () => {
-  const html = axe.testUtils.html;
-
-  const fixture = document.getElementById('fixture');
-
-  afterEach(() => {
-    fixture.innerHTML = '';
-  });
+  const { html, fixtureSetup } = axe.testUtils;
 
   it('should return null if the attribute is not found', () => {
-    fixture.innerHTML = '<a id="link" href="#target">Hi</a>';
+    fixtureSetup('<a id="link" href="#target">Hi</a>');
     const node = document.getElementById('link'),
       result = axe.commons.dom.getElementByReference(node, 'usemap');
 
@@ -16,7 +10,7 @@ describe('dom.getElementByReference', () => {
   });
 
   it('should return null if the attribute does not start with "#"', () => {
-    fixture.innerHTML = '<a id="link" usemap="target">Hi</a>';
+    fixtureSetup('<a id="link" usemap="target">Hi</a>');
     const node = document.getElementById('link'),
       result = axe.commons.dom.getElementByReference(node, 'href');
 
@@ -24,7 +18,7 @@ describe('dom.getElementByReference', () => {
   });
 
   it('should return null if no targets are found', () => {
-    fixture.innerHTML = '<a id="link" href="#target">Hi</a>';
+    fixtureSetup('<a id="link" href="#target">Hi</a>');
     const node = document.getElementById('link'),
       result = axe.commons.dom.getElementByReference(node, 'href');
 
@@ -32,10 +26,10 @@ describe('dom.getElementByReference', () => {
   });
 
   it('should return node if target is found (href)', () => {
-    fixture.innerHTML = html`
+    fixtureSetup(html`
       <a id="link" href="#target">Hi</a>
       <a id="target"></a>
-    `;
+    `);
 
     const node = document.getElementById('link'),
       expected = document.getElementById('target'),
@@ -45,10 +39,10 @@ describe('dom.getElementByReference', () => {
   });
 
   it('should return node if target is found (usemap)', () => {
-    fixture.innerHTML = html`
+    fixtureSetup(html`
       <img id="link" usemap="#target">Hi</a>
       <map id="target"></map>
-    `;
+    `);
 
     const node = document.getElementById('link'),
       expected = document.getElementById('target'),
@@ -58,11 +52,11 @@ describe('dom.getElementByReference', () => {
   });
 
   it('should prioritize ID', () => {
-    fixture.innerHTML = html`
+    fixtureSetup(html`
       <a id="link" href="#target">Hi</a>
       <a id="target"></a>
       <a name="target"></a>
-    `;
+    `);
 
     const node = document.getElementById('link'),
       expected = document.getElementById('target'),
@@ -72,10 +66,10 @@ describe('dom.getElementByReference', () => {
   });
 
   it('should fallback to name', () => {
-    fixture.innerHTML = html`
+    fixtureSetup(html`
       <a id="link" href="#target">Hi</a>
       <a name="target" id="target0"></a>
-    `;
+    `);
 
     const node = document.getElementById('link'),
       expected = document.getElementById('target0'),
@@ -85,11 +79,11 @@ describe('dom.getElementByReference', () => {
   });
 
   it('should return the first matching element with name', () => {
-    fixture.innerHTML = html`
+    fixtureSetup(html`
       <a id="link" href="#target">Hi</a>
       <a name="target" id="target0"></a>
       <a name="target"></a>
-    `;
+    `);
 
     const node = document.getElementById('link'),
       expected = document.getElementById('target0'),
@@ -99,11 +93,11 @@ describe('dom.getElementByReference', () => {
   });
 
   it('returns the first matching element using Angular skiplinks', () => {
-    fixture.innerHTML = html`
+    fixtureSetup(html`
       <a id="link" href="/#target">Hi</a>
       <a name="target" id="target0"></a>
       <a name="target"></a>
-    `;
+    `);
 
     const node = document.getElementById('link'),
       expected = document.getElementById('target0'),
@@ -115,9 +109,11 @@ describe('dom.getElementByReference', () => {
   it('should work with absolute links', () => {
     const currentPage = window.location.origin + window.location.pathname;
 
-    fixture.innerHTML = html`<a id="link" href="${currentPage}#target">Hi</a>
-      <a id="target"></a>
-      <a name="target"></a>`;
+    fixtureSetup(
+      html`<a id="link" href="${currentPage}#target">Hi</a>
+        <a id="target"></a>
+        <a name="target"></a> `
+    );
 
     const node = document.getElementById('link'),
       expected = document.getElementById('target'),

--- a/test/commons/dom/visibility-methods.js
+++ b/test/commons/dom/visibility-methods.js
@@ -150,6 +150,16 @@ describe('dom.visibility-methods', () => {
       const vNode = queryFixture('<div id="target"></div>');
       assert.isFalse(ariaHidden(vNode));
     });
+
+    it('should return true for element with ElementInternals ariaHidden=true', () => {
+      const vNode = queryFixture(
+        html`<testutils-element
+          id="target"
+          with-aria-hidden="true"
+        ></testutils-element>`
+      );
+      assert.isTrue(ariaHidden(vNode));
+    });
   });
 
   describe('opacityHidden', () => {


### PR DESCRIPTION
Updates the `commons/dom` directory to use the new `getAriaValue` or `hasAriaValue` functions where it makes sense. Also update any uses of `node.getAttribute` or `node.hasAttribute` where it made sense as well.

Here's a report of the full directory:

* `commons/dom/focus-disabled` - hasAttr(disabled), disabled (not aria-disabled) is not an ARIA prop so remains hasAttr
* `commons/dom/get-element-by-reference` - looks up non-aria attrs, should still use .attr, but do we need to split the logic to handle non-aria vs aria attributes differently?
* `commons/dom/tabbable-elements` - looks at tabindex, should still use .attr
* `commons/dom/has-lang-text` - looks at lang attr, should still use .attr
* `commons/dom/idrefs` - superceded by `get-resolved-refs` so won't update uses
* `Commons/dom/inserted-into-focus-order` - looks at tabindex, should still use .attr
* `commons/dom/is-current-page-link` - looks at href, should still use .attr (or getAttribute in this case since it has to deal with html anchor only properties)
* `commons/dom/is-focusable` - tabindex, use .attr
* `commons/dom/is-in-tab-order` - tabindex, use .attr
* `commons/dom/is-inert` - inert, use .hasAttr
* `commons/dom/is-natively-focusable` - href, use .hasAttr
* `commons/dom/is-visibile (deprecated)` - no conversion
* `commons/dom/url-props-from-attribute` - needs node (`ownerSVGElement` prop), so no conversion from getAttribute
* `commons/dom/visibility-methods` - only the aria-hidden use should move to getAriaValue, others are non-aria attrs

Refs: https://github.com/dequelabs/axe-core/issues/5142
Refs: https://github.com/dequelabs/axe-core/issues/5043
