### PR TITLE
refactor: use virtual node attr/hasAttr in rules and checks

### DIFF
--- a/lib/checks/generic/page-no-duplicate-evaluate.js
+++ b/lib/checks/generic/page-no-duplicate-evaluate.js
@@ -28,8 +28,7 @@ function pageNoDuplicateEvaluate(node, options, virtualNode) {
   if (typeof options.nativeScopeFilter === 'string') {
     elms = elms.filter(elm => {
       return (
-        elm.actualNode.hasAttribute('role') ||
-        !findUpVirtual(elm, options.nativeScopeFilter)
+        elm.hasAttr('role') || !findUpVirtual(elm, options.nativeScopeFilter)
       );
     });
   }

--- a/lib/checks/label/help-same-as-label-evaluate.js
+++ b/lib/checks/label/help-same-as-label-evaluate.js
@@ -8,7 +8,7 @@ import { hasAriaValue } from '../../commons/aria';
 
 function helpSameAsLabelEvaluate(node, options, virtualNode) {
   const labelText = labelVirtual(virtualNode);
-  let check = node.getAttribute('title');
+  let check = virtualNode.attr('title');
 
   if (!labelText) {
     return false;

--- a/lib/checks/label/hidden-explicit-label-evaluate.js
+++ b/lib/checks/label/hidden-explicit-label-evaluate.js
@@ -9,7 +9,7 @@ function hiddenExplicitLabelEvaluate(node, options, virtualNode) {
     }
 
     const root = getRootNode(node);
-    const id = escapeSelector(node.getAttribute('id'));
+    const id = escapeSelector(virtualNode.attr('id'));
     const label = root.querySelector(`label[for="${id}"]`);
 
     if (label && !isVisibleToScreenReaders(label)) {

--- a/lib/checks/label/multiple-label-evaluate.js
+++ b/lib/checks/label/multiple-label-evaluate.js
@@ -6,8 +6,8 @@ import {
 } from '../../commons/dom';
 import { escapeSelector } from '../../core/utils';
 
-function multipleLabelEvaluate(node) {
-  const id = escapeSelector(node.getAttribute('id'));
+function multipleLabelEvaluate(node, options, virtualNode) {
+  const id = escapeSelector(virtualNode.attr('id'));
   let parent = node.parentNode;
   let root = getRootNode(node);
   root = root.documentElement || root;

--- a/lib/checks/parsing/duplicate-id-evaluate.js
+++ b/lib/checks/parsing/duplicate-id-evaluate.js
@@ -1,8 +1,8 @@
 import { getRootNode } from '../../commons/dom';
 import { escapeSelector } from '../../core/utils';
 
-function duplicateIdEvaluate(node) {
-  const id = node.getAttribute('id').trim();
+function duplicateIdEvaluate(node, options, virtualNode) {
+  const id = virtualNode.attr('id').trim();
   // Since empty ID's are not meaningful and are ignored by Edge, we'll
   // let those pass.
   if (!id) {

--- a/lib/checks/tables/scope-value-evaluate.js
+++ b/lib/checks/tables/scope-value-evaluate.js
@@ -1,5 +1,5 @@
-function scopeValueEvaluate(node, options) {
-  const value = node.getAttribute('scope').toLowerCase();
+function scopeValueEvaluate(node, options, virtualNode) {
+  const value = virtualNode.attr('scope').toLowerCase();
 
   return options.values.indexOf(value) !== -1;
 }

--- a/lib/rules/duplicate-id-active-matches.js
+++ b/lib/rules/duplicate-id-active-matches.js
@@ -2,8 +2,8 @@ import { getRootNode, isFocusable } from '../commons/dom';
 import { isAccessibleRef } from '../commons/aria';
 import { escapeSelector } from '../core/utils';
 
-function duplicateIdActiveMatches(node) {
-  const id = node.getAttribute('id').trim();
+function duplicateIdActiveMatches(node, virtualNode) {
+  const id = virtualNode.attr('id').trim();
   const idSelector = `*[id="${escapeSelector(id)}"]`;
   const idMatchingElms = Array.from(
     getRootNode(node).querySelectorAll(idSelector)

--- a/lib/rules/duplicate-id-misc-matches.js
+++ b/lib/rules/duplicate-id-misc-matches.js
@@ -2,8 +2,8 @@ import { getRootNode, isFocusable } from '../commons/dom';
 import { isAccessibleRef } from '../commons/aria';
 import { escapeSelector } from '../core/utils';
 
-function duplicateIdMiscMatches(node) {
-  const id = node.getAttribute('id').trim();
+function duplicateIdMiscMatches(node, virtualNode) {
+  const id = virtualNode.attr('id').trim();
   const idSelector = `*[id="${escapeSelector(id)}"]`;
   const idMatchingElms = Array.from(
     getRootNode(node).querySelectorAll(idSelector)

--- a/lib/rules/frame-title-has-text-matches.js
+++ b/lib/rules/frame-title-has-text-matches.js
@@ -1,7 +1,7 @@
 import { sanitize } from '../commons/text';
 
-function frameTitleHasTextMatches(node) {
-  const title = node.getAttribute('title');
+function frameTitleHasTextMatches(node, virtualNode) {
+  const title = virtualNode.attr('title');
   return !!sanitize(title);
 }
 

--- a/lib/rules/landmark-has-body-context-matches.js
+++ b/lib/rules/landmark-has-body-context-matches.js
@@ -6,7 +6,8 @@ function landmarkHasBodyContextMatches(node, virtualNode) {
   // Filter elements that, within certain contexts, don't map their role.
   // e.g. a <header> inside a <main> is not a banner, but in the <body> context it is
   return (
-    node.hasAttribute('role') || !findUpVirtual(virtualNode, nativeScopeFilter)
+    virtualNode.hasAttr('role') ||
+    !findUpVirtual(virtualNode, nativeScopeFilter)
   );
 }
 

--- a/lib/rules/xml-lang-mismatch-matches.js
+++ b/lib/rules/xml-lang-mismatch-matches.js
@@ -1,11 +1,11 @@
 import { getBaseLang, isValidLang } from '../core/utils';
 
-function xmlLangMismatchMatches(node) {
+function xmlLangMismatchMatches(node, virtualNode) {
   // using -> "selector": "html[lang][xml\\:lang]" to narrow down html with lang and xml:lang attributes
 
   // get primary base language for each of the attributes
-  const primaryLangValue = getBaseLang(node.getAttribute('lang'));
-  const primaryXmlLangValue = getBaseLang(node.getAttribute('xml:lang'));
+  const primaryLangValue = getBaseLang(virtualNode.attr('lang'));
+  const primaryXmlLangValue = getBaseLang(virtualNode.attr('xml:lang'));
 
   // ensure that the value specified is valid lang for both `lang` and `xml:lang`
   return isValidLang(primaryLangValue) && isValidLang(primaryXmlLangValue);

--- a/test/checks/label/multiple-label.js
+++ b/test/checks/label/multiple-label.js
@@ -19,7 +19,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1, l2]);
   });
@@ -31,7 +36,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1]);
   });
@@ -50,7 +60,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1, l2, l3]);
   });
@@ -64,7 +79,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1]);
   });
@@ -80,7 +100,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1]);
   });
