### PR TITLE
chore: fix getAriaValue and hasAriaValue to handle external api internals

### DIFF
--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -41,7 +41,7 @@ export default function getAriaValue(node, attrName, options = {}) {
 
   for (const { source, getValue } of sources) {
     let value = getValue(vNode, attrStandard, attrName);
-    if (value === null) {
+    if (value === null || value === undefined) {
       continue;
     }
 

--- a/lib/commons/aria/has-aria-value.js
+++ b/lib/commons/aria/has-aria-value.js
@@ -31,7 +31,8 @@ function hasAttributeValue(vNode, attrName) {
 function hasPropertyValue(vNode, attrStandard) {
   const { prop } = attrStandard;
   if (prop && vNode.actualNode) {
-    return vNode.actualNode[prop] !== null;
+    const propValue = vNode.actualNode[prop];
+    return propValue !== null && propValue !== undefined;
   }
   return false;
 }
@@ -39,7 +40,8 @@ function hasPropertyValue(vNode, attrStandard) {
 function hasInternalValue(vNode, attrStandard) {
   const { prop } = attrStandard;
   if (prop && vNode.elementInternals) {
-    return vNode.elementInternals[prop] !== null;
+    const internalsValue = vNode.elementInternals[prop];
+    return internalsValue !== null && internalsValue !== undefined;
   }
   return false;
 }

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -271,8 +271,9 @@ describe('aria.getAriaValue', () => {
         };
 
         assert.doesNotThrow(() => {
-          assert.isNull(getAriaValue(vNode, 'aria-label', { lowercase: true }));
+          getAriaValue(vNode, 'aria-label', { lowercase: true });
         });
+        assert.getAriaValue(vNode, 'aria-label', { lowercase: true });
       });
     });
   });

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -273,7 +273,7 @@ describe('aria.getAriaValue', () => {
         assert.doesNotThrow(() => {
           getAriaValue(vNode, 'aria-label', { lowercase: true });
         });
-        assert.getAriaValue(vNode, 'aria-label', { lowercase: true });
+        assert.isNull(getAriaValue(vNode, 'aria-label', { lowercase: true }));
       });
     });
   });

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -152,6 +152,15 @@ describe('aria.getAriaValue', () => {
     });
   });
 
+  it('returns null for missing elementInternals property when set via external api', () => {
+    const vNode = queryFixture(html`<div id="target"></div>`);
+    vNode.elementInternals = {
+      role: 'button'
+    };
+
+    assert.isNull(getAriaValue(vNode, 'aria-label'));
+  });
+
   describe('idref', () => {
     it('returns the attribute value over the property value', () => {
       const vNode = queryFixture(
@@ -253,6 +262,17 @@ describe('aria.getAriaValue', () => {
           lowercase: true
         });
         assert.equal(value, 'true');
+      });
+
+      it('does not throw for missing elementInternals property when set via external api', () => {
+        const vNode = queryFixture(html`<div id="target"></div>`);
+        vNode.elementInternals = {
+          role: 'button'
+        };
+
+        assert.doesNotThrow(() => {
+          assert.isNull(getAriaValue(vNode, 'aria-label', { lowercase: true }));
+        });
       });
     });
   });

--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -69,6 +69,15 @@ describe('aria.hasAriaValue', () => {
     assert.throws(() => hasAriaValue(vNode, 'id'));
   });
 
+  it('returns false for missing elementInternals property when set via external api', () => {
+    const vNode = queryFixture(html`<div id="target"></div>`);
+    vNode.elementInternals = {
+      role: 'button'
+    };
+
+    assert.isFalse(hasAriaValue(vNode, 'aria-label'));
+  });
+
   describe('SerialVirtualNode', () => {
     it('returns true if element has attribute', () => {
       // SerialVirtualNode will not support `props` or `elementInternals` so everything must be part of the `attributes` property


### PR DESCRIPTION
Discovered as part of the [conversion of commons/dom](https://github.com/dequelabs/axe-core/pull/5163). @chutchins25 had pointed out that the `null` only check would fail if the value was ever `undefined`, but since all browsers supported `null` on all ARIA prop values I didn't think it was necessary. Well turns out that when we set the internals to an object for the external api code, the values no longer return `null` when missing but `undefined`. So need to add the `undefined` check for those cases.

Is `chore` as we don't need to announce this fix in the changelog as the feature hasn't be released yet