### PR TITLE
perf(aria): cache ARIA values on the virtual node

### DIFF
--- a/lib/commons/aria/get-aria-value.js
+++ b/lib/commons/aria/get-aria-value.js
@@ -39,6 +39,14 @@ export default function getAriaValue(node, attrName, options = {}) {
   const { vNode } = nodeLookup(node);
   const { lowercase } = options;
 
+  // ARIA values are read repeatedly for the same node during a run, so cache
+  // them on the virtual node. Serialized nodes have no cache and skip this.
+  const cacheKey = `getAriaValue:${attrName}:${!!lowercase}`;
+  const nodeCache = vNode?._cache;
+  if (nodeCache && cacheKey in nodeCache) {
+    return nodeCache[cacheKey];
+  }
+
   for (const { source, getValue } of sources) {
     let value = getValue(vNode, attrStandard, attrName);
     if (value === null || value === undefined) {
@@ -64,10 +72,17 @@ export default function getAriaValue(node, attrName, options = {}) {
         ']';
     }
 
-    return { value, source };
+    return cacheValue(nodeCache, cacheKey, { value, source });
   }
 
-  return { value: null, source: null };
+  return cacheValue(nodeCache, cacheKey, { value: null, source: null });
+}
+
+function cacheValue(nodeCache, cacheKey, value) {
+  if (nodeCache) {
+    nodeCache[cacheKey] = value;
+  }
+  return value;
 }
 
 function getAttributeValue(vNode, attrStandard, attrName) {

--- a/lib/commons/aria/has-aria-value.js
+++ b/lib/commons/aria/has-aria-value.js
@@ -17,11 +17,24 @@ export default function hasAriaValue(node, attrName) {
   }
 
   const { vNode } = nodeLookup(node);
-  return (
+
+  // ARIA values are read repeatedly for the same node during a run, so cache
+  // them on the virtual node. Serialized nodes have no cache and skip this.
+  const cacheKey = `hasAriaValue:${attrName}`;
+  const nodeCache = vNode?._cache;
+  if (nodeCache && cacheKey in nodeCache) {
+    return nodeCache[cacheKey];
+  }
+
+  const hasValue =
     hasAttributeValue(vNode, attrName) ||
     hasPropertyValue(vNode, attrStandard) ||
-    hasInternalValue(vNode, attrStandard)
-  );
+    hasInternalValue(vNode, attrStandard);
+
+  if (nodeCache) {
+    nodeCache[cacheKey] = hasValue;
+  }
+  return hasValue;
 }
 
 function hasAttributeValue(vNode, attrName) {

--- a/lib/commons/dom/get-resolved-refs.js
+++ b/lib/commons/dom/get-resolved-refs.js
@@ -24,10 +24,18 @@ export default function getResolvedRefs(node, attr, options = {}) {
   const { self = true } = options;
   const { vNode, domNode } = nodeLookup(node);
 
+  // resolving idrefs walks the document for every reference, and the same
+  // node/attribute pair is resolved repeatedly during a run
+  const cacheKey = `getResolvedRefs:${attr}:${self}`;
+  const nodeCache = vNode?._cache;
+  if (nodeCache && cacheKey in nodeCache) {
+    return nodeCache[cacheKey];
+  }
+
   try {
     const attrValue = getIdrefsValue(vNode, attr);
     if (!attrValue) {
-      return [];
+      return cacheRefs(nodeCache, cacheKey, []);
     }
 
     let refs;
@@ -43,15 +51,26 @@ export default function getResolvedRefs(node, attr, options = {}) {
     if (!self) {
       refs = refs.filter(n => n !== domNode);
     }
-    return refs.map(n => {
-      const virtualNode = getNodeFromTree(n);
-      return virtualNode ? virtualNode : null;
-    });
+    return cacheRefs(
+      nodeCache,
+      cacheKey,
+      refs.map(n => {
+        const virtualNode = getNodeFromTree(n);
+        return virtualNode ? virtualNode : null;
+      })
+    );
   } catch (cause) {
     throw new TypeError('Cannot resolve id references for non-DOM nodes', {
       cause
     });
   }
+}
+
+function cacheRefs(nodeCache, cacheKey, refs) {
+  if (nodeCache) {
+    nodeCache[cacheKey] = refs;
+  }
+  return refs;
 }
 
 function getIdrefsValue(vNode, attr) {

--- a/test/checks/label/title-only.js
+++ b/test/checks/label/title-only.js
@@ -14,7 +14,13 @@ describe('title-only', () => {
     node.type = 'text';
     node.title = 'Duplicate';
 
+    const labelledNode = document.createElement('input');
+    labelledNode.type = 'text';
+    labelledNode.title = 'Duplicate';
+    labelledNode.setAttribute('aria-label', 'woop');
+
     fixture.appendChild(node);
+    fixture.appendChild(labelledNode);
 
     axe.testUtils.flatTreeSetup(fixture);
 
@@ -25,12 +31,11 @@ describe('title-only', () => {
         axe.utils.getNodeFromTree(node)
       )
     );
-    node.setAttribute('aria-label', 'woop');
     assert.isFalse(
       axe.testUtils.getCheckEvaluate('title-only')(
-        node,
+        labelledNode,
         undefined,
-        axe.utils.getNodeFromTree(node)
+        axe.utils.getNodeFromTree(labelledNode)
       )
     );
   });
@@ -39,11 +44,18 @@ describe('title-only', () => {
     const node = document.createElement('input');
     node.type = 'text';
     node.setAttribute('aria-describedby', 'dby');
+
+    const labelledNode = document.createElement('input');
+    labelledNode.type = 'text';
+    labelledNode.setAttribute('aria-describedby', 'dby');
+    labelledNode.setAttribute('aria-label', 'woop');
+
     const dby = document.createElement('div');
     dby.id = 'dby';
     dby.innerHTML = 'woop';
 
     fixture.appendChild(node);
+    fixture.appendChild(labelledNode);
     fixture.appendChild(dby);
 
     axe.testUtils.flatTreeSetup(fixture);
@@ -55,12 +67,11 @@ describe('title-only', () => {
         axe.utils.getNodeFromTree(node)
       )
     );
-    node.setAttribute('aria-label', 'woop');
     assert.isFalse(
       axe.testUtils.getCheckEvaluate('title-only')(
-        node,
+        labelledNode,
         undefined,
-        axe.utils.getNodeFromTree(node)
+        axe.utils.getNodeFromTree(labelledNode)
       )
     );
   });


### PR DESCRIPTION
Closes #5300

## What

`getAriaValue`, `hasAriaValue` and `getResolvedRefs` now cache their result on the virtual node's existing `_cache` object, keyed by attribute name plus whichever option changes the answer — `lowercase` for `getAriaValue`, `self` for `getResolvedRefs`. Serialized virtual nodes have no `_cache` and fall through uncached.

## On the question in the issue

The issue asked whether to cache every property or only high-use ones. Instrumenting a run over an ARIA-heavy page (1,500 groups with labels, descriptions, states and idrefs) gives 112,524 calls, of which 13.3% would be repeats. Your split was right — a handful of attributes are read several times per node, and many are read exactly once:

| Call | Repeat rate |
|---|---|
| `getResolvedRefs:aria-labelledby` | 50% |
| `hasAriaValue:aria-labelledby` | 37% |
| `getAriaValue:aria-hidden` | 27% |
| `getAriaValue:aria-label` | 25% |
| `hasAriaValue:aria-owns` | 20% |
| `aria-disabled`, `aria-errormessage`, `aria-invalid`, `aria-level`, `aria-checked` | 0% |

This caches all of them rather than a selected list, since the cache is a property write on an object the virtual node already carries and a cold entry costs one missed key lookup.

## Honest note on the numbers

**I measure this as neutral, and I would rather say so than dress it up.** Three alternating rounds of ten runs on the ARIA-heavy fixture:

| Round | develop | this branch |
|---|---|---|
| 1 | 3982 ms | 4036 ms |
| 2 | 4026 ms | 3965 ms |
| 3 | 3719 ms | 3809 ms |

The sign flips between rounds, so it is inside the run-to-run noise on my machine. A 12,000 element page is likewise unchanged (4997 ms vs 4951 ms). An earlier prototype appeared to show -13.6%, but that did not survive repeated rounds — it was drift.

So the case for this rests on the call counts rather than a wall-clock win I can demonstrate. If you know of page shapes where these lookups dominate, they would be worth pointing the benchmark at; my fixtures may simply not be the right ones.

## The trade-off worth reviewing

Caching means an ARIA value is read once per node per run instead of on every call, so mutating an attribute part way through a run no longer changes the result.

That crosses a line the code currently draws deliberately: `VirtualNode` caches `props` and `attrNames` in `_cache`, but `attr()` reads live through `getAttribute`. Two tests in `test/checks/label/title-only.js` depended on the live read — they evaluated a node, set `aria-label` on it, and evaluated it again. They now use two separate elements and assert the same two behaviours without relying on a mid-run mutation. Nothing else in the suite was affected.

The pattern is reachable through public API — `axe.setup()` followed by manual check evaluation — so it is worth a deliberate decision rather than my assumption.

## Testing

Full unit suite: 484 test files passing. Results identical on every benchmark fixture.
