### PR TITLE
ci: increase wait-for-npm-ready timeout for publish scan delay

### DIFF
--- a/.github/bin/wait-for-npm-ready.sh
+++ b/.github/bin/wait-for-npm-ready.sh
@@ -7,8 +7,8 @@ if [ -z "$VERSION" ] || [ -z "$PACKAGE_NAME" ]; then
   exit 1
 fi
 
-SLEEP_SECONDS=${SLEEP_SECONDS:-10}
-MAX_ATTEMPTS=${MAX_ATTEMPTS:-30}
+SLEEP_SECONDS=${SLEEP_SECONDS:-120}
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-12}
 
 echo "::group::Waiting for ${PACKAGE_NAME}@${VERSION} to be available on npm registry..."
 


### PR DESCRIPTION
### Summary

npm now [scans published packages before they go live](https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/), adding a delay of up to 15+ minutes between calling `publish` and the package becoming available. Our `wait-for-npm-ready.sh` retry loop was tuned for near-instant availability (10s × 30 = ~5 min), so it can now time out before the package appears.

This raises the retry interval to **120s** and caps attempts at **12** (~22 min worst case).

### Notes

- The two callers in `deploy.yml` (`validate-next-deploy`, `validate-deploy`) rely on the 360-min default job timeout, so no `timeout-minutes` changes were needed.

Closes #5266