### PR TITLE
fix: honor `ariaLabelledByElements` in label resolution

### DIFF
--- a/lib/checks/label/multiple-label-evaluate.js
+++ b/lib/checks/label/multiple-label-evaluate.js
@@ -1,8 +1,8 @@
 import {
   getRootNode,
+  getResolvedRefs,
   isHiddenForEveryone,
-  isVisibleToScreenReaders,
-  idrefs
+  isVisibleToScreenReaders
 } from '../../commons/dom';
 import { escapeSelector } from '../../core/utils';
 
@@ -40,7 +40,9 @@ function multipleLabelEvaluate(node) {
       return undefined;
     }
     // make sure the ONE AT visible label is in the list of idRefs of aria-labelledby
-    const labelledby = idrefs(node, 'aria-labelledby');
+    const labelledby = getResolvedRefs(node, 'aria-labelledby')
+      .filter(ref => ref?.actualNode)
+      .map(ref => ref.actualNode);
     return !labelledby.includes(ATVisibleLabels[0]) ? undefined : false;
   }
 

--- a/lib/commons/aria/arialabelledby-text.js
+++ b/lib/commons/aria/arialabelledby-text.js
@@ -1,4 +1,4 @@
-import idrefs from '../dom/idrefs';
+import getResolvedRefs from '../dom/get-resolved-refs';
 import accessibleText from '../text/accessible-text';
 import { nodeLookup } from '../../core/utils';
 
