### PR TITLE
fix(aria-prohibited-attr): visible aria-labelledby requires review only

### DIFF
--- a/lib/checks/aria/aria-prohibited-attr-evaluate.js
+++ b/lib/checks/aria/aria-prohibited-attr-evaluate.js
@@ -1,4 +1,9 @@
-import { getRole, getExplicitRole, getRoleType } from '../../commons/aria';
+import {
+  getRole,
+  getExplicitRole,
+  getRoleType,
+  arialabelledbyText
+} from '../../commons/aria';
 import { sanitize, subtreeText } from '../../commons/text';
 import { getResolvedRefs, isVisibleToScreenReaders } from '../../commons/dom';
 import standards from '../../standards';
@@ -58,15 +63,18 @@ export default function ariaProhibitedAttrEvaluate(
     return false;
   }
 
+  // Prohibited aria-labelledby needs review rather than a failure, depending
+  // on what it references
+  // @see https://github.com/dequelabs/axe-core/issues/5180
+  const labelledbyReviewKey = getLabelledbyReviewKey(virtualNode, prohibited);
+  if (labelledbyReviewKey) {
+    this.data({ role, nodeName, messageKey: labelledbyReviewKey, prohibited });
+    return undefined;
+  }
+
   let messageKey = role !== null ? 'hasRole' : 'noRole';
   messageKey += prohibited.length > 1 ? 'Plural' : 'Singular';
   this.data({ role, nodeName, messageKey, prohibited });
-
-  // Don't fail if aria-labelledby would provide the accessible name
-  // @see https://github.com/dequelabs/axe-core/issues/5180
-  if (hasIncompleteLabelledbyEdgeCase(virtualNode, prohibited)) {
-    return undefined;
-  }
 
   // `subtreeDescendant` to override namedFromContents
   const textContent = subtreeText(virtualNode, { subtreeDescendant: true });
@@ -78,38 +86,55 @@ export default function ariaProhibitedAttrEvaluate(
 }
 
 /**
- * Whether prohibited aria-labelledby should be needs-review instead of a failure.
+ * Message key for prohibited aria-labelledby that needs review rather than a
+ * failure, or `null` when the element should fail.
  *
- * - Visible refs: AccName would use labelledby (aria-label is ignored).
- * - Missing refs with no aria-label: uncertain, needs review.
- * - Missing refs with aria-label: AccName falls through to aria-label → fail.
- * - Any AT-hidden ref: fail.
+ * Only aria-labelledby can be reviewable, and only when it provides the
+ * accessible name:
+ *
+ * - Every reference is visible to screen readers: the name repeats content
+ *   that is in the page, so information may not be lost.
+ * - No reference resolves: the accessible name cannot be determined.
+ * - Any reference hidden from screen readers, or any other prohibited
+ *   attribute, is a failure.
+ *
+ * A prohibited aria-label is exempt only when aria-labelledby gives the element
+ * its name, since the accessible name computation ignores aria-label in that
+ * case. When aria-labelledby resolves to no name, the name comes from the
+ * prohibited aria-label instead, which is a failure.
  *
  * @param {VirtualNode} vNode
  * @param {String[]} prohibited
- * @return {Boolean}
+ * @return {String|null}
  */
