### PR TITLE
feat(checks/tables): support ARIA element internals properties

### DIFF
--- a/lib/checks/tables/th-has-data-cells-evaluate.js
+++ b/lib/checks/tables/th-has-data-cells-evaluate.js
@@ -1,6 +1,7 @@
 import * as tableUtils from '../../commons/table';
 import { sanitize } from '../../commons/text';
 import { getExplicitRole } from '../../commons/aria';
+import { getResolvedRefs } from '../../commons/dom';
 
 function thHasDataCellsEvaluate(node) {
   const cells = tableUtils.getAllCells(node);
@@ -14,10 +15,15 @@ function thHasDataCellsEvaluate(node) {
       reffedHeaders = reffedHeaders.concat(headers.split(/\s+/));
     }
 
-    const ariaLabel = cell.getAttribute('aria-labelledby');
-    if (ariaLabel) {
-      reffedHeaders = reffedHeaders.concat(ariaLabel.split(/\s+/));
-    }
+    // resolve aria-labelledby through getResolvedRefs so a reference set via the
+    // reflected AOM property (or element internals) is honored, not only the
+    // HTML attribute; collect the referenced ids to match against header ids
+    getResolvedRefs(cell, 'aria-labelledby').forEach(ref => {
+      const id = ref?.attr('id');
+      if (id) {
+        reffedHeaders.push(id);
+      }
+    });
   });
 
   // Get all the headers

--- a/test/checks/tables/th-has-data-cells.js
+++ b/test/checks/tables/th-has-data-cells.js
@@ -100,6 +100,35 @@ describe('th-has-data-cells', () => {
     );
   });
 
+  it('should return true if referred to with the aria-labelledby AOM property', () => {
+    // built-in table cells can't have ElementInternals, but the reflected
+    // ariaLabelledByElements property can reference headers without an attribute
+    fixture.innerHTML = html`
+      <table>
+        <tr>
+          <td>hi</td>
+          <td>hello</td>
+        </tr>
+        <tr>
+          <th id="a">H</th>
+          <th id="b">H</th>
+        </tr>
+      </table>
+    `;
+
+    axe.testUtils.flatTreeSetup(fixture);
+    const node = fixture.querySelector('table');
+    const tds = node.querySelectorAll('td');
+    tds[0].ariaLabelledByElements = [node.querySelector('#a')];
+    tds[1].ariaLabelledByElements = [node.querySelector('#b')];
+
+    assert.isTrue(
+      axe.testUtils
+        .getCheckEvaluate('th-has-data-cells')
+        .call(checkContext, node)
+    );
+  });
+
   it('should return true if the th element is empty', () => {
     fixture.innerHTML = html`
       <table>


### PR DESCRIPTION
Part of #5044, sub-issue #5147 (`lib/checks/tables`). Converts the one `checks/tables` ARIA-reference read to the internals-aware resolver from #5151 (`getResolvedRefs`).

## What
- `th-has-data-cells` — resolve a cell's `aria-labelledby` via **`getResolvedRefs`** (from #5151) instead of `getAttribute('aria-labelledby').split()`, collecting the referenced header ids. A header referenced through the reflected AOM property (or element internals) is now honored, not only the HTML attribute.

## Scope notes
- **`th-has-data-cells` is the only convertible check in the directory.** `td-headers-attr` (the issue's other named file) reads only `getRole` (role — out of scope, #5039) and the HTML `headers` attribute (not ARIA), so it needs no change. The other table checks (`caption-faked`, `html5-scope`, `same-caption-summary`, `scope-value`, `td-has-header`) read no ARIA attributes.
- **Pure `ElementInternals` isn't reachable here:** `getAllCells` returns built-in `td`/`th` cells (via `table.rows[].cells[]`), and `ElementInternals` can't attach to built-in elements. So the reachable non-attribute source is the **reflected AOM property** (`element.ariaLabelledByElements`) — which the new test exercises. A literal `_internals`/`axeInternalsMap` fixture isn't applicable to built-in table cells.
- No `th-has-data-cells` message names an ARIA attribute, so there's no source-aware message change.

## Verification
- 11 existing `th-has-data-cells` tests unchanged + 1 new AOM-property test; full `checks/tables` (57) and `td-has-header` integration (9) green; `eslint`/`tsc` clean.
- **Flag-off behavior:** the `elementInternals` flag gates only the *internals* source; the reflected AOM property (`ariaLabelledByElements`) is read regardless (consistent with `getResolvedRefs`/`getAriaValue`). The HTML-attribute-only behavior is unchanged.

Closes #5147