### PR TITLE
fix(aria-prohibited-attr): allow aria-label/labelledby on form

### DIFF
--- a/doc/check-options.md
+++ b/doc/check-options.md
@@ -102,7 +102,8 @@ All checks allow these global options:
   "applet",
   "input",
   "section",
-  "aside"
+  "aside",
+  "form"
 ]</code></pre>
         </td>
       <td align="left">List of element names that without a role, are allowed an `aria-label` and `aria-labelledby` attribute</td>

--- a/lib/checks/aria/aria-prohibited-attr.json
+++ b/lib/checks/aria/aria-prohibited-attr.json
@@ -2,7 +2,7 @@
   "id": "aria-prohibited-attr",
   "evaluate": "aria-prohibited-attr-evaluate",
   "options": {
-    "elementsAllowedAriaLabel": ["applet", "input", "section", "aside"],
+    "elementsAllowedAriaLabel": ["applet", "input", "section", "aside", "form"],
     "elementsProhibitedAriaLabel": ["body", "label"]
   },
   "metadata": {

--- a/test/checks/aria/aria-prohibited-attr.js
+++ b/test/checks/aria/aria-prohibited-attr.js
@@ -320,6 +320,21 @@ describe('aria-prohibited-attr', () => {
       );
       assert.isFalse(checkEvaluate.apply(checkContext, params));
     });
+
+    it('should allow aria-labelledby on a form without an accessible name', () => {
+      const params = checkSetup(
+        '<form id="target" aria-labelledby="foo"></form><p id="foo"></p>',
+        { elementsAllowedAriaLabel: ['section', 'aside', 'form'] }
+      );
+      assert.isFalse(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should allow aria-label on a form with an accessible name', () => {
+      const params = checkSetup(
+        '<form id="target" aria-label="Search"></form>'
+      );
+      assert.isFalse(checkEvaluate.apply(checkContext, params));
+    });
   });
 
   describe('elementsProhibitedAriaLabel (body and label)', () => {

--- a/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.html
+++ b/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.html
@@ -17,6 +17,8 @@
 <article><aside id="pass12" aria-labelledby="passref2"></aside></article>
 <p id="passref2"></p>
 <section id="pass13" aria-label="Products"></section>
+<form id="pass14" aria-labelledby="passref3"></form>
+<p id="passref3"></p>
 
 <div role="caption" aria-label="value" id="fail1"></div>
 <div role="caption" aria-labelledby="value" id="fail2"></div>

--- a/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.json
+++ b/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.json
@@ -14,7 +14,8 @@
     ["#pass10"],
     ["#pass11"],
     ["#pass12"],
-    ["#pass13"]
+    ["#pass13"],
+    ["#pass14"]
   ],
   "incomplete": [
     ["#incomplete1"],


### PR DESCRIPTION
Extends the #5185 fix to the `form` element, which has the same false positive.

> **Stacked PR** — targets `chut/3410-body-label-prohibit` (#3410), which is itself stacked on #5185. GitHub will auto-retarget as the parents merge.

## What & why

Follow-up to #5244 / #5185. An unnamed `<form>` resolves to a `null` role in axe (`implicit-html-roles.js`: `hasAccessibleName(vNode) ? 'form' : null`), so `aria-prohibited-attr` wrongly prohibited `aria-label`/`aria-labelledby` on `<form aria-labelledby="…">` with an empty/unresolved reference.

Per [ARIA in HTML](https://www.w3.org/TR/html-aria/) (`#el-form`): the form element allows **Global `aria-*` attributes**, and "A `form` is not exposed as a landmark region unless it has been provided an accessible name."

## Audit result

I audited `implicit-html-roles.js` for the name-dependent-null-role pattern. Only `section`, `aside` (fixed in #5185) and **`form`** match. `header`/`footer` map to `null` based on *ancestor* (not accessible name), and a scoped `<footer>`/`<header>` is exposed as `generic` — which *prohibits* naming — so flagging those is correct and they are intentionally excluded.

## Fix
Add `form` to the `elementsAllowedAriaLabel` option (named forms already pass via the `form` landmark role).

## Tests
- `aria-prohibited-attr` check unit — form with empty `aria-labelledby`; named form.
- `aria-prohibited-attr` integration — form with empty `aria-labelledby` pass case.
- `doc/check-options.md` default updated.

Closes #5244
