### PR TITLE
perf(aria): cache getRole per node

### DIFF
--- a/lib/commons/aria/get-role.js
+++ b/lib/commons/aria/get-role.js
@@ -117,14 +117,13 @@ export function hasConflictResolution(vNode) {
 /**
  *
  * @method resolveRole
- * @param {Element|VirtualNode} node
+ * @param {VirtualNode} vNode
  * @param {Object} options
  * @see getRole for option details
  * @returns {string|null} Role or null
  * @deprecated noImplicit option is deprecated. Use aria.getExplicitRole instead.
  */
-function resolveRole(node, { noImplicit, ...roleOptions } = {}) {
-  const { vNode } = nodeLookup(node);
+function resolveRole(vNode, { noImplicit, ...roleOptions } = {}) {
   if (vNode.props.nodeType !== 1) {
     return null;
   }
@@ -184,7 +183,7 @@ function getRole(node, options = {}) {
   // still re-enter for the same node while it is being computed.
   const nodeCache = vNode?._cache;
   if (!nodeCache) {
-    return resolveRoleWithOptions(node, options);
+    return resolveRoleWithOptions(vNode, options);
   }
 
   const { noImplicit, fallback, abstracts, dpub, noPresentational, chromium } =
@@ -194,13 +193,13 @@ function getRole(node, options = {}) {
     return nodeCache[cacheKey];
   }
 
-  const role = resolveRoleWithOptions(node, options);
+  const role = resolveRoleWithOptions(vNode, options);
   nodeCache[cacheKey] = role;
   return role;
 }
 
-function resolveRoleWithOptions(node, { noPresentational, ...options }) {
-  const role = resolveRole(node, options);
+function resolveRoleWithOptions(vNode, { noPresentational, ...options }) {
+  const role = resolveRole(vNode, options);
 
   if (noPresentational && ['presentation', 'none'].includes(role)) {
     return null;

--- a/lib/commons/aria/get-role.js
+++ b/lib/commons/aria/get-role.js
@@ -175,7 +175,31 @@ function resolveRole(node, { noImplicit, ...roleOptions } = {}) {
  *
  * @deprecated noImplicit option is deprecated. Use aria.getExplicitRole instead.
  */
-function getRole(node, { noPresentational, ...options } = {}) {
+function getRole(node, options = {}) {
+  const { vNode } = nodeLookup(node);
+
+  // the role of a node is read many times over during a run, so cache it per
+  // node. The options change the answer, so they are part of the key. Written
+  // only after resolving, so a throw is not cached and role resolution can
+  // still re-enter for the same node while it is being computed.
+  const nodeCache = vNode?._cache;
+  if (!nodeCache) {
+    return resolveRoleWithOptions(node, options);
+  }
+
+  const { noImplicit, fallback, abstracts, dpub, noPresentational, chromium } =
+    options;
+  const cacheKey = `getRole:${!!noImplicit}${!!fallback}${!!abstracts}${!!dpub}${!!noPresentational}${!!chromium}`;
+  if (cacheKey in nodeCache) {
+    return nodeCache[cacheKey];
+  }
+
+  const role = resolveRoleWithOptions(node, options);
+  nodeCache[cacheKey] = role;
+  return role;
+}
+
+function resolveRoleWithOptions(node, { noPresentational, ...options }) {
   const role = resolveRole(node, options);
 
   if (noPresentational && ['presentation', 'none'].includes(role)) {


### PR DESCRIPTION
Refs #5327 — the `getRole` part of it. `accessibleText` and the `aria`/`ariaSource`/`ref` accessors are deliberately not included; reasons at the bottom.

## What

`getRole` caches its result on the virtual node's `_cache`. The cache lives inside `getRole` rather than as a `vNode.role` getter, so all 33 call sites benefit without any of them changing.

Three details that are load-bearing:

**The options are part of the key.** The pseudo-code in the issue is `get role => memoize(this, getRole(this))`, but `getRole` takes six booleans that change the answer, and instrumenting a run shows six distinct shapes actually in use:

| Key | Calls (ARIA-heavy page) |
|---|---|
| no options | 82,518 |
| `{ dpub, fallback }` | 15,000 |
| `{ fallback }` | 9,000 |
| `{ noPresentational }` | 4,500 |
| `{ noImplicit }` | 3,000 |
| `{ noPresentational, chromium }` | 1,500 |

A single cached value would return the wrong role for five of those.

**The entry is written after the role resolves, not before.** That keeps a throw from `getInheritedRole` out of the cache, and it means role resolution can still re-enter for a node while that node is being resolved, exactly as it does today.

**The virtual node is resolved once per call.** `getRole` needs it to reach `_cache`, and `resolveRole` used to look it up again, so a cache miss paid for two lookups where it previously paid for one. The resolved node is now passed down (second commit).

## Results

**The cache hits often and saves nothing measurable.**

| | ARIA-heavy | 12,000 elements |
|---|---|---|
| `getRole` calls | 115,518 | 60,626 |
| Cache hits | 73,514 (**63.6%**) | 42,740 (**70.5%**) |

Three alternating rounds of ten runs on the ARIA-heavy page, against a `develop` build that includes #5325:

| Round | develop | this branch |
|---|---|---|
| 1 | 2228 ms | 2278 ms |
| 2 | 2269 ms | 2260 ms |
| 3 | 2254 ms | 2278 ms |

12,000 element page: 2182 ms vs 2165 ms. The sign flips between rounds, so it is inside the run-to-run noise here.

So the hit rate is high — far higher than the 13% measured for the ARIA value accessors in #5300 — and the wall clock does not move. The conclusion I draw is that `getRole` is simply cheap: removing 70% of the calls is not worth anything because the calls were not costing anything. Results are identical throughout and the full suite passes.

Worth having in front of you as code rather than as a claim, since my measurements have been the less reliable half of this epic. If your benchmark sites disagree, the branch is here to run.

## Not included

**`accessibleText`.** `accessibleTextVirtual(virtualNode, context)` takes a context that carries `alreadyProcessed`, which is the guard against the role/accessible-name re-entrancy cycle. Caching on the node alone would ignore it, and getting that wrong is a correctness bug rather than a neutral result. Worth deciding deliberately.

**`aria`, `ariaSource` and `ref`.** These are `getAriaValue` and `getResolvedRefs`, which #5300 closed as not worth caching, with your own benchmark data showing 252,143 calls costing 120ms.

**`roleType`** is worth a note if this idea is taken further: 10 of its 11 call sites pass a role *string* rather than a node (`getRoleType(role)`), and only `is-in-text-block.js:84` passes a node. A `vNode.roleType` getter would therefore only serve that one call site.

## Testing

Full unit suite: 484 test files passing.
