### PR TITLE
fix(dq-element): remove memoize wrapper around constructor

### DIFF
--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -4,7 +4,6 @@ import getXpath from './get-xpath';
 import getNodeFromTree from './get-node-from-tree';
 import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
 import cache from '../base/cache';
-import memoize from './memoize';
 import getSource from './get-element-source';
 
 const CACHE_KEY = 'DqElm.RunOptions';
@@ -16,7 +15,7 @@ const CACHE_KEY = 'DqElm.RunOptions';
  * @param {Object} options Propagated from axe.run/etc
  * @param {Object} spec Properties to use in place of the element when instantiated on Elements from other frames
  */
-const DqElement = memoize(function DqElementMemoized(elm, options, spec) {
+const DqElement = function DqElement(elm, options, spec) {
   options ??= null;
   spec ??= {};
 
@@ -67,7 +66,7 @@ const DqElement = memoize(function DqElementMemoized(elm, options, spec) {
   }
 
   return this;
-});
+};
 
 DqElement.prototype = {
   /**


### PR DESCRIPTION
Closes #5298

### What
Removes the `memoize` wrapper around the DqElement constructor.

### Why
Closes #5298. The `memoize` wrapper was hurting performance and adding ~20s to reporter initialization. Each `new DqElement` call had to unwrap the memoize wrapper, which is more expensive than direct instantiation.

### Changes
- Removed `import memoize from './memoize';` from `lib/core/utils/dq-element.js`
- Changed `const DqElement = memoize(function DqElementMemoized(...))` to `const DqElement = function DqElement(...)`
- Renamed inner function name to match the variable
- 1 file changed, 2 insertions(+), 3 deletions(-)


Closes:
