### PR TITLE
ci: fix format github action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,12 +17,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - name: Install dependencies
-        run: npm ci
       - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
       # Workflows are not allowed to edit workflows. As result, we need to prevent Prettier from formatting them.
       - name: Prevent workflows from being formatted
         run: echo ".github" >> .prettierignore && cat .prettierignore


### PR DESCRIPTION
The script tries to install dependencies before setting up node, and one of the dependencies requires node 24 [so fails](https://github.com/dequelabs/axe-core/actions/runs/30015780360/job/89235273874?pr=5252). So just swapping the order so we setup node before installing.