### PR TITLE
docs: add example for light DOM selection of fromShadowDom selector

### DIFF
--- a/doc/context.md
+++ b/doc/context.md
@@ -198,6 +198,22 @@ To select elements in nested shadow DOM trees, axe will need a selector for each
 axe.run({ fromShadowDom: ['app-root', '.header', '#search'] });
 ```
 
+To select elements which reside in the light DOM of a nested shadow DOM tree (for example when using a `<slot>` element), the selector should resolve to the elements position in the light DOM and not to the resolved position inside the nested shadow DOM tree. For example, if we wanted to selected the `deeply-nested-element` from the following DOM tree structure:
+
+```
+custom-element
+  #shadow-root
+    nested-element
+      #shadow-root
+        <slot>
+    deeply-nested-element
+      #shadow-root
+        <slot>
+      button#target
+```
+
+The selector should be `['custom-element', 'deeply-nested-element']` and not `['custom-element', 'nested-element', 'deeply-nested-element']` as the `deeply-nested-element` resides inside the `custom-elements` light DOM.
+
 The `fromShadowDom` selector object can also be used as part of an `exclude` or `include` property. It can be by itself, or part of an array along with other selectors. The following example shows how to exclude all `.comment` elements inside the `<blog-comments>` custom element, as well as excluding the `footer` element:
 
 ```js


### PR DESCRIPTION
Closes: https://github.com/dequelabs/axe-core/issues/4025
