### PR TITLE
perf(dq-element): cache DqElement per element

### DIFF
--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -34,7 +34,6 @@ const DqElement = function DqElement(elm, options, spec) {
     if (cachedDqElement) {
       return cachedDqElement;
     }
-    dqElementCache.set(elm, this);
   }
 
   options ??= null;
@@ -84,6 +83,12 @@ const DqElement = function DqElement(elm, options, spec) {
   // TODO: es-modules_audit
   if (!axe._audit.noHtml) {
     this.source = this.spec.source ?? getSource(this._element);
+  }
+
+  // cached only once initialization has succeeded, so a constructor that
+  // throws does not leave a half built instance for the next caller
+  if (isCacheable) {
+    dqElementCache.set(elm, this);
   }
 
   return this;

--- a/lib/core/utils/dq-element.js
+++ b/lib/core/utils/dq-element.js
@@ -4,7 +4,6 @@ import getXpath from './get-xpath';
 import getNodeFromTree from './get-node-from-tree';
 import AbstractVirtualNode from '../base/virtual-node/abstract-virtual-node';
 import cache from '../base/cache';
-import memoize from './memoize';
 import getSource from './get-element-source';
 
 const CACHE_KEY = 'DqElm.RunOptions';
@@ -16,7 +15,28 @@ const CACHE_KEY = 'DqElm.RunOptions';
  * @param {Object} options Propagated from axe.run/etc
  * @param {Object} spec Properties to use in place of the element when instantiated on Elements from other frames
  */
-const DqElement = memoize(function DqElementMemoized(elm, options, spec) {
+const DqElement = function DqElement(elm, options, spec) {
+  // Memoizing DqElement is slow on large pages, because memoizee resolves the
+  // cache key by scanning every argument it has already seen. Deduplicating is
+  // still worth it though: without it a node that appears in many relatedNodes
+  // is serialized once per appearance.
+  // @see https://github.com/dequelabs/axe-core/pull/4452
+  // @see https://github.com/dequelabs/axe-core/issues/5298
+  const dqElementCache = cache.get('DqElementCache', () => new WeakMap());
+
+  // nodeSerializer passes a fresh spec for an element it has already created a
+  // DqElement for, so only calls without options or spec can share an instance.
+  // elm has to be an object to be a WeakMap key; it previously could be null
+  const isCacheable =
+    !options && !spec && elm !== null && typeof elm === 'object';
+  if (isCacheable) {
+    const cachedDqElement = dqElementCache.get(elm);
+    if (cachedDqElement) {
+      return cachedDqElement;
+    }
+    dqElementCache.set(elm, this);
+  }
+
   options ??= null;
   spec ??= {};
 
@@ -67,7 +87,7 @@ const DqElement = memoize(function DqElementMemoized(elm, options, spec) {
   }
 
   return this;
-});
+};
 
 DqElement.prototype = {
   /**

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -31,6 +31,41 @@ describe('DqElement', () => {
     assert.equal(result, result2);
   });
 
+  it('should return the same DqElement when instantiated with the same node', () => {
+    const vNode = queryFixture('<div id="target"></div>');
+    const result = new DqElement(vNode.actualNode);
+    const result2 = new DqElement(vNode.actualNode);
+    assert.equal(result, result2);
+  });
+
+  it('should not share a DqElement when a spec is passed', () => {
+    const vNode = queryFixture('<div id="target"></div>');
+    const shared = new DqElement(vNode);
+    const withSpec = new DqElement(vNode, null, { source: 'woot' });
+
+    assert.notEqual(withSpec, shared);
+    assert.equal(withSpec.source, 'woot');
+  });
+
+  it('should not let a spec replace the shared DqElement', () => {
+    const vNode = queryFixture('<div id="target"></div>');
+    const shared = new DqElement(vNode);
+    new DqElement(vNode, null, { source: 'woot' });
+
+    assert.equal(new DqElement(vNode), shared);
+  });
+
+  it('should not cache a DqElement that failed to initialize', () => {
+    const vNode = queryFixture('<div id="target"></div>');
+    const audit = axe._audit;
+
+    axe._audit = undefined;
+    assert.throws(() => new DqElement(vNode));
+    axe._audit = audit;
+
+    assert.isString(new DqElement(vNode).source);
+  });
+
   describe('element', () => {
     it('should store reference to the element', () => {
       const vNode = queryFixture('<div id="target"></div>');

--- a/test/core/utils/dq-element.js
+++ b/test/core/utils/dq-element.js
@@ -50,8 +50,9 @@ describe('DqElement', () => {
   it('should not let a spec replace the shared DqElement', () => {
     const vNode = queryFixture('<div id="target"></div>');
     const shared = new DqElement(vNode);
-    new DqElement(vNode, null, { source: 'woot' });
+    const withSpec = new DqElement(vNode, null, { source: 'woot' });
 
+    assert.notEqual(withSpec, shared);
     assert.equal(new DqElement(vNode), shared);
   });
 

--- a/test/core/utils/node-serializer.js
+++ b/test/core/utils/node-serializer.js
@@ -185,6 +185,7 @@ describe('nodeSerializer', () => {
     });
 
     it('converts DqElements relatedNodes to specs', () => {
+      fixture.innerHTML = '<p>related</p>';
       const dqElm = new DqElement(fixture);
       const related = new DqElement(fixture.querySelector('p'));
       const rawNodeResults = [


### PR DESCRIPTION
Closes #5298

Implements @straker's design from the issue, with the open TODO resolved.

## Why the memoize could not simply be removed

Both halves of the issue are true at once. Memoizing the constructor is slow, because memoizee resolves its cache key by scanning every argument it has already seen — but the deduplication it provides is load-bearing. #4452 added it precisely because a node appearing in many `relatedNodes` was otherwise serialized once per appearance, and removing it reinstates that. #5303 tried the deletion and measured 18% *slower* on a page of 5,000 duplicate ids.

So the fix is to keep the deduplication and make the lookup cheap.

## What

Replaces the `memoize` wrapper with a `WeakMap` held in the run cache, keyed on the element:

```js
const dqElementCache = cache.get('DqElementCache', () => new WeakMap());

const isCacheable = !options && !spec && elm !== null && typeof elm === 'object';
if (isCacheable) {
  const cachedDqElement = dqElementCache.get(elm);
  if (cachedDqElement) {
    return cachedDqElement;
  }
  dqElementCache.set(elm, this);
}
```

**On the TODO in the issue.** The sketch noted that the `set` would displace a cached instance when a `spec` was passed. Guarding the write with the same condition as the read fixes that: `nodeSerializer` passes a fresh spec for an element it has already created a `DqElement` for, and those calls now neither read from nor write to the cache. Seven of the nine call sites pass only a node and are cacheable; the two that pass a spec — `nodeSerializer.cloneLimitedDqElement` and the cross-frame path in `dq-element.js` — bypass it entirely.

The cache lives in the axe run cache, which `axe.teardown()` clears, so nothing survives a run.

## Results

Chrome, `duplicate-id-aria` over a page of 5,000 duplicate ARIA-referenced ids — the shape #4452 was written for:

| | Before | After |
|---|---|---|
| Total `axe.run` | 10700 ms | **5100 ms** |
| | | **-52.3%** |

A page without repeated related nodes is unchanged (4803 ms vs 4770 ms on a 12,000 element page, 12-run medians). Results are identical on both, and the deduplication contract still holds — `new DqElement(vNode)` twice returns the same instance, which `test/core/utils/dq-element.js` asserts.

## One question for review: the `null` guard

`elm !== null && typeof elm === 'object'` is there only to preserve existing behaviour. A `WeakMap` cannot key `null`, where memoizee could, so without it `new DqElement(null)` would throw instead of returning an object with an undefined element. `DqElement` is public API as `axe.utils.DqElement`.

No production path passes `null` — `rule.js:336` explicitly guards with `node.actualNode ? new DqElement(node) : null` — so this is purely about not breaking an external caller. Happy to drop it and let `null` throw if you would rather; it is two conditions of noise otherwise.

## A pre-existing test bug this surfaced

`test/core/utils/node-serializer.js` never populates its fixture, so `fixture.querySelector('p')` has always returned `null`. The test named "converts DqElements relatedNodes to specs" was building its related node from nothing, and passed only because the old cache tolerated a `null` key. It now creates a real `<p>` so it tests what its name says.

## Testing

Full unit suite: 484 test files passing.
