### PR TITLE
perf(check-helper): iterate relatedNodes without copying the array

### DIFF
--- a/lib/core/utils/check-helper.js
+++ b/lib/core/utils/check-helper.js
@@ -1,4 +1,3 @@
-import toArray from './to-array';
 import DqElement from './dq-element';
 import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
 
@@ -34,19 +33,18 @@ function checkHelper(checkResult, options, resolve, reject) {
         nodes instanceof AbstractVirtualNode
       ) {
         nodes = [nodes];
-      } else {
-        nodes = toArray(nodes);
       }
+
       checkResult.relatedNodes = [];
-      nodes.forEach(node => {
+      for (let i = 0; i < nodes.length; i++) {
+        let node = nodes[i];
         if (node instanceof AbstractVirtualNode) {
           node = node.actualNode;
         }
         if (node instanceof window.Node) {
-          const dqElm = new DqElement(node);
-          checkResult.relatedNodes.push(dqElm);
+          checkResult.relatedNodes.push(new DqElement(node));
         }
-      });
+      }
     }
   };
 }


### PR DESCRIPTION
Closes #5320

## What

`checkHelper.relatedNodes` copied the incoming array-like into a real array with `toArray` purely so it could be walked with `forEach`. The copy is now unnecessary — the loop reads the array-like directly.

```diff
-      } else {
-        nodes = toArray(nodes);
       }
+
       checkResult.relatedNodes = [];
-      nodes.forEach(node => {
+      for (let i = 0; i < nodes.length; i++) {
+        let node = nodes[i];
```

The `toArray` import is dropped with it. One file, +9/-7.

## Why

`toArray` is `Array.prototype.slice.call(thing)`, so every call allocated a second array the same size as the input. Both that copy and the original are unreachable as soon as the function returns, so a check reporting thousands of related nodes generates a large amount of short-lived garbage for no benefit.

## Results

Chrome, a page of 5,000 duplicate ARIA-referenced ids running `duplicate-id-aria` — the shape that produces the largest `relatedNodes` arrays in the suite (4,999 related nodes per result):

| | Median of 3 runs |
|---|---|
| Before | 10,505 ms |
| After | 10,276 ms |
| | **-2.2%** |

Results are identical (same incomplete count, same 4,999 related nodes).

For context on why the gain is bounded on this fixture, a CPU profile of that run attributes 48% of the time to memoizee's cache-key resolution inside `DqElement`, 13% to selector generation, and only 1.0% to garbage collection with 0.2% in `relatedNodes` itself. The allocation removed here is real, but on current `develop` it is not what dominates this workload.

## Testing

Full unit suite: 484 test files passing. `test/core/utils/check-helper.js` already covers the input shapes this touches — `HTMLCollection`, a single node, a real array, a single virtual node, `vNode.children`, a mixed array containing `null`/`true`/strings, and a `SerialVirtualNode` that must no-op.
