### PR TITLE
feat(element-internals): enable ElementInternals by default

### DIFF
--- a/doc/element-internals.md
+++ b/doc/element-internals.md
@@ -4,8 +4,6 @@ Axe-core supports CustomElements with attached ElementInternals or ARIA Properti
 
 > [!Note]
 > At this time, axe-core only supports the ElementInternals `role` property and no others (e.g. `ariaLabel`), though support for other properties is planned. Additionally axe-core will not validate the value of the ElementInternals `role`, and many rules will not run against the element (e.g. `aria-required-attr`). Rules that do run may only be partially supported (e.g. `aria-required-children`).
->
-> Lastly, support for ElementInternals is behind a feature flag `axe._enableElementInternals`, which must manually be set to `true` before axe runs.
 
 ```js
 CustomElements.define(

--- a/doc/external-apis.md
+++ b/doc/external-apis.md
@@ -60,9 +60,6 @@ const internals = await chrome.scripting.executeScript({
 
 See [element-internals.md](element-internals.md) for more information on what ElementInternal properties are supported.
 
-> [!Note]
-> Support for ElementInternals is behind a feature flag `axe._enableElementInternals`, which must manually be set to `true` before axe runs, even when passing in `elementInternals` data.
-
 ## axe.externalAPIs({ elementInternalsTimeout })
 
 Since gathering ElementInternals data is an async operation, you can configure how long axe-core will wait for `elementInternals` promise to resolve. By default the timeout is set to 1 second. If the timeout occurs axe-core will not run and will throw an error.

--- a/lib/core/base/virtual-node/virtual-node.js
+++ b/lib/core/base/virtual-node/virtual-node.js
@@ -195,12 +195,6 @@ export default class VirtualNode extends AbstractVirtualNode {
    * @return {ElementInternals}
    */
   get elementInternals() {
-    // feature flag to enable internals. uses globalThis.axe as it can be run outside of axe context
-    // TODO: remove when feature is fully enabled
-    if (!axe._enableElementInternals) {
-      return;
-    }
-
     if (!this._cache.hasOwnProperty('elementInternals')) {
       this._cache.elementInternals = getElementInternals(this.actualNode);
     }

--- a/test/commons/text/native-text-alternative.js
+++ b/test/commons/text/native-text-alternative.js
@@ -69,18 +69,5 @@ describe('text.nativeTextAlternative', () => {
       `);
       assert.equal(nativeTextAlternative(vNode), '');
     });
-
-    it('does not add a label when element internals are disabled', () => {
-      axe._enableElementInternals = false;
-      try {
-        const vNode = queryFixture(`
-          <label for="target">My explicit label</label>
-          <testutils-form-element id="target"></testutils-form-element>
-        `);
-        assert.equal(nativeTextAlternative(vNode), '');
-      } finally {
-        axe._enableElementInternals = true;
-      }
-    });
   });
 });

--- a/test/core/base/virtual-node/virtual-node.js
+++ b/test/core/base/virtual-node/virtual-node.js
@@ -6,10 +6,6 @@ describe('VirtualNode', () => {
     node = document.createElement('div');
   });
 
-  afterEach(() => {
-    axe._enableElementInternals = true;
-  });
-
   it('should be a function', () => {
     assert.isFunction(VirtualNode);
   });
@@ -472,26 +468,6 @@ describe('VirtualNode', () => {
         const internals = vNode.elementInternals;
         assert.ok(internals);
         assert.equal(internals.role, 'link');
-      });
-
-      it('returns undefined when feature flag is off', () => {
-        delete axe._enableElementInternals;
-        node = document.createElement('testutils-element');
-        const vNode = new VirtualNode(node);
-        const internals = vNode.elementInternals;
-
-        assert.isUndefined(internals);
-      });
-
-      it('returns internals when feature flag is on', () => {
-        delete axe._enableElementInternals;
-        axe._enableElementInternals = true;
-        node = document.createElement('testutils-element');
-        const vNode = new VirtualNode(node);
-        const internals = vNode.elementInternals;
-
-        assert.ok(internals);
-        assert.equal(internals.role, 'button');
       });
     });
   });

--- a/test/integration/full/external-apis/index.js
+++ b/test/integration/full/external-apis/index.js
@@ -5,10 +5,6 @@ describe('external-apis', () => {
     axe.testUtils.awaitNestedLoad(done);
   });
 
-  afterEach(() => {
-    axe._enableElementInternals = true;
-  });
-
   it('correctly sets elementInternals data on nodes for rules', async () => {
     const options = { runOnly: ruleName };
     const context = { exclude: [] };
@@ -30,32 +26,6 @@ describe('external-apis', () => {
 
     assert.lengthOf(results.passes, 1);
     assert.lengthOf(results.violations, 0);
-    assert.lengthOf(results.incomplete, 0);
-    assert.lengthOf(results.inapplicable, 0);
-  });
-
-  it('requires the feature flag in order to work', async () => {
-    const options = { runOnly: ruleName };
-    const context = { exclude: [] };
-
-    axe._enableElementInternals = false;
-    axe.externalAPIs({
-      getElementInternals() {
-        return Promise.resolve([
-          {
-            ancestry: 'html > body > external-api-element',
-            internals: {
-              role: 'list'
-            }
-          }
-        ]);
-      }
-    });
-
-    const results = await axe.run(context, options);
-
-    assert.lengthOf(results.passes, 0);
-    assert.lengthOf(results.violations, 1);
     assert.lengthOf(results.incomplete, 0);
     assert.lengthOf(results.inapplicable, 0);
   });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -112,10 +112,6 @@ const declarativeShadowDOMRegex =
     );
   }
 
-  // turn on elementInternals feature flag
-  // TODO: remove when feature is fully enabled
-  axe._enableElementInternals = true;
-
   // determine which checks are used only in the `none` array of rules
   const noneChecks = [];
 


### PR DESCRIPTION
Removes the `axe._enableElementInternals` feature flag, graduating ElementInternals support to on-by-default. Closes #5277.

## Changes

- **`lib/core/base/virtual-node/virtual-node.js`** — the `elementInternals` getter no longer gates on the flag, so ElementInternals is always computed. This also un-gates the `externalAPIs` `getElementInternals` path, which relied on this getter.
- **Tests** — removed the flag setup and flag-specific tests: the global toggle in `testutils.js`, the `afterEach` hooks that reset it, and the "feature flag on/off" and "requires the feature flag" tests. Existing tests (`caches`/`sets`/`gets element internals`, the external-apis "correctly sets…" test) continue to cover the behavior.
- **Docs** — removed the "behind a feature flag" instructions from `doc/element-internals.md` and `doc/external-apis.md`.

## Notes

Per the ElementInternals epic, the commons ElementInternals surface is unreleased, so removing the flag is not a breaking change — it's the feature landing on by default.

Verified: no `_enableElementInternals` references remain; `virtual-node` + `native-text-alternative` unit tests pass; the `external-apis` full integration test passes (3/3) with the flag gone.
