### PR TITLE
fix(color-contrast): fix various stacking context bugs

### DIFF
--- a/lib/commons/dom/create-grid.js
+++ b/lib/commons/dom/create-grid.js
@@ -12,7 +12,6 @@ import { getIntersectionRect } from '../math';
 const ROOT_LEVEL = 0;
 const DEFAULT_LEVEL = 0.1;
 const FLOAT_LEVEL = 0.2;
-const POSITION_LEVEL = 0.3;
 let nodeIndex = 0;
 
 /**
@@ -42,7 +41,7 @@ export default function createGrid(
 
     nodeIndex = 0;
     vNode._stackingOrder = [
-      createStackingContext(ROOT_LEVEL, nodeIndex++, null)
+      createStackingContext(ROOT_LEVEL, true, nodeIndex++, null)
     ];
     rootGrid ??= new Grid();
     addNodeToGrid(rootGrid, vNode);
@@ -264,23 +263,27 @@ function isFlexOrGridContainer(vNode) {
 function createStackingOrder(vNode, parentVNode, treeOrder) {
   const stackingOrder = parentVNode._stackingOrder.slice();
 
-  // if an element creates a stacking context, find the first
-  // true stack (not a "fake" stack created from positioned or
-  // floated elements without a z-index) and create a new stack at
-  // that point (step #5 and step #8)
-  // @see https://www.w3.org/Style/css2-updates/css2/zindex.html
-  if (isStackingContext(vNode, parentVNode)) {
-    const index = stackingOrder.findIndex(({ stackLevel }) =>
-      [ROOT_LEVEL, FLOAT_LEVEL, POSITION_LEVEL].includes(stackLevel)
-    );
-    if (index !== -1) {
-      stackingOrder.splice(index, stackingOrder.length - index);
+  // if an element is positioned or creates a stacking context, find the first
+  // true stack (not a pseudo stack created from positioned or floated elements
+  // without a z-index) and create a new stack at that point (step #5 and step #8)
+  // @see https://www.w3.org/TR/CSS2/zindex.html
+  const isRealStack = isStackingContext(vNode, parentVNode);
+  const isPositioned =
+    vNode.getComputedStylePropertyValue('position') !== 'static';
+
+  if (isRealStack || isPositioned) {
+    const firstPseudo = stackingOrder.findIndex(({ pseudo }) => !!pseudo);
+    if (firstPseudo !== -1) {
+      stackingOrder.splice(firstPseudo);
     }
   }
 
   const stackLevel = getStackLevel(vNode, parentVNode);
   if (stackLevel !== null) {
-    stackingOrder.push(createStackingContext(stackLevel, treeOrder, vNode));
+    // pseudo only if this element does not create a real stacking context
+    stackingOrder.push(
+      createStackingContext(stackLevel, !isRealStack, treeOrder, vNode)
+    );
   }
   return stackingOrder;
 }
@@ -291,12 +294,14 @@ function createStackingOrder(vNode, parentVNode, treeOrder) {
  * @see https://www.w3.org/Style/css2-updates/css2/zindex.html
  * @see https://www.w3.org/Style/css2-updates/css2/visuren.html#layers
  * @param {Number} stackLevel - The stack level of the stacking context
+ * @param {Boolean} pseudo - If the stack is a pseudo stack or a true stack
  * @param {Number} treeOrder - The elements depth-first traversal order
  * @param {VirtualNode} vNode - The virtual node that is the container for the stacking context
  */