@@ -36,13 +36,18 @@ function arialabelledbyText(element, context = {}) {
   if (
     vNode.props.nodeType !== 1 ||
     context.inLabelledByContext ||
-    context.inControlContext ||
-    !vNode.attr('aria-labelledby')
+    context.inControlContext
   ) {
     return '';
   }
 
-  const refs = idrefs(vNode, 'aria-labelledby').filter(elm => elm);
+  const refs = getResolvedRefs(vNode, 'aria-labelledby')
+    .filter(ref => ref?.actualNode)
+    .map(ref => ref.actualNode);
+  if (!refs.length) {
+    return '';
+  }
+
   return refs.reduce((accessibleName, elm) => {
     const accessibleNameAdd = accessibleText(elm, {
       // Prevent the infinite reference loop:

--- a/lib/commons/aria/label-virtual.js
+++ b/lib/commons/aria/label-virtual.js
@@ -1,7 +1,6 @@
-import idrefs from '../dom/idrefs';
+import getResolvedRefs from '../dom/get-resolved-refs';
 import visibleVirtual from '../text/visible-virtual';
 import sanitize from '../text/sanitize';
-import { getNodeFromTree } from '../../core/utils';
 
 /**
  * Gets the accessible ARIA label text of a given element
@@ -13,22 +12,15 @@ import { getNodeFromTree } from '../../core/utils';
  * @return {Mixed}  String of visible text, or `null` if no label is found
  */
 function labelVirtual(virtualNode) {
-  let ref, candidate;
+  let candidate;
 
-  if (virtualNode.attr('aria-labelledby')) {
-    // aria-labelledby
-    ref = idrefs(virtualNode.actualNode, 'aria-labelledby');
-    candidate = ref
-      .map(thing => {
-        const vNode = getNodeFromTree(thing);
-        return vNode ? visibleVirtual(vNode) : '';
-      })
-      .join(' ')
-      .trim();
+  candidate = getResolvedRefs(virtualNode, 'aria-labelledby')
+    .map(ref => (ref ? visibleVirtual(ref) : ''))
+    .join(' ')
+    .trim();
 
-    if (candidate) {
-      return candidate;
-    }
+  if (candidate) {
+    return candidate;
   }
 
   // aria-label
@@ -42,5 +34,4 @@ function labelVirtual(virtualNode) {
 
   return null;
 }
-
 export default labelVirtual;

--- a/test/checks/label/multiple-label.js
+++ b/test/checks/label/multiple-label.js
@@ -243,6 +243,22 @@ describe('multiple-label', () => {
     );
   });
 
+  it('should return false when ariaLabelledByElements overrides aria-labelledby', () => {
+    fixtureSetup(html`
+      <input type="checkbox" id="F" aria-labelledby="G" />
+      <label for="F" id="G" aria-hidden="true">Please</label>
+      <label for="F" id="H">Excuse</label>
+    `);
+    const target = fixture.querySelector('#F');
+    target.ariaLabelledByElements = [fixture.querySelector('#H')];
+
+    assert.isFalse(
+      axe.testUtils
+        .getCheckEvaluate('multiple-label')
+        .call(checkContext, target)
+    );
+  });
+
   it('should return false given multiple labels, one label visible, and no aria-labelledby', () => {
     fixtureSetup(html`
       <input type="checkbox" id="I" />

--- a/test/checks/label/multiple-label.js
+++ b/test/checks/label/multiple-label.js
@@ -259,6 +259,22 @@ describe('multiple-label', () => {
     );
   });
 
+  it('should return false when ariaLabelledByElements overrides aria-labelledby with aria-label present', () => {
+    fixtureSetup(html`
+      <input type="checkbox" id="F" aria-labelledby="G" aria-label="Nope" />
+      <label for="F" id="G" aria-hidden="true">Please</label>
+      <label for="F" id="H">Excuse</label>
+    `);
+    const target = fixture.querySelector('#F');
+    target.ariaLabelledByElements = [fixture.querySelector('#H')];
+
+    assert.isFalse(
+      axe.testUtils
+        .getCheckEvaluate('multiple-label')
+        .call(checkContext, target)
+    );
+  });
+
   it('should return false given multiple labels, one label visible, and no aria-labelledby', () => {
     fixtureSetup(html`
       <input type="checkbox" id="I" />

--- a/test/commons/aria/arialabelledby-text.js
+++ b/test/commons/aria/arialabelledby-text.js
@@ -121,4 +121,18 @@ describe('aria.arialabelledbyText', () => {
     const accName = aria.arialabelledbyText(target);
     assert.equal(accName, 'Foo text');
   });
+
+  it('prefers ariaLabelledByElements over aria-labelledby', () => {
+    const target = queryFixture(html`
+      <div role="heading" id="target" aria-labelledby="foo"></div>
+      <div id="foo">Foo text</div>
+      <div id="bar">Bar text</div>
+    `);
+    target.actualNode.ariaLabelledByElements = [
+      target.actualNode.nextElementSibling.nextElementSibling
+    ];
+
+    const accName = aria.arialabelledbyText(target);
+    assert.equal(accName, 'Bar text');
+  });
 });

--- a/test/commons/aria/arialabelledby-text.js
+++ b/test/commons/aria/arialabelledby-text.js
@@ -135,4 +135,23 @@ describe('aria.arialabelledbyText', () => {
     const accName = aria.arialabelledbyText(target);
     assert.equal(accName, 'Bar text');
   });
+
+  it('prefers ariaLabelledByElements over aria-labelledby and aria-label', () => {
+    const target = queryFixture(html`
+      <div
+        role="heading"
+        id="target"
+        aria-labelledby="foo"
+        aria-label="Baz text"
+      ></div>
+      <div id="foo">Foo text</div>
+      <div id="bar">Bar text</div>
+    `);
+    target.actualNode.ariaLabelledByElements = [
+      target.actualNode.nextElementSibling.nextElementSibling
+    ];
+
+    const accName = aria.arialabelledbyText(target);
+    assert.equal(accName, 'Bar text');
+  });
 });

--- a/test/commons/aria/arialabelledby-text.js
+++ b/test/commons/aria/arialabelledby-text.js
@@ -108,4 +108,17 @@ describe('aria.arialabelledbyText', () => {
     const accName = aria.arialabelledbyText(target);
     assert.equal(accName, spaced);
   });
+
+  it('returns the accessible name from ariaLabelledByElements when aria-labelledby is unset', () => {
+    const target = queryFixture(html`
+      <div role="heading" id="target"></div>
+      <div id="foo">Foo text</div>
+    `);
+    target.actualNode.ariaLabelledByElements = [
+      target.actualNode.nextElementSibling
+    ];
+
+    const accName = aria.arialabelledbyText(target);
+    assert.equal(accName, 'Foo text');
+  });
 });

--- a/test/commons/aria/label-virtual.js
+++ b/test/commons/aria/label-virtual.js
@@ -58,6 +58,18 @@ describe('aria.labelVirtual', () => {
       assert.equal(axe.commons.aria.labelVirtual(target), 'monkeys bananas');
     });
 
+    it('should prefer ariaLabelledByElements over aria-labelledby', () => {
+      fixtureSetup(html`
+        <div id="monkeys">monkeys</div>
+        <div id="bananas">bananas</div>
+        <input id="target" aria-labelledby="monkeys" />
+      `);
+      const target = axe.utils.querySelectorAll(axe._tree[0], '#target')[0];
+      target.actualNode.ariaLabelledByElements = [fixture.querySelector('#bananas')];
+
+      assert.equal(axe.commons.aria.labelVirtual(target), 'bananas');
+    });
+
     it('should ignore whitespace only labels', () => {
       fixtureSetup(html`
         <div id="monkeys"></div>

--- a/test/commons/aria/label-virtual.js
+++ b/test/commons/aria/label-virtual.js
@@ -72,6 +72,20 @@ describe('aria.labelVirtual', () => {
       assert.equal(axe.commons.aria.labelVirtual(target), 'bananas');
     });
 
+    it('should prefer ariaLabelledByElements over aria-labelledby and aria-label', () => {
+      fixtureSetup(html`
+        <div id="monkeys">monkeys</div>
+        <div id="bananas">bananas</div>
+        <input id="target" aria-labelledby="monkeys" aria-label="grapes" />
+      `);
+      const target = axe.utils.querySelectorAll(axe._tree[0], '#target')[0];
+      target.actualNode.ariaLabelledByElements = [
+        fixture.querySelector('#bananas')
+      ];
+
+      assert.equal(axe.commons.aria.labelVirtual(target), 'bananas');
+    });
+
     it('should ignore whitespace only labels', () => {
       fixtureSetup(html`
         <div id="monkeys"></div>

--- a/test/commons/aria/label-virtual.js
+++ b/test/commons/aria/label-virtual.js
@@ -65,7 +65,9 @@ describe('aria.labelVirtual', () => {
         <input id="target" aria-labelledby="monkeys" />
       `);
       const target = axe.utils.querySelectorAll(axe._tree[0], '#target')[0];
-      target.actualNode.ariaLabelledByElements = [fixture.querySelector('#bananas')];
+      target.actualNode.ariaLabelledByElements = [
+        fixture.querySelector('#bananas')
+      ];
 
       assert.equal(axe.commons.aria.labelVirtual(target), 'bananas');
     });

--- a/test/commons/dom/get-resolved-refs.js
+++ b/test/commons/dom/get-resolved-refs.js
@@ -102,7 +102,9 @@ describe('dom.getResolvedRefs', () => {
       <div id="target2"></div>
     `);
 
-    vNode.actualNode.ariaLabelledByElements = [document.getElementById('target2')];
+    vNode.actualNode.ariaLabelledByElements = [
+      document.getElementById('target2')
+    ];
 
     const expected = [getNodeFromTree(document.getElementById('target2'))];
 

--- a/test/commons/dom/get-resolved-refs.js
+++ b/test/commons/dom/get-resolved-refs.js
@@ -95,6 +95,20 @@ describe('dom.getResolvedRefs', () => {
     assert.deepEqual(getResolvedRefs(vNode, 'aria-controls'), expected);
   });
 
+  it('should prefer idrefs property over the attribute value', () => {
+    const vNode = queryFixture(html`
+      <div id="target" aria-labelledby="target1"></div>
+      <div id="target1"></div>
+      <div id="target2"></div>
+    `);
+
+    vNode.actualNode.ariaLabelledByElements = [document.getElementById('target2')];
+
+    const expected = [getNodeFromTree(document.getElementById('target2'))];
+
+    assert.deepEqual(getResolvedRefs(vNode, 'aria-labelledby'), expected);
+  });
+
   it('should work with idrefs elementInternals', () => {
     const vNode = queryFixture(html`
       <testutils-element id="target"></testutils-element>

--- a/test/commons/text/label-virtual.js
+++ b/test/commons/text/label-virtual.js
@@ -74,6 +74,21 @@ describe('text.labelVirtual', () => {
       assert.equal(axe.commons.text.labelVirtual(target), 'bananas');
     });
 
+    it('should prefer ariaLabelledByElements over aria-labelledby and aria-label', () => {
+      fixture.innerHTML = html`
+        <div id="monkeys">monkeys</div>
+        <div id="bananas">bananas</div>
+        <input id="target" aria-labelledby="monkeys" aria-label="grapes" />
+      `;
+
+      const tree = axe.testUtils.flatTreeSetup(document.body);
+      const target = axe.utils.querySelectorAll(tree, '#target')[0];
+      target.actualNode.ariaLabelledByElements = [
+        fixture.querySelector('#bananas')
+      ];
+      assert.equal(axe.commons.text.labelVirtual(target), 'bananas');
+    });
+
     it('should take precedence over explicit labels', () => {
       fixture.innerHTML = html`
         <div id="monkeys">monkeys</div>

--- a/test/commons/text/label-virtual.js
+++ b/test/commons/text/label-virtual.js
@@ -59,6 +59,19 @@ describe('text.labelVirtual', () => {
       assert.equal(axe.commons.text.labelVirtual(target), 'monkeys bananas');
     });
 
+    it('should prefer ariaLabelledByElements over aria-labelledby', () => {
+      fixture.innerHTML = html`
+        <div id="monkeys">monkeys</div>
+        <div id="bananas">bananas</div>
+        <input id="target" aria-labelledby="monkeys" />
+      `;
+
+      const tree = axe.testUtils.flatTreeSetup(document.body);
+      const target = axe.utils.querySelectorAll(tree, '#target')[0];
+      target.actualNode.ariaLabelledByElements = [fixture.querySelector('#bananas')];
+      assert.equal(axe.commons.text.labelVirtual(target), 'bananas');
+    });
+
     it('should take precedence over explicit labels', () => {
       fixture.innerHTML = html`
         <div id="monkeys">monkeys</div>

--- a/test/commons/text/label-virtual.js
+++ b/test/commons/text/label-virtual.js
@@ -68,7 +68,9 @@ describe('text.labelVirtual', () => {
 
       const tree = axe.testUtils.flatTreeSetup(document.body);
       const target = axe.utils.querySelectorAll(tree, '#target')[0];
-      target.actualNode.ariaLabelledByElements = [fixture.querySelector('#bananas')];
+      target.actualNode.ariaLabelledByElements = [
+        fixture.querySelector('#bananas')
+      ];
       assert.equal(axe.commons.text.labelVirtual(target), 'bananas');
     });
 


### PR DESCRIPTION
## Summary

This PR updates label resolution to include `ariaLabelledByElements`.

**Disclaimer:** I used Copilot to help drive this PR. The code looks good from what I can tell and tests are passing locally, but this is my first time contributing, so I could be missing something. Happy to make any requested changes!

Closes: #4943
