### PR TITLE
perf(color-contrast): memoize findPseudoElement

### DIFF
--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -181,24 +181,34 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
   return isValid;
 }
 
-const findPseudoElement = memoize(
-  function findPseudoElementMemoized(vNode, pseudoSizeThreshold) {
-    // assigned in the body rather than as a default parameter: default
-    // parameters are excluded from fn.length, which memoize uses to decide how
-    // many arguments to cache on
-    pseudoSizeThreshold ??= 0.25;
+function findPseudoElement(vNode, pseudoSizeThreshold) {
+  // assigned in the body rather than as a default parameter: default
+  // parameters are excluded from fn.length, which memoize uses to decide how
+  // many arguments to cache on
+  pseudoSizeThreshold ??= 0.25;
 
-    const rect = vNode.boundingClientRect;
-    const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
-    let ancestor = vNode;
-    do {
-      const beforeSize = getPseudoElementArea(ancestor, ':before');
-      const afterSize = getPseudoElementArea(ancestor, ':after');
-      if (beforeSize + afterSize > minimumSize) {
-        // Combined area of before and after exceeds the minimum size
-        return ancestor;
-      }
-    } while ((ancestor = ancestor.parent));
+  const rect = vNode.boundingClientRect;
+  const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
+  return findPseudoElementAbove(vNode, minimumSize);
+}
+
+// recursive rather than a loop so that each ancestor is cached in its own
+// right: descendants that resolve to the same minimum size reuse the answer
+// for the ancestors they share, instead of rewalking the chain
+const findPseudoElementAbove = memoize(
+  function findPseudoElementAboveMemoized(vNode, minimumSize) {
+    if (!vNode) {
+      return undefined;
+    }
+
+    const beforeSize = getPseudoElementArea(vNode, ':before');
+    const afterSize = getPseudoElementArea(vNode, ':after');
+    if (beforeSize + afterSize > minimumSize) {
+      // Combined area of before and after exceeds the minimum size
+      return vNode;
+    }
+
+    return findPseudoElementAbove(vNode.parent, minimumSize);
   },
   { primitive: true }
 );

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -55,10 +55,9 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
 
   // if element or a parent has pseudo content then we need to mark
   // as needs review
-  const pseudoElm = findPseudoElement(virtualNode, {
-    ignorePseudo,
-    pseudoSizeThreshold
-  });
+  const pseudoElm = ignorePseudo
+    ? undefined
+    : findPseudoElement(virtualNode, pseudoSizeThreshold);
   if (pseudoElm) {
     this.data({
       fontSize: `${((fontSize * 72) / 96).toFixed(1)}pt (${fontSize}px)`,
@@ -182,23 +181,27 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
   return isValid;
 }
 
-function findPseudoElement(
-  vNode,
-  { pseudoSizeThreshold = 0.25, ignorePseudo = false }
-) {
-  if (ignorePseudo) {
-    return;
-  }
-  const rect = vNode.boundingClientRect;
-  const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
-  do {
-    const beforeSize = getPseudoElementArea(vNode, ':before');
-    const afterSize = getPseudoElementArea(vNode, ':after');
-    if (beforeSize + afterSize > minimumSize) {
-      return vNode; // Combined area of before and after exceeds the minimum size
-    }
-  } while ((vNode = vNode.parent));
-}
+const findPseudoElement = memoize(
+  function findPseudoElementMemoized(vNode, pseudoSizeThreshold) {
+    // assigned in the body rather than as a default parameter: default
+    // parameters are excluded from fn.length, which memoize uses to decide how
+    // many arguments to cache on
+    pseudoSizeThreshold ??= 0.25;
+
+    const rect = vNode.boundingClientRect;
+    const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
+    let ancestor = vNode;
+    do {
+      const beforeSize = getPseudoElementArea(ancestor, ':before');
+      const afterSize = getPseudoElementArea(ancestor, ':after');
+      if (beforeSize + afterSize > minimumSize) {
+        // Combined area of before and after exceeds the minimum size
+        return ancestor;
+      }
+    } while ((ancestor = ancestor.parent));
+  },
+  { primitive: true }
+);
 
 const getPseudoElementArea = memoize(
   function getPseudoElementAreaMemoized(vNode, pseudo) {

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -1278,6 +1278,46 @@ x
       );
       assert.isUndefined(contrastEvaluate.apply(checkContext, params));
     });
+
+    it('should evaluate the same element separately per pseudoSizeThreshold', () => {
+      const params = checkSetup(
+        html`
+          <style>
+            .foo {
+              position: relative;
+              width: 100px;
+              height: 100px;
+            }
+            .foo:before {
+              content: '';
+              position: absolute;
+              width: 22%;
+              height: 100%;
+              background: red;
+            }
+          </style>
+          <p id="target" class="foo">Content</p>
+        `,
+        {
+          pseudoSizeThreshold: 0.2
+        }
+      );
+      const [node, options, vNode] = params;
+
+      // the pseudo element covers 22%, so it exceeds a 0.2 threshold
+      assert.isUndefined(contrastEvaluate.apply(checkContext, params));
+      assert.equal(checkContext._data.messageKey, 'pseudoContent');
+
+      // ...and the same element does not exceed a 0.3 one. A cache that left
+      // the threshold out of its key would report pseudo content here too
+      checkContext.reset();
+      contrastEvaluate.apply(checkContext, [
+        node,
+        { ...options, pseudoSizeThreshold: 0.3 },
+        vNode
+      ]);
+      assert.notEqual(checkContext._data?.messageKey, 'pseudoContent');
+    });
   });
 
   it('returns colors across Shadow DOM boundaries', () => {


### PR DESCRIPTION
Closes #5297

## What

`findPseudoElement` walked the ancestor chain in a loop, which meant it could not benefit from memoization: two sibling elements sharing thirty ancestors each rewalked all thirty. It is now split in two.

```js
function findPseudoElement(vNode, pseudoSizeThreshold) {
  pseudoSizeThreshold ??= 0.25;
  const rect = vNode.boundingClientRect;
  const minimumSize = rect.width * rect.height * pseudoSizeThreshold;
  return findPseudoElementAbove(vNode, minimumSize);
}

const findPseudoElementAbove = memoize(
  function findPseudoElementAboveMemoized(vNode, minimumSize) { ... },
  { primitive: true }
);
```

The outer function resolves the minimum size once; the inner one recurses, so **each ancestor is cached in its own right** and descendants resolving to the same minimum size reuse the answers for the ancestors they share. Thanks @straker — that was the missing piece, and it is the same shape that made #5296 worthwhile.

Two supporting changes let it be memoized at all:

- `ignorePseudo` moves to the call site, so a call that would return immediately never reaches the function
- `minimumSize` is carried down as a number rather than an options object, which also puts it in the cache key

`pseudoSizeThreshold ??= 0.25` is assigned in the body rather than as a default parameter, because default parameters are excluded from `fn.length` and memoizee sizes its key from that — as a default it would silently drop out of the key, exactly as `buffer` did in `getScroll`.

## Honest note on the numbers

**This measures neutral, and the win the ticket was after has already been collected by #5324.**

When the ticket was sized, profiling memoizee's key resolution attributed **49ms** on a 12,000 element page to the `findPseudoElement → colorContrastEvaluate` path. That was not `findPseudoElement` itself — it was `getPseudoElementArea`'s cache lookup, and #5324 converted that function to primitive mode. On current develop, `findPseudoElement` measures 0–2ms of self time and `getPseudoElementArea` measures 0ms.

End-to-end after the recursive rewrite, medians of 10 runs:

| Fixture | develop | this branch |
|---|---|---|
| 120 branches × 30 deep, `::before`/`::after` on every level | 1069 ms | 1056 ms |
| same, second round | 1058 ms | 1058 ms |
| 12,000 elements | 2186 ms | 2183 ms |

The deep fixture exists specifically to stress this: deep ancestor chains, real pseudo content at every level, contrast-checked text at every leaf. The recursion removes the repeated traversal, but the traversal was already cheap — `getPseudoElementArea` has been memoized per ancestor since #5324, so every level was resolving from cache regardless.

So this is better-shaped code that does not move the clock. Happy for it to be closed unmerged like #5326 if you would rather not carry it, and equally happy to be wrong if your benchmark sites show otherwise.

## Test

`should evaluate the same element separately per pseudoSizeThreshold` covers the key that Copilot flagged: one element whose pseudo content covers 22% reports `pseudoContent` at a `0.2` threshold and does not at `0.3`. Verified against the defect rather than just observed passing — setting `{ length: 1 }` on the memoize call, which is what an arity mistake looks like, fails it with `expected 'pseudoContent' to not equal 'pseudoContent'`.

## Testing

Full unit suite: 484 test files passing.
