### PR TITLE
test(node): add new version for node 20 and jsdom

### DIFF
--- a/test/node/node.js
+++ b/test/node/node.js
@@ -41,7 +41,8 @@ function initJsdom(callback) {
       12: ['jsdom@19.0.0'],
       14: ['jsdom@21.1.2'],
       16: ['jsdom@22.1.0'],
-      18: ['jsdom@26.1.0']
+      18: ['jsdom@26.1.0'],
+      20: ['jsdom@29.1.1']
     };
 
     var majorNodeVersion = process.versions.node.split('.')[0];


### PR DESCRIPTION
[jsdom@30.0.0](https://github.com/jsdom/jsdom/releases/tag/v30.0.0) dropped support for node 20.