-function createStackingContext(stackLevel, treeOrder, vNode) {
+function createStackingContext(stackLevel, pseudo, treeOrder, vNode) {
   return {
     stackLevel,
+    pseudo,
     treeOrder,
     vNode
   };
@@ -314,24 +319,20 @@ function getStackLevel(vNode, parentVNode) {
     return parseInt(zIndex);
   }
 
-  // if a positioned element has z-index: auto or 0 (step #8), or if
-  // a non-positioned floating element (step #5), treat it as its
-  // own stacking context
-  // @see https://www.w3.org/Style/css2-updates/css2/zindex.html
+  // both real and pseudo stacks get sorted at the same layer (step #7)
+  const isRealStack = isStackingContext(vNode, parentVNode);
+  const isPseudoStack =
+    vNode.getComputedStylePropertyValue('position') !== 'static';
 
   // Put positioned elements above floated elements
-  if (vNode.getComputedStylePropertyValue('position') !== 'static') {
-    return POSITION_LEVEL;
+  if (isRealStack || isPseudoStack) {
+    return DEFAULT_LEVEL;
   }
 
   // Put floated elements above z-index: 0
   // (step #5 floating get sorted below step #8 positioned)
   if (vNode.getComputedStylePropertyValue('float') !== 'none') {
     return FLOAT_LEVEL;
-  }
-
-  if (isStackingContext(vNode, parentVNode)) {
-    return DEFAULT_LEVEL;
   }
 
   return null;

--- a/lib/commons/dom/create-grid.js
+++ b/lib/commons/dom/create-grid.js
@@ -319,18 +319,16 @@ function getStackLevel(vNode, parentVNode) {
     return parseInt(zIndex);
   }
 
-  // both real and pseudo stacks get sorted at the same layer (step #7)
+  // step #7 both real and pseudo stacks get sorted at the same layer
   const isRealStack = isStackingContext(vNode, parentVNode);
   const isPseudoStack =
     vNode.getComputedStylePropertyValue('position') !== 'static';
 
-  // Put positioned elements above floated elements
   if (isRealStack || isPseudoStack) {
     return DEFAULT_LEVEL;
   }
 
-  // Put floated elements above z-index: 0
-  // (step #5 floating get sorted below step #8 positioned)
+  // step #5 floating elements
   if (vNode.getComputedStylePropertyValue('float') !== 'none') {
     return FLOAT_LEVEL;
   }

--- a/lib/commons/dom/create-grid.js
+++ b/lib/commons/dom/create-grid.js
@@ -10,8 +10,8 @@ import getOverflowHiddenAncestors from './get-overflow-hidden-ancestors';
 import { getIntersectionRect } from '../math';
 
 const ROOT_LEVEL = 0;
-const DEFAULT_LEVEL = 0.1;
-const FLOAT_LEVEL = 0.2;
+const FLOAT_LEVEL = 0.1;
+const DEFAULT_LEVEL = 0.2;
 let nodeIndex = 0;
 
 /**
@@ -291,8 +291,8 @@ function createStackingOrder(vNode, parentVNode, treeOrder) {
 /**
  * Create a stacking context, keeping track of the stack level, tree order, and virtual
  * node container.
- * @see https://www.w3.org/Style/css2-updates/css2/zindex.html
- * @see https://www.w3.org/Style/css2-updates/css2/visuren.html#layers
+ * @see https://www.w3.org/TR/CSS2/zindex.html
+ * @see https://www.w3.org/TR/CSS2/visuren.html#layers
  * @param {Number} stackLevel - The stack level of the stacking context
  * @param {Boolean} pseudo - If the stack is a pseudo stack or a true stack
  * @param {Number} treeOrder - The elements depth-first traversal order
@@ -319,18 +319,19 @@ function getStackLevel(vNode, parentVNode) {
     return parseInt(zIndex);
   }
 
-  // step #7 both real and pseudo stacks get sorted at the same layer
+  // step #5 floating elements are sorted below step #8, even if the floating
+  // element is itself a stacking context (real or pseudo)
+  if (vNode.getComputedStylePropertyValue('float') !== 'none') {
+    return FLOAT_LEVEL;
+  }
+
+  // step #8 both real and pseudo stacks get sorted at the same layer
   const isRealStack = isStackingContext(vNode, parentVNode);
   const isPseudoStack =
     vNode.getComputedStylePropertyValue('position') !== 'static';
 
   if (isRealStack || isPseudoStack) {
     return DEFAULT_LEVEL;
-  }
-
-  // step #5 floating elements
-  if (vNode.getComputedStylePropertyValue('float') !== 'none') {
-    return FLOAT_LEVEL;
   }
 
   return null;

--- a/test/commons/dom/create-grid.js
+++ b/test/commons/dom/create-grid.js
@@ -89,6 +89,7 @@ describe('create-grid', () => {
       // implementation details that can easily change
       assert.hasAllKeys(vNode._stackingOrder[0], [
         'stackLevel',
+        'pseudo',
         'treeOrder',
         'vNode'
       ]);

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -832,6 +832,32 @@ describe('dom.getElementStack', () => {
       const stack = mapToIDs(getElementStack(target));
       assert.deepEqual(stack, ['target', 'container']);
     });
+
+    it('should correctly order floating and non-positioned stacking contexts', () => {
+      fixture.innerHTML = html`
+        <div id="1" style="position: relative; z-index: 5">
+          <div id="2" style="float: left;">hello world there</div>
+          <div id="target" style="opacity: 0.95; width: 140px;">text</div>
+        </div>
+      `;
+      axe.testUtils.flatTreeSetup(fixture);
+      const target = fixture.querySelector('#target');
+      const stack = mapToIDs(getElementStack(target));
+      assert.deepEqual(stack, ['target', '2', '1', 'fixture']);
+    });
+
+    it('should correctly order floating non-positioned stacking contexts and non-positioned stacking contexts', () => {
+      fixture.innerHTML = html`
+        <div id="1" style="position: relative; z-index: 5">
+          <div id="2" style="float: left; opacity: 0.5">hello world there</div>
+          <div id="target" style="opacity: 0.95; width: 140px;">text</div>
+        </div>
+      `;
+      axe.testUtils.flatTreeSetup(fixture);
+      const target = fixture.querySelector('#target');
+      const stack = mapToIDs(getElementStack(target));
+      assert.deepEqual(stack, ['target', '2', '1', 'fixture']);
+    });
   });
 
   describe('scroll regions', () => {

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -762,6 +762,76 @@ describe('dom.getElementStack', () => {
         'fixture'
       ]);
     });
+
+    it('should correctly order real and pseudo stacks correctly', () => {
+      fixture.innerHTML = html`
+        <div id="1" style="position: fixed; z-index: 50">
+          <!-- real stack -->
+          <div id="2" style="position: relative">
+            <!-- pseudo stack -->
+            <div id="3" style="position: relative">
+              <!-- pseudo stack -->
+              <div id="target" style="opacity: 0.5">text</div>
+              <!-- real stack -->
+            </div>
+          </div>
+        </div>
+      `;
+      axe.testUtils.flatTreeSetup(fixture);
+      const target = fixture.querySelector('#target');
+      const stack = mapToIDs(getElementStack(target));
+      assert.deepEqual(stack, ['target', '3', '2', '1']);
+    });
+
+    it('should correctly order nested combinations of positioning and stacking contexts', () => {
+      fixture.innerHTML = html`
+        <div
+          id="1"
+          style="position: relative; z-index: 4; width: 200px; height: 200px;"
+        >
+          <div id="2" style="position: absolute;">
+            <div id="3" style="transform: translate3d(0px, 0px, 0px);">
+              <span id="target">text</span>
+            </div>
+          </div>
+        </div>
+      `;
+      axe.testUtils.flatTreeSetup(fixture);
+      const target = fixture.querySelector('#target');
+      const stack = mapToIDs(getElementStack(target));
+      assert.deepEqual(stack, ['target', '3', '2', '1', 'fixture']);
+    });
+
+    it('should correctly order z-index: 0', () => {
+      fixture.innerHTML = html`
+        <div id="parent" style="position: relative; z-index: 0">
+          <div
+            id="target"
+            style="position: relative; z-index: -1; background: red"
+          >
+            text
+          </div>
+        </div>
+      `;
+      axe.testUtils.flatTreeSetup(fixture);
+      const target = fixture.querySelector('#target');
+      const stack = mapToIDs(getElementStack(target));
+      assert.deepEqual(stack, ['target', 'parent', 'fixture']);
+    });
+
+    it('should correctly order filter', () => {
+      fixture.innerHTML = html`
+        <div id="container" style="position: fixed; background: #333;">
+          <span id="target" style="filter: contrast(100%); color: #eee">
+            Hello world
+          </span>
+        </div>
+      `;
+      axe.testUtils.flatTreeSetup(fixture);
+      const target = fixture.querySelector('#target');
+      const stack = mapToIDs(getElementStack(target));
+      assert.deepEqual(stack, ['target', 'container']);
+    });
   });
 
   describe('scroll regions', () => {

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -765,14 +765,14 @@ describe('dom.getElementStack', () => {
 
     it('should correctly order real and pseudo stacks', () => {
       fixture.innerHTML = html`
+        <!-- real stack -->
         <div id="1" style="position: fixed; z-index: 50">
-          <!-- real stack -->
+          <!-- pseudo stack -->
           <div id="2" style="position: relative">
             <!-- pseudo stack -->
             <div id="3" style="position: relative">
-              <!-- pseudo stack -->
-              <div id="target" style="opacity: 0.5">text</div>
               <!-- real stack -->
+              <div id="target" style="opacity: 0.5">text</div>
             </div>
           </div>
         </div>

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -835,15 +835,25 @@ describe('dom.getElementStack', () => {
 
     it('should correctly order floating and non-positioned stacking contexts', () => {
       fixture.innerHTML = html`
-        <div id="1" style="position: relative; z-index: 5">
-          <div id="2" style="float: left;">hello world there</div>
+        <div id="one" style="position: relative; z-index: 5">
+          <div id="two" style="float: left;">hello world there</div>
           <div id="target" style="opacity: 0.95; width: 140px;">text</div>
         </div>
       `;
+
       axe.testUtils.flatTreeSetup(fixture);
       const target = fixture.querySelector('#target');
+      const one = fixture.querySelector('#one');
+      const two = fixture.querySelector('#two');
+
+      console.log({
+        one: one.getBoundingClientRect(),
+        two: two.getBoundingClientRect(),
+        target: target.getBoundingClientRect()
+      });
+
       const stack = mapToIDs(getElementStack(target));
-      assert.deepEqual(stack, ['target', '2', '1', 'fixture']);
+      assert.deepEqual(stack, ['target', 'two', 'one', 'fixture']);
     });
 
     it('should correctly order floating non-positioned stacking contexts and non-positioned stacking contexts', () => {

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -763,7 +763,7 @@ describe('dom.getElementStack', () => {
       ]);
     });
 
-    it('should correctly order real and pseudo stacks correctly', () => {
+    it('should correctly order real and pseudo stacks', () => {
       fixture.innerHTML = html`
         <div id="1" style="position: fixed; z-index: 50">
           <!-- real stack -->

--- a/test/commons/dom/get-element-stack.js
+++ b/test/commons/dom/get-element-stack.js
@@ -837,21 +837,11 @@ describe('dom.getElementStack', () => {
       fixture.innerHTML = html`
         <div id="one" style="position: relative; z-index: 5">
           <div id="two" style="float: left;">hello world there</div>
-          <div id="target" style="opacity: 0.95; width: 140px;">text</div>
+          <div id="target" style="opacity: 0.95; width: 175px;">text</div>
         </div>
       `;
-
       axe.testUtils.flatTreeSetup(fixture);
       const target = fixture.querySelector('#target');
-      const one = fixture.querySelector('#one');
-      const two = fixture.querySelector('#two');
-
-      console.log({
-        one: one.getBoundingClientRect(),
-        two: two.getBoundingClientRect(),
-        target: target.getBoundingClientRect()
-      });
-
       const stack = mapToIDs(getElementStack(target));
       assert.deepEqual(stack, ['target', 'two', 'one', 'fixture']);
     });
@@ -860,7 +850,7 @@ describe('dom.getElementStack', () => {
       fixture.innerHTML = html`
         <div id="1" style="position: relative; z-index: 5">
           <div id="2" style="float: left; opacity: 0.5">hello world there</div>
-          <div id="target" style="opacity: 0.95; width: 140px;">text</div>
+          <div id="target" style="opacity: 0.95; width: 175px;">text</div>
         </div>
       `;
       axe.testUtils.flatTreeSetup(fixture);

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -514,3 +514,35 @@
 <textarea id="pass24" style="background-color: white; color: black">
 Hello world</textarea
 >
+
+<div style="position: relative; z-index: 1; width: 200px; height: 200px">
+  <div style="position: absolute">
+    <div style="transform: translate3d(0px, 0px, 0px)">
+      <span id="fail13" style="background-color: #111; color: #000"
+        >low contrast</span
+      >
+      <span id="pass25" style="background-color: #fff; color: #000"
+        >ok contrast</span
+      >
+    </div>
+  </div>
+</div>
+
+<div style="position: relative; z-index: 1; width: 200px; height: 200px">
+  <div style="position: absolute">
+    <div style="opacity: 0.99">
+      <span id="fail14" style="background-color: #111; color: #000"
+        >low contrast</span
+      >
+      <span id="pass26" style="background-color: #fff; color: #000"
+        >ok contrast</span
+      >
+    </div>
+  </div>
+</div>
+
+<div style="position: fixed; background: #333">
+  <span id="pass27" style="filter: contrast(100%); color: #eee">
+    Hello world
+  </span>
+</div>

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -541,8 +541,18 @@ Hello world</textarea
   </div>
 </div>
 
-<div style="position: fixed; background: #333">
+<div style="position: fixed; top: 100px; left: 100px; background: #333">
   <span id="pass27" style="filter: contrast(100%); color: #eee">
     Hello world
   </span>
+</div>
+
+<div style="position: fixed; z-index: 50; top: 200px; height: 200px">
+  <div style="position: fixed; background: #280071">
+    <div style="position: relative">
+      <div id="pass28" style="transform: matrix(1, 0, 0, 1, 0, 0); color: #fff">
+        text
+      </div>
+    </div>
+  </div>
 </div>

--- a/test/integration/rules/color-contrast/color-contrast.json
+++ b/test/integration/rules/color-contrast/color-contrast.json
@@ -43,7 +43,8 @@
     ["#pass24"],
     ["#pass25"],
     ["#pass26"],
-    ["#pass27"]
+    ["#pass27"],
+    ["#pass28"]
   ],
   "incomplete": [
     ["#canttell1"],

--- a/test/integration/rules/color-contrast/color-contrast.json
+++ b/test/integration/rules/color-contrast/color-contrast.json
@@ -11,7 +11,9 @@
     ["#fail9"],
     ["#fail10"],
     ["#fail11"],
-    ["#fail12"]
+    ["#fail12"],
+    ["#fail13"],
+    ["#fail14"]
   ],
   "passes": [
     ["#pass1"],
@@ -38,7 +40,10 @@
     ["#pass21"],
     ["#pass22"],
     ["#pass23"],
-    ["#pass24"]
+    ["#pass24"],
+    ["#pass25"],
+    ["#pass26"],
+    ["#pass27"]
   ],
   "incomplete": [
     ["#canttell1"],


### PR DESCRIPTION
This should correctly fix various stacking context order bugs we have. The main issues was I was misinterpreting the [paint order spec](https://www.w3.org/Style/css2-updates/css2/zindex.html) and conflating "non-positioned" and "positioned" elements as being sorted in different layers. However the spec seems to imply that these should be sorted together. I also didn't realize that the pseudo stack replacement in step #8 applied to both stacking contexts _and_ positioned elements.

Closes: https://github.com/dequelabs/axe-core/issues/4542
Closes: https://github.com/dequelabs/axe-core/issues/4540
Closes: https://github.com/dequelabs/axe-core/issues/4629
Closes: #5213
