### PR TITLE
test(hasAriaValue): reenable skipped test due to firefox crash

### DIFF
--- a/test/commons/aria/has-aria-value.js
+++ b/test/commons/aria/has-aria-value.js
@@ -37,21 +37,15 @@ describe('aria.hasAriaValue', () => {
     assert.isTrue(hasAriaValue(vNode, 'aria-label'));
   });
 
-  // TODO: remove when we resolve https://github.com/dequelabs/axe-core/issues/5139
-  // accessing empty idrefs element internal values crashes firefox
-  // @see https://bugzilla.mozilla.org/show_bug.cgi?id=2045887
-  (navigator.userAgent.indexOf('Firefox') > 0 ? it.skip : it)(
-    'returns true if elementInternals idrefs is empty',
-    () => {
-      const vNode = queryFixture(
-        html`<testutils-element id="target"></testutils-element>`
-      );
-      const node = vNode.actualNode;
-      node._internals.ariaLabelledByElements = [];
+  it('returns true if elementInternals idrefs is empty', () => {
+    const vNode = queryFixture(
+      html`<testutils-element id="target"></testutils-element>`
+    );
+    const node = vNode.actualNode;
+    node._internals.ariaLabelledByElements = [];
 
-      assert.isTrue(hasAriaValue(vNode, 'aria-labelledby'));
-    }
-  );
+    assert.isTrue(hasAriaValue(vNode, 'aria-labelledby'));
+  });
 
   it('returns false if missing attribute', () => {
     const vNode = queryFixture(


### PR DESCRIPTION
Tested in latest Firefox (153.0) and this looks like it doesn't crash the browser anymore. The other non-crash issues still exist (logging the warning, `null` for empty `ariaLabelledByElements `), but we should be able to reenable the test now.

Closes: https://github.com/dequelabs/axe-core/issues/5139
