### PR TITLE
feat(commons/text): support form-associated labels via element internals

### DIFF
--- a/lib/commons/text/label-text.js
+++ b/lib/commons/text/label-text.js
@@ -25,6 +25,25 @@ function labelText(virtualNode, context = {}) {
   }
 
   const labelContext = { inControlContext: true, ...context };
+
+  // Form-associated custom elements expose their associated labels (both
+  // explicit `for=` and implicit wrapping) via ElementInternals. When present,
+  // that list is the authoritative, complete set, so use it directly instead
+  // of resolving labels from the DOM.
+  const internals = virtualNode.elementInternals;
+  if (internals) {
+    try {
+      // `labels` throws on custom elements that aren't form-associated
+      const internalLabels = Array.from(internals.labels);
+      return internalLabels
+        .map(label => accessibleText(label, labelContext))
+        .filter(text => text !== '')
+        .join(' ');
+    } catch {
+      // not a form-associated custom element; fall through to DOM resolution
+    }
+  }
+
   const explicitLabels = getExplicitLabels(virtualNode);
   const implicitLabel = closest(virtualNode, 'label');
 

--- a/lib/commons/text/label-text.js
+++ b/lib/commons/text/label-text.js
@@ -40,7 +40,13 @@ function labelText(virtualNode, context = {}) {
         .filter(text => text !== '')
         .join(' ');
     } catch {
-      // not a form-associated custom element; fall through to DOM resolution
+      // Not a form-associated custom element, so ElementInternals exposes no
+      // labels. We still fall through to DOM label resolution instead of
+      // returning '': the no-implicit-explicit-label check
+      // (aria-input-field-name / aria-toggle-field-name) calls labelText
+      // directly and needs any visible <label> pointing at this element —
+      // even when the element isn't natively labelable — to compare against
+      // its accessible name.
     }
   }
 

