### PR TITLE
perf(color): replace private class members in Color

### DIFF
--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -124,70 +124,63 @@ export default class Color {
    */
   parseString(colorString) {
     // parsing is by far the most expensive part of Color, and a page reuses
-    // the same handful of color strings across thousands of elements
-    const parsedColors = cache.get('parsedColors', () => new Map());
-    const parsed = parsedColors.get(colorString);
-    if (parsed) {
-      this.r = parsed.r;
-      this.g = parsed.g;
-      this.b = parsed.b;
-      this.alpha = parsed.alpha;
-      return this;
-    }
-    const cacheKey = colorString;
+    // the same handful of color strings across thousands of elements.
+    // null prototype so a colour string like `constructor` can't resolve to
+    // an inherited property
+    const parsedColors = cache.get('parsedColors', () => Object.create(null));
+    let color = parsedColors[colorString];
 
-    // Colorjs <v0.5.0 does not support rad or turn angle values
-    // @see https://github.com/LeaVerou/color.js/issues/311
-    colorString = colorString.replace(hslRegex, (match, angle, unit) => {
-      const value = angle + unit;
+    if (!color) {
+      const cacheKey = colorString;
 
-      switch (unit) {
-        case 'rad':
-          return match.replace(value, radToDeg(angle));
-        case 'turn':
-          return match.replace(value, turnToDeg(angle));
+      // Colorjs <v0.5.0 does not support rad or turn angle values
+      // @see https://github.com/LeaVerou/color.js/issues/311
+      colorString = colorString.replace(hslRegex, (match, angle, unit) => {
+        const value = angle + unit;
+
+        switch (unit) {
+          case 'rad':
+            return match.replace(value, radToDeg(angle));
+          case 'turn':
+            return match.replace(value, turnToDeg(angle));
+        }
+      });
+
+      try {
+        // revert prototype.js override of Array.from
+        // in order to get color-contrast working
+        // @see https://github.com/dequelabs/axe-core/issues/4428
+        let prototypeArrayFrom;
+        if ('Prototype' in window && 'Version' in window.Prototype) {
+          prototypeArrayFrom = Array.from;
+          Array.from = ArrayFrom;
+        }
+
+        // srgb values are between 0 and 1
+        color = new Colorjs(colorString)
+          .toGamut({
+            space: 'srgb',
+            method: 'clip'
+          })
+          .to('srgb');
+
+        if (prototypeArrayFrom) {
+          Array.from = prototypeArrayFrom;
+          prototypeArrayFrom = null;
+        }
+      } catch {
+        incompleteData.set('colorParse', colorString);
+        throw new Error(`Unable to parse color "${colorString}"`);
       }
-    });
 
-    try {
-      // revert prototype.js override of Array.from
-      // in order to get color-contrast working
-      // @see https://github.com/dequelabs/axe-core/issues/4428
-      let prototypeArrayFrom;
-      if ('Prototype' in window && 'Version' in window.Prototype) {
-        prototypeArrayFrom = Array.from;
-        Array.from = ArrayFrom;
-      }
-
-      // srgb values are between 0 and 1
-      const color = new Colorjs(colorString)
-        .toGamut({
-          space: 'srgb',
-          method: 'clip'
-        })
-        .to('srgb');
-
-      if (prototypeArrayFrom) {
-        Array.from = prototypeArrayFrom;
-        prototypeArrayFrom = null;
-      }
-
-      this.r = color.r;
-      this.g = color.g;
-      this.b = color.b;
-      // color.alpha is a Number object so convert it to a number
-      this.alpha = +color.alpha;
-    } catch {
-      incompleteData.set('colorParse', colorString);
-      throw new Error(`Unable to parse color "${colorString}"`);
+      parsedColors[cacheKey] = color;
     }
 
-    parsedColors.set(cacheKey, {
-      r: this.r,
-      g: this.g,
-      b: this.b,
-      alpha: this.alpha
-    });
+    this.r = color.r;
+    this.g = color.g;
+    this.b = color.b;
+    // color.alpha is a Number object so convert it to a number
+    this.alpha = +color.alpha;
 
     return this;
   }

--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -1,5 +1,6 @@
 import { Colorjs, ArrayFrom } from '../../core/imports';
 import incompleteData from './incomplete-data';
+import cache from '../../core/base/cache';
 
 const hexRegex = /^#[0-9a-f]{3,8}$/i;
 const hslRegex = /hsl\(\s*([-\d.]+)(rad|turn)/;
@@ -122,6 +123,19 @@ export default class Color {
    * @instance
    */
   parseString(colorString) {
+    // parsing is by far the most expensive part of Color, and a page reuses
+    // the same handful of color strings across thousands of elements
+    const parsedColors = cache.get('parsedColors', () => new Map());
+    const parsed = parsedColors.get(colorString);
+    if (parsed) {
+      this.r = parsed.r;
+      this.g = parsed.g;
+      this.b = parsed.b;
+      this.alpha = parsed.alpha;
+      return this;
+    }
+    const cacheKey = colorString;
+
     // Colorjs <v0.5.0 does not support rad or turn angle values
     // @see https://github.com/LeaVerou/color.js/issues/311
     colorString = colorString.replace(hslRegex, (match, angle, unit) => {
@@ -167,6 +181,13 @@ export default class Color {
       incompleteData.set('colorParse', colorString);
       throw new Error(`Unable to parse color "${colorString}"`);
     }
+
+    parsedColors.set(cacheKey, {
+      r: this.r,
+      g: this.g,
+      b: this.b,
+      alpha: this.alpha
+    });
 
     return this;
   }

--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -13,15 +13,6 @@ const hslRegex = /hsl\(\s*([-\d.]+)(rad|turn)/;
  * @param {number} alpha
  */
 export default class Color {
-  // color channel values typically in the range of 0-1 (can go below or above)
-  #r;
-  #g;
-  #b;
-  // color component values resolved to the sRGB color space (0-255)
-  #red;
-  #green;
-  #blue;
-
   constructor(red, green, blue, alpha = 1) {
     if (red instanceof Color) {
       // preserve out of gamut values
@@ -47,57 +38,57 @@ export default class Color {
   }
 
   get r() {
-    return this.#r;
+    return this._r;
   }
 
   set r(value) {
-    this.#r = value;
-    this.#red = Math.round(clamp(value, 0, 1) * 255);
+    this._r = value;
+    this._red = Math.round(clamp(value, 0, 1) * 255);
   }
 
   get g() {
-    return this.#g;
+    return this._g;
   }
 
   set g(value) {
-    this.#g = value;
-    this.#green = Math.round(clamp(value, 0, 1) * 255);
+    this._g = value;
+    this._green = Math.round(clamp(value, 0, 1) * 255);
   }
 
   get b() {
-    return this.#b;
+    return this._b;
   }
 
   set b(value) {
-    this.#b = value;
-    this.#blue = Math.round(clamp(value, 0, 1) * 255);
+    this._b = value;
+    this._blue = Math.round(clamp(value, 0, 1) * 255);
   }
 
   get red() {
-    return this.#red;
+    return this._red;
   }
 
   set red(value) {
-    this.#r = value / 255;
-    this.#red = clamp(value, 0, 255);
+    this._r = value / 255;
+    this._red = clamp(value, 0, 255);
   }
 
   get green() {
-    return this.#green;
+    return this._green;
   }
 
   set green(value) {
-    this.#g = value / 255;
-    this.#green = clamp(value, 0, 255);
+    this._g = value / 255;
+    this._green = clamp(value, 0, 255);
   }
 
   get blue() {
-    return this.#blue;
+    return this._blue;
   }
 
   set blue(value) {
-    this.#b = value / 255;
-    this.#blue = clamp(value, 0, 255);
+    this._b = value / 255;
+    this._blue = clamp(value, 0, 255);
   }
 
   /**
@@ -242,20 +233,6 @@ export default class Color {
   }
 
   /**
-   * Add a value to the color channels
-   * @private
-   * @param  {number}  value  The value to add
-   * @return {Color} A new color instance
-   */
-  #add(value) {
-    const C = new Color(this);
-    C.r += value;
-    C.g += value;
-    C.b += value;
-    return C;
-  }
-
-  /**
    * Get the luminosity of a color
    * using algorithm from https://www.w3.org/TR/compositing-1/#blendingnonseparable
    * @method getLuminosity
@@ -278,7 +255,7 @@ export default class Color {
    */
   setLuminosity(L) {
     const d = L - this.getLuminosity();
-    return this.#add(d).clip();
+    return addToChannels(this, d).clip();
   }
 
   /**
@@ -373,4 +350,18 @@ function radToDeg(rad) {
 // convert turn to degrees
 function turnToDeg(turn) {
   return turn * 360;
+}
+
+/**
+ * Add a value to each color channel
+ * @param  {Color}  color  The color to add to
+ * @param  {number} value  The value to add
+ * @return {Color} A new color instance
+ */
+function addToChannels(color, value) {
+  const C = new Color(color);
+  C.r += value;
+  C.g += value;
+  C.b += value;
+  return C;
 }

--- a/lib/commons/color/color.js
+++ b/lib/commons/color/color.js
@@ -124,10 +124,8 @@ export default class Color {
    */
   parseString(colorString) {
     // parsing is by far the most expensive part of Color, and a page reuses
-    // the same handful of color strings across thousands of elements.
-    // null prototype so a colour string like `constructor` can't resolve to
-    // an inherited property
-    const parsedColors = cache.get('parsedColors', () => Object.create(null));
+    // the same handful of color strings across thousands of elements
+    const parsedColors = cache.get('parsedColors', () => ({}));
     let color = parsedColors[colorString];
 
     if (!color) {


### PR DESCRIPTION
Closes #5295

Two commits, covering both halves of the issue:

- **`769c85d4`** — remove the private class members from `Color`.
- **`c37e5e1d`** — stop calling colorjs repeatedly for the same colour string.

## What

**Private members.** The six private channel fields `#r #g #b #red #green #blue` become `_r _g _b _red _green _blue`, and the private method `#add(value)` becomes a module level `addToChannels(color, value)` helper. The getter/setter pairs and the 0-1 ↔ 0-255 synchronisation are unchanged.

**Parse cache.** `parseString` now memoises its result for the run in a `Map` held in the axe cache, keyed on the colour string. The lookup happens before the `hsl` rewrite so a hit skips that too, and the entry is only written on success, so unparseable colours still throw and record `incompleteData` exactly as before.

## Why

Babel compiles private fields and methods into per-instance helper calls. A CPU profile of a 12,000 element page attributed **852ms of 5,323ms to `_classPrivateFieldInitSpec` alone**, every caller being `Color`:

```
303ms  Color <- createStackingContext <- addToStackingContext
 86ms  Color <- getOwnBackgroundColor <- _getBackgroundColor
 66ms  Color <- getOwnBackgroundColor <- _getStackingContext
 65ms  Color <- createStackingContext <- _stackingContextToColor
```

Separately, every `parseString` call built a fresh `Colorjs` instance and ran it through `toGamut()` and a colour space conversion. A page reuses a small palette across thousands of elements, so nearly all of that work was repeated. Note that `parseString`'s own self time is only ~27ms — the cost is almost entirely in its callees, which is why caching it is worth far more than a self-time reading suggests.

## Results

Chrome, medians of 12 runs:

| Fixture | Before | After private members | After both | Total change |
|---|---|---|---|---|
| 12,000 elements | 5393 ms | 3465 ms | **2772 ms** | **-48.6%** |
| 4,000 paragraphs, 8×4 colour palette | 1862 ms | — | **1472 ms** | **-21.0%** |

`_classPrivateFieldInitSpec` drops from 935ms to 40ms; the residue is the bundled colorjs, which still uses private fields internally and is pinned by #4428. Results are identical throughout — same violations, passes, incomplete and relatedNodes counts.

## Observable changes

Private fields are not merely an implementation detail, so this is worth stating plainly rather than calling it a no-op:

1. **The channel storage is now enumerable.** `Object.keys(color)` and `{ ...color }` include the six underscore properties, where previously `alpha` was the only own enumerable property. `JSON.stringify` is unaffected, because `toJSON()` already controls serialisation.
2. **The channel storage is now writable from outside.** Assigning `color._r` directly no longer updates `_red`, so a caller can put a `Color` into an inconsistent state. Going through the documented `r` / `red` setters still maintains the pair, exactly as before.

This matches how every other public class in axe-core stores its internals — `VirtualNode._cache` / `_isHidden` / `_isXHTML` / `_type`, `SerialVirtualNode._props` / `_attrs`, and `DqElement._element` / `_virtualNode` / `_options` are all enumerable and writable.

Deriving one representation from the other, so the invariant could not be broken at all, is not equivalent: the setters are deliberately asymmetric. `set r` rounds (`Math.round(clamp(value, 0, 1) * 255)`) while `set red` does not (`clamp(value, 0, 255)`), so `new Color(64.5, …)` preserves `red === 64.5` today. Deriving would round it and change behaviour.

## Testing

Full unit suite: 484 test files passing.

This also strengthens the colour suites incidentally: because the channel values were previously private, the ~117 `assert.deepEqual(colorA, colorB)` assertions across `test/commons/color/` were comparing only `alpha`. They now compare all six channels, and still pass.
