### PR TITLE
chore: support elements not in tree for get/hasAriaValue

### DIFF
--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -85,7 +85,7 @@ function getAttributeValue(node, attrStandard, attrName) {
   }
 
   // return null for the attribute if the value is empty but the idref(s) prop is not
-  const propValue = getPropertyValue(vNode, attrStandard);
+  const propValue = getPropertyValue(node, attrStandard);
   const propEmpty = Array.isArray(propValue) ? propValue.length : !!propValue;
   return propEmpty ? null : value;
 }

--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -35,11 +35,12 @@ export default function getAriaValue(node, attrName, options = {}) {
     return null;
   }
 
+  const { vNode, domNode } = nodeLookup(node);
   const { type } = attrStandard;
   const { lowercase } = options;
 
   for (const { source, getValue } of sources) {
-    let value = getValue(node, attrStandard, attrName);
+    let value = getValue(vNode, domNode, attrStandard, attrName);
     if (value === null || value === undefined) {
       continue;
     }
@@ -68,8 +69,7 @@ export default function getAriaValue(node, attrName, options = {}) {
   return null;
 }
 
-function getAttributeValue(node, attrStandard, attrName) {
-  const { vNode, domNode } = nodeLookup(node);
+function getAttributeValue(vNode, domNode, attrStandard, attrName) {
   const { type } = attrStandard;
   const value = vNode ? vNode.attr(attrName) : domNode.getAttribute(attrName);
 
@@ -85,21 +85,25 @@ function getAttributeValue(node, attrStandard, attrName) {
   }
 
   // return null for the attribute if the value is empty but the idref(s) prop is not
-  const propValue = getPropertyValue(node, attrStandard);
+  const propValue = getPropertyValue(vNode, domNode, attrStandard);
   const propEmpty = Array.isArray(propValue) ? propValue.length : !!propValue;
   return propEmpty ? null : value;
 }
 
-function getPropertyValue(node, attrStandard) {
-  const { domNode } = nodeLookup(node);
+function getPropertyValue(vNode, domNode, attrStandard) {
   const { prop } = attrStandard;
   return prop && domNode ? domNode[prop] : null;
 }
 
-function getInternalValue(node, attrStandard) {
-  const { vNode, domNode } = nodeLookup(node);
+function getInternalValue(vNode, domNode, attrStandard) {
   const { prop } = attrStandard;
   if (!prop) {
+    return null;
+  }
+
+  // feature flag to enable internals. uses globalThis.axe as it can be run outside of axe context
+  // TODO: remove when feature is fully enabled
+  if (!axe._enableElementInternals) {
     return null;
   }
 

--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -1,4 +1,4 @@
-import { nodeLookup } from '../../core/utils';
+import { nodeLookup, getElementInternals } from '../../core/utils';
 import standards from '../../standards';
 
 const idrefTypes = ['idref', 'idrefs'];
@@ -36,11 +36,10 @@ export default function getAriaValue(node, attrName, options = {}) {
   }
 
   const { type } = attrStandard;
-  const { vNode } = nodeLookup(node);
   const { lowercase } = options;
 
   for (const { source, getValue } of sources) {
-    let value = getValue(vNode, attrStandard, attrName);
+    let value = getValue(node, attrStandard, attrName);
     if (value === null || value === undefined) {
       continue;
     }
@@ -69,9 +68,10 @@ export default function getAriaValue(node, attrName, options = {}) {
   return null;
 }
 
-function getAttributeValue(vNode, attrStandard, attrName) {
+function getAttributeValue(node, attrStandard, attrName) {
+  const { vNode, domNode } = nodeLookup(node);
   const { type } = attrStandard;
-  const value = vNode.attr(attrName);
+  const value = vNode ? vNode.attr(attrName) : domNode.getAttribute(attrName);
 
   // setting an ARIA idref(s) prop value can result in empty attribute values, so we'll need extra processing for idref(s)
   // e.g. el.ariaLabelledByElements = [label]; el.getAttribute('aria-labelledby') === ''
@@ -90,12 +90,22 @@ function getAttributeValue(vNode, attrStandard, attrName) {
   return propEmpty ? null : value;
 }
 
-function getPropertyValue(vNode, attrStandard) {
+function getPropertyValue(node, attrStandard) {
+  const { domNode } = nodeLookup(node);
   const { prop } = attrStandard;
-  return prop && vNode.actualNode ? vNode.actualNode[prop] : null;
+  return prop && domNode ? domNode[prop] : null;
 }
 
-function getInternalValue(vNode, attrStandard) {
+function getInternalValue(node, attrStandard) {
+  const { vNode, domNode } = nodeLookup(node);
   const { prop } = attrStandard;
-  return prop && vNode.elementInternals ? vNode.elementInternals[prop] : null;
+  if (!prop) {
+    return null;
+  }
+
+  const internals = vNode
+    ? vNode.elementInternals
+    : getElementInternals(domNode);
+
+  return internals ? internals[prop] : null;
 }

--- a/lib/commons/aria/has-aria-value.js
+++ b/lib/commons/aria/has-aria-value.js
@@ -1,4 +1,4 @@
-import { nodeLookup } from '../../core/utils';
+import { nodeLookup, getElementInternals } from '../../core/utils';
 import standards from '../../standards';
 
 /**
@@ -16,31 +16,37 @@ export default function hasAriaValue(node, attrName) {
     throw new TypeError(`Attribute ${attrName} is not an ARIA attribute`);
   }
 
-  const { vNode } = nodeLookup(node);
   return (
-    hasAttributeValue(vNode, attrName) ||
-    hasPropertyValue(vNode, attrStandard) ||
-    hasInternalValue(vNode, attrStandard)
+    hasAttributeValue(node, attrName) ||
+    hasPropertyValue(node, attrStandard) ||
+    hasInternalValue(node, attrStandard)
   );
 }
 
-function hasAttributeValue(vNode, attrName) {
-  return vNode.hasAttr(attrName);
+function hasAttributeValue(node, attrName) {
+  const { vNode, domNode } = nodeLookup(node);
+  return vNode ? vNode.hasAttr(attrName) : domNode.hasAttribute(attrName);
 }
 
-function hasPropertyValue(vNode, attrStandard) {
+function hasPropertyValue(node, attrStandard) {
   const { prop } = attrStandard;
-  if (prop && vNode.actualNode) {
-    const propValue = vNode.actualNode[prop];
+  const { domNode } = nodeLookup(node);
+  if (prop && domNode) {
+    const propValue = domNode[prop];
     return propValue !== null && propValue !== undefined;
   }
   return false;
 }
 
-function hasInternalValue(vNode, attrStandard) {
+function hasInternalValue(node, attrStandard) {
+  const { vNode, domNode } = nodeLookup(node);
   const { prop } = attrStandard;
-  if (prop && vNode.elementInternals) {
-    const internalsValue = vNode.elementInternals[prop];
+  const internals = vNode
+    ? vNode.elementInternals
+    : getElementInternals(domNode);
+
+  if (prop && internals) {
+    const internalsValue = internals[prop];
     return internalsValue !== null && internalsValue !== undefined;
   }
   return false;

--- a/lib/commons/aria/has-aria-value.js
+++ b/lib/commons/aria/has-aria-value.js
@@ -16,21 +16,21 @@ export default function hasAriaValue(node, attrName) {
     throw new TypeError(`Attribute ${attrName} is not an ARIA attribute`);
   }
 
+  const { vNode, domNode } = nodeLookup(node);
+
   return (
-    hasAttributeValue(node, attrName) ||
-    hasPropertyValue(node, attrStandard) ||
-    hasInternalValue(node, attrStandard)
+    hasAttributeValue(vNode, domNode, attrName) ||
+    hasPropertyValue(vNode, domNode, attrStandard) ||
+    hasInternalValue(vNode, domNode, attrStandard)
   );
 }
 
-function hasAttributeValue(node, attrName) {
-  const { vNode, domNode } = nodeLookup(node);
+function hasAttributeValue(vNode, domNode, attrName) {
   return vNode ? vNode.hasAttr(attrName) : domNode.hasAttribute(attrName);
 }
 
-function hasPropertyValue(node, attrStandard) {
+function hasPropertyValue(vNode, domNode, attrStandard) {
   const { prop } = attrStandard;
-  const { domNode } = nodeLookup(node);
   if (prop && domNode) {
     const propValue = domNode[prop];
     return propValue !== null && propValue !== undefined;
@@ -38,9 +38,15 @@ function hasPropertyValue(node, attrStandard) {
   return false;
 }
 
-function hasInternalValue(node, attrStandard) {
-  const { vNode, domNode } = nodeLookup(node);
+function hasInternalValue(vNode, domNode, attrStandard) {
   const { prop } = attrStandard;
+
+  // feature flag to enable internals. uses globalThis.axe as it can be run outside of axe context
+  // TODO: remove when feature is fully enabled
+  if (!axe._enableElementInternals) {
+    return false;
+  }
+
   const internals = vNode
     ? vNode.elementInternals
     : getElementInternals(domNode);

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -161,6 +161,31 @@ describe('aria.getAriaValue', () => {
     assert.isNull(getAriaValue(vNode, 'aria-label'));
   });
 
+  it('returns attribute from an element not in the tree', () => {
+    fixture.innerHTML = html`<div id="target" aria-label="hello"></div>`;
+    const node = fixture.querySelector('#target');
+
+    const result = getAriaValue(node, 'aria-label');
+    assert.deepEqual(result, {
+      value: 'hello',
+      source: 'attribute'
+    });
+  });
+
+  it('returns element internals from an element not in the tree', () => {
+    fixture.innerHTML = html`<testutils-element
+      id="target"
+      with-aria-label="hello"
+    ></testutils-element>`;
+    const node = fixture.querySelector('#target');
+
+    const result = getAriaValue(node, 'aria-label');
+    assert.deepEqual(result, {
+      value: 'hello',
+      source: 'internals'
+    });
+  });
+
   describe('idref', () => {
     it('returns the attribute value over the property value', () => {
       const vNode = queryFixture(

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -3,6 +3,10 @@ describe('aria.getAriaValue', () => {
   const getAriaValue = axe.commons.aria.getAriaValue;
   const SerialVirtualNode = axe.SerialVirtualNode;
 
+  afterEach(() => {
+    axe._enableElementInternals = true;
+  });
+
   it('returns the aria attribute value', () => {
     const vNode = queryFixture(
       html`<div id="target" aria-label="hello"></div>`
@@ -173,6 +177,7 @@ describe('aria.getAriaValue', () => {
   });
 
   it('returns element internals from an element not in the tree', () => {
+    axe._elemen;
     fixture.innerHTML = html`<testutils-element
       id="target"
       with-aria-label="hello"
@@ -184,6 +189,17 @@ describe('aria.getAriaValue', () => {
       value: 'hello',
       source: 'internals'
     });
+  });
+
+  it('does not return element internals from an element not in the tree when feature flag is off', () => {
+    axe._enableElementInternals = false;
+    fixture.innerHTML = html`<testutils-element
+      id="target"
+      with-aria-label="hello"
+    ></testutils-element>`;
+    const node = fixture.querySelector('#target');
+
+    assert.isNull(getAriaValue(node, 'aria-label'));
   });
 
   describe('idref', () => {

--- a/test/commons/aria/get-aria-value.js
+++ b/test/commons/aria/get-aria-value.js
@@ -229,6 +229,21 @@ describe('aria.getAriaValue', () => {
         source: 'attribute'
       });
     });
+
+    it('returns stringified value from an element not in the tree', () => {
+      fixture.innerHTML = html`<div id="target">
+        <div id="child"></div>
+      </div>`;
+      const node = fixture.querySelector('#target');
+      const child = fixture.querySelector('#child');
+      node.ariaActiveDescendantElement = child;
+
+      const result = getAriaValue(node, 'aria-activedescendant');
+      assert.deepEqual(result, {
+        value: 'DIV',
+        source: 'property'
+      });
+    });
   });
 
   describe('idrefs', () => {
@@ -272,6 +287,22 @@ describe('aria.getAriaValue', () => {
       assert.deepEqual(result, {
         value: '',
         source: 'attribute'
+      });
+    });
+
+    it('returns stringified value from an element not in the tree', () => {
+      fixture.innerHTML = html`<div id="target"></div>
+        <div id="label1"></div>
+        <div id="label2"></div>`;
+      const node = fixture.querySelector('#target');
+      const label1 = fixture.querySelector('#label1');
+      const label2 = fixture.querySelector('#label2');
+      node.ariaLabelledByElements = [label1, label2];
+
+      const result = getAriaValue(node, 'aria-labelledby');
+      assert.deepEqual(result, {
+        value: '[DIV,DIV]',
+        source: 'property'
       });
     });
   });

--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -1,5 +1,5 @@
 describe('aria.hasAriaValue', () => {
-  const { queryFixture, html } = axe.testUtils;
+  const { queryFixture, fixture, html } = axe.testUtils;
   const hasAriaValue = axe.commons.aria.hasAriaValue;
   const SerialVirtualNode = axe.SerialVirtualNode;
 
@@ -76,6 +76,23 @@ describe('aria.hasAriaValue', () => {
     };
 
     assert.isFalse(hasAriaValue(vNode, 'aria-label'));
+  });
+
+  it('returns true if element not in the tree has attribute', () => {
+    fixture.innerHTML = html`<div id="target" aria-label="hello"></div>`;
+    const node = fixture.querySelector('#target');
+
+    assert.isTrue(hasAriaValue(node, 'aria-label'));
+  });
+
+  it('returns true if element has elementInternals', () => {
+    fixture.innerHTML = html`<testutils-element
+      id="target"
+      with-aria-label="hello"
+    ></testutils-element>`;
+    const node = fixture.querySelector('#target');
+
+    assert.isTrue(hasAriaValue(node, 'aria-label'));
   });
 
   describe('SerialVirtualNode', () => {

--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -3,6 +3,10 @@ describe('aria.hasAriaValue', () => {
   const hasAriaValue = axe.commons.aria.hasAriaValue;
   const SerialVirtualNode = axe.SerialVirtualNode;
 
+  afterEach(() => {
+    axe._enableElementInternals = true;
+  });
+
   it('returns true if element has attribute', () => {
     const vNode = queryFixture(
       html`<div id="target" aria-label="hello"></div>`
@@ -93,6 +97,17 @@ describe('aria.hasAriaValue', () => {
     const node = fixture.querySelector('#target');
 
     assert.isTrue(hasAriaValue(node, 'aria-label'));
+  });
+
+  it('returns false if element not in the tree has elementInternals but feature flag is off', () => {
+    axe._enableElementInternals = false;
+    fixture.innerHTML = html`<testutils-element
+      id="target"
+      with-aria-label="hello"
+    ></testutils-element>`;
+    const node = fixture.querySelector('#target');
+
+    assert.isFalse(hasAriaValue(node, 'aria-label'));
   });
 
   describe('SerialVirtualNode', () => {

--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -85,7 +85,7 @@ describe('aria.hasAriaValue', () => {
     assert.isTrue(hasAriaValue(node, 'aria-label'));
   });
 
-  it('returns true if element has elementInternals', () => {
+  it('returns true if element not in the tree has elementInternals', () => {
     fixture.innerHTML = html`<testutils-element
       id="target"
       with-aria-label="hello"


### PR DESCRIPTION
Found this when tying to update our [matches functions](https://github.com/dequelabs/axe-core/pull/5168). 

There's a few times when we traverse up the DOM tree (`getComposedParent`, just a loop, etc.) and we want to get an ARIA attribute from it (e.g. `aria-hidden-focus-matches.js` walks up the tree looking for any ancestor with `aria-hidden`). Currently it's a bit clunky to have to handle both elements that could or could not be part of the tree as `getAriaValue` assumes vNode, so you have to do something like this:

```js
const vNode = getNodeFromTree(el);
const ariaHidden = vNode
  ? getAriaValue(vNode, 'aria-hidden', { lowercase: true })?.value
  : (el.getAttribute('aria-hidden') || '').toLowerCase();
```

This is also a problem if the element we want to look at is a custom element outside the tree, as we won't be able to look at the element internals of it.

This fixes that by allowing the two get/has aria value functions to fallback to DOM nodes if the node is not in the tree.