### PR TITLE
test(arialabelledby-text): cover closed shadow DOM and out-of-tree idrefs

### DIFF
--- a/test/commons/aria/arialabelledby-text.js
+++ b/test/commons/aria/arialabelledby-text.js
@@ -168,7 +168,7 @@ describe('aria.arialabelledbyText', () => {
     assert.equal(accName, 'Bar text');
   });
 
-  it('does not throw when aria-labelledby references a slot in shadow DOM (issue 4335)', () => {
+  it('does not throw when aria-labelledby references a slot in shadow DOM', () => {
     // The slot is not tracked in the virtual tree; resolving the reference
     // previously threw "Cannot read properties of undefined (reading 'props')".
     const target = axe.testUtils.queryShadowFixture(
@@ -178,12 +178,7 @@ describe('aria.arialabelledbyText', () => {
     assert.equal(aria.arialabelledbyText(target), '');
   });
 
-  // Lookups outside the virtual tree (issue 5221). Axe reaches nodes outside
-  // its virtual tree only through reflected AOM idref properties such as
-  // `ariaLabelledByElements`. Closed shadow roots are never flattened into the
-  // tree, and nodes attached after setup are never added to it, so in both
-  // cases resolving the reference must not throw and must contribute no name.
-  it('returns "" when ElementInternals references a node in a closed shadow root (issue 5221)', () => {
+  it('returns "" when ElementInternals references a node in a closed shadow root', () => {
     // A custom element labels itself, via ElementInternals, with an element in
     // its own closed shadow root. The referenced node is outside the virtual
     // tree, so it resolves to nothing.
@@ -199,22 +194,7 @@ describe('aria.arialabelledbyText', () => {
     assert.equal(aria.arialabelledbyText(vNode), '');
   });
 
-  it('returns "" when aria-labelledby references an id inside a closed (declarative) shadow root (issue 5221)', () => {
-    // #foo lives in a closed declarative shadow root, so it is unreachable from
-    // the light DOM's getElementById and absent from the virtual tree; the
-    // string idref must resolve to nothing.
-    fixtureSetup(
-      '<div id="host">' +
-        '<template shadowrootmode="closed"><span id="foo">Foo text</span></template>' +
-        '</div>' +
-        '<div role="heading" id="target" aria-labelledby="foo"></div>',
-      { shadow: true }
-    );
-    const target = axe.utils.querySelectorAll(axe._tree[0], '#target')[0];
-    assert.equal(aria.arialabelledbyText(target), '');
-  });
-
-  it('returns "" when ariaLabelledByElements references a node outside the virtual tree (issue 5221)', () => {
+  it('returns "" when ariaLabelledByElements references a node outside the virtual tree', () => {
     const target = queryFixture('<div role="heading" id="target"></div>');
     const outOfTree = document.createElement('div');
     outOfTree.textContent = 'Foo text';

--- a/test/commons/aria/arialabelledby-text.js
+++ b/test/commons/aria/arialabelledby-text.js
@@ -2,6 +2,8 @@ describe('aria.arialabelledbyText', () => {
   const html = axe.testUtils.html;
   const aria = axe.commons.aria;
   const queryFixture = axe.testUtils.queryFixture;
+  const fixtureSetup = axe.testUtils.fixtureSetup;
+  const fixture = axe.testUtils.fixture;
 
   it('returns the accessible name of the aria-labelledby references', () => {
     const target = queryFixture(html`
@@ -173,6 +175,38 @@ describe('aria.arialabelledbyText', () => {
       '<div id="shadow"></div>',
       '<section id="target" aria-labelledby="foo"></section><slot id="foo"></slot>'
     );
+    assert.equal(aria.arialabelledbyText(target), '');
+  });
+
+  // Lookups outside the virtual tree (issue 5221). Axe reaches nodes outside
+  // its virtual tree only through reflected AOM idref properties such as
+  // `ariaLabelledByElements`. Closed shadow roots are never flattened into the
+  // tree, and nodes attached after setup are never added to it, so in both
+  // cases resolving the reference must not throw and must contribute no name.
+  it('returns "" when ElementInternals references a node in a closed shadow root (issue 5221)', () => {
+    // A custom element labels itself, via ElementInternals, with an element in
+    // its own closed shadow root. The referenced node is outside the virtual
+    // tree, so it resolves to nothing.
+    const target = document.createElement('testutils-element');
+    target.id = 'target';
+    const shadowRoot = target.attachShadow({ mode: 'closed' });
+    shadowRoot.innerHTML = '<span>Foo text</span>';
+
+    fixtureSetup(target);
+    target._internals.ariaLabelledByElements = [shadowRoot.firstElementChild];
+
+    const vNode = axe.utils.getNodeFromTree(target);
+    assert.equal(aria.arialabelledbyText(vNode), '');
+  });
+
+  it('returns "" when ariaLabelledByElements references a node outside the virtual tree (issue 5221)', () => {
+    const target = queryFixture('<div role="heading" id="target"></div>');
+    const outOfTree = document.createElement('div');
+    outOfTree.textContent = 'Foo text';
+    // Appended after axe.setup, so the node is never part of the virtual tree.
+    fixture.appendChild(outOfTree);
+    target.actualNode.ariaLabelledByElements = [outOfTree];
+
     assert.equal(aria.arialabelledbyText(target), '');
   });
 });

--- a/test/commons/aria/arialabelledby-text.js
+++ b/test/commons/aria/arialabelledby-text.js
@@ -199,6 +199,21 @@ describe('aria.arialabelledbyText', () => {
     assert.equal(aria.arialabelledbyText(vNode), '');
   });
 
+  it('returns "" when aria-labelledby references an id inside a closed (declarative) shadow root (issue 5221)', () => {
+    // #foo lives in a closed declarative shadow root, so it is unreachable from
+    // the light DOM's getElementById and absent from the virtual tree; the
+    // string idref must resolve to nothing.
+    fixtureSetup(
+      '<div id="host">' +
+        '<template shadowrootmode="closed"><span id="foo">Foo text</span></template>' +
+        '</div>' +
+        '<div role="heading" id="target" aria-labelledby="foo"></div>',
+      { shadow: true }
+    );
+    const target = axe.utils.querySelectorAll(axe._tree[0], '#target')[0];
+    assert.equal(aria.arialabelledbyText(target), '');
+  });
+
   it('returns "" when ariaLabelledByElements references a node outside the virtual tree (issue 5221)', () => {
     const target = queryFixture('<div role="heading" id="target"></div>');
     const outOfTree = document.createElement('div');


### PR DESCRIPTION
### Summary

Adds tests codifying how axe-core handles idref references that point outside its virtual tree — the two scenarios in #5221:

1. **Closed shadow DOM** — a custom element self-labels via `ElementInternals.ariaLabelledByElements` with a node inside its own closed shadow root. Closed roots aren't flattened into the virtual tree, so the reference is unreachable.
2. **Out-of-tree node** — `ariaLabelledByElements` points at a node appended after `axe.setup()`, so it never enters the tree.

Both codify the current behavior: `getResolvedRefs` maps the unreachable node to `null`, the accessible-name function drops it, and `arialabelledbyText` returns `""` **without throwing**.

### Notes

- Tests-only; no runtime behavior change.
- The closed-shadow case is built with manual DOM (`attachShadow({ mode: "closed" })`) since `queryShadowFixture` is open-mode only.

Closes #5221