-function hasIncompleteLabelledbyEdgeCase(vNode, prohibited) {
+function getLabelledbyReviewKey(vNode, prohibited) {
+  // Without a DOM node, idref references cannot be resolved
   if (!vNode.actualNode || !prohibited.includes('aria-labelledby')) {
-    return false;
+    return null;
   }
 
-  // Other prohibited attrs (e.g. aria-actions) still fail. aria-label is
-  // ignored when labelledby resolves because AccName prefers labelledby.
   const otherProhibited = prohibited.filter(
     attr => attr !== 'aria-label' && attr !== 'aria-labelledby'
   );
   if (otherProhibited.length) {
-    return false;
+    return null;
   }
 
+  const hasProhibitedAriaLabel = prohibited.includes('aria-label');
   const resolved = getResolvedRefs(vNode, 'aria-labelledby').filter(Boolean);
   if (resolved.length === 0) {
-    // Does Acc name fall back to prohibited aria-label?
-    return !prohibited.includes('aria-label');
+    return hasProhibitedAriaLabel ? null : 'unresolvedLabel';
   }
 
-  return resolved.every(ref => isVisibleToScreenReaders(ref));
+  if (!resolved.every(ref => isVisibleToScreenReaders(ref))) {
+    return null;
+  }
+
+  if (hasProhibitedAriaLabel && sanitize(arialabelledbyText(vNode)) === '') {
+    return null;
+  }
+
+  return prohibited.length > 1 ? 'visibleLabelPlural' : 'visibleLabelSingular';
 }
 
 function listProhibitedAttrs(vNode, nodeName, elementsAllowedAriaLabel) {

--- a/lib/checks/aria/aria-prohibited-attr-evaluate.js
+++ b/lib/checks/aria/aria-prohibited-attr-evaluate.js
@@ -1,5 +1,6 @@
 import { getRole, getExplicitRole, getRoleType } from '../../commons/aria';
 import { sanitize, subtreeText } from '../../commons/text';
+import { getResolvedRefs, isVisibleToScreenReaders } from '../../commons/dom';
 import standards from '../../standards';
 import { getElementSpec } from '../../commons/standards';
 import memoize from '../../core/utils/memoize';
@@ -61,6 +62,12 @@ export default function ariaProhibitedAttrEvaluate(
   messageKey += prohibited.length > 1 ? 'Plural' : 'Singular';
   this.data({ role, nodeName, messageKey, prohibited });
 
+  // Don't fail if aria-labelledby would provide the accessible name
+  // @see https://github.com/dequelabs/axe-core/issues/5180
+  if (hasIncompleteLabelledbyEdgeCase(virtualNode, prohibited)) {
+    return undefined;
+  }
+
   // `subtreeDescendant` to override namedFromContents
   const textContent = subtreeText(virtualNode, { subtreeDescendant: true });
   if (sanitize(textContent) !== '') {
@@ -68,6 +75,41 @@ export default function ariaProhibitedAttrEvaluate(
     return undefined;
   }
   return true;
+}
+
+/**
+ * Whether prohibited aria-labelledby should be needs-review instead of a failure.
+ *
+ * - Visible refs: AccName would use labelledby (aria-label is ignored).
+ * - Missing refs with no aria-label: uncertain, needs review.
+ * - Missing refs with aria-label: AccName falls through to aria-label → fail.
+ * - Any AT-hidden ref: fail.
+ *
+ * @param {VirtualNode} vNode
+ * @param {String[]} prohibited
+ * @return {Boolean}
+ */
+function hasIncompleteLabelledbyEdgeCase(vNode, prohibited) {
+  if (!vNode.actualNode || !prohibited.includes('aria-labelledby')) {
+    return false;
+  }
+
+  // Other prohibited attrs (e.g. aria-actions) still fail. aria-label is
+  // ignored when labelledby resolves because AccName prefers labelledby.
+  const otherProhibited = prohibited.filter(
+    attr => attr !== 'aria-label' && attr !== 'aria-labelledby'
+  );
+  if (otherProhibited.length) {
+    return false;
+  }
+
+  const resolved = getResolvedRefs(vNode, 'aria-labelledby').filter(Boolean);
+  if (resolved.length === 0) {
+    // Does Acc name fall back to prohibited aria-label?
+    return !prohibited.includes('aria-label');
+  }
+
+  return resolved.every(ref => isVisibleToScreenReaders(ref));
 }
 
 function listProhibitedAttrs(vNode, nodeName, elementsAllowedAriaLabel) {

--- a/lib/checks/aria/aria-prohibited-attr.json
+++ b/lib/checks/aria/aria-prohibited-attr.json
@@ -18,7 +18,10 @@
         "hasRoleSingular": "${data.prohibited} attribute is not well supported with role \"${data.role}\".",
         "hasRolePlural": "${data.prohibited} attributes are not well supported with role \"${data.role}\".",
         "noRoleSingular": "${data.prohibited} attribute is not well supported on a ${data.nodeName} with no valid role attribute.",
-        "noRolePlural": "${data.prohibited} attributes are not well supported on a ${data.nodeName} with no valid role attribute."
+        "noRolePlural": "${data.prohibited} attributes are not well supported on a ${data.nodeName} with no valid role attribute.",
+        "visibleLabelSingular": "${data.prohibited} attribute is not well supported, but the elements referenced by aria-labelledby are visible in the page. Verify the label is not necessary.",
+        "visibleLabelPlural": "${data.prohibited} attributes are not well supported, but the elements referenced by aria-labelledby are visible in the page. Verify the labels are not necessary.",
+        "unresolvedLabel": "${data.prohibited} attribute is not well supported, and does not reference an existing element. Verify the label is not necessary."
       }
     }
   }

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -510,7 +510,10 @@
         "hasRoleSingular": "${data.prohibited} attribute is not well supported with role \"${data.role}\".",
         "hasRolePlural": "${data.prohibited} attributes are not well supported with role \"${data.role}\".",
         "noRoleSingular": "${data.prohibited} attribute is not well supported on a ${data.nodeName} with no valid role attribute.",
-        "noRolePlural": "${data.prohibited} attributes are not well supported on a ${data.nodeName} with no valid role attribute."
+        "noRolePlural": "${data.prohibited} attributes are not well supported on a ${data.nodeName} with no valid role attribute.",
+        "visibleLabelSingular": "${data.prohibited} attribute is not well supported, but the elements referenced by aria-labelledby are visible in the page. Verify the label is not necessary.",
+        "visibleLabelPlural": "${data.prohibited} attributes are not well supported, but the elements referenced by aria-labelledby are visible in the page. Verify the labels are not necessary.",
+        "unresolvedLabel": "${data.prohibited} attribute is not well supported, and does not reference an existing element. Verify the label is not necessary."
       }
     },
     "aria-required-attr": {

--- a/test/checks/aria/aria-prohibited-attr.js
+++ b/test/checks/aria/aria-prohibited-attr.js
@@ -307,7 +307,7 @@ describe('aria-prohibited-attr', () => {
       assert.deepEqual(checkContext._data, {
         nodeName: 'div',
         role: null,
-        messageKey: 'noRoleSingular',
+        messageKey: 'visibleLabelSingular',
         prohibited: ['aria-labelledby']
       });
     });
@@ -341,7 +341,7 @@ describe('aria-prohibited-attr', () => {
       assert.deepEqual(checkContext._data, {
         nodeName: 'code',
         role: null,
-        messageKey: 'noRolePlural',
+        messageKey: 'visibleLabelPlural',
         prohibited: ['aria-label', 'aria-labelledby']
       });
     });
@@ -355,7 +355,7 @@ describe('aria-prohibited-attr', () => {
       assert.deepEqual(checkContext._data, {
         nodeName: 'div',
         role: 'code',
-        messageKey: 'hasRoleSingular',
+        messageKey: 'visibleLabelSingular',
         prohibited: ['aria-labelledby']
       });
     });
@@ -386,11 +386,55 @@ describe('aria-prohibited-attr', () => {
       assert.isUndefined(checkEvaluate.apply(checkContext, params));
     });
 
+    it('should return true for a visible empty reference and aria-label', () => {
+      // The accessible name comes from the prohibited aria-label, because
+      // aria-labelledby resolves to an empty string
+      const params = checkSetup(html`
+        <code id="target" aria-labelledby="hd" aria-label="Hello world"></code>
+        <p id="hd"></p>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+      assert.deepEqual(checkContext._data, {
+        nodeName: 'code',
+        role: null,
+        messageKey: 'noRolePlural',
+        prohibited: ['aria-label', 'aria-labelledby']
+      });
+    });
+
+    it('should return true for a whitespace only reference and aria-label', () => {
+      const params = checkSetup(html`
+        <code id="target" aria-labelledby="hd" aria-label="Hello world"></code>
+        <p id="hd">&nbsp;</p>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return undefined for a reference to itself', () => {
+      // The accessible name is empty, as the element has no content
+      const params = checkSetup(
+        '<div id="target" aria-labelledby="target"></div>'
+      );
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+      assert.deepEqual(checkContext._data, {
+        nodeName: 'div',
+        role: null,
+        messageKey: 'visibleLabelSingular',
+        prohibited: ['aria-labelledby']
+      });
+    });
+
     it('should return undefined for a missing reference', () => {
       const params = checkSetup(
         '<div id="target" aria-labelledby="missing"></div>'
       );
       assert.isUndefined(checkEvaluate.apply(checkContext, params));
+      assert.deepEqual(checkContext._data, {
+        nodeName: 'div',
+        role: null,
+        messageKey: 'unresolvedLabel',
+        prohibited: ['aria-labelledby']
+      });
     });
 
     it('should return undefined when a reference is missing among visible ones', () => {

--- a/test/checks/aria/aria-prohibited-attr.js
+++ b/test/checks/aria/aria-prohibited-attr.js
@@ -36,8 +36,9 @@ describe('aria-prohibited-attr', () => {
   });
 
   it('should return true for multiple prohibited attributes', () => {
+    // labelledby does not resolve, so AccName uses aria-label
     const params = checkSetup(
-      '<div id="target" role="code" aria-hidden="false"  aria-label="foo" aria-labelledby="foo"></div>'
+      '<div id="target" role="code" aria-hidden="false" aria-label="foo" aria-labelledby="foo"></div>'
     );
     assert.isTrue(checkEvaluate.apply(checkContext, params));
     assert.deepEqual(checkContext._data, {
@@ -107,6 +108,7 @@ describe('aria-prohibited-attr', () => {
   });
 
   it('should return true if element has no role and no text content (plural)', () => {
+    // labelledby does not resolve, so AccName uses aria-label
     const params = checkSetup(
       '<div id="target" aria-label="foo" aria-labelledby="foo"></div>'
     );
@@ -262,7 +264,7 @@ describe('aria-prohibited-attr', () => {
 
     it('should not allow aria-labelledby on descendant of non-widget', () => {
       const params = checkSetup(html`
-        <div id="foo">hello world</div>
+        <div id="foo" hidden>hello world</div>
         <div role="grid">
           <span>
             <span id="target" aria-labelledby="foo"></span>
@@ -292,6 +294,163 @@ describe('aria-prohibited-attr', () => {
         </button>
       `);
       assert.isTrue(checkEvaluate.apply(checkContext, params));
+    });
+  });
+
+  describe('visible aria-labelledby references', () => {
+    it('should return undefined for a visible reference outside the element', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="hd"></div>
+        <h1 id="hd">Hello world</h1>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+      assert.deepEqual(checkContext._data, {
+        nodeName: 'div',
+        role: null,
+        messageKey: 'noRoleSingular',
+        prohibited: ['aria-labelledby']
+      });
+    });
+
+    it('continues to fail other prohibited attributes', () => {
+      const params = checkSetup(html`
+        <code
+          id="target"
+          role="code"
+          aria-labelledby="hd"
+          aria-actions="hd"
+        ></code>
+        <h1 id="hd">Hello world</h1>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+      assert.deepEqual(checkContext._data, {
+        nodeName: 'code',
+        role: 'code',
+        messageKey: 'hasRolePlural',
+        prohibited: ['aria-actions', 'aria-labelledby']
+      });
+    });
+
+    it('should return undefined with a visible labelledby and aria-label', () => {
+      // aria-label is an exception, as it is ignored when aria-labelledby resolves
+      const params = checkSetup(html`
+        <code id="target" aria-labelledby="hd" aria-label="Hello world"></code>
+        <h1 id="hd">Hello world</h1>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+      assert.deepEqual(checkContext._data, {
+        nodeName: 'code',
+        role: null,
+        messageKey: 'noRolePlural',
+        prohibited: ['aria-label', 'aria-labelledby']
+      });
+    });
+
+    it('should return undefined for a visible reference on a prohibiting role', () => {
+      const params = checkSetup(html`
+        <div id="target" role="code" aria-labelledby="hd"></div>
+        <h1 id="hd">Hello world</h1>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+      assert.deepEqual(checkContext._data, {
+        nodeName: 'div',
+        role: 'code',
+        messageKey: 'hasRoleSingular',
+        prohibited: ['aria-labelledby']
+      });
+    });
+
+    it('should return true when any of multiple references is not visible', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="hidden hd"></div>
+        <h1 id="hidden" hidden>Hidden</h1>
+        <h1 id="hd">Hello world</h1>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return undefined when all of multiple references are visible', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="a b"></div>
+        <h1 id="a">Hello</h1>
+        <h1 id="b">world</h1>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return undefined for a visible empty reference', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="hd"></div>
+        <p id="hd"></p>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return undefined for a missing reference', () => {
+      const params = checkSetup(
+        '<div id="target" aria-labelledby="missing"></div>'
+      );
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return undefined when a reference is missing among visible ones', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="missing hd"></div>
+        <h1 id="hd">Hello world</h1>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return true when a reference is missing among hidden ones', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="missing hd"></div>
+        <h1 id="hd" hidden>Hello world</h1>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return true for a hidden reference', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="hd"></div>
+        <h1 id="hd" hidden>Hello world</h1>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return true for a display:none reference', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="hd"></div>
+        <h1 id="hd" style="display: none">Hello world</h1>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return true for an aria-hidden reference', () => {
+      const params = checkSetup(html`
+        <div id="target" aria-labelledby="hd"></div>
+        <h1 id="hd" aria-hidden="true">Hello world</h1>
+      `);
+      assert.isTrue(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return undefined for a visible reference on a custom element', () => {
+      const params = checkSetup(html`
+        <h1 id="hd">Hello world</h1>
+        <my-element id="target" role="code" aria-labelledby="hd"></my-element>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
+    });
+
+    it('should return undefined for a visible reference inside shadow DOM', () => {
+      const params = checkSetup(html`
+        <div>
+          <template shadowrootmode="open">
+            <div id="target" aria-labelledby="hd"></div>
+            <h1 id="hd">Hello world</h1>
+          </template>
+        </div>
+      `);
+      assert.isUndefined(checkEvaluate.apply(checkContext, params));
     });
   });
 });

--- a/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.html
+++ b/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.html
@@ -141,3 +141,10 @@ conflict, which was true in ARIA 1.1. This changed in ARIA 1.2 but so far has on
 <div id="incomplete1" aria-label="foo">Foo</div>
 <div id="incomplete2" aria-labelledby="missing">Foo</div>
 <div id="incomplete3" aria-label="foo" role="code">Foo</div>
+<div id="incomplete4" aria-labelledby="hd"></div>
+<h1 id="hd">Hello world</h1>
+<div id="incomplete5" aria-labelledby="missing-only"></div>
+
+<div id="value" hidden>value</div>
+<div id="fail101" aria-labelledby="hidden-hd"></div>
+<h1 id="hidden-hd" hidden>Hello world</h1>

--- a/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.json
+++ b/test/integration/rules/aria-prohibited-attr/aria-prohibited-attr.json
@@ -15,7 +15,13 @@
     ["#pass11"],
     ["#pass12"]
   ],
-  "incomplete": [["#incomplete1"], ["#incomplete2"], ["#incomplete3"]],
+  "incomplete": [
+    ["#incomplete1"],
+    ["#incomplete2"],
+    ["#incomplete3"],
+    ["#incomplete4"],
+    ["#incomplete5"]
+  ],
   "violations": [
     ["#fail1"],
     ["#fail2"],
@@ -116,6 +122,7 @@
     ["#fail97"],
     ["#fail98"],
     ["#fail99"],
-    ["#fail100"]
+    ["#fail100"],
+    ["#fail101"]
   ]
 }

--- a/test/integration/virtual-rules/aria-prohibited-attr.js
+++ b/test/integration/virtual-rules/aria-prohibited-attr.js
@@ -59,6 +59,23 @@ describe('aria-prohibited-attr virtual-rule', () => {
     assert.lengthOf(results.incomplete, 0);
   });
 
+  it('should fail for prohibited aria-labelledby without throwing', () => {
+    const vNode = new axe.SerialVirtualNode({
+      nodeName: 'div',
+      attributes: {
+        role: 'code',
+        'aria-labelledby': 'hd'
+      }
+    });
+    vNode.children = [];
+
+    const results = axe.runVirtualRule('aria-prohibited-attr', vNode);
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 1);
+    assert.lengthOf(results.incomplete, 0);
+  });
+
   it('should fail for prohibited aria-actions', () => {
     const vNode = new axe.SerialVirtualNode({
       nodeName: 'div',


### PR DESCRIPTION
If the only prohibited attribute is aria-labelledby, it doesn't reference hidden elements, mark the element as needs review. Ignore aria-label as a prohibited attribute if this is the case, as the acc name fallback would have skipped it anyway.


Closes: https://github.com/dequelabs/axe-core/issues/5180, closes https://github.com/dequelabs/axe-core/issues/4118
