### PR TITLE
perf(commons): use primitive mode for DOM node memoizations

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -192,8 +192,8 @@ function findPseudoElement(
   const rect = vNode.boundingClientRect;
   const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
   do {
-    const beforeSize = getPseudoElementArea(vNode.actualNode, ':before');
-    const afterSize = getPseudoElementArea(vNode.actualNode, ':after');
+    const beforeSize = getPseudoElementArea(vNode, ':before');
+    const afterSize = getPseudoElementArea(vNode, ':after');
     if (beforeSize + afterSize > minimumSize) {
       return vNode; // Combined area of before and after exceeds the minimum size
     }
@@ -201,8 +201,8 @@ function findPseudoElement(
 }
 
 const getPseudoElementArea = memoize(
-  function getPseudoElementAreaMemoized(node, pseudo) {
-    const style = window.getComputedStyle(node, pseudo);
+  function getPseudoElementAreaMemoized(vNode, pseudo) {
+    const style = window.getComputedStyle(vNode.actualNode, pseudo);
     const matchPseudoStyle = (prop, value) =>
       style.getPropertyValue(prop) === value;
     if (
@@ -229,7 +229,8 @@ const getPseudoElementArea = memoize(
       return pseudoWidth.value === 0 || pseudoHeight.value === 0 ? 0 : Infinity;
     }
     return pseudoWidth.value * pseudoHeight.value;
-  }
+  },
+  { primitive: true }
 );
 
 function textIsEmojis(visibleText) {

--- a/lib/commons/dom/get-visible-child-text-rects.js
+++ b/lib/commons/dom/get-visible-child-text-rects.js
@@ -10,9 +10,13 @@ import getOverflowHiddenAncestors from './get-overflow-hidden-ancestors';
  * @instance
  * @param {Element} node
  */
-const getVisibleChildTextRects = memoize(
-  function getVisibleChildTextRectsMemoized(node) {
-    const vNode = getNodeFromTree(node);
+function getVisibleChildTextRects(node) {
+  return getVisibleChildTextRectsVirtual(getNodeFromTree(node));
+}
+
+const getVisibleChildTextRectsVirtual = memoize(
+  function getVisibleChildTextRectsMemoized(vNode) {
+    const node = vNode.actualNode;
     const nodeRect = vNode.boundingClientRect;
     const clientRects = [];
     const overflowHiddenNodes = getOverflowHiddenAncestors(vNode);
@@ -47,7 +51,8 @@ const getVisibleChildTextRects = memoize(
     return clientRects.length
       ? clientRects
       : filterHiddenRects([nodeRect], overflowHiddenNodes);
-  }
+  },
+  { primitive: true }
 );
 export default getVisibleChildTextRects;
 

--- a/lib/commons/table/to-grid.js
+++ b/lib/commons/table/to-grid.js
@@ -9,16 +9,11 @@ import { getNodeFromTree, memoize } from '../../core/utils';
  * @return {Array<HTMLTableCellElement>} Array of HTMLTableCellElements
  */
 function toGrid(node) {
-  const vNode = getNodeFromTree(node);
-  // tables outside the virtual tree have no key to cache against
-  return vNode ? toGridVirtual(vNode) : computeGrid(node);
+  return toGridVirtual(getNodeFromTree(node));
 }
 
 function toGridMemoized(vNode) {
-  return computeGrid(vNode.actualNode);
-}
-
-function computeGrid(node) {
+  const node = vNode.actualNode;
   const table = [];
   const rows = node.rows;
   for (let i = 0, rowLength = rows.length; i < rowLength; i++) {

--- a/lib/commons/table/to-grid.js
+++ b/lib/commons/table/to-grid.js
@@ -1,4 +1,4 @@
-import { memoize } from '../../core/utils';
+import { getNodeFromTree, memoize } from '../../core/utils';
 
 /**
  * Converts a table to an Array of arrays, normalized for row and column spans
@@ -9,6 +9,16 @@ import { memoize } from '../../core/utils';
  * @return {Array<HTMLTableCellElement>} Array of HTMLTableCellElements
  */
 function toGrid(node) {
+  const vNode = getNodeFromTree(node);
+  // tables outside the virtual tree have no key to cache against
+  return vNode ? toGridVirtual(vNode) : computeGrid(node);
+}
+
+function toGridMemoized(vNode) {
+  return computeGrid(vNode.actualNode);
+}
+
+function computeGrid(node) {
   const table = [];
   const rows = node.rows;
   for (let i = 0, rowLength = rows.length; i < rowLength; i++) {
@@ -45,4 +55,6 @@ function toGrid(node) {
   return table;
 }
 
-export default memoize(toGrid);
+const toGridVirtual = memoize(toGridMemoized, { primitive: true });
+
+export default toGrid;

--- a/test/checks/tables/caption-faked.js
+++ b/test/checks/tables/caption-faked.js
@@ -26,6 +26,8 @@ describe('caption-faked', () => {
       </table>
     `;
 
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
+
     const node = fixture.querySelector('table');
     assert.isTrue(captionFaked.evaluate(node));
   });
@@ -42,6 +44,8 @@ describe('caption-faked', () => {
       </table>
     `;
 
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
+
     const node = fixture.querySelector('table');
     assert.isTrue(captionFaked.evaluate(node));
   });
@@ -54,6 +58,8 @@ describe('caption-faked', () => {
         </tr>
       </table>
     `;
+
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
 
     const node = fixture.querySelector('table');
     assert.isTrue(captionFaked.evaluate(node));
@@ -72,6 +78,8 @@ describe('caption-faked', () => {
       </table>
     `;
 
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
+
     const node = fixture.querySelector('table');
     assert.isTrue(captionFaked.evaluate(node));
   });
@@ -89,6 +97,8 @@ describe('caption-faked', () => {
       </table>
     `;
 
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
+
     const node = fixture.querySelector('table');
     assert.isFalse(captionFaked.evaluate(node));
   });
@@ -105,6 +115,8 @@ describe('caption-faked', () => {
         </tr>
       </table>
     `;
+
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
 
     const node = fixture.querySelector('table');
     assert.isFalse(captionFaked.evaluate(node));

--- a/test/commons/table/to-grid.js
+++ b/test/commons/table/to-grid.js
@@ -24,6 +24,8 @@ describe('table.toGrid', () => {
       </table>
     `;
 
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
+
     const target = fixture.querySelector('table');
 
     assert.deepEqual(axe.commons.table.toGrid(target), [
@@ -44,6 +46,8 @@ describe('table.toGrid', () => {
         </tr>
       </table>
     `;
+
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
 
     const target = fixture.querySelector('table');
 
@@ -68,6 +72,8 @@ describe('table.toGrid', () => {
       </table>
     `;
 
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
+
     const target = fixture.querySelector('table');
 
     assert.deepEqual(axe.commons.table.toGrid(target), [
@@ -88,6 +94,8 @@ describe('table.toGrid', () => {
         </tr>
       </table>
     `;
+
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
 
     const target = fixture.querySelector('table');
 
@@ -112,6 +120,8 @@ describe('table.toGrid', () => {
       </table>
     `;
 
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
+
     const target = fixture.querySelector('table');
 
     assert.deepEqual(axe.commons.table.toGrid(target), [
@@ -129,6 +139,8 @@ describe('table.toGrid', () => {
         </tr>
       </table>
     `;
+
+    axe.testUtils.flatTreeSetup(fixture.firstElementChild);
 
     const target = fixture.querySelector('table');
 


### PR DESCRIPTION
Refs #5294 — the passthrough half, following on from #5319.

## The criterion

Primitive mode builds its cache key by calling `String()` on each argument up to `fn.length`, so a function is convertible only if **every** keyed argument stringifies uniquely. After #5319 a virtual node does, via `AbstractVirtualNode#toString`; strings, numbers and booleans always have. Objects do not — every `HTMLTableCellElement` stringifies to the same `[object HTMLTableCellElement]`.

Applying that to the five memoized functions that take a DOM node:

| Function | Arguments | Convertible |
|---|---|---|
| `getVisibleChildTextRects` | `(node)` | ✅ single node → virtual node |
| `toGrid` | `(node)` | ✅ single node → virtual node |
| `getPseudoElementArea` | `(node, pseudo)` | ✅ node → virtual node, `pseudo` is `':before'` / `':after'` |
| `getScroll` | `(elm, buffer)` | ⛔ keys fine, but blocked by an architectural rule — see below |
| `getCellPosition` | `(cell, tableGrid)` | ⛔ second argument is an array of cells |

## What changed

The three convertible functions now resolve the node to a virtual node and delegate to a primitive-mode memoized function, so the cache keys on a string rather than object identity:

- **`getVisibleChildTextRects`** — the example given in the issue. It already called `getNodeFromTree` internally; that now happens in the passthrough.
- **`toGrid`** — same shape, plus an uncached path for tables outside the virtual tree (see below).
- **`getPseudoElementArea`** — no passthrough needed: both call sites already hold the virtual node and were passing `vNode.actualNode`, so it now takes the virtual node directly.

## Honest note on the numbers

**This is a consistency change, not a measured win.** Neither function is hot enough for the cache-key lookup to register:

| | develop | this branch |
|---|---|---|
| `getVisibleChildTextRects` (4,000 paragraph page) | 0 ms | 0 ms |
| `toGrid` (60 tables × 26 × 8) | 2 ms | 0 ms |

Whole-run timing is flat in both directions across two rounds of 12, with overlapping ranges — no gain and no regression. The value is that these no longer scale as O(N²) in cache lookups if they ever do become hot, and that the codebase applies one pattern consistently.

## A note on the tests

`toGrid` is called from tests that set `fixture.innerHTML` without building a virtual tree, so `getNodeFromTree` returned `null` once it started resolving the node. Since any function in `commons` can expect the tree to be set up, the fix is in the tests: `test/commons/table/to-grid.js` and `test/checks/tables/caption-faked.js` now call `axe.testUtils.flatTreeSetup(fixture.firstElementChild)`, matching `test/commons/table/get-cell-position.js`.

## Why the other two are not converted

**`getScroll` — blocked by the `core/utils` boundary, not by its arguments.** `(elm, buffer)` would key perfectly well as a virtual node plus a number. The problem is that adding a passthrough means touching a virtual node inside `lib/core/utils/`, which our own eslint rule rejects:

> Utils is meant for utility functions that work independently of axe's state; utilities that require the virtual tree to be set up should go in commons, not utils.

There is an `ignores` list, but it is explicitly for files with "known uses of virtual node that are legacy before this rule was enforced", so adding `get-scroll.js` would be working around the rule rather than qualifying for it. The options are to move `getScroll` to `commons` — it is public API as `axe.utils.getScroll` — to widen the exemption, or to leave it. That is a design call, so it is raised on #5294 rather than decided here. It applies to any other `core/utils` function we would want to convert this way.

**`getCellPosition` — the second argument defeats the key.** It takes `(cell, tableGrid)` where `tableGrid` is an array of cells. The primitive key would be `String(tableGrid)`, and since every cell stringifies to `[object HTMLTableCellElement]`, two structurally identical tables produce an identical key — the second table would silently receive the first table's positions.

Keying on `cell` alone would be correct today: the position is a function of the cell, and all three callers pass `toGrid(findUp(cell, 'table'))`, the cell's own grid. But that makes correctness depend on no future caller passing a foreign grid, so it is left in default mode pending a decision on #5294.

## Testing

Full unit suite: 484 test files passing. Results identical on every benchmark fixture.

