### PR TITLE
perf(aria): cache implicitRole per node

### DIFF
--- a/lib/commons/aria/implicit-role.js
+++ b/lib/commons/aria/implicit-role.js
@@ -23,6 +23,27 @@ function implicitRole(node, { chromium } = {}) {
     );
   }
 
+  // getRole is not cached, so every caller asking a node for its role asks
+  // that node for its implicit role again. Some of those answers are costly:
+  // header and footer walk their ancestors, form, section and aside compute an
+  // accessible name. Cache per node, keyed on whether chromium roles are
+  // included, since that changes the answer.
+  const cacheKey = chromium ? 'implicitRoleChromium' : 'implicitRole';
+  // SerialVirtualNode has no cache to read or write
+  const nodeCache = vNode._cache;
+  if (nodeCache && cacheKey in nodeCache) {
+    return nodeCache[cacheKey];
+  }
+
+  const role = resolveImplicitRole(vNode, chromium);
+  if (nodeCache) {
+    // written after resolving, so a throw is never cached
+    nodeCache[cacheKey] = role;
+  }
+  return role;
+}
+
+function resolveImplicitRole(vNode, chromium) {
   if (vNode.elementInternals?.role) {
     return vNode.elementInternals.role;
   }

--- a/test/commons/aria/implicit-role.js
+++ b/test/commons/aria/implicit-role.js
@@ -552,6 +552,38 @@ describe('aria.implicitRole', () => {
     assert.equal(implicitRole(node), 'columnheader');
   });
 
+  describe('caching', () => {
+    it('resolves the role of a node only once', () => {
+      const vNode = queryFixture('<a id="target" href="#"></a>');
+      assert.equal(implicitRole(vNode), 'link');
+
+      // a second lookup must not re-resolve the role
+      vNode.actualNode.removeAttribute('href');
+      assert.equal(implicitRole(vNode), 'link');
+    });
+
+    it('caches the role on the virtual node', () => {
+      const vNode = queryFixture('<a id="target" href="#"></a>');
+      assert.equal(implicitRole(vNode.actualNode), 'link');
+      assert.equal(vNode._cache.implicitRole, 'link');
+    });
+
+    it('caches chromium roles separately from implicit html roles', () => {
+      const vNode = queryFixture('<canvas id="target"></canvas>');
+      assert.isNull(implicitRole(vNode));
+      assert.equal(implicitRole(vNode, { chromium: true }), 'Canvas');
+    });
+
+    it('does not cache when the node has no cache to write to', () => {
+      const vNode = new axe.SerialVirtualNode({
+        nodeName: 'a',
+        attributes: { href: '#' }
+      });
+      assert.equal(implicitRole(vNode), 'link');
+      assert.equal(implicitRole(vNode), 'link');
+    });
+  });
+
   describe('ElementInternals', () => {
     it('returns element internals role', () => {
       const vNode = queryFixture(


### PR DESCRIPTION
Third of the items in Wilco's codeblock on #5327 (`getRole` was first, closed unmerged as #5329; `getRoleType` is #5330).

### What this does

Splits resolution out into `resolveImplicitRole` and caches the answer on `vNode._cache`, keyed `implicitRole` / `implicitRoleChromium` — the `chromium` option changes the result, so it can't share a slot. The entry is written after resolving, so a throw is never cached, and it's skipped entirely when the node has no `_cache`.

`getRole` is not cached on develop, so every caller that asks a node for its role asks that node for its implicit role all over again. Most of those answers are a dictionary lookup, but some are not:

- `header` / `footer` — `closest()` walk up the ancestors against the sectioning-content selector
- `form` / `section` / `aside` — `hasAccessibleName()`, a full accessible-name computation

### Numbers

Isolated (`getRole` over every element ×5, 7 samples, median), three alternating rounds. No overlap between the two sets:

| fixture | develop | this branch | |
| --- | --- | --- | --- |
| sectioning-heavy (250 articles w/ header, footer, section, aside, form) | 29.8 / 28.6 / 29.2 ms | 4.2 / 4.1 / 4.2 ms | **7× faster** |
| large DOM (12,009 elements) | 15.5 / 16.1 / 19.3 ms | 10.0 / 10.0 / 10.3 ms | **1.6× faster** |

Full run, same rounds, both builds from `d50cdf6e`, checksums confirmed different, identical results either way:

| fixture | develop | this branch | Δ |
| --- | --- | --- | --- |
| sectioning-heavy | 833 / 835 / 843 ms | 821 / 829 / 827 ms | **−1.3%** |
| large DOM, aria-heavy, link-heavy text | — | — | within noise |

So the function itself gets a lot cheaper, but it's only ~3.5% of a run to begin with, which caps what the page-level number can be. Worth your read on whether that trade is worth the cache.

Cache hit rates, measured before any timing: 73% on large DOM (44,546 calls), 63% on sectioning-heavy, 96% on link-heavy text, 59% on aria-heavy. Pages whose elements are each asked once — my colour-heavy fixtures — get 0% and are unaffected either way.

### Tests

Four added, two of which fail on a diagnostic revert of the implementation.

The other two are regression guards. One is worth calling out: my first attempt did `cacheKey in vNode._cache` unguarded and broke 10 existing tests, because `SerialVirtualNode` has no `_cache` — only `VirtualNode` defines it. `does not cache when the node has no cache to write to` locks that in.

### Unrelated observation

While tracing the `chromium` option I noticed `lib/rules/presentation-role-conflict-matches.js:7` calls `getImplicitRole(virtualNode, { chromiumRoles: true })`, but `implicitRole` destructures `{ chromium }`. The names have never matched, so that matcher has never actually received chromium roles — it's been the default path since #2948. The matcher is marked `@deprecated Will be removed in axe-core 5.0.0`, so I've left it alone rather than change rule behaviour in a perf PR. Flagging in case it's news.

Refs issue #5327
