### PR TITLE
fix(commons/dom): treat a select's button and selectedcontent as inert

### DIFF
--- a/lib/commons/dom/is-inert.js
+++ b/lib/commons/dom/is-inert.js
@@ -17,10 +17,25 @@ export default function isInert(vNode, { skipAncestors, isAncestor } = {}) {
 }
 
 /**
+ * Determine if a node is a select element's button or selectedcontent.
+ * These are inert per the HTML spec, regardless of the select's rendered
+ * appearance (e.g. `appearance: base-select`).
+ * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
+ */
+function isInertSelectContent(vNode) {
+  const { nodeName } = vNode.props;
+  if (nodeName === 'selectedcontent') {
+    return true;
+  }
+
+  return nodeName === 'button' && vNode.parent?.props.nodeName === 'select';
+}
+
+/**
  * Check the element for inert
  */
 const isInertSelf = memoize(function isInertSelfMemoized(vNode, isAncestor) {
-  if (vNode.hasAttr('inert')) {
+  if (vNode.hasAttr('inert') || isInertSelectContent(vNode)) {
     return true;
   }
 

--- a/lib/rules/button-name-matches.js
+++ b/lib/rules/button-name-matches.js
@@ -1,0 +1,9 @@
+import noExplicitNameRequired from './no-explicit-name-required-matches';
+import { isInert } from '../commons/dom';
+
+export default function buttonNameMatches(node, virtualNode) {
+  if (isInert(virtualNode)) {
+    return false;
+  }
+  return noExplicitNameRequired(node, virtualNode);
+}

--- a/lib/rules/button-name.json
+++ b/lib/rules/button-name.json
@@ -2,7 +2,7 @@
   "id": "button-name",
   "impact": "critical",
   "selector": "button",
-  "matches": "no-explicit-name-required-matches",
+  "matches": "button-name-matches",
   "tags": [
     "cat.name-role-value",
     "wcag2a",

--- a/test/commons/dom/focus-disabled.js
+++ b/test/commons/dom/focus-disabled.js
@@ -74,6 +74,14 @@ describe('dom.focus-disabled', () => {
     assert.isTrue(focusDisabled(vNode));
   });
 
+  it('returns true for a select button', () => {
+    const vNode = queryFixture(
+      '<select><button id="target"><selectedcontent></selectedcontent></button><option>a</option></select>'
+    );
+
+    assert.isTrue(focusDisabled(vNode));
+  });
+
   describe('SerialVirtualNode', () => {
     it('returns false if element is hidden for everyone', () => {
       const vNode = new axe.SerialVirtualNode({

--- a/test/commons/dom/is-focusable.js
+++ b/test/commons/dom/is-focusable.js
@@ -26,6 +26,15 @@ describe('dom.isFocusable', () => {
     assert.isTrue(axe.commons.dom.isFocusable(el));
   });
 
+  it('should return false for a select button', () => {
+    fixture.innerHTML =
+      '<select><button id="target"><selectedcontent></selectedcontent></button><option>a</option></select>';
+    const el = document.getElementById('target');
+    flatTreeSetup(fixture);
+
+    assert.isFalse(axe.commons.dom.isFocusable(el));
+  });
+
   it('should return true for visible, enabled, non-hidden inputs', () => {
     fixture.innerHTML = '<input type="text" id="target">';
     const el = document.getElementById('target');

--- a/test/commons/dom/is-inert.js
+++ b/test/commons/dom/is-inert.js
@@ -2,7 +2,7 @@ describe('dom.isInert', () => {
   const html = axe.testUtils.html;
   const fixture = document.querySelector('#fixture');
   const isInert = axe.commons.dom.isInert;
-  const { queryFixture, flatTreeSetup } = axe.testUtils;
+  const { queryFixture, queryShadowFixture, flatTreeSetup } = axe.testUtils;
 
   it('returns true for element with "inert=false`', () => {
     const vNode = queryFixture('<div id="target" inert="false"></div>');
@@ -78,6 +78,111 @@ describe('dom.isInert', () => {
     const vNode = axe.utils.querySelectorAll(tree, '#target')[0];
 
     assert.isFalse(isInert(vNode));
+  });
+
+  describe('select button/selectedcontent', () => {
+    it('returns true for a button that is a direct child of select', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button id="target"><selectedcontent></selectedcontent></button>
+          <option>a</option>
+        </select>
+      `);
+
+      assert.isTrue(isInert(vNode));
+    });
+
+    it('returns true for selectedcontent', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button><selectedcontent id="target"></selectedcontent></button>
+          <option>a</option>
+        </select>
+      `);
+
+      assert.isTrue(isInert(vNode));
+    });
+
+    it('returns true for a descendant of the select button', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button><span id="target">v</span></button>
+          <option>a</option>
+        </select>
+      `);
+
+      assert.isTrue(isInert(vNode));
+    });
+
+    it('returns false for the select element itself', () => {
+      const vNode = queryFixture(html`
+        <select id="target">
+          <button><selectedcontent></selectedcontent></button>
+          <option>a</option>
+        </select>
+      `);
+
+      assert.isFalse(isInert(vNode));
+    });
+
+    it('returns false for an option inside the select', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button><selectedcontent></selectedcontent></button>
+          <option id="target">a</option>
+        </select>
+      `);
+
+      assert.isFalse(isInert(vNode));
+    });
+
+    it('returns false for a button that is not inside a select', () => {
+      const vNode = queryFixture('<button id="target">click</button>');
+
+      assert.isFalse(isInert(vNode));
+    });
+
+    it('returns false for a button that is not a direct child of select', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <div><button id="target"></button></div>
+          <option>a</option>
+        </select>
+      `);
+
+      assert.isFalse(isInert(vNode));
+    });
+
+    it('returns true with skipAncestors true for the select button itself', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button id="target"><selectedcontent></selectedcontent></button>
+          <option>a</option>
+        </select>
+      `);
+
+      assert.isTrue(isInert(vNode, { skipAncestors: true }));
+    });
+
+    it('returns false with skipAncestors true for a descendant of the select button', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button><span id="target">v</span></button>
+          <option>a</option>
+        </select>
+      `);
+
+      assert.isFalse(isInert(vNode, { skipAncestors: true }));
+    });
+
+    it('returns true for a select button inside an open shadow DOM', () => {
+      const vNode = queryShadowFixture(
+        '<div id="shadow"></div>',
+        '<select><button id="target"><selectedcontent></selectedcontent></button><option>a</option></select>'
+      );
+
+      assert.isTrue(isInert(vNode));
+    });
   });
 
   describe('options.skipAncestors', () => {

--- a/test/commons/dom/is-visible-to-screenreader.js
+++ b/test/commons/dom/is-visible-to-screenreader.js
@@ -281,4 +281,46 @@ describe('dom.isVisibleToScreenReaders', () => {
       assert.isFalse(isVisibleToScreenReaders(vNode));
     });
   });
+
+  describe('select button/selectedcontent', () => {
+    it('should return false for the select button', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button id="target"><selectedcontent></selectedcontent></button>
+          <option>a</option>
+        </select>
+      `);
+      assert.isFalse(isVisibleToScreenReaders(vNode));
+    });
+
+    it('should return false for selectedcontent', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button><selectedcontent id="target"></selectedcontent></button>
+          <option>a</option>
+        </select>
+      `);
+      assert.isFalse(isVisibleToScreenReaders(vNode));
+    });
+
+    it('should return true for an option inside the select', () => {
+      const vNode = queryFixture(html`
+        <select>
+          <button><selectedcontent></selectedcontent></button>
+          <option id="target">a</option>
+        </select>
+      `);
+      assert.isTrue(isVisibleToScreenReaders(vNode));
+    });
+
+    it('should return true for the select itself', () => {
+      const vNode = queryFixture(html`
+        <select id="target">
+          <button><selectedcontent></selectedcontent></button>
+          <option>a</option>
+        </select>
+      `);
+      assert.isTrue(isVisibleToScreenReaders(vNode));
+    });
+  });
 });

--- a/test/integration/rules/button-name/button-name.html
+++ b/test/integration/rules/button-name/button-name.html
@@ -27,3 +27,8 @@
 <span id="inapplicable1" role="button">Does not apply</span>
 <input type="submit" value="submit" role="button" id="inapplicable2" />
 <button id="inapplicable2" role="gridcell" disabled></button>
+
+<select>
+  <button id="inapplicable3"><selectedcontent></selectedcontent></button>
+  <option>a</option>
+</select>

--- a/test/integration/virtual-rules/button-name.js
+++ b/test/integration/virtual-rules/button-name.js
@@ -268,4 +268,23 @@ describe('button-name virtual-rule', () => {
     assert.lengthOf(results.violations, 1);
     assert.lengthOf(results.incomplete, 0);
   });
+
+  it('should be inapplicable for a select button', () => {
+    const select = new axe.SerialVirtualNode({
+      nodeName: 'select'
+    });
+    const node = new axe.SerialVirtualNode({
+      nodeName: 'button'
+    });
+    node.parent = select;
+    node.children = [];
+    select.children = [node];
+    select.parent = null;
+
+    const results = axe.runVirtualRule('button-name', node);
+
+    assert.lengthOf(results.passes, 0);
+    assert.lengthOf(results.violations, 0);
+    assert.lengthOf(results.incomplete, 0);
+  });
 });

--- a/test/rule-matches/button-name-matches.js
+++ b/test/rule-matches/button-name-matches.js
@@ -1,0 +1,41 @@
+describe('button-name-matches', () => {
+  const fixture = document.getElementById('fixture');
+  const queryFixture = axe.testUtils.queryFixture;
+  let rule;
+
+  beforeEach(() => {
+    rule = axe.utils.getRule('button-name');
+  });
+
+  afterEach(() => {
+    fixture.innerHTML = '';
+  });
+
+  it('returns true for a normal button', () => {
+    const vNode = queryFixture('<button id="target"></button>');
+    const actual = rule.matches(vNode.actualNode, vNode);
+    assert.isTrue(actual);
+  });
+
+  it('returns false for a select button', () => {
+    const vNode = queryFixture(
+      '<select><button id="target"><selectedcontent></selectedcontent></button><option>a</option></select>'
+    );
+    const actual = rule.matches(vNode.actualNode, vNode);
+    assert.isFalse(actual);
+  });
+
+  it('returns true when element has an explicit role that requires an accessible name', () => {
+    const vNode = queryFixture('<button id="target" role="button"></button>');
+    const actual = rule.matches(vNode.actualNode, vNode);
+    assert.isTrue(actual);
+  });
+
+  it('returns false when element has a role that does not require an accessible name and is not focusable', () => {
+    const vNode = queryFixture(
+      '<button id="target" role="separator" disabled></button>'
+    );
+    const actual = rule.matches(vNode.actualNode, vNode);
+    assert.isFalse(actual);
+  });
+});


### PR DESCRIPTION
The HTML spec makes the button and selectedcontent inside a select inert: they are excluded from the accessibility tree and cannot be focused. Without this, the customizable-select (`appearance: base-select`) markup reports a false-positive `button-name` violation.

#### Describe the changes

- `isInert` (`lib/commons/dom/is-inert.js`) now treats any `<button>` that is a direct child of a `<select>`, and any `<selectedcontent>` element, as inert, per the [HTML spec's `select` element definition](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element). This is unconditional — it doesn't check the select's rendered `appearance` — since inertness is an HTML behavior, not a CSS one. This change propagates to `isVisibleToScreenReaders` and `focusDisabled`/`isFocusable`, which already delegate to `isInert`, so `nested-interactive`, `color-contrast`, and any other rule relying on those utilities also benefit.
- Added `lib/rules/button-name-matches.js`, wrapping `no-explicit-name-required-matches` with an `isInert` check, and pointed `button-name.json`'s `matches` at it. This is needed because `axe.runVirtualRule` forces `excludeHidden: false` and bypasses the gather-time visibility filter that `axe.run` applies.
- Added unit tests covering the select button/`selectedcontent` cases (including Shadow DOM) in `test/commons/dom/is-inert.js`, `is-visible-to-screenreader.js`, `focus-disabled.js`, and `is-focusable.js`.
- Added `test/rule-matches/button-name-matches.js` and a `SerialVirtualNode` case in `test/integration/virtual-rules/button-name.js` to cover the `matches` function directly.
- Added an inapplicable select-button fixture to `test/integration/rules/button-name/button-name.html`.

#### Closes:

Closes issue #5315