@@ -95,7 +120,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1, l2]);
   });
@@ -113,7 +143,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1, l3]);
   });
@@ -130,7 +165,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1, l2]);
   });
@@ -147,7 +187,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1, l2]);
   });
@@ -162,7 +207,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
     assert.deepEqual(checkContext._relatedNodes, [l1, l2]);
   });
@@ -175,7 +225,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -193,7 +248,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -211,7 +271,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -225,7 +290,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -239,7 +309,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -256,7 +331,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -271,7 +351,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -285,7 +370,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -303,7 +393,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -317,7 +412,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, target)
+        .call(
+          checkContext,
+          target,
+          undefined,
+          axe.utils.getNodeFromTree(target)
+        )
     );
   });
 
@@ -332,7 +432,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, shadowTarget.firstElementChild)
+        .call(
+          checkContext,
+          shadowTarget.firstElementChild,
+          undefined,
+          axe.utils.getNodeFromTree(shadowTarget.firstElementChild)
+        )
     );
   });
 
@@ -349,7 +454,12 @@ describe('multiple-label', () => {
     assert.isFalse(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, shadowTarget.firstElementChild)
+        .call(
+          checkContext,
+          shadowTarget.firstElementChild,
+          undefined,
+          axe.utils.getNodeFromTree(shadowTarget.firstElementChild)
+        )
     );
   });
 
