### PR TITLE
fix(aria-prohibited-attr): allow aria-label/labelledby on section and aside

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -99,18 +99,10 @@ All checks allow these global options:
       </td>
       <td align="left">
         <pre lang=js><code>[
-  "audio",
   "applet",
-  "canvas",
-  "dl",
-  "embed",
-  "iframe",
   "input",
-  "label",
-  "meter",
-  "object",
-  "svg",
-  "video"
+  "section",
+  "aside"
 ]</code></pre>
         </td>
       <td align="left">List of element names that without a role, are allowed an `aria-label` and `aria-labelledby` attribute</td>

--- a/lib/checks/aria/aria-prohibited-attr.json
+++ b/lib/checks/aria/aria-prohibited-attr.json
@@ -2,7 +2,7 @@
   "id": "aria-prohibited-attr",
   "evaluate": "aria-prohibited-attr-evaluate",
   "options": {
-    "elementsAllowedAriaLabel": ["applet", "input"]
+    "elementsAllowedAriaLabel": ["applet", "input", "section", "aside"]
   },
   "metadata": {
     "impact": "serious",

--- a/test/checks/aria/aria-prohibited-attr.js
+++ b/test/checks/aria/aria-prohibited-attr.js
@@ -287,4 +287,38 @@ describe('aria-prohibited-attr', () => {
       assert.isTrue(checkEvaluate.apply(checkContext, params));
     });
   });
+
+  describe('section and aside', () => {
+    it('should allow aria-labelledby on a section without an accessible name', () => {
+      const params = checkSetup(
+        '<section id="target" aria-labelledby="foo"></section><p id="foo"></p>',
+        { elementsAllowedAriaLabel: ['section', 'aside'] }
+      );
+      assert.isFalse(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should allow aria-labelledby on an aside nested in sectioning content', () => {
+      const params = checkSetup(
+        '<article><aside id="target" aria-labelledby="foo"></aside></article><p id="foo"></p>',
+        { elementsAllowedAriaLabel: ['section', 'aside'] }
+      );
+      assert.isFalse(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should allow aria-label on a section with an accessible name', () => {
+      const params = checkSetup(
+        '<section id="target" aria-label="Cart"></section>'
+      );
+      assert.isFalse(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should allow aria-labelledby on a section without a name in shadow DOM', () => {
+      const params = axe.testUtils.shadowCheckSetup(
+        '<div id="shadow"></div>',
+        '<section id="target" aria-labelledby="foo"></section><p id="foo"></p>',
+        { elementsAllowedAriaLabel: ['section', 'aside'] }
+      );
+      assert.isFalse(checkEvaluate.apply(checkContext, params));
+    });
+  });
 });

--- a/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.html
+++ b/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.html
@@ -12,6 +12,11 @@
   aria-label="Internals progressbar"
 ></testutils-element>
 <div role="button" aria-actions="value" id="pass10"></div>
+<section id="pass11" aria-labelledby="passref1"></section>
+<p id="passref1"></p>
+<article><aside id="pass12" aria-labelledby="passref2"></aside></article>
+<p id="passref2"></p>
+<section id="pass13" aria-label="Products"></section>
 
 <div role="caption" aria-label="value" id="fail1"></div>
 <div role="caption" aria-labelledby="value" id="fail2"></div>

--- a/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.json
+++ b/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.json
@@ -11,7 +11,10 @@
     ["#pass7"],
     ["#pass8"],
     ["#pass9"],
-    ["#pass10"]
+    ["#pass10"],
+    ["#pass11"],
+    ["#pass12"],
+    ["#pass13"]
   ],
   "incomplete": [["#incomplete1"], ["#incomplete2"], ["#incomplete3"]],
   "violations": [


### PR DESCRIPTION
Allows `aria-label` / `aria-labelledby` on a `<section>` or `<aside>` that has no accessible name, per ARIA in HTML.

## What & why

Per [ARIA in HTML](https://www.w3.org/TR/html-aria/) (`#el-section`, `#el-aside`), both elements allow **Global `aria-*` attributes** regardless of the role they resolve to.

In axe, an unnamed `<section>` (or an unnamed `<aside>` nested in sectioning content) resolves to a **`null` role**. The `aria-prohibited-attr` check treats a null-role element as prohibiting `aria-label`/`aria-labelledby`, so `<section aria-labelledby="…">` whose reference resolves to an empty name was wrongly flagged.

## Fix

Add `section` and `aside` to the check's `elementsAllowedAriaLabel` option. Named `section`/`aside` already pass (they resolve to `region`/`complementary`, which have no prohibited label attrs), so this only changes the null-role/empty-name case.

## Tests
- `aria-prohibited-attr` check unit — section with empty `aria-labelledby`, aside nested in sectioning content, named section, and an open **Shadow DOM** case.
- `aria-prohibited-attr` integration HTML/JSON — pass cases for section/aside with empty `aria-labelledby` and a named section.
- No virtual-rule cases: `aria-labelledby` idref resolution throws on serial (non-DOM) nodes, so the empty-labelledby scenario can't be exercised there.

## Doc reconciliation

`doc/check-options.md` documented the `elementsAllowedAriaLabel` default as a 12-element list that no longer matched the shipped default (`["applet", "input"]`). Corrected to the accurate current default (`applet`, `input`, `section`, `aside`).

Closes #5185
