### PR TITLE
docs: clarify experimental rules are disabled in the axe browser extensions

### DIFF
--- a/build/configure.mjs
+++ b/build/configure.mjs
@@ -72,7 +72,7 @@ function buildRules(ctx, options, callback) {
       experimental: {
         title: 'Experimental Rules',
         intro:
-          'Rules we are still testing and developing. They are disabled by default in axe-core, but are enabled for the axe browser extensions.',
+          'Rules we are still testing and developing. They are disabled by default in axe-core and the axe browser extensions.',
         rules: []
       },
       deprecated: {

--- a/doc/rule-descriptions.md
+++ b/doc/rule-descriptions.md
@@ -138,7 +138,7 @@ Rules that check for conformance to WCAG AAA success criteria that can be fully 
 
 ## Experimental Rules
 
-Rules we are still testing and developing. They are disabled by default in axe-core, but are enabled for the axe browser extensions.
+Rules we are still testing and developing. They are disabled by default in axe-core and the axe browser extensions.
 
 | Rule ID                                                                                                                           | Description                                                                                                               | Impact   | Tags                                                                                                                             | Issue Type                 | [ACT Rules](https://www.w3.org/WAI/standards-guidelines/act/rules/) |
 | :-------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ | :------- | :------------------------------------------------------------------------------------------------------------------------------- | :------------------------- | :------------------------------------------------------------------ |


### PR DESCRIPTION
The **Experimental Rules** section of `doc/rule-descriptions.md` stated that
experimental rules "are enabled for the axe browser extensions." They are
disabled there by default — the old axe "coconut" extension enabled them, but
axe DevTools does not. The old wording led users to expect experimental rules
such as `label-content-name-mismatch` to run in the extension and file false
"missing" reports when they didn't (#4381).

This corrects the section blurb at its source (`build/configure.mjs`) and
regenerates `doc/rule-descriptions.md`. The matching copy in
[dequelabs/axe-rule-help#250](https://github.com/dequelabs/axe-rule-help/pull/250)
updates the rendered docs on dequeuniversity.com.

Closes #4381
