### PR TITLE
test: setup the virtual tree using root rather than fixture

### DIFF
--- a/test/checks/navigation/region.js
+++ b/test/checks/navigation/region.js
@@ -428,8 +428,7 @@ describe('region', () => {
     const div = document.createElement('div');
     const shadow = div.attachShadow({ mode: 'open' });
     shadow.innerHTML = 'Some text';
-    fixtureSetup(div);
-    const virutalNode = axe._tree[0];
+    const virutalNode = fixtureSetup(div);
 
     // fixture is the outermost element
     assert.isFalse(

--- a/test/commons/dom/create-grid.js
+++ b/test/commons/dom/create-grid.js
@@ -30,7 +30,7 @@ describe('create-grid', () => {
 
     createGrid();
     assert.isDefined(fixture._grid);
-    assert.equal(fixture._grid, fixture.children[0]._grid);
+    assert.isTrue(fixture._grid === fixture.children[0]._grid);
   });
 
   it('adds elements to the correct cell in the grid', () => {

--- a/test/commons/text/subtree-text.js
+++ b/test/commons/text/subtree-text.js
@@ -33,14 +33,14 @@ describe('text.subtreeText', () => {
   });
 
   it('returns `` for embedded content', () => {
-    fixtureSetup(
+    const fixture = fixtureSetup(
       `<video>foo</video>` +
         `<audio>foo</audio>` +
         `<canvas>foo</canvas>` +
         `<iframe>foo</iframe>` +
         `<svg>foo</svg>`
     );
-    const children = axe._tree[0].children;
+    const children = fixture.children;
     assert.lengthOf(children, 5);
     children.forEach(embeddedContent => {
       assert.equal(subtreeText(embeddedContent), '');

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -111,9 +111,16 @@ describe('DqElement', () => {
   describe('nodeIndexes', () => {
     it('is taken from virtualNode', () => {
       fixtureSetup('<i></i><b></b><s></s>');
-      assert.deepEqual(new DqElement(fixture.children[0]).nodeIndexes, [1]);
-      assert.deepEqual(new DqElement(fixture.children[1]).nodeIndexes, [2]);
-      assert.deepEqual(new DqElement(fixture.children[2]).nodeIndexes, [3]);
+      const startIndex = axe.utils.getNodeFromTree(fixture).nodeIndex;
+      assert.deepEqual(new DqElement(fixture.children[0]).nodeIndexes, [
+        startIndex + 1
+      ]);
+      assert.deepEqual(new DqElement(fixture.children[1]).nodeIndexes, [
+        startIndex + 2
+      ]);
+      assert.deepEqual(new DqElement(fixture.children[2]).nodeIndexes, [
+        startIndex + 3
+      ]);
     });
 
     it('is taken from spec, over virtualNode', () => {

--- a/test/core/utils/merge-results.js
+++ b/test/core/utils/merge-results.js
@@ -1,6 +1,7 @@
 describe('axe.utils.mergeResults', () => {
   const queryFixture = axe.testUtils.queryFixture;
   const RuleError = axe.utils.RuleError;
+  const fixture = axe.testUtils.fixture;
 
   it('should normalize empty results', () => {
     const result = axe.utils.mergeResults([
@@ -17,6 +18,7 @@ describe('axe.utils.mergeResults', () => {
 
   it('merges frame content, including all selector types', () => {
     const iframe = queryFixture('<iframe id="target"></iframe>').actualNode;
+    const startIndex = axe.utils.getNodeFromTree(fixture).nodeIndex;
     let node = {
       selector: ['#foo'],
       xpath: ['html/#foo'],
@@ -46,11 +48,12 @@ describe('axe.utils.mergeResults', () => {
       'html > body > div:nth-child(1) > iframe',
       'html > div'
     ]);
-    assert.deepEqual(node.nodeIndexes, [1, 123]);
+    assert.deepEqual(node.nodeIndexes, [startIndex + 1, 123]);
   });
 
   it('merges frame specs', () => {
     const iframe = queryFixture('<iframe id="target"></iframe>').actualNode;
+    const startIndex = axe.utils.getNodeFromTree(fixture).nodeIndex;
     const frameSpec = new axe.utils.DqElement(iframe).toJSON();
     let node = {
       selector: ['#foo'],
@@ -81,7 +84,7 @@ describe('axe.utils.mergeResults', () => {
       'html > body > div:nth-child(1) > iframe',
       'html > div'
     ]);
-    assert.deepEqual(node.nodeIndexes, [1, 123]);
+    assert.deepEqual(node.nodeIndexes, [startIndex + 1, 123]);
   });
 
   it('sorts results from iframes into their correct DOM position', () => {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -314,7 +314,8 @@ const declarativeShadowDOMRegex =
     }
 
     // query the composed tree AFTER shadowDOM has been attached
-    const vFixture = axe.setup();
+    axe.setup();
+    const vFixture = axe.utils.getNodeFromTree(fixture);
     return axe.utils.getNodeFromTree(targetCandidate) || vFixture;
   };
 

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -228,7 +228,8 @@ const declarativeShadowDOMRegex =
   testUtils.fixtureSetup = (content, options = {}) => {
     testUtils.injectIntoFixture(content, options);
     axe.teardown();
-    return axe.setup(fixture);
+    axe.setup();
+    return axe.utils.getNodeFromTree(fixture);
   };
 
   /**
@@ -313,7 +314,7 @@ const declarativeShadowDOMRegex =
     }
 
     // query the composed tree AFTER shadowDOM has been attached
-    const vFixture = axe.setup(fixtureNode);
+    const vFixture = axe.setup();
     return axe.utils.getNodeFromTree(targetCandidate) || vFixture;
   };
 
@@ -347,7 +348,7 @@ const declarativeShadowDOMRegex =
   };
 
   /**
-   * Setup axe._tree flat tree
+   * Setup axe._tree flat tree. Note that this will create a partial virtual tree.
    * @param Node   Stuff to go in the flat tree
    * @returns vNode[]
    */


### PR DESCRIPTION
The tests only set up the virtual tree from the `fixture` down. This causes problems in our tests when code walks up the DOM tree (not the virtual tree) and tries to get virtual nodes from the walk. This causes tests to fail when it wouldn't fail in an actual run (as doing `axe.run` setups the virtual tree for the entire page).

This updates the testutils functions to set up the virtual tree using the entire DOM to parity an actual run.