### PR TITLE
feat(checks/label): support ARIA element internals properties

### DIFF
--- a/lib/checks/label/help-same-as-label-evaluate.js
+++ b/lib/checks/label/help-same-as-label-evaluate.js
@@ -1,4 +1,8 @@
-import { labelVirtual, accessibleText, sanitize } from '../../commons/text';
+import {
+  labelVirtual,
+  accessibleTextVirtual,
+  sanitize
+} from '../../commons/text';
 import { getResolvedRefs } from '../../commons/dom';
 import { hasAriaValue } from '../../commons/aria';
 
@@ -16,8 +20,8 @@ function helpSameAsLabelEvaluate(node, options, virtualNode) {
     if (hasAriaValue(virtualNode, 'aria-describedby')) {
       const ref = getResolvedRefs(virtualNode, 'aria-describedby');
       check = ref
-        .map(thing => {
-          return thing ? accessibleText(thing.actualNode) : '';
+        .map(vNode => {
+          return vNode ? accessibleTextVirtual(vNode) : '';
         })
         .join('');
     }

--- a/lib/checks/label/help-same-as-label-evaluate.js
+++ b/lib/checks/label/help-same-as-label-evaluate.js
@@ -1,5 +1,6 @@
 import { labelVirtual, accessibleText, sanitize } from '../../commons/text';
-import { idrefs } from '../../commons/dom';
+import { getResolvedRefs } from '../../commons/dom';
+import { hasAriaValue } from '../../commons/aria';
 
 function helpSameAsLabelEvaluate(node, options, virtualNode) {
   const labelText = labelVirtual(virtualNode);
@@ -12,11 +13,11 @@ function helpSameAsLabelEvaluate(node, options, virtualNode) {
   if (!check) {
     check = '';
 
-    if (node.getAttribute('aria-describedby')) {
-      const ref = idrefs(node, 'aria-describedby');
+    if (hasAriaValue(virtualNode, 'aria-describedby')) {
+      const ref = getResolvedRefs(virtualNode, 'aria-describedby');
       check = ref
         .map(thing => {
-          return thing ? accessibleText(thing) : '';
+          return thing ? accessibleText(thing.actualNode) : '';
         })
         .join('');
     }

--- a/lib/checks/label/multiple-label-evaluate.js
+++ b/lib/checks/label/multiple-label-evaluate.js
@@ -2,9 +2,9 @@ import {
   getRootNode,
   isHiddenForEveryone,
   isVisibleToScreenReaders,
-  idrefs
+  getResolvedRefs
 } from '../../commons/dom';
-import { escapeSelector } from '../../core/utils';
+import { escapeSelector, getNodeFromTree } from '../../core/utils';
 
 function multipleLabelEvaluate(node) {
   const id = escapeSelector(node.getAttribute('id'));
@@ -40,8 +40,11 @@ function multipleLabelEvaluate(node) {
       return undefined;
     }
     // make sure the ONE AT visible label is in the list of idRefs of aria-labelledby
-    const labelledby = idrefs(node, 'aria-labelledby');
-    return !labelledby.includes(ATVisibleLabels[0]) ? undefined : false;
+    const vNode = getNodeFromTree(node);
+    const labelledby = getResolvedRefs(vNode, 'aria-labelledby');
+    return !labelledby.some(ref => ref?.actualNode === ATVisibleLabels[0])
+      ? undefined
+      : false;
   }
 
   // only 1 CSS visible label

--- a/lib/checks/label/multiple-label-evaluate.js
+++ b/lib/checks/label/multiple-label-evaluate.js
@@ -4,7 +4,7 @@ import {
   isVisibleToScreenReaders,
   getResolvedRefs
 } from '../../commons/dom';
-import { escapeSelector, getNodeFromTree } from '../../core/utils';
+import { escapeSelector } from '../../core/utils';
 
 function multipleLabelEvaluate(node) {
   const id = escapeSelector(node.getAttribute('id'));
@@ -40,8 +40,7 @@ function multipleLabelEvaluate(node) {
       return undefined;
     }
     // make sure the ONE AT visible label is in the list of idRefs of aria-labelledby
-    const vNode = getNodeFromTree(node);
-    const labelledby = getResolvedRefs(vNode, 'aria-labelledby');
+    const labelledby = getResolvedRefs(node, 'aria-labelledby');
     return !labelledby.some(ref => ref?.actualNode === ATVisibleLabels[0])
       ? undefined
       : false;

--- a/lib/checks/label/title-only-evaluate.js
+++ b/lib/checks/label/title-only-evaluate.js
@@ -1,12 +1,12 @@
 import { labelVirtual, titleText } from '../../commons/text';
-import { hasAriaValue } from '../../commons/aria';
+import { getAriaValue } from '../../commons/aria';
 
 function titleOnlyEvaluate(node, options, virtualNode) {
   const labelText = labelVirtual(virtualNode);
   const title = titleText(virtualNode);
-  const ariaDescribedBy = hasAriaValue(virtualNode, 'aria-describedby');
+  const ariaDescribedBy = getAriaValue(virtualNode, 'aria-describedby');
 
-  return !labelText && !!(title || ariaDescribedBy);
+  return !labelText && !!(title || ariaDescribedBy?.value);
 }
 
 export default titleOnlyEvaluate;

--- a/lib/checks/label/title-only-evaluate.js
+++ b/lib/checks/label/title-only-evaluate.js
@@ -1,9 +1,10 @@
 import { labelVirtual, titleText } from '../../commons/text';
+import { hasAriaValue } from '../../commons/aria';
 
 function titleOnlyEvaluate(node, options, virtualNode) {
   const labelText = labelVirtual(virtualNode);
   const title = titleText(virtualNode);
-  const ariaDescribedBy = virtualNode.attr('aria-describedby');
+  const ariaDescribedBy = hasAriaValue(virtualNode, 'aria-describedby');
 
   return !labelText && !!(title || ariaDescribedBy);
 }

--- a/test/checks/label/help-same-as-label.js
+++ b/test/checks/label/help-same-as-label.js
@@ -1,4 +1,6 @@
 describe('help-same-as-label', () => {
+  const { checkSetup, html } = axe.testUtils;
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('help-same-as-label');
   const fixture = document.getElementById('fixture');
 
   afterEach(() => {
@@ -81,5 +83,19 @@ describe('help-same-as-label', () => {
         axe.utils.getNodeFromTree(node)
       )
     );
+  });
+
+  describe('ElementInternals', () => {
+    it('should return true if an element has a label and elementInternals aria-describedby with the same text', () => {
+      const params = checkSetup(html`
+        <div id="dby">Duplicate</div>
+        <testutils-element
+          id="target"
+          aria-label="Duplicate"
+          with-aria-describedby="dby"
+        ></testutils-element>
+      `);
+      assert.isTrue(checkEvaluate.apply(null, params));
+    });
   });
 });

--- a/test/checks/label/multiple-label.js
+++ b/test/checks/label/multiple-label.js
@@ -337,4 +337,19 @@ describe('multiple-label', () => {
         .call(checkContext, shadowTarget.firstElementChild)
     );
   });
+
+  describe('ElementInternals', () => {
+    it('should return false given multiple labels, one label AT visible, and elementInternals aria-labelledby for AT visible', () => {
+      const checkEvaluate = axe.testUtils.getCheckEvaluate('multiple-label');
+      const params = axe.testUtils.checkSetup(html`
+        <label for="target" aria-hidden="true" id="l1">Please</label>
+        <label for="target" id="l2">Excuse</label>
+        <testutils-element
+          id="target"
+          with-aria-labelledby="l2"
+        ></testutils-element>
+      `);
+      assert.isFalse(checkEvaluate.call(checkContext, ...params));
+    });
+  });
 });

--- a/test/checks/label/multiple-label.js
+++ b/test/checks/label/multiple-label.js
@@ -243,6 +243,38 @@ describe('multiple-label', () => {
     );
   });
 
+  // ariaLabelledByElements (reflected AOM property) coverage adapted from
+  // @jcfranco's work in #5187 (issue #4943)
+  it('should return false when ariaLabelledByElements overrides aria-labelledby', () => {
+    fixtureSetup(html`
+      <input type="checkbox" id="F" aria-labelledby="G" />
+      <label for="F" id="G" aria-hidden="true">Please</label>
+      <label for="F" id="H">Excuse</label>
+    `);
+    const target = fixture.querySelector('#F');
+    target.ariaLabelledByElements = [fixture.querySelector('#H')];
+    assert.isFalse(
+      axe.testUtils
+        .getCheckEvaluate('multiple-label')
+        .call(checkContext, target)
+    );
+  });
+
+  it('should return false when ariaLabelledByElements overrides aria-labelledby with aria-label present', () => {
+    fixtureSetup(html`
+      <input type="checkbox" id="F" aria-labelledby="G" aria-label="Nope" />
+      <label for="F" id="G" aria-hidden="true">Please</label>
+      <label for="F" id="H">Excuse</label>
+    `);
+    const target = fixture.querySelector('#F');
+    target.ariaLabelledByElements = [fixture.querySelector('#H')];
+    assert.isFalse(
+      axe.testUtils
+        .getCheckEvaluate('multiple-label')
+        .call(checkContext, target)
+    );
+  });
+
   it('should return false given multiple labels, one label visible, and no aria-labelledby', () => {
     fixtureSetup(html`
       <input type="checkbox" id="I" />

--- a/test/checks/label/title-only.js
+++ b/test/checks/label/title-only.js
@@ -1,4 +1,7 @@
 describe('title-only', () => {
+  const checkSetup = axe.testUtils.checkSetup;
+  const html = axe.testUtils.html;
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('title-only');
   const fixture = document.getElementById('fixture');
 
   afterEach(() => {
@@ -60,5 +63,18 @@ describe('title-only', () => {
         axe.utils.getNodeFromTree(node)
       )
     );
+  });
+
+  describe('ElementInternals', () => {
+    it('should return true if an element only has elementInternals aria-describedby', () => {
+      const params = checkSetup(html`
+        <div id="dby">description</div>
+        <testutils-element
+          id="target"
+          with-aria-describedby="dby"
+        ></testutils-element>
+      `);
+      assert.isTrue(checkEvaluate.apply(null, params));
+    });
   });
 });

--- a/test/checks/label/title-only.js
+++ b/test/checks/label/title-only.js
@@ -65,6 +65,20 @@ describe('title-only', () => {
     );
   });
 
+  it('should return false if aria-describedby is empty and there is no title or label', () => {
+    const node = document.createElement('input');
+    node.type = 'text';
+    node.setAttribute('aria-describedby', '');
+
+    fixture.appendChild(node);
+
+    axe.testUtils.flatTreeSetup(fixture);
+
+    assert.isFalse(
+      checkEvaluate(node, undefined, axe.utils.getNodeFromTree(node))
+    );
+  });
+
   describe('ElementInternals', () => {
     it('should return true if an element only has elementInternals aria-describedby', () => {
       const params = checkSetup(html`


### PR DESCRIPTION
Updates the `checks/label` directory to use the new `getAriaValue`, `hasAriaValue`, and `getResolvedRefs` functions where it makes sense.

Here's a report of the full directory:

* `checks/label/help-same-as-label` - aria-describedby: replaced `node.getAttribute` + `idrefs()` with `hasAriaValue` + `getResolvedRefs`; since `getResolvedRefs` returns VirtualNodes, updated `accessibleText(thing)` to `accessibleText(thing.actualNode)`
* `checks/label/multiple-label` - aria-labelledby: replaced `idrefs()` with `getResolvedRefs`; since VirtualNodes are returned, updated `.includes(domNode)` to `.some(ref => ref?.actualNode === domNode)`
* `checks/label/title-only` - aria-describedby: replaced `.attr()` truthy check with `hasAriaValue` since only presence is needed
* `checks/label/alt-space-value` - checks alt attribute, not an ARIA prop
* `checks/label/duplicate-img-label` - compares accessible names, no direct ARIA attr access
* `checks/label/explicit` - checks label[for] association, no ARIA attr access
* `checks/label/hidden-explicit-label` - checks label visibility, no ARIA attr access
* `checks/label/implicit` - checks implicit label wrapping, no ARIA attr access
* `checks/label/label-content-name-mismatch` - computes accessible names, no direct ARIA attr access
* `checks/label/no-implicit-explicit-label` - no direct ARIA attr access (in aria directory, not label)

Closes: https://github.com/dequelabs/axe-core/issues/5146