@@ -366,7 +476,12 @@ describe('multiple-label', () => {
     assert.isUndefined(
       axe.testUtils
         .getCheckEvaluate('multiple-label')
-        .call(checkContext, shadowTarget.firstElementChild)
+        .call(
+          checkContext,
+          shadowTarget.firstElementChild,
+          undefined,
+          axe.utils.getNodeFromTree(shadowTarget.firstElementChild)
+        )
     );
   });
 

--- a/test/checks/parser/duplicate-id.js
+++ b/test/checks/parser/duplicate-id.js
@@ -14,7 +14,9 @@ describe('duplicate-id', () => {
     fixture.innerHTML = '<div id="target"></div>';
     const node = fixture.querySelector('#target');
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
     assert.equal(checkContext._data, node.id);
     assert.deepEqual(checkContext._relatedNodes, []);
@@ -24,7 +26,9 @@ describe('duplicate-id', () => {
     fixture.innerHTML = '<div id="target"></div><div id="target"></div>';
     const node = fixture.querySelector('#target');
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
     assert.equal(checkContext._data, node.id);
     assert.deepEqual(checkContext._relatedNodes, [node.nextSibling]);
@@ -47,7 +51,9 @@ describe('duplicate-id', () => {
     const node = fixture.querySelector('[data-testelm="1"]');
 
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
   });
 
@@ -63,7 +69,9 @@ describe('duplicate-id', () => {
     const node = fixture.querySelector('[data-testelm="1"]');
 
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
   });
 
@@ -76,7 +84,9 @@ describe('duplicate-id', () => {
     fixture.appendChild(div);
 
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
     assert.lengthOf(checkContext._relatedNodes, 1);
     assert.deepEqual(checkContext._relatedNodes, [shadow.querySelector('p')]);
@@ -90,7 +100,9 @@ describe('duplicate-id', () => {
     fixture.appendChild(node);
 
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
     assert.lengthOf(checkContext._relatedNodes, 0);
   });
@@ -104,7 +116,9 @@ describe('duplicate-id', () => {
     fixture.appendChild(div);
 
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
     assert.lengthOf(checkContext._relatedNodes, 0);
   });
@@ -118,7 +132,9 @@ describe('duplicate-id', () => {
     fixture.appendChild(node);
 
     assert.isFalse(
-      axe.testUtils.getCheckEvaluate('duplicate-id').call(checkContext, node)
+      axe.testUtils
+        .getCheckEvaluate('duplicate-id')
+        .call(checkContext, node, undefined, new axe.VirtualNode(node))
     );
     assert.lengthOf(checkContext._relatedNodes, 1);
     assert.deepEqual(checkContext._relatedNodes, [node.querySelector('p')]);

--- a/test/checks/tables/scope-value.js
+++ b/test/checks/tables/scope-value.js
@@ -9,14 +9,26 @@ describe('scope-value', () => {
     fixture.innerHTML = '<table><tr><td scope="col"></td></tr></table>';
     const node = fixture.querySelector('td');
 
-    assert.isTrue(axe.testUtils.getCheckEvaluate('scope-value')(node));
+    assert.isTrue(
+      axe.testUtils.getCheckEvaluate('scope-value')(
+        node,
+        undefined,
+        new axe.VirtualNode(node)
+      )
+    );
   });
 
   it('should return true if scope is "row"', () => {
     fixture.innerHTML = '<table><tr><td scope="row"></td></tr></table>';
     const node = fixture.querySelector('td');
 
-    assert.isTrue(axe.testUtils.getCheckEvaluate('scope-value')(node));
+    assert.isTrue(
+      axe.testUtils.getCheckEvaluate('scope-value')(
+        node,
+        undefined,
+        new axe.VirtualNode(node)
+      )
+    );
   });
 
   it('should return false otherwise', () => {
@@ -24,7 +36,13 @@ describe('scope-value', () => {
       '<table><tr><td scope="hahahahanothx"></td></tr></table>';
     const node = fixture.querySelector('td');
 
-    assert.isFalse(axe.testUtils.getCheckEvaluate('scope-value')(node));
+    assert.isFalse(
+      axe.testUtils.getCheckEvaluate('scope-value')(
+        node,
+        undefined,
+        new axe.VirtualNode(node)
+      )
+    );
   });
 
   it('should support options.values', () => {
@@ -33,9 +51,13 @@ describe('scope-value', () => {
     const node = fixture.querySelector('td');
 
     assert.isTrue(
-      axe.testUtils.getCheckEvaluate('scope-value')(node, {
-        values: ['hahahahanothx']
-      })
+      axe.testUtils.getCheckEvaluate('scope-value')(
+        node,
+        {
+          values: ['hahahahanothx']
+        },
+        new axe.VirtualNode(node)
+      )
     );
   });
 });

--- a/test/rule-matches/frame-title-has-text-matches.js
+++ b/test/rule-matches/frame-title-has-text-matches.js
@@ -13,18 +13,18 @@ describe('layout-table-matches', () => {
   it('should return true if title attribute has text', () => {
     fixture.innerHTML = '<iframe title="hello"></iframe>';
     const node = fixture.firstChild;
-    assert.isTrue(rule.matches(node));
+    assert.isTrue(rule.matches(node, new axe.VirtualNode(node)));
   });
 
   it('should return false if title attribute is empty', () => {
     fixture.innerHTML = '<iframe title=""></iframe>';
     const node = fixture.firstChild;
-    assert.isFalse(rule.matches(node));
+    assert.isFalse(rule.matches(node, new axe.VirtualNode(node)));
   });
 
   it('should return false if title attribute contains only whitespace', () => {
     fixture.innerHTML = '<iframe title="    "></iframe>';
     const node = fixture.firstChild;
-    assert.isFalse(rule.matches(node));
+    assert.isFalse(rule.matches(node, new axe.VirtualNode(node)));
   });
 });

--- a/test/rule-matches/html-xml-lang-mismatch.js
+++ b/test/rule-matches/html-xml-lang-mismatch.js
@@ -20,20 +20,20 @@ describe('xml-lang-mismatch-matches', () => {
     });
 
     it('returns false if the element does not contain lang or xml:lang attribute', () => {
-      const actual = rule.matches(dom);
+      const actual = rule.matches(dom, new axe.VirtualNode(dom));
       assert.isFalse(actual);
     });
 
     it('returns false if the element contains either/ only one of the lang or xml:lang attribute', () => {
       dom.setAttribute('lang', 'nl');
-      const actual = rule.matches(dom);
+      const actual = rule.matches(dom, new axe.VirtualNode(dom));
       assert.isFalse(actual);
     });
 
     it('returns true if the element contains both lang and xml:lang attribute', () => {
       dom.setAttribute('lang', 'en');
       dom.setAttribute('xml:lang', 'nl');
-      const actual = rule.matches(dom);
+      const actual = rule.matches(dom, new axe.VirtualNode(dom));
       assert.isTrue(actual);
     });
 
@@ -41,7 +41,7 @@ describe('xml-lang-mismatch-matches', () => {
       const node = document.createElement('svg');
       node.setAttribute('lang', '');
       node.setAttribute('xml:lang', 'nl');
-      const actual = rule.matches(node);
+      const actual = rule.matches(node, new axe.VirtualNode(node));
       assert.isFalse(actual);
     });
   });


### PR DESCRIPTION
Converts `getAttribute`/`hasAttribute` calls to the VirtualNode `.attr()`/`.hasAttr()` equivalents where it's a safe, behavior-preserving drop-in. `.attr()`/`.hasAttr()` return the raw attribute value (or `null`) exactly like `getAttribute`/`hasAttribute` — no trimming or normalization — so these swaps preserve behavior.

## Scope

A full sweep of `lib/` found **71 raw `getAttribute`/`hasAttribute` calls** (74 grep hits − 3 JSDoc comments). Of these, **13 are converted here**; the remaining **58 are intentionally left as-is** (52 must-stay + 6 judgment). #5043 is satisfied by converting where it makes sense, not by driving the count to zero.

### ✅ Converted (13)

**`lib/rules/*-matches` (6):**

| Site | Change |
|------|--------|
| `xml-lang-mismatch-matches` | `getAttribute('lang')`, `getAttribute('xml:lang')` → `.attr()` |
| `duplicate-id-active-matches` | `getAttribute('id').trim()` → `.attr('id').trim()` |
| `duplicate-id-misc-matches` | `getAttribute('id').trim()` → `.attr('id').trim()` |
| `frame-title-has-text-matches` | `getAttribute('title')` → `.attr('title')` |
| `landmark-has-body-context-matches` | `hasAttribute('role')` → `.hasAttr('role')` |

**`lib/checks/` (7):**

| Site | Change |
|------|--------|
| `label/help-same-as-label` | `getAttribute('title')`, `getAttribute('aria-describedby')` → `.attr()` |
| `label/hidden-explicit-label` | `getAttribute('id')` → `.attr('id')` |
| `label/multiple-label` | `getAttribute('id')` → `.attr('id')` |
| `parsing/duplicate-id` | `getAttribute('id').trim()` → `.attr('id').trim()` |
| `tables/scope-value` | `getAttribute('scope').toLowerCase()` → `.attr('scope').toLowerCase()` |
| `generic/page-no-duplicate` | `elm.actualNode.hasAttribute('role')` → `elm.hasAttr('role')` |

`matches` functions receive `virtualNode` as the 2nd argument and checks as the 3rd, so the virtual node is always available (a few functions had the parameter added). Affected `matches`/check tests were updated to pass a virtual node argument.

### ⏸️ Left as-is — must-stay (52)

These operate on real DOM by design; converting them would be incorrect or pointless.

| Area | Sites | Reason |
|------|-------|--------|
| `core/utils/is-hidden`, `preload-media`, `get-xpath`, `get-selector`, `preload-cssom` | 14 | `core/utils` works on real DOM by design |
| `core/base/context/create-frame-context` | 3 | Runs before the tree is built (raw frame element) |
| `core/base/virtual-node` | 3 | This *is* the `.attr()`/`.hasAttr()` implementation + constructor |
| `commons/table` (`to-grid`, `is-header`, `is-data-table`, `get-headers`) | 11 | Raw cells accessed via `.rows`/`.cells`; `is-data-table` takes a real DOM table |
| `commons/aria/get-accessible-refs` | 3 | Raw `childNodes` recursion |
| `commons/dom` (`idrefs`, `is-current-page-link`, `url-props-from-attribute`, `is-visible`) | 6 | `idrefs` left per #5138; live URL props; `is-visible:147` is an intentional vNode-null fallback |
| `checks/tables/th-has-data-cells`, `td-headers-attr` | 8 | Raw cells; table cells can't be custom elements |
| `checks/aria/aria-required-parent` | 2 | `parentElement` walk on the raw element |
| `rules/aria-hidden-focus-matches` | 1 | Real-DOM composed-parent walk (no vNode in the recursion) |
| `rules/color-contrast-matches` | 1 | `control` comes from `getAccessibleRefs` (raw refs); color-contrast is #5150 scope |

### ⏸️ Left as-is — judgment (6)

These mix attribute reads with live DOM/property reads, so converting only the attribute reads would be inconsistent.

| Site | Sites | Reason |
|------|-------|--------|
| `commons/aria/lookup-table` | 3 | `evaluateRoleForElement` handlers read live props (`node.type`, etc.) alongside the attribute |
| `checks/media/no-autoplay-audio-evaluate`, `rules/no-autoplay-audio-matches` | 3 | Mixed with live media props (`node.duration`, `node.currentSrc`) |

## Testing

- `matches`/check tests updated to pass a virtual node argument (some previously passed only the DOM node and would throw on the new `.attr()` reads).
- `npm run eslint`, `npm run test:tsc`, `npm run build`, and the affected rule-matches + check suites all pass.

Closes #5043
