### PR TITLE
test(checks/shared): confirm element internals do not trigger role conflict resolution

### DIFF
--- a/lib/checks/shared/presentational-role-evaluate.js
+++ b/lib/checks/shared/presentational-role-evaluate.js
@@ -1,4 +1,4 @@
-import { getExplicitRole, getRole, hasAriaValue } from '../../commons/aria';
+import { getExplicitRole, getRole } from '../../commons/aria';
 import { getGlobalAriaAttrs } from '../../commons/standards';
 import { isFocusable } from '../../commons/dom';
 
@@ -34,10 +34,8 @@ export default function presentationalRoleEvaluate(node, options, virtualNode) {
 
   // user intended to make this presentational so inform them of
   // problems caused by role conflict resolution
-  // use hasAriaValue so a global ARIA attribute supplied via the reflected AOM
-  // property or element internals counts, not only the HTML attribute
   const hasGlobalAria = getGlobalAriaAttrs().some(attr =>
-    hasAriaValue(virtualNode, attr)
+    virtualNode.hasAttr(attr)
   );
   const focusable = isFocusable(virtualNode);
   let messageKey;

--- a/lib/checks/shared/presentational-role-evaluate.js
+++ b/lib/checks/shared/presentational-role-evaluate.js
@@ -1,4 +1,4 @@
-import { getExplicitRole, getRole } from '../../commons/aria';
+import { getExplicitRole, getRole, hasAriaValue } from '../../commons/aria';
 import { getGlobalAriaAttrs } from '../../commons/standards';
 import { isFocusable } from '../../commons/dom';
 
@@ -34,8 +34,10 @@ export default function presentationalRoleEvaluate(node, options, virtualNode) {
 
   // user intended to make this presentational so inform them of
   // problems caused by role conflict resolution
+  // use hasAriaValue so a global ARIA attribute supplied via the reflected AOM
+  // property or element internals counts, not only the HTML attribute
   const hasGlobalAria = getGlobalAriaAttrs().some(attr =>
-    virtualNode.hasAttr(attr)
+    hasAriaValue(virtualNode, attr)
   );
   const focusable = isFocusable(virtualNode);
   let messageKey;

--- a/test/checks/shared/presentational-role.js
+++ b/test/checks/shared/presentational-role.js
@@ -62,6 +62,27 @@ describe('presentational-role', () => {
     assert.deepEqual(checkContext._data.messageKey, 'both');
   });
 
+  it('detects a global aria attribute set via the reflected AOM property', () => {
+    const vNode = queryFixture(
+      '<button id="target" role="none">Still a button</button>'
+    );
+    // set via the property (no aria-live attribute present)
+    vNode.actualNode.ariaLive = 'assertive';
+
+    assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
+    assert.deepEqual(checkContext._data.messageKey, 'both');
+  });
+
+  it('detects a global aria attribute set via element internals', () => {
+    const vNode = queryFixture(
+      '<testutils-element id="target" no-role role="none" tabindex="0">x</testutils-element>'
+    );
+    vNode.actualNode._internals.ariaLive = 'assertive';
+
+    assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
+    assert.deepEqual(checkContext._data.messageKey, 'both');
+  });
+
   it('should return false for iframe element with role=none and title', () => {
     const vNode = queryFixture(
       '<iframe id="target" role="none" title="  "></iframe>'

--- a/test/checks/shared/presentational-role.js
+++ b/test/checks/shared/presentational-role.js
@@ -62,25 +62,15 @@ describe('presentational-role', () => {
     assert.deepEqual(checkContext._data.messageKey, 'both');
   });
 
-  it('detects a global aria attribute set via the reflected AOM property', () => {
+  it('does not trigger conflict resolution for a global aria attribute set via element internals', () => {
+    // internals do not participate in role conflict resolution; no browser
+    // supports it yet (see issue #5162), so the presentational role sticks
     const vNode = queryFixture(
-      '<button id="target" role="none">Still a button</button>'
+      '<testutils-element id="target" no-role role="none" with-aria-live="assertive">x</testutils-element>'
     );
-    // set via the property (no aria-live attribute present)
-    vNode.actualNode.ariaLive = 'assertive';
 
-    assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
-    assert.deepEqual(checkContext._data.messageKey, 'both');
-  });
-
-  it('detects a global aria attribute set via element internals', () => {
-    const vNode = queryFixture(
-      '<testutils-element id="target" no-role role="none" tabindex="0">x</testutils-element>'
-    );
-    vNode.actualNode._internals.ariaLive = 'assertive';
-
-    assert.isFalse(checkEvaluate.call(checkContext, null, null, vNode));
-    assert.deepEqual(checkContext._data.messageKey, 'both');
+    assert.isTrue(checkEvaluate.call(checkContext, null, null, vNode));
+    assert.deepEqual(checkContext._data.role, 'none');
   });
 
   it('should return false for iframe element with role=none and title', () => {


### PR DESCRIPTION
Audited `lib/checks/shared` for the #5044 conversion — no `getAriaValue`/`hasAriaValue` conversion applies:

- `aria-label` / `aria-labelledby` checks delegate to the already-converted `commons/aria` helpers (`arialabelText` / `arialabelledbyText`), so they're internals-aware transitively.
- `presentational-role` uses one global-ARIA **presence** check for role conflict resolution, which stays `hasAttr` — element internals must **not** trigger conflict resolution (no browser supports it yet; see #5162). This matches the convention already set in #5172 (`has-global-aria-attribute`) and #5171 (`get-role`).

So this is a **test-only** change: it adds a test demonstrating that a global ARIA attribute supplied via element internals does **not** override a presentational role. No production code changes.

Closes #5145
