### PR TITLE
feat(commons/text): support ARIA element internals properties

### DIFF
--- a/lib/commons/text/form-control-value.js
+++ b/lib/commons/text/form-control-value.js
@@ -150,8 +150,7 @@ function ariaListboxValue(node, context) {
   const selected = getOwnedVirtual(vNode).filter(
     owned =>
       getRole(owned) === 'option' &&
-      getAriaValue(owned, 'aria-selected', { lowercase: true })?.value ===
-        'true'
+      getAriaValue(owned, 'aria-selected')?.value === 'true'
   );
 
   if (selected.length === 0) {

--- a/lib/commons/text/form-control-value.js
+++ b/lib/commons/text/form-control-value.js
@@ -12,6 +12,8 @@ import getOwnedVirtual from '../aria/get-owned-virtual';
 import isHiddenForEveryone from '../dom/is-hidden-for-everyone';
 import { nodeLookup, querySelectorAll } from '../../core/utils';
 import log from '../../core/log';
+import getAriaValue from '../aria/get-aria-value';
+import hasAriaValue from '../aria/has-aria-value';
 
 export const controlValueRoles = [
   'textbox',
@@ -147,7 +149,9 @@ function ariaListboxValue(node, context) {
 
   const selected = getOwnedVirtual(vNode).filter(
     owned =>
-      getRole(owned) === 'option' && owned.attr('aria-selected') === 'true'
+      getRole(owned) === 'option' &&
+      getAriaValue(owned, 'aria-selected', { lowercase: true })?.value ===
+        'true'
   );
 
   if (selected.length === 0) {
@@ -190,12 +194,12 @@ function ariaComboboxValue(node, context) {
  */
 function ariaRangeValue(node) {
   const { vNode } = nodeLookup(node);
-  if (!isAriaRange(vNode) || !vNode.hasAttr('aria-valuenow')) {
+  if (!isAriaRange(vNode) || !hasAriaValue(vNode, 'aria-valuenow')) {
     return '';
   }
   // Validate the number, if not, return 0.
   // Chrome 70 typecasts this, Firefox 62 does not
-  const valueNow = +vNode.attr('aria-valuenow');
+  const valueNow = +getAriaValue(vNode, 'aria-valuenow')?.value;
   return !isNaN(valueNow) ? String(valueNow) : '0';
 }
 

--- a/test/commons/text/form-control-value.js
+++ b/test/commons/text/form-control-value.js
@@ -437,7 +437,7 @@ describe('text.formControlValue', () => {
     });
 
     it('returns the selected aria option value from elementInternals', () => {
-      const vNode = queryFixture(html`
+      const target = queryFixture(html`
         <div id="target" role="listbox">
           <testutils-element no-role role="option" with-aria-selected="true"
             >Selected Option</testutils-element
@@ -445,10 +445,7 @@ describe('text.formControlValue', () => {
           <div role="option" aria-selected="false">Unselected</div>
         </div>
       `);
-      assert.equal(
-        axe.commons.text.formControlValueMethods.ariaListboxValue(vNode, {}),
-        'Selected Option'
-      );
+      assert.equal(ariaListboxValue(target), 'Selected Option');
     });
   });
 
@@ -537,7 +534,7 @@ describe('text.formControlValue', () => {
     });
 
     it('returns the aria range value from elementInternals', () => {
-      const vNode = queryFixture(
+      const target = queryFixture(
         html`<testutils-element
           id="target"
           role="slider"
@@ -546,10 +543,7 @@ describe('text.formControlValue', () => {
           with-aria-valuemax="100"
         ></testutils-element>`
       );
-      assert.equal(
-        axe.commons.text.formControlValueMethods.ariaRangeValue(vNode),
-        '50'
-      );
+      assert.equal(ariaRangeValue(target), '50');
     });
   });
 });

--- a/test/commons/text/form-control-value.js
+++ b/test/commons/text/form-control-value.js
@@ -435,6 +435,21 @@ describe('text.formControlValue', () => {
         assert.equal(ariaListboxValue(target), 'foo');
       });
     });
+
+    it('returns the selected aria option value from elementInternals', () => {
+      const vNode = queryFixture(html`
+        <div id="target" role="listbox">
+          <testutils-element no-role role="option" with-aria-selected="true"
+            >Selected Option</testutils-element
+          >
+          <div role="option" aria-selected="false">Unselected</div>
+        </div>
+      `);
+      assert.equal(
+        axe.commons.text.formControlValueMethods.ariaListboxValue(vNode, {}),
+        'Selected Option'
+      );
+    });
   });
 
   describe('ariaComboboxValue', () => {
@@ -519,6 +534,22 @@ describe('text.formControlValue', () => {
           assert.equal(ariaRangeValue(target), '-1');
         });
       });
+    });
+
+    it('returns the aria range value from elementInternals', () => {
+      const vNode = queryFixture(
+        html`<testutils-element
+          id="target"
+          role="slider"
+          with-aria-valuenow="50"
+          with-aria-valuemin="0"
+          with-aria-valuemax="100"
+        ></testutils-element>`
+      );
+      assert.equal(
+        axe.commons.text.formControlValueMethods.ariaRangeValue(vNode),
+        '50'
+      );
     });
   });
 });


### PR DESCRIPTION
Updates the `commons/text` directory to use the new `getAriaValue` and `hasAriaValue` functions where it makes sense.

Here's a report of the full directory:

* `commons/text/form-control-value` - aria-selected → getAriaValue; aria-valuenow → hasAriaValue + getAriaValue
* `commons/text/accessible-text` / `accessible-text-virtual` - computes accessible names via commons/aria functions; no direct ARIA attr access
* `commons/text/label-text` / `label-virtual` / `label` - delegates to commons/aria functions; no direct ARIA attr access
* `commons/text/native-text-alternative` / `native-text-methods` / `native-element-type` - checks native HTML semantics (type, value, placeholder, etc.), not ARIA props
* `commons/text/title-text` - checks title attribute, not an ARIA prop
* `commons/text/visible-virtual` / `visible` / `visible-text-nodes` / `subtree-text` - text visibility utilities, no ARIA attr access
* `commons/text/sanitize` / `unicode` / `has-unicode` / `remove-unicode` / `is-human-interpretable` / `is-icon-ligature` / `is-valid-autocomplete` - text processing utilities, no ARIA attr access

Closes: https://github.com/dequelabs/axe-core/issues/5141