--- a/lib/commons/text/native-text-alternative.js
+++ b/lib/commons/text/native-text-alternative.js
@@ -39,6 +39,21 @@ export default function nativeTextAlternative(virtualNode, context = {}) {
 function findTextMethods(virtualNode) {
   const elmSpec = getElementSpec(virtualNode, { noMatchAccessibleName: true });
   const methods = elmSpec.namingMethods || [];
+  const textMethods = methods.map(methodName => nativeTextMethods[methodName]);
 
-  return methods.map(methodName => nativeTextMethods[methodName]);
+  // Element specs don't cover custom element names, so a form-associated
+  // custom element never picks up its native `<label>` association. Detect it
+  // via ElementInternals and add labelText manually.
+  const internals = virtualNode.elementInternals;
+  if (internals && !methods.includes('labelText')) {
+    try {
+      // `labels` throws on custom elements that aren't form-associated
+      internals.labels;
+      textMethods.push(nativeTextMethods.labelText);
+    } catch {
+      // not a form-associated custom element
+    }
+  }
+
+  return textMethods;
 }

--- a/lib/commons/text/native-text-alternative.js
+++ b/lib/commons/text/native-text-alternative.js
@@ -47,9 +47,13 @@ function findTextMethods(virtualNode) {
   const internals = virtualNode.elementInternals;
   if (internals && !methods.includes('labelText')) {
     try {
-      // `labels` throws on custom elements that aren't form-associated
-      internals.labels;
-      textMethods.push(nativeTextMethods.labelText);
+      // `labels` throws on custom elements that aren't form-associated;
+      // guard on a real collection (a NodeList is always truthy, even when
+      // empty) so a plain internals object without a `labels` property
+      // doesn't wrongly add labelText
+      if (internals.labels) {
+        textMethods.push(nativeTextMethods.labelText);
+      }
     } catch {
       // not a form-associated custom element
     }

--- a/test/commons/text/label-text.js
+++ b/test/commons/text/label-text.js
@@ -160,9 +160,11 @@ describe('text.labelText', () => {
       globalThis._elementInternals = new WeakMap();
       globalThis._elementInternals.set(actualNode, internals);
 
-      assert.equal(labelText(target), 'My explicit label');
-
-      delete globalThis._elementInternals;
+      try {
+        assert.equal(labelText(target), 'My explicit label');
+      } finally {
+        delete globalThis._elementInternals;
+      }
     });
 
     it('falls back to DOM resolution for non-form-associated custom elements', () => {

--- a/test/commons/text/label-text.js
+++ b/test/commons/text/label-text.js
@@ -2,6 +2,7 @@ describe('text.labelText', () => {
   const html = axe.testUtils.html;
   const labelText = axe.commons.text.labelText;
   const queryFixture = axe.testUtils.queryFixture;
+  const queryShadowFixture = axe.testUtils.queryShadowFixture;
 
   it('returns the text of an implicit label', () => {
     const target = queryFixture(html`
@@ -103,6 +104,84 @@ describe('text.labelText', () => {
         html`<label for="target">My explicit label</label><input id="target" />`
       );
       assert.equal(labelText(target, { inLabelledByContext: true }), '');
+    });
+  });
+
+  describe('form-associated custom elements', () => {
+    it('returns the text of an explicit label from element internals', () => {
+      const target = queryFixture(html`
+        <label for="target">My explicit label</label>
+        <testutils-form-element id="target"></testutils-form-element>
+      `);
+      assert.equal(labelText(target), 'My explicit label');
+    });
+
+    it('returns the text of an implicit label from element internals', () => {
+      const target = queryFixture(
+        html`<label
+          >My implicit label<testutils-form-element
+            id="target"
+          ></testutils-form-element
+        ></label>`
+      );
+      assert.equal(labelText(target), 'My implicit label');
+    });
+
+    it('concatenates multiple labels from element internals', () => {
+      const target = queryFixture(html`
+        <label for="target">My label 1</label>
+        <label for="target">My label 2</label>
+        <testutils-form-element id="target"></testutils-form-element>
+      `);
+      assert.equal(labelText(target), 'My label 1 My label 2');
+    });
+
+    it('does not return an implicit + explicit label twice', () => {
+      const target = queryFixture(
+        html`<label for="target"
+          >My implicit and explicit label<testutils-form-element
+            id="target"
+          ></testutils-form-element
+        ></label>`
+      );
+      assert.equal(labelText(target), 'My implicit and explicit label');
+    });
+
+    it('resolves labels when internals come from the global map', () => {
+      const target = queryFixture(html`
+        <label for="target">My explicit label</label>
+        <testutils-form-element id="target"></testutils-form-element>
+      `);
+      const { actualNode } = target;
+      const internals = actualNode._internals;
+      // remove the property protocol so the global map is the only source.
+      // elementInternals is read lazily, so the first read happens below
+      delete actualNode._internals;
+      globalThis._elementInternals = new WeakMap();
+      globalThis._elementInternals.set(actualNode, internals);
+
+      assert.equal(labelText(target), 'My explicit label');
+
+      delete globalThis._elementInternals;
+    });
+
+    it('falls back to DOM resolution for non-form-associated custom elements', () => {
+      const target = queryFixture(html`
+        <label for="target">My explicit label</label>
+        <testutils-element id="target" no-role></testutils-element>
+      `);
+      // testutils-element is not form-associated, so reading internals.labels
+      // throws and we fall through to resolving label[for] from the DOM
+      assert.equal(labelText(target), 'My explicit label');
+    });
+
+    it('resolves labels inside a shadow tree', () => {
+      const target = queryShadowFixture(
+        '<div id="shadow"></div>',
+        `<label for="target">My explicit label</label>
+         <testutils-form-element id="target"></testutils-form-element>`
+      );
+      assert.equal(labelText(target), 'My explicit label');
     });
   });
 });

--- a/test/commons/text/native-text-alternative.js
+++ b/test/commons/text/native-text-alternative.js
@@ -72,12 +72,15 @@ describe('text.nativeTextAlternative', () => {
 
     it('does not add a label when element internals are disabled', () => {
       axe._enableElementInternals = false;
-      const vNode = queryFixture(`
-        <label for="target">My explicit label</label>
-        <testutils-form-element id="target"></testutils-form-element>
-      `);
-      assert.equal(nativeTextAlternative(vNode), '');
-      axe._enableElementInternals = true;
+      try {
+        const vNode = queryFixture(`
+          <label for="target">My explicit label</label>
+          <testutils-form-element id="target"></testutils-form-element>
+        `);
+        assert.equal(nativeTextAlternative(vNode), '');
+      } finally {
+        axe._enableElementInternals = true;
+      }
     });
   });
 });

--- a/test/commons/text/native-text-alternative.js
+++ b/test/commons/text/native-text-alternative.js
@@ -44,4 +44,40 @@ describe('text.nativeTextAlternative', () => {
     const vNode = queryFixture('<img id="target" alt="foo" role="none" />');
     assert.equal(nativeTextAlternative(vNode), '');
   });
+
+  describe('form-associated custom elements', () => {
+    it('returns the explicit label text of a form-associated custom element', () => {
+      const vNode = queryFixture(`
+        <label for="target">My explicit label</label>
+        <testutils-form-element id="target"></testutils-form-element>
+      `);
+      assert.equal(nativeTextAlternative(vNode), 'My explicit label');
+    });
+
+    it('returns the implicit label text of a form-associated custom element', () => {
+      const vNode = queryFixture(
+        '<label>My implicit label' +
+          '<testutils-form-element id="target"></testutils-form-element></label>'
+      );
+      assert.equal(nativeTextAlternative(vNode), 'My implicit label');
+    });
+
+    it('does not add a label for non-form-associated custom elements', () => {
+      const vNode = queryFixture(`
+        <label for="target">My explicit label</label>
+        <testutils-element id="target" no-role></testutils-element>
+      `);
+      assert.equal(nativeTextAlternative(vNode), '');
+    });
+
+    it('does not add a label when element internals are disabled', () => {
+      axe._enableElementInternals = false;
+      const vNode = queryFixture(`
+        <label for="target">My explicit label</label>
+        <testutils-form-element id="target"></testutils-form-element>
+      `);
+      assert.equal(nativeTextAlternative(vNode), '');
+      axe._enableElementInternals = true;
+    });
+  });
 });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -95,6 +95,23 @@ const declarativeShadowDOMRegex =
     );
   }
 
+  // create a form-associated custom element that label tests can use. Unlike
+  // testutils-element, this is form-associated so `internals.labels` resolves
+  // the element's associated `<label>` elements instead of throwing.
+  if (!customElements.get('testutils-form-element')) {
+    customElements.define(
+      'testutils-form-element',
+      class TestutilsFormElement extends HTMLElement {
+        static formAssociated = true;
+
+        constructor() {
+          super();
+          this._internals = this.attachInternals();
+        }
+      }
+    );
+  }
+
   // turn on elementInternals feature flag
   // TODO: remove when feature is fully enabled
   axe._enableElementInternals = true;


### PR DESCRIPTION
## Summary

Form-associated custom elements (`static formAssociated = true` + `attachInternals()`) can be labeled with native `<label>` elements, which the browser exposes through `ElementInternals.labels`. axe-core's accessible-name computation dropped these labels entirely, because:

1. `nativeTextAlternative` builds its naming methods from the element spec, and `getElementSpec()` returns `{}` for custom element names — so `labelText` was never invoked for a custom element.
2. Label resolution in `labelText` only looked at the DOM by `id` (`label[for]`) / ancestor wrapping.

This wires up the [proposal's final step](https://github.com/dequelabs/ocarina-team/blob/main/proposals/axe-core/element-internals.md#supporting-formassociated-elements-with-labels).

## Changes

- **`native-text-alternative.js`** — `findTextMethods` detects a form-associated custom element via `ElementInternals` and appends `labelText`.
- **`label-text.js`** — `labelText` reads `internals.labels` directly when present (the authoritative, complete set of explicit + implicit labels), falling back to the existing DOM resolution otherwise.

`ElementInternals.labels` throws `NotSupportedError` on a custom element that isn't form-associated, so both reads are guarded with try/catch. Both paths are gated by the existing `elementInternals` run option — with the flag off, `vNode.elementInternals` is `undefined` and behavior is unchanged.

### Why `internals.labels` (not the DOM lookup)?

It's the browser-authoritative association and is the *complete* set — it already includes the ancestor-wrapping label. Routing it through the existing explicit + implicit merge would count a wrapping label twice, so `labelText` uses the internals list exclusively when present.

## Out of scope

- **`checks/label` (`explicit`/`implicit`)** — no change needed. They resolve labels via `label[for=id]` / `closest('label')`, which already cover custom elements, and the `label` rule selector is `input, textarea` anyway. Matches the proposal ("rules that look at implicit/explicit labels will not need to be updated") and #5170 leaving those checks untouched.
- **Non-labelable custom elements with a stray `<label for>`** — labelable-ness/role territory (#5039), pre-existing.
- `getResolvedRefs` (#5151) — native `<label>`/`for` association isn't an ARIA idref, so it doesn't apply here.

## Testing

- `test/testutils.js` — new shared `testutils-form-element` (form-associated).
- `label-text.js` — explicit, implicit, multiple, implicit+explicit dedup, global-map protocol, non-form-associated fall-through, Shadow DOM.
- `native-text-alternative.js` — explicit/implicit pickup, gating (non-form-associated gets no label), flag-off no-op.

No integration test added — this is a `commons/text` change with no rule/check edits; the nearest rule impact (`aria-input-field-name` on a role-bearing custom element) depends on role-via-internals selection (#5039), which isn't wired yet.

Closes #5045