### PR TITLE
chore: add chokidar to dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,8 @@ updates:
         versions: ['>=5.0.0']
       - dependency-name: 'conventional-commits-parser'
         versions: ['>=6.0.0']
+      - dependency-name: 'chokidar'
+        versions: ['>=5.0.0']
       # Prevent Webpack error caused by v0.11+ of esbuild
       # @see https://github.com/dequelabs/axe-core/issues/3771
       - dependency-name: 'esbuild'


### PR DESCRIPTION
Chokidar moved to [ESM only](https://github.com/paulmillr/chokidar/releases/tag/5.0.0) in v5.