### PR TITLE
test: disable aria-practices listbox-actions

### DIFF
--- a/test/aria-practices/apg.spec.js
+++ b/test/aria-practices/apg.spec.js
@@ -42,7 +42,8 @@ describe('aria-practices', function () {
 
   const skippedPages = [
     'toolbar/examples/help.html', // Embedded into another page
-    'tabs/examples/tabs-actions.html' // dequelabs/axe-core#4584
+    'tabs/examples/tabs-actions.html', // dequelabs/axe-core#4584
+    'listbox/examples/listbox-actions.html' // dequelabs/axe-core#4584
   ];
 
   it('finds examples', () => {


### PR DESCRIPTION
ARIA practices added [a new listbox actions example](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-actions/) which uses the proposed `aria-actions` attribute and pattern. We don't support that yet so we'll skip it. We already had to do this for a tab pattern they added previously. See https://github.com/dequelabs/axe-core/issues/4584
