### PR TITLE
fix(get-selector): escape control characters in attribute selectors

### DIFF
--- a/lib/core/utils/get-selector.js
+++ b/lib/core/utils/get-selector.js
@@ -30,7 +30,11 @@ const ignoredAttributes = [
 
 const MAXATTRIBUTELENGTH = 31;
 const attrCharsRegex = /([\\"])/g;
-const newlineChars = /(\r\n|\r|\n)/g;
+// C0 control characters (U+0000–U+001F) and DEL (U+007F) cannot appear raw
+// inside a CSS string. In particular the CSS newlines U+000A, U+000C (form
+// feed) and U+000D terminate the string, producing an invalid selector that
+// throws in `Element.matches`. Escape each as a CSS numeric escape (`\<hex> `).
+const controlCharsRegex = /[\u0000-\u001f\u007f]/g;
 
 /**
  * Escape an attribute selector string.
@@ -43,7 +47,10 @@ function escapeAttribute(str) {
       // @see https://www.py4u.net/discuss/286669
       .replace(attrCharsRegex, '\\$1')
       // @see https://stackoverflow.com/a/20354013/2124254
-      .replace(newlineChars, '\\a ')
+      .replace(
+        controlCharsRegex,
+        char => '\\' + char.charCodeAt(0).toString(16) + ' '
+      )
   );
 }
 

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -545,6 +545,46 @@ describe('axe.utils.getSelector', () => {
     assert.isTrue(axe.utils.matchesSelector(div2, expected));
   });
 
+  it('should escape control characters in attribute (issue 5204)', () => {
+    const div1 = document.createElement('div');
+    div1.setAttribute('data-thing', 'foobar');
+
+    const div2 = document.createElement('div');
+    // Form feed (U+000C), vertical tab (U+000B) and U+001F previously passed
+    // through raw, producing an invalid selector that threw in matches().
+    div2.setAttribute(
+      'data-thing',
+      ' ' + String.fromCharCode(0x0c, 0x0b, 0x1f)
+    );
+
+    const expected = 'div[data-thing=" \\c \\b \\1f "]';
+    fixtureSetup([div1, div2]);
+    assert.equal(axe.utils.getSelector(div2), expected);
+    assert.isTrue(axe.utils.matchesSelector(div2, expected));
+  });
+
+  it('should escape CR and CRLF in attribute (issue 5204)', () => {
+    const div1 = document.createElement('div');
+    div1.setAttribute('data-thing', 'foobar');
+
+    const div2 = document.createElement('div');
+    // CR (U+000D) and CRLF now round-trip as `\d ` / `\d \a ` rather than
+    // collapsing to `\a ` (the old newline handling this change subsumes).
+    div2.setAttribute(
+      'data-thing',
+      'a' +
+        String.fromCharCode(0x0d) +
+        'b' +
+        String.fromCharCode(0x0d, 0x0a) +
+        'c'
+    );
+
+    const expected = 'div[data-thing="a\\d b\\d \\a c"]';
+    fixtureSetup([div1, div2]);
+    assert.equal(axe.utils.getSelector(div2), expected);
+    assert.isTrue(axe.utils.matchesSelector(div2, expected));
+  });
+
   it('should not generate universal selectors', () => {
     const node = document.createElement('div');
     node.setAttribute('role', 'menuitem');


### PR DESCRIPTION
Fixes #5204. When an element's attribute value contains a C0 control character (observed: form feed `U+000C`), `generateSelector` emitted it raw into an attribute selector. In CSS, form feed is a string-terminating newline, so `img[alt=" \f¼"]` is **invalid**, `Element.matches` throws inside `getNthChildString`, and the **entire `axe.run()` fails** — one bad attribute value on a page kills the whole audit.

## Fix

`escapeAttribute` (in `lib/core/utils/get-selector.js`) previously escaped only `\`, `"`, and CR/LF newlines — missing form feed and every other control character. It now escapes **all C0 control characters (`U+0000–U+001F`) and DEL (`U+007F`)** as CSS numeric escapes (`\<hex> `), which subsumes the existing newline handling (`U+000A` → `\a `, `U+000C` → `\c `). This matches the issue's minimal proof that `CSS.escape('\f')` produces a valid selector.

## Compatibility

No behavior change for existing cases: newline (`U+000A`) still escapes to `\a `. CR and CRLF now escape to `\d `/`\d \a ` (previously both collapsed to `\a `) — more correct round-tripping, and not covered by any existing test. All existing `get-selector` escape tests still pass.

## Test

`test/core/utils/get-selector.js` — an attribute value containing form feed, vertical tab, and `U+001F` now produces a valid selector that both matches the expected escaped string and passes `matchesSelector` (which threw on the pre-fix code).

Confirmed by @straker on the issue.

Closes #5204
