### PR TITLE
chore: remove unused @babel/runtime-corejs3 devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-object-rest-spread": "^7.29.7",
     "@babel/preset-env": "^7.20.2",
-    "@babel/runtime-corejs3": "^7.20.7",
     "@deque/dot": "^1.1.5",
     "@types/node": "^4.9.5",
     "@web/test-runner": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@babel/preset-env':
         specifier: ^7.20.2
         version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/runtime-corejs3':
-        specifier: ^7.20.7
-        version: 7.29.7
       '@deque/dot':
         specifier: ^1.1.5
         version: 1.1.5
@@ -686,10 +683,6 @@ packages:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-
-  '@babel/runtime-corejs3@7.29.7':
-    resolution: {integrity: sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -4912,10 +4905,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.7
       esutils: 2.0.3
-
-  '@babel/runtime-corejs3@7.29.7':
-    dependencies:
-      core-js-pure: 3.49.0
 
   '@babel/template@7.29.7':
     dependencies:


### PR DESCRIPTION
## What

Removes the `@babel/runtime-corejs3` entry from `devDependencies` in `package.json`, along with its three corresponding entries in `pnpm-lock.yaml` (the root importer record plus the package and snapshot blocks).

Nothing else changes. `core-js`, `core-js-pure`, and their `allowBuilds: false` entries in `pnpm-workspace.yaml` are unrelated and stay put.

## Why

This resolves Dependabot PR #5194, which proposed bumping `@babel/runtime-corejs3` from 7.29.7 to 8.0.0 — a major release whose headline breaking change is *"Remove corejs exports for `@babel/runtime-corejs3`"*. Rather than absorb a major bump, investigation showed the package is entirely unused:

- The only occurrence outside the lockfile was its own declaration in `package.json`.
- `@babel/runtime-corejs3` is only ever consumed via `@babel/plugin-transform-runtime`. That plugin is not installed and appears nowhere in the repository.
- `.babelrc` — the only Babel config the build reads, via `build/run-build/babel-transform.mjs` → `full-build.mjs` — uses `@babel/preset-env` with no `useBuiltIns` or `corejs` options, plus `@babel/plugin-transform-object-rest-spread`. Nothing pulls the runtime helpers in.
- Runtime polyfills come from `core-js-pure` directly in `lib/core/imports/polyfills.js` and `lib/core/imports/index.js`, which are untouched.
- `doc/examples/jest_react/` has its own isolated `package.json` and never referenced it.
- `pnpm-lock.yaml` listed it only as a root importer devDependency; no other package depended on it.

It arrived in a bulk dependency update in d01532c2 (#3539, 2022) and has never been imported.

## Note on the lockfile diff

The lockfile edit is deliberately scoped to the three affected blocks rather than produced by a full `pnpm install` regeneration.

`package.json` pins `"chromedriver": "latest"`. Because that is a floating spec, *any* manifest edit causes `pnpm install` to re-resolve it — a full regeneration here also bumped `chromedriver` 151.0.2 → 151.0.5 and dragged along `axios`, `adm-zip`, and `form-data`, burying a 12-line removal in ~57 lines of unrelated churn. The scoped lockfile is verified consistent: `pnpm install --frozen-lockfile` accepts it and correctly prunes the package.

That floating pin will keep polluting the diff of every future dependency change; worth addressing separately.

## Acceptance criteria

- [x] `@babel/runtime-corejs3` absent from `package.json` devDependencies
- [x] All three `pnpm-lock.yaml` blocks (importer, `packages:`, `snapshots:`) removed, with no residual reference
- [x] `pnpm install --frozen-lockfile` succeeds and proposes no lockfile drift
- [x] Built `axe.js` / `axe.min.js` byte-identical to a `develop` build
- [x] `pnpm test`, `pnpm run fmt:check`, and `pnpm run eslint` all clean

## Related

Supersedes Dependabot PR #5194.
