### PR TITLE
feat(aria): add notRecommended standards flag for needs-review

### DIFF
--- a/lib/checks/aria/not-recommended-attr-evaluate.js
+++ b/lib/checks/aria/not-recommended-attr-evaluate.js
@@ -1,0 +1,42 @@
+import standards from '../../standards';
+
+/**
+ * Check that an element does not use any not recommended ARIA attributes.
+ *
+ * Not recommended attributes are taken from the `ariaAttrs` standards object
+ * from the attribute's `notRecommended` property.
+ *
+ * ##### Data:
+ * <table class="props">
+ *   <thead>
+ *     <tr>
+ *       <th>Type</th>
+ *       <th>Description</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td><code>String[]</code></td>
+ *       <td>List of all not recommended attributes</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ * @memberof checks
+ * @return {Boolean|undefined} True if no not recommended ARIA attributes are
+ * used, undefined (needs review) if any are.
+ */
+export default function notRecommendedAttrEvaluate(node, options, virtualNode) {
+  const notRecommendedAttrs = virtualNode.attrNames.filter(
+    attrName => standards.ariaAttrs[attrName]?.notRecommended
+  );
+
+  if (!notRecommendedAttrs.length) {
+    return true;
+  }
+
+  this.data(notRecommendedAttrs);
+  // Not recommended attributes are still valid, so this is a needs-review
+  // rather than a violation.
+  return undefined;
+}

--- a/lib/checks/aria/not-recommended-attr.json
+++ b/lib/checks/aria/not-recommended-attr.json
@@ -1,0 +1,14 @@
+{
+  "id": "not-recommended-attr",
+  "evaluate": "not-recommended-attr-evaluate",
+  "metadata": {
+    "impact": "minor",
+    "messages": {
+      "pass": "No not recommended ARIA attributes are used",
+      "incomplete": {
+        "singular": "The attribute is not recommended and should be reviewed: ${data.values}",
+        "plural": "The attributes are not recommended and should be reviewed: ${data.values}"
+      }
+    }
+  }
+}

--- a/lib/checks/aria/not-recommended-role-evaluate.js
+++ b/lib/checks/aria/not-recommended-role-evaluate.js
@@ -1,0 +1,24 @@
+import standards from '../../standards';
+import { getRole } from '../../commons/aria';
+
+/**
+ * Check that an element does not use a role that is not recommended.
+ *
+ * Not recommended roles are taken from the `ariaRoles` standards object from
+ * the role's `notRecommended` property.
+ *
+ * @memberof checks
+ * @return {Boolean|undefined} True if the element's semantic role is
+ * recommended, undefined (needs review) if it is not recommended.
+ */
+export default function notRecommendedRoleEvaluate(node, options, virtualNode) {
+  const role = getRole(virtualNode, { dpub: true, fallback: true });
+  if (!standards.ariaRoles[role]?.notRecommended) {
+    return true;
+  }
+
+  this.data(role);
+  // Not recommended roles are still valid, so this is a needs-review rather
+  // than a violation.
+  return undefined;
+}

--- a/lib/checks/aria/not-recommended-role.json
+++ b/lib/checks/aria/not-recommended-role.json
@@ -1,0 +1,11 @@
+{
+  "id": "not-recommended-role",
+  "evaluate": "not-recommended-role-evaluate",
+  "metadata": {
+    "impact": "minor",
+    "messages": {
+      "pass": "ARIA role is recommended",
+      "incomplete": "The role used is not recommended and should be reviewed: ${data}"
+    }
+  }
+}

--- a/lib/core/public/run-virtual-rule.js
+++ b/lib/core/public/run-virtual-rule.js
@@ -1,5 +1,6 @@
 import SerialVirtualNode from '../base/virtual-node/serial-virtual-node';
 import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
+import cache from '../base/cache';
 import * as helpers from '../reporters/helpers';
 import {
   publishMetaData,
@@ -21,6 +22,12 @@ export default function runVirtualRule(ruleId, vNode, options = {}) {
   // TODO: es-modules axe._selectorData
   options.reporter = options.reporter || axe._audit.reporter || 'v1';
   axe._selectorData = {};
+
+  // Unlike axe.run, runVirtualRule has no teardown step, so the query cache is
+  // never cleared between calls. Clear it here so standards-derived data cached
+  // by a previous call (e.g. the global aria attribute list) does not mask
+  // axe.configure() changes made before this call.
+  cache.clear();
 
   if (!(vNode instanceof AbstractVirtualNode)) {
     vNode = new SerialVirtualNode(vNode);

--- a/lib/rules/aria-allowed-attr.json
+++ b/lib/rules/aria-allowed-attr.json
@@ -19,7 +19,8 @@
   "all": [
     "aria-allowed-attr",
     "aria-allowed-attr-elm",
-    "aria-no-deprecated-attr"
+    "aria-no-deprecated-attr",
+    "not-recommended-attr"
   ],
   "any": [],
   "none": ["aria-unsupported-attr"]

--- a/lib/rules/aria-allowed-role.json
+++ b/lib/rules/aria-allowed-role.json
@@ -9,7 +9,7 @@
     "description": "Ensure role attribute has an appropriate value for the element",
     "help": "ARIA role should be appropriate for the element"
   },
-  "all": [],
+  "all": ["not-recommended-role"],
   "any": ["aria-allowed-role"],
   "none": []
 }

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -621,6 +621,17 @@
       "pass": "There is no mismatch between a <label> and accessible name",
       "incomplete": "Check that the <label> does not need be part of the ARIA ${data} field's name"
     },
+    "not-recommended-attr": {
+      "pass": "No not recommended ARIA attributes are used",
+      "incomplete": {
+        "singular": "The attribute is not recommended and should be reviewed: ${data.values}",
+        "plural": "The attributes are not recommended and should be reviewed: ${data.values}"
+      }
+    },
+    "not-recommended-role": {
+      "pass": "ARIA role is recommended",
+      "incomplete": "The role used is not recommended and should be reviewed: ${data}"
+    },
     "unsupportedrole": {
       "pass": "ARIA role is supported",
       "fail": "The role used is not widely supported in screen readers and assistive technologies: ${data}"

--- a/test/checks/aria/not-recommended-attr.js
+++ b/test/checks/aria/not-recommended-attr.js
@@ -1,0 +1,77 @@
+describe('not-recommended-attr', () => {
+  const checkContext = axe.testUtils.MockCheckContext();
+  const checkSetup = axe.testUtils.checkSetup;
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('not-recommended-attr');
+
+  afterEach(() => {
+    checkContext.reset();
+    axe.reset();
+  });
+
+  it('returns undefined (needs review) for a not recommended attribute', () => {
+    axe.configure({
+      standards: {
+        ariaAttrs: {
+          'aria-fizz': {
+            type: 'nmtoken',
+            notRecommended: true
+          }
+        }
+      }
+    });
+    const params = checkSetup(
+      '<div id="target" aria-fizz="buzz">Contents</div>'
+    );
+    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    assert.deepEqual(checkContext._data, ['aria-fizz']);
+  });
+
+  it('collects multiple not recommended attributes', () => {
+    axe.configure({
+      standards: {
+        ariaAttrs: {
+          'aria-fizz': {
+            type: 'nmtoken',
+            notRecommended: true
+          },
+          'aria-buzz': {
+            type: 'nmtoken',
+            notRecommended: true
+          }
+        }
+      }
+    });
+    const params = checkSetup(
+      '<div id="target" aria-fizz="foo" aria-buzz="bar">Contents</div>'
+    );
+    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    assert.deepEqual(checkContext._data, ['aria-fizz', 'aria-buzz']);
+  });
+
+  it('returns true when no not recommended attributes are used', () => {
+    const params = checkSetup(
+      '<div id="target" role="button" aria-label="foo">Contents</div>'
+    );
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
+    assert.isNull(checkContext._data);
+  });
+
+  it('returns undefined for a not recommended attribute in shadow DOM', () => {
+    axe.configure({
+      standards: {
+        ariaAttrs: {
+          'aria-fizz': {
+            type: 'nmtoken',
+            notRecommended: true
+          }
+        }
+      }
+    });
+    const params = axe.testUtils.shadowCheckSetup(
+      '<div id="shadow"></div>',
+      '<div id="target" aria-fizz="buzz">Contents</div>'
+    );
+    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    assert.deepEqual(checkContext._data, ['aria-fizz']);
+  });
+});

--- a/test/checks/aria/not-recommended-role.js
+++ b/test/checks/aria/not-recommended-role.js
@@ -1,0 +1,61 @@
+describe('not-recommended-role', () => {
+  const checkContext = axe.testUtils.MockCheckContext();
+  const checkSetup = axe.testUtils.checkSetup;
+  const checkEvaluate = axe.testUtils.getCheckEvaluate('not-recommended-role');
+
+  afterEach(() => {
+    checkContext.reset();
+    axe.reset();
+  });
+
+  it('returns undefined (needs review) if applied to a not recommended role', () => {
+    axe.configure({
+      standards: {
+        ariaRoles: {
+          melon: {
+            type: 'widget',
+            notRecommended: true
+          }
+        }
+      }
+    });
+    const params = checkSetup('<div id="target" role="melon">Contents</div>');
+    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    assert.deepEqual(checkContext._data, 'melon');
+  });
+
+  it('returns true if applied to a recommended role', () => {
+    let params = checkSetup('<div id="target" role="button">Contents</div>');
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
+    assert.isNull(checkContext._data);
+
+    params = checkSetup('<button id="target">Contents</button>');
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
+    assert.isNull(checkContext._data);
+  });
+
+  it('returns true if applied to an invalid role', () => {
+    const params = checkSetup('<input id="target" role="foo">');
+    assert.isTrue(checkEvaluate.apply(checkContext, params));
+    assert.isNull(checkContext._data);
+  });
+
+  it('returns undefined for a not recommended role in shadow DOM', () => {
+    axe.configure({
+      standards: {
+        ariaRoles: {
+          melon: {
+            type: 'widget',
+            notRecommended: true
+          }
+        }
+      }
+    });
+    const params = axe.testUtils.shadowCheckSetup(
+      '<div id="shadow"></div>',
+      '<div id="target" role="melon">Contents</div>'
+    );
+    assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    assert.deepEqual(checkContext._data, 'melon');
+  });
+});

--- a/test/integration/virtual-rules/aria-allowed-attr.js
+++ b/test/integration/virtual-rules/aria-allowed-attr.js
@@ -1,4 +1,8 @@
 describe('aria-allowed-attr virtual-rule', () => {
+  afterEach(() => {
+    axe.reset();
+  });
+
   it('should pass for required attributes', () => {
     const results = axe.runVirtualRule('aria-allowed-attr', {
       nodeName: 'div',
@@ -139,6 +143,32 @@ describe('aria-allowed-attr virtual-rule', () => {
       attributes: {
         role: 'button',
         'aria-grabbed': true
+      }
+    });
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 1);
+  });
+
+  it('should incomplete for a not recommended attribute', () => {
+    axe.configure({
+      standards: {
+        ariaAttrs: {
+          'aria-fizz': {
+            type: 'nmtoken',
+            global: true,
+            notRecommended: true
+          }
+        }
+      }
+    });
+
+    const results = axe.runVirtualRule('aria-allowed-attr', {
+      nodeName: 'div',
+      attributes: {
+        role: 'button',
+        'aria-fizz': 'buzz'
       }
     });
 

--- a/test/integration/virtual-rules/aria-allowed-role.js
+++ b/test/integration/virtual-rules/aria-allowed-role.js
@@ -54,6 +54,30 @@ describe('aria-allowed-role virtual-rule', () => {
     assert.lengthOf(results.incomplete, 0);
   });
 
+  it('should incomplete for a not recommended role', () => {
+    axe.configure({
+      standards: {
+        ariaRoles: {
+          melon: {
+            type: 'widget',
+            notRecommended: true
+          }
+        }
+      }
+    });
+
+    const results = axe.runVirtualRule('aria-allowed-role', {
+      nodeName: 'div',
+      attributes: {
+        role: 'melon'
+      }
+    });
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 1);
+  });
+
   it('should incomplete for hidden element', () => {
     const results = axe.runVirtualRule('aria-allowed-role', {
       nodeName: 'dd',


### PR DESCRIPTION
Adds a reusable `notRecommended: true` standards flag for ARIA roles and attributes that surfaces as **needs review**. Mirrors the `aria-no-deprecated-attr` needs-review pattern from #5246 (now merged).

## What & why

Per the discussion on #3341 ([@WilcoFiers](https://github.com/dequelabs/axe-core/issues/3341) / Steven Lambert), axe should have a general, data-driven way to return **needs review** for ARIA that is *valid but not recommended* — rather than handling each case ad hoc.

This is **additive** and changes no existing behavior:
- A `notRecommended: true` flag can be set on any role (`ariaRoles`) or attribute (`ariaAttrs`).
- `not-recommended-role` (on the `aria-allowed-role` rule) returns needs-review when the element's resolved role is `notRecommended`.
- `not-recommended-attr` (on the `aria-allowed-attr` rule) returns needs-review when the element uses a `notRecommended` attribute.
- As with `aria-deprecated-attr`, a needs-review outcome yields to a sibling check's failure (e.g. an unallowed attribute still fails the rule).

Existing `deprecated` handling (`aria-deprecated-attr`, `aria-deprecated-role`) is untouched — `deprecated` and `notRecommended` remain distinct.

## No real data yet

No role or attribute is flagged `notRecommended` today — this PR provides the reusable capability Steve asked for. The checks are therefore verified **data-driven** via `axe.configure` mocks (same approach as the deprecated-attr tests), not integration fixtures.

## Tests
- `not-recommended-attr` / `not-recommended-role` check units — mocked flag via `axe.configure`, single + multiple, negative case, open **Shadow DOM** case.
- `aria-allowed-attr` / `aria-allowed-role` virtual-rules — mocked flag yields `incomplete`.
- `locales/_template.json` gains exactly the two new check blocks; `doc/rule-descriptions.md` unchanged (no new rule); full check/commons/integration/virtual-rule suites green.

Closes #5247

