### PR TITLE
chore: Readability tweaks get-selector rewrite

### DIFF
--- a/lib/core/utils/get-selector/attr-format.js
+++ b/lib/core/utils/get-selector/attr-format.js
@@ -92,14 +92,14 @@ function escapeAttribute(str) {
  * introduces a `\$="` that trips the same check. Reporting the form
  * explicitly avoids the guesswork.
  *
- * @param {Element} node		The element that has the attribute
- * @param {Attribute} at		The attribute
+ * @param {Element} node   The element that has the attribute
+ * @param {Attr}    attr   The attribute
  * @returns {{atnv: String, isSuffix: Boolean, rawName: String, suffix: String}}
  *   `rawName` is the original attribute name (not CSS-escaped).
  *   `suffix` is set only when `isSuffix` is true.
  */
-export function getAttributeNameValue(node, at) {
-  const name = at.name;
+export function getAttributeNameValue(node, attr) {
+  const name = attr.name;
   const escName = escapeSelector(name);
 
   // Substring match (not equality) catches related URL-carrying
@@ -122,21 +122,22 @@ export function getAttributeNameValue(node, at) {
     };
   }
   return {
-    atnv: escName + '="' + escapeAttribute(at.value) + '"',
+    atnv: escName + '="' + escapeAttribute(attr.value) + '"',
     isSuffix: false,
     rawName: name
   };
 }
 
 /**
- * Filter the attributes
- * @param {Attribute}		The potential attribute
- * @return {Boolean}		 Whether to include or exclude
+ * Whether this attribute is eligible to appear in a selector.
+ *
+ * @param {Attr} attr   The potential attribute
+ * @return {Boolean}    Whether to include or exclude
  */
-export function filterAttributes(at) {
+export function filterAttributes(attr) {
   return (
-    !ignoredAttributes.includes(at.name) &&
-    at.name.indexOf(':') === -1 &&
-    (!at.value || at.value.length < MAXATTRIBUTELENGTH)
+    !ignoredAttributes.includes(attr.name) &&
+    attr.name.indexOf(':') === -1 &&
+    (!attr.value || attr.value.length < MAXATTRIBUTELENGTH)
   );
 }

--- a/lib/core/utils/get-selector/bit-index.js
+++ b/lib/core/utils/get-selector/bit-index.js
@@ -100,15 +100,15 @@
  * the bit within that word. Used at end-of-walk to flip every accumulated
  * `Map<key, Number[]>` source list into its bitmap form.
  *
- * @param {Number[]} list
+ * @param {Number[]} nodeIdxs
  * @param {Number}   wordCount   how many Uint32 words the result needs
  * @returns {Uint32Array}
  */
-export function listToBits(list, wordCount) {
+export function listToBits(nodeIdxs, wordCount) {
   const bits = new Uint32Array(wordCount);
-  for (let i = 0; i < list.length; i++) {
-    const j = list[i];
-    bits[j >>> 5] |= 1 << (j & 31);
+  for (let i = 0; i < nodeIdxs.length; i++) {
+    const nodeIdx = nodeIdxs[i];
+    bits[nodeIdx >>> 5] |= 1 << (nodeIdx & 31);
   }
   return bits;
 }
@@ -120,18 +120,18 @@ export function listToBits(list, wordCount) {
  * against the wanted suffix at query time. This does that check for one
  * node.
  *
- * @param {Object} rec           per-node record
- * @param {Array}  suffixAttrs   [{name, suffix}, ...]
+ * @param {NodeRecord} nodeRecord
+ * @param {Array<{rawName: String, suffix: String}>} suffixAttrs
  * @returns {Boolean}
  */
-function matchesSuffixAttrs(rec, suffixAttrs) {
-  const urls = rec.urlAttrs;
-  if (!urls) {
+function matchesSuffixAttrs(nodeRecord, suffixAttrs) {
+  const urlAttrs = nodeRecord.urlAttrs;
+  if (!urlAttrs) {
     return false;
   }
-  for (let s = 0; s < suffixAttrs.length; s++) {
-    const raw = urls[suffixAttrs[s].name];
-    if (typeof raw !== 'string' || !raw.endsWith(suffixAttrs[s].suffix)) {
+  for (let i = 0; i < suffixAttrs.length; i++) {
+    const rawUrl = urlAttrs[suffixAttrs[i].rawName];
+    if (typeof rawUrl !== 'string' || !rawUrl.endsWith(suffixAttrs[i].suffix)) {
       return false;
     }
   }
@@ -149,42 +149,44 @@ function matchesSuffixAttrs(rec, suffixAttrs) {
  * need to find *all* matching nodes at once, `bitsForFragment` is faster
  * because it works on bitmaps.
  *
- * @param {Object} fragment  shape built by `computeFragment` in generate.js
- * @param {Number} nodeIdx
- * @param {Array}  perNode   per-node records (`Rec[]`) from `getSelectorData`
+ * @param {Fragment}     fragment
+ * @param {Number}       nodeIdx
+ * @param {NodeRecord[]} nodeRecords   from `getSelectorData`
  * @returns {Boolean}
  */
-export function fragmentMatchesIdx(fragment, nodeIdx, perNode) {
-  const rec = perNode[nodeIdx];
+export function fragmentMatchesIdx(fragment, nodeIdx, nodeRecords) {
+  const nodeRecord = nodeRecords[nodeIdx];
   if (fragment.id) {
-    return rec.id === fragment.id;
+    return nodeRecord.id === fragment.id;
   }
   // Both sides store the tag in the same lowercased form, so we can just
   // string-compare.
-  if (fragment.tag && rec.tag !== fragment.tag) {
+  if (fragment.tag && nodeRecord.tag !== fragment.tag) {
     return false;
   }
   if (fragment.classes) {
     for (let i = 0; i < fragment.classes.length; i++) {
-      if (rec.classes.indexOf(fragment.classes[i]) === -1) {
+      if (nodeRecord.classes.indexOf(fragment.classes[i]) === -1) {
         return false;
       }
     }
   }
   if (fragment.exactAttrs) {
-    const recAttrs = rec.matchAttrs;
     for (let i = 0; i < fragment.exactAttrs.length; i++) {
-      if (recAttrs.indexOf(fragment.exactAttrs[i]) === -1) {
+      if (nodeRecord.exactAttrs.indexOf(fragment.exactAttrs[i]) === -1) {
         return false;
       }
     }
   }
-  if (fragment.suffixAttrs && !matchesSuffixAttrs(rec, fragment.suffixAttrs)) {
+  if (
+    fragment.suffixAttrs &&
+    !matchesSuffixAttrs(nodeRecord, fragment.suffixAttrs)
+  ) {
     return false;
   }
   if (
-    typeof fragment.nthChild === 'number' &&
-    rec.nthChild !== fragment.nthChild
+    fragment.nthChild !== undefined &&
+    nodeRecord.nthChild !== fragment.nthChild
   ) {
     return false;
   }
@@ -198,34 +200,34 @@ export function fragmentMatchesIdx(fragment, nodeIdx, perNode) {
  * we cache them, and both want the same cache key: `(rootId, fragment
  * string)`. So they share one entry with two lazy fields.
  *
- * @param {Object} selectorData
- * @param {Number} rootId
- * @param {String} key             fragment.selectorString
- * @returns {Object}               entry object with lazy `bits` and `indices` fields
+ * @typedef {Object} CachedMatch
+ * @property {Uint32Array|null} [bits]      absent until first computed
+ * @property {Number[]}         [indices]   absent until first computed
  */
-function getMatchCacheEntry(selectorData, rootId, key) {
-  let cache = selectorData._matchCache;
-  if (!cache) {
-    cache = selectorData._matchCache = [];
-  }
-  let rootCache = cache[rootId];
-  if (!rootCache) {
-    // Fragment strings are untrusted keys: a bare unknown tag name
-    // like `<constructor>` parses fine and produces the fragment
-    // `constructor`. If the root cache inherited from Object.prototype,
-    // `rootCache['constructor']` would return the Object constructor
-    // (truthy), the entry-init below would never fire, and the
-    // assignments in bitsForFragment / indicesForFragment would end up
-    // on the global Object — one root's bitmap leaking into another,
-    // then stranded on Object for the life of the page. Null-prototype
-    // objects have no such inheritance.
-    rootCache = cache[rootId] = Object.create(null);
-  }
-  let entry = rootCache[key];
-  if (!entry) {
-    entry = rootCache[key] = {};
-  }
-  return entry;
+
+/**
+ * @param {SelectorData} selectorData
+ * @param {Number}       rootId
+ * @param {Fragment}     fragment   keyed by its `selectorString`
+ * @returns {CachedMatch}           with `bits` / `indices` possibly absent
+ */
+function getCachedMatch(selectorData, rootId, fragment) {
+  selectorData._matchCache ??= [];
+  const cache = selectorData._matchCache;
+  // Fragment strings are untrusted keys: a bare unknown tag name
+  // like `<constructor>` parses fine and produces the fragment
+  // `constructor`. If the root cache inherited from Object.prototype,
+  // `rootCache['constructor']` would return the Object constructor
+  // (truthy), the entry-init below would never fire, and the
+  // assignments in bitsForFragment / indicesForFragment would end up
+  // on the global Object — one root's bitmap leaking into another,
+  // then stranded on Object for the life of the page. Null-prototype
+  // objects have no such inheritance.
+  cache[rootId] ??= Object.create(null);
+  const rootCache = cache[rootId];
+  const key = fragment.selectorString;
+  rootCache[key] ??= {};
+  return rootCache[key];
 }
 
 /**
@@ -238,32 +240,31 @@ function getMatchCacheEntry(selectorData, rootId, key) {
  * fragment" set as bitmaps, "keep candidates whose parent matches" is one
  * bit-test per candidate — much faster than running the CSS engine.
  *
- * @param {Object}      fragment     shape built by `computeFragment` in generate.js
- * @param {String}      key          fragment.selectorString, cache key
- * @param {Object}      selectorData
- * @param {Number}      rootId       restrict matches to this root
+ * @param {Fragment}     fragment
+ * @param {SelectorData} selectorData
+ * @param {Number}       rootId       restrict matches to this root
  * @returns {Uint32Array|null}
  */
-export function bitsForFragment(fragment, key, selectorData, rootId) {
-  const entry = getMatchCacheEntry(selectorData, rootId, key);
-  if ('bits' in entry) {
-    return entry.bits;
+export function bitsForFragment(fragment, selectorData, rootId) {
+  const cachedMatch = getCachedMatch(selectorData, rootId, fragment);
+  if ('bits' in cachedMatch) {
+    return cachedMatch.bits;
   }
 
-  const perNode = selectorData._perNode;
+  const nodeRecords = selectorData._nodeRecords;
   const wordCount = selectorData._wordCount;
 
   // An id, if it made it into the fragment, is already known to be unique
   // in its root — so exactly one bit is ever set. Skip the full intersect.
   if (fragment.id) {
-    const idx = selectorData._idToIdx[rootId][fragment.id];
-    if (idx === undefined) {
-      entry.bits = null;
+    const nodeIdx = selectorData._idToIdx[rootId][fragment.id];
+    if (nodeIdx === undefined) {
+      cachedMatch.bits = null;
       return null;
     }
     const bits = new Uint32Array(wordCount);
-    bits[idx >>> 5] |= 1 << (idx & 31);
-    entry.bits = bits;
+    bits[nodeIdx >>> 5] |= 1 << (nodeIdx & 31);
+    cachedMatch.bits = bits;
     return bits;
   }
 
@@ -273,47 +274,47 @@ export function bitsForFragment(fragment, key, selectorData, rootId) {
   // at all (e.g. no node on the page has this class), the result is
   // definitely empty — bail early.
   const bits = new Uint32Array(wordCount);
-  let seeded = false;
+  let isSeeded = false;
 
-  const applyBits = src => {
-    if (!seeded) {
-      bits.set(src);
-      seeded = true;
+  const applyBits = featureBits => {
+    if (!isSeeded) {
+      bits.set(featureBits);
+      isSeeded = true;
     } else {
       for (let w = 0; w < wordCount; w++) {
-        bits[w] &= src[w];
+        bits[w] &= featureBits[w];
       }
     }
   };
 
   if (fragment.tag) {
-    const src = selectorData._tagBits[fragment.tag];
-    if (!src) {
-      entry.bits = null;
+    const tagBits = selectorData._tagBits[fragment.tag];
+    if (!tagBits) {
+      cachedMatch.bits = null;
       return null;
     }
-    applyBits(src);
+    applyBits(tagBits);
   }
 
   if (fragment.classes) {
     for (let i = 0; i < fragment.classes.length; i++) {
-      const src = selectorData._classBits[fragment.classes[i]];
-      if (!src) {
-        entry.bits = null;
+      const classBits = selectorData._classBits[fragment.classes[i]];
+      if (!classBits) {
+        cachedMatch.bits = null;
         return null;
       }
-      applyBits(src);
+      applyBits(classBits);
     }
   }
 
   if (fragment.exactAttrs) {
     for (let i = 0; i < fragment.exactAttrs.length; i++) {
-      const src = selectorData._attrBits[fragment.exactAttrs[i]];
-      if (!src) {
-        entry.bits = null;
+      const attrBits = selectorData._attrBits[fragment.exactAttrs[i]];
+      if (!attrBits) {
+        cachedMatch.bits = null;
         return null;
       }
-      applyBits(src);
+      applyBits(attrBits);
     }
   }
 
@@ -323,18 +324,11 @@ export function bitsForFragment(fragment, key, selectorData, rootId) {
   // matches drop out.
   const rootBits = selectorData._rootBits[rootId];
   if (rootBits) {
-    if (!seeded) {
-      bits.set(rootBits);
-      seeded = true;
-    } else {
-      for (let w = 0; w < wordCount; w++) {
-        bits[w] &= rootBits[w];
-      }
-    }
+    applyBits(rootBits);
   }
 
-  if (!seeded) {
-    entry.bits = null;
+  if (!isSeeded) {
+    cachedMatch.bits = null;
     return null;
   }
 
@@ -347,9 +341,8 @@ export function bitsForFragment(fragment, key, selectorData, rootId) {
   // (as a value with just that bit); `31 - Math.clz32(lsb)` turns that
   // back into a bit index; `word ^= lsb` clears the bit so the next
   // iteration finds the next one up.
-  const nth = typeof fragment.nthChild === 'number' ? fragment.nthChild : -1;
-  const suffixAttrs = fragment.suffixAttrs;
-  if (nth !== -1 || suffixAttrs) {
+  const { nthChild, suffixAttrs } = fragment;
+  if (nthChild !== undefined || suffixAttrs) {
     for (let w = 0; w < wordCount; w++) {
       let word = bits[w];
       let keep = 0;
@@ -357,10 +350,12 @@ export function bitsForFragment(fragment, key, selectorData, rootId) {
         const lsb = word & -word;
         const bitIdx = 31 - Math.clz32(lsb);
         const nodeIdx = (w << 5) + bitIdx;
-        const rec = perNode[nodeIdx];
-        const nthOk = nth === -1 || rec.nthChild === nth;
-        const suffixOk = !suffixAttrs || matchesSuffixAttrs(rec, suffixAttrs);
-        if (nthOk && suffixOk) {
+        const nodeRecord = nodeRecords[nodeIdx];
+        const matchesNth =
+          nthChild === undefined || nodeRecord.nthChild === nthChild;
+        const matchesSuffix =
+          !suffixAttrs || matchesSuffixAttrs(nodeRecord, suffixAttrs);
+        if (matchesNth && matchesSuffix) {
           keep |= lsb;
         }
         word ^= lsb;
@@ -369,7 +364,7 @@ export function bitsForFragment(fragment, key, selectorData, rootId) {
     }
   }
 
-  entry.bits = bits;
+  cachedMatch.bits = bits;
   return bits;
 }
 
@@ -381,20 +376,20 @@ export function bitsForFragment(fragment, key, selectorData, rootId) {
  * @returns {Number[]}
  */
 function enumerateBits(bits, wordCount) {
-  const out = [];
+  const nodeIdxs = [];
   if (!bits) {
-    return out;
+    return nodeIdxs;
   }
   for (let w = 0; w < wordCount; w++) {
     let word = bits[w];
     while (word !== 0) {
       const lsb = word & -word;
       const bitIdx = 31 - Math.clz32(lsb);
-      out.push((w << 5) + bitIdx);
+      nodeIdxs.push((w << 5) + bitIdx);
       word ^= lsb;
     }
   }
-  return out;
+  return nodeIdxs;
 }
 
 /**
@@ -405,50 +400,57 @@ function enumerateBits(bits, wordCount) {
  * pages with lots of repeated structure many targets share the same
  * first fragment.
  *
- * @param {Object} fragment      shape built by `computeFragment` in generate.js
- * @param {String} key           fragment.selectorString
- * @param {Object} selectorData
- * @param {Number} rootId
- * @returns {Number[]}           nodeIdx values that match
+ * @param {Fragment}     fragment
+ * @param {SelectorData} selectorData
+ * @param {Number}       rootId
+ * @returns {Number[]}   nodeIdx values that match
  */
-export function indicesForFragment(fragment, key, selectorData, rootId) {
-  const entry = getMatchCacheEntry(selectorData, rootId, key);
-  if ('indices' in entry) {
-    return entry.indices;
+export function indicesForFragment(fragment, selectorData, rootId) {
+  const cachedMatch = getCachedMatch(selectorData, rootId, fragment);
+  if ('indices' in cachedMatch) {
+    return cachedMatch.indices;
   }
-  const bits = bitsForFragment(fragment, key, selectorData, rootId);
-  entry.indices = enumerateBits(bits, selectorData._wordCount);
-  return entry.indices;
+  const bits = bitsForFragment(fragment, selectorData, rootId);
+  cachedMatch.indices = enumerateBits(bits, selectorData._wordCount);
+  return cachedMatch.indices;
 }
 
 /**
- * One step of the ancestor walk in `generateSelector`. Given a list of
- * candidate nodes and a bitmap of "nodes that match the parent fragment",
- * for each candidate: look at its parent (via `parentOf`) and keep the
- * candidate only if that parent is in the bitmap. Writes the survivors
- * into `anc` (which may be the same array as `source` — in-place is safe
- * because we always write behind the read cursor).
+ * One step of the ancestor walk in `generateSelector`. Given candidates
+ * matching the chain-so-far, return the parents that match `fragment`.
  *
- * @param {Int32Array}         anc       destination buffer
- * @param {Int32Array|Number[]} source   candidates from the previous step
- * @param {Number}             count     number of valid entries in `source`
- * @param {Int32Array}         parentOf  flat table of parent indices
- * @param {Uint32Array|null}   ancBits   parent-fragment match bitmap
- * @returns {Number}                     new candidate count
+ * For each candidate: look up its parent (via `_parentOf`) and keep that
+ * parent if it is in the fragment's match bitmap. Returns a new array —
+ * the input list is never mutated, so it can be shared through the chain
+ * cache.
+ *
+ * @param {Number[]}     candidateIdxs   candidates from the previous step
+ * @param {Fragment}     parentFragment
+ * @param {SelectorData} selectorData
+ * @param {Number}       rootId
+ * @returns {Number[]}   parent nodeIdx values that match
  */
-export function advanceAndFilter(anc, source, count, parentOf, ancBits) {
-  if (!ancBits) {
-    return 0;
+export function matchingParents(
+  candidateIdxs,
+  parentFragment,
+  selectorData,
+  rootId
+) {
+  const parentBits = bitsForFragment(parentFragment, selectorData, rootId);
+  if (!parentBits) {
+    return [];
   }
-  let write = 0;
-  for (let i = 0; i < count; i++) {
-    const parent = parentOf[source[i]];
+
+  const parentOf = selectorData._parentOf;
+  const matchedParents = [];
+  for (let i = 0; i < candidateIdxs.length; i++) {
+    const parent = parentOf[candidateIdxs[i]];
     if (parent < 0) {
       continue;
     }
-    if (ancBits[parent >>> 5] & (1 << (parent & 31))) {
-      anc[write++] = parent;
+    if (parentBits[parent >>> 5] & (1 << (parent & 31))) {
+      matchedParents.push(parent);
     }
   }
-  return write;
+  return matchedParents;
 }

--- a/lib/core/utils/get-selector/bit-index.js
+++ b/lib/core/utils/get-selector/bit-index.js
@@ -420,15 +420,19 @@ export function indicesForFragment(fragment, selectorData, rootId) {
  * matching the chain-so-far, return the parents that match `fragment`.
  *
  * For each candidate: look up its parent (via `_parentOf`) and keep that
- * parent if it is in the fragment's match bitmap. Returns a new array —
- * the input list is never mutated, so it can be shared through the chain
- * cache.
+ * parent if it is in the fragment's match bitmap.
  *
- * @param {Number[]}     candidateIdxs   candidates from the previous step
- * @param {Fragment}     parentFragment
- * @param {SelectorData} selectorData
- * @param {Number}       rootId
- * @returns {Number[]}   parent nodeIdx values that match
+ * Writes into a reused `Int32Array` (`selectorData._candidateBuf`) and
+ * returns a view of the filled prefix. Filtering writes behind the read
+ * cursor, so the same buffer can be the source and the destination.
+ * Callers that stash the result (the chain cache) must copy it — the
+ * next call overwrites the buffer.
+ *
+ * @param {ArrayLike<Number>} candidateIdxs   candidates from the previous step
+ * @param {Fragment}          parentFragment
+ * @param {SelectorData}      selectorData
+ * @param {Number}            rootId
+ * @returns {ArrayLike<Number>} parent nodeIdx values that match
  */
 export function matchingParents(
   candidateIdxs,
@@ -442,15 +446,21 @@ export function matchingParents(
   }
 
   const parentOf = selectorData._parentOf;
-  const matchedParents = [];
-  for (let i = 0; i < candidateIdxs.length; i++) {
+  const count = candidateIdxs.length;
+  let dest = selectorData._candidateBuf;
+  if (!dest || dest.length < count) {
+    dest = selectorData._candidateBuf = new Int32Array(count);
+  }
+
+  let write = 0;
+  for (let i = 0; i < count; i++) {
     const parent = parentOf[candidateIdxs[i]];
     if (parent < 0) {
       continue;
     }
     if (parentBits[parent >>> 5] & (1 << (parent & 31))) {
-      matchedParents.push(parent);
+      dest[write++] = parent;
     }
   }
-  return matchedParents;
+  return dest.subarray(0, write);
 }

--- a/lib/core/utils/get-selector/features.js
+++ b/lib/core/utils/get-selector/features.js
@@ -7,13 +7,8 @@ import isXHTML from '../is-xhtml';
  * Read-only against the precomputed data in `precompute.js`.
  *
  * FEATURE. A candidate piece of a selector: a class or an attribute
- * that's rare enough on this page to be worth including. Shape:
- *
- *     { name: String, count: Number, species: 'class' | 'attribute' }
- *
- * `name` is the rendered form (`cta` or `data-x="1"`), `count` is how
- * many elements on the page have it, `species` is the kind — which
- * drives how it gets emitted (`.name` vs `[name]`).
+ * that's rare enough on this page to be worth including. See the
+ * `Feature` typedef below.
  *
  * UNCOMMON = appears on FEWER elements than this element's tag does.
  * The heuristic: if a class shows up more often than the tag itself,
@@ -25,6 +20,13 @@ import isXHTML from '../is-xhtml';
  * `selectorData` is the object `precompute.js` returned from
  * `getSelectorData`; every function here reads its fields but writes
  * nothing.
+ *
+ * @typedef {Object} Feature
+ * @property {String} name    the rendered form: `cta` for a class,
+ *                            `data-x="1"` (an atnv) for an attribute
+ * @property {Number} count   how many elements on the page have it
+ * @property {'class'|'attribute'} kind   drives how it gets emitted:
+ *                            `.name` for a class, `[name]` for an attribute
  */
 
 function countSort(a, b) {
@@ -46,27 +48,25 @@ export function getBaseSelector(elm) {
  * own tag does — i.e. the ones that would actually narrow a selector down.
  * Sorted rarest-first so the caller can pick the most distinctive ones.
  *
- * @param {Element} node
- * @param {Object}  selectorData
- * @returns {Array<{name: String, count: Number, species: 'class'}>}
+ * @param {Element}      node
+ * @param {SelectorData} selectorData
+ * @returns {Feature[]}  `kind: 'class'` features, rarest first
  */
 function uncommonClasses(node, selectorData) {
-  const retVal = [];
-  const idx = selectorData._elmToIdx.get(node);
-  if (idx === undefined) {
-    return retVal;
+  const features = [];
+  const nodeIdx = selectorData._elmToIdx.get(node);
+  if (nodeIdx === undefined) {
+    return features;
   }
-  const rec = selectorData._perNode[idx];
-  const classData = selectorData.classes;
-  const tagCount = selectorData.tags[rec.nodeName];
-  for (let i = 0; i < rec.classes.length; i++) {
-    const name = rec.classes[i];
-    const count = classData[name];
+  const nodeRecord = selectorData._nodeRecords[nodeIdx];
+  const tagCount = selectorData.tags[nodeRecord.nodeName];
+  for (const name of nodeRecord.classes) {
+    const count = selectorData.classes[name];
     if (count < tagCount) {
-      retVal.push({ name, count, species: 'class' });
+      features.push({ name, count, kind: 'class' });
     }
   }
-  return retVal.sort(countSort);
+  return features.sort(countSort);
 }
 
 /**
@@ -74,27 +74,27 @@ function uncommonClasses(node, selectorData) {
  * ones that appear less often than this element's tag, so they're worth
  * putting in a selector.
  *
- * @param {Element} node
- * @param {Object}  selectorData
- * @returns {Array<{name: String, count: Number, species: 'attribute'}>}
+ * @param {Element}      node
+ * @param {SelectorData} selectorData
+ * @returns {Feature[]}  `kind: 'attribute'` features, rarest first
  */
 function uncommonAttributes(node, selectorData) {
-  const retVal = [];
-  const idx = selectorData._elmToIdx.get(node);
-  if (idx === undefined) {
-    return retVal;
+  const features = [];
+  const nodeIdx = selectorData._elmToIdx.get(node);
+  if (nodeIdx === undefined) {
+    return features;
   }
-  const rec = selectorData._perNode[idx];
-  const attrData = selectorData.attributes;
-  const tagCount = selectorData.tags[rec.nodeName];
-  for (let i = 0; i < rec.attrs.length; i++) {
-    const name = rec.attrs[i];
-    const count = attrData[name];
+  const nodeRecord = selectorData._nodeRecords[nodeIdx];
+  const attrCounts = selectorData.attributes;
+  const tagCount = selectorData.tags[nodeRecord.nodeName];
+  for (let i = 0; i < nodeRecord.featureAttrs.length; i++) {
+    const name = nodeRecord.featureAttrs[i];
+    const count = attrCounts[name];
     if (count < tagCount) {
-      retVal.push({ name, count, species: 'attribute' });
+      features.push({ name, count, kind: 'attribute' });
     }
   }
-  return retVal.sort(countSort);
+  return features.sort(countSort);
 }
 
 /**
@@ -102,30 +102,51 @@ function uncommonAttributes(node, selectorData) {
  * `#id` selector string. Otherwise return `undefined` so the caller falls
  * back to tag/class/attribute features.
  *
- * We answer the "is it unique?" question from the precomputed count table
- * built in `getSelectorData` rather than a `querySelectorAll('#id')` at
- * this point — same answer, no DOM round-trip.
+ * For nodes `getSelectorData` walked, uniqueness comes from the
+ * precomputed count table — same answer as `querySelectorAll('#id')`,
+ * no DOM round-trip. For nodes the tree never saw, those counts don't
+ * include this element, so we verify against the live DOM instead.
  *
  * @param {Element} elm
  * @returns {String|undefined}  `#id` if usable, otherwise undefined
  */
 export function getElmId(elm) {
-  if (!elm.getAttribute('id')) {
+  const id = idSelector(elm);
+  if (!id) {
     return;
   }
-  const id = '#' + escapeSelector(elm.getAttribute('id') || '');
-  // YouTube regenerates these on every page load, so an id-based selector
-  // wouldn't work the next time the page is checked. Skip them.
-  if (id.match(/player_uid_/)) {
-    return;
-  }
+
   const selectorData = axe._selectorData;
   const root = (elm.getRootNode && elm.getRootNode()) || document;
+  if (!selectorData._elmToIdx.has(elm)) {
+    return root.querySelectorAll(id).length === 1 ? id : undefined;
+  }
+
   const rootId = selectorData._rootMap.get(root);
   if (rootId === undefined) {
     return;
   }
   return selectorData._idCounts[rootId][id] === 1 ? id : undefined;
+}
+
+/**
+ * Escaped `#id` if the element has an id we're willing to use.
+ * YouTube regenerates `player_uid_` ids on every page load, so an
+ * id-based selector wouldn't work the next time the page is checked.
+ *
+ * @param {Element} elm
+ * @returns {String|undefined}
+ */
+function idSelector(elm) {
+  const rawId = elm.getAttribute && elm.getAttribute('id');
+  if (!rawId) {
+    return;
+  }
+  const id = '#' + escapeSelector(rawId);
+  if (id.match(/player_uid_/)) {
+    return;
+  }
+  return id;
 }
 
 /**
@@ -135,38 +156,38 @@ export function getElmId(elm) {
  * alongside the structured pieces (tag flag + list of features) so
  * match-time code can use them without re-parsing.
  *
- * @param {Element} elm
- * @param {Object}  selectorData  from `getSelectorData`
- * @returns {{selector: String, tag: (String|null), features: Array}}
+ * @param {Element}      elm
+ * @param {SelectorData} selectorData  from `getSelectorData`
+ * @returns {{selectorString: String, tag: (String|null), features: Feature[]}}
  */
 export function getThreeLeastCommonFeatures(elm, selectorData) {
   let features;
   let hasTag = false;
-  const clss = uncommonClasses(elm, selectorData);
-  const atts = uncommonAttributes(elm, selectorData);
+  const classFeatures = uncommonClasses(elm, selectorData);
+  const attrFeatures = uncommonAttributes(elm, selectorData);
 
-  if (clss.length && clss[0].count === 1) {
+  if (classFeatures.length && classFeatures[0].count === 1) {
     // A class unique on the whole page IS the selector — no need for
     // a tag or anything else. Same for attributes below.
-    features = [clss[0]];
-  } else if (atts.length && atts[0].count === 1) {
-    features = [atts[0]];
+    features = [classFeatures[0]];
+  } else if (attrFeatures.length && attrFeatures[0].count === 1) {
+    features = [attrFeatures[0]];
     // Attribute-only fragments read poorly (`[data-x="1"]` vs
     // `button[data-x="1"]`), so put the tag back in front.
     hasTag = true;
   } else {
-    features = clss.concat(atts).sort(countSort).slice(0, 3);
+    features = classFeatures.concat(attrFeatures).sort(countSort).slice(0, 3);
 
-    if (!features.some(feat => feat.species === 'class')) {
+    if (!features.some(feature => feature.kind === 'class')) {
       hasTag = true;
     } else {
       // Classes first, attributes after — `button.foo[data-x="1"]`
       // rather than `button[data-x="1"].foo`. Matches how humans
       // typically write CSS and what browser devtools display.
       features.sort((a, b) => {
-        return a.species !== b.species && a.species === 'class'
+        return a.kind !== b.kind && a.kind === 'class'
           ? -1
-          : a.species === b.species
+          : a.kind === b.kind
             ? 0
             : 1;
       });
@@ -175,10 +196,10 @@ export function getThreeLeastCommonFeatures(elm, selectorData) {
 
   // construct the return value
   const tag = hasTag ? getBaseSelector(elm) : null;
-  let selector = tag || '';
-  for (const feat of features) {
-    selector +=
-      feat.species === 'class' ? '.' + feat.name : '[' + feat.name + ']';
+  let selectorString = tag || '';
+  for (const feature of features) {
+    selectorString +=
+      feature.kind === 'class' ? '.' + feature.name : '[' + feature.name + ']';
   }
-  return { selector, tag, features };
+  return { selectorString, tag, features };
 }

--- a/lib/core/utils/get-selector/features.js
+++ b/lib/core/utils/get-selector/features.js
@@ -60,7 +60,8 @@ function uncommonClasses(node, selectorData) {
   }
   const nodeRecord = selectorData._nodeRecords[nodeIdx];
   const tagCount = selectorData.tags[nodeRecord.nodeName];
-  for (const name of nodeRecord.classes) {
+  for (let i = 0; i < nodeRecord.classes.length; i++) {
+    const name = nodeRecord.classes[i];
     const count = selectorData.classes[name];
     if (count < tagCount) {
       features.push({ name, count, kind: 'class' });
@@ -102,10 +103,17 @@ function uncommonAttributes(node, selectorData) {
  * `#id` selector string. Otherwise return `undefined` so the caller falls
  * back to tag/class/attribute features.
  *
- * For nodes `getSelectorData` walked, uniqueness comes from the
- * precomputed count table — same answer as `querySelectorAll('#id')`,
- * no DOM round-trip. For nodes the tree never saw, those counts don't
- * include this element, so we verify against the live DOM instead.
+ * For nodes `getSelectorData` recorded, `_idToIdx` answers this: it only
+ * holds ids that resolve to exactly one node in their root, so "does this
+ * id map back to *this* element?" is the same question as
+ * `querySelectorAll('#id')` returning just us, with no DOM round-trip.
+ * It has to be `_idToIdx` and not the `_idCounts` tally, because
+ * `bitsForFragment` resolves an `#id` fragment through `_idToIdx` — an id
+ * we vend that it can't resolve would collapse the candidate list to
+ * nothing.
+ *
+ * For nodes never recorded, the precomputed tables don't include this
+ * element at all, so we verify against the live DOM instead.
  *
  * @param {Element} elm
  * @returns {String|undefined}  `#id` if usable, otherwise undefined
@@ -118,15 +126,13 @@ export function getElmId(elm) {
 
   const selectorData = axe._selectorData;
   const root = (elm.getRootNode && elm.getRootNode()) || document;
-  if (!selectorData._elmToIdx.has(elm)) {
+  const rootId = selectorData._rootMap.get(root);
+  const nodeIdx = selectorData._elmToIdx.get(elm);
+  if (rootId === undefined || nodeIdx === undefined) {
     return root.querySelectorAll(id).length === 1 ? id : undefined;
   }
 
-  const rootId = selectorData._rootMap.get(root);
-  if (rootId === undefined) {
-    return;
-  }
-  return selectorData._idCounts[rootId][id] === 1 ? id : undefined;
+  return selectorData._idToIdx[rootId][id] === nodeIdx ? id : undefined;
 }
 
 /**

--- a/lib/core/utils/get-selector/generate.js
+++ b/lib/core/utils/get-selector/generate.js
@@ -1,4 +1,3 @@
-import escapeSelector from '../escape-selector';
 import matchesSelector from '../element-matches';
 import {
   getBaseSelector,
@@ -6,10 +5,9 @@ import {
   getThreeLeastCommonFeatures
 } from './features';
 import {
-  advanceAndFilter,
-  bitsForFragment,
   fragmentMatchesIdx,
-  indicesForFragment
+  indicesForFragment,
+  matchingParents
 } from './bit-index';
 
 /*
@@ -22,23 +20,16 @@ import {
  *   element. No combinators inside. `computeFragment` produces one per
  *   element. The rendered form is a string like `button.cta:nth-child(3)`;
  *   the same info is also kept as a structured shape that `bit-index.js`
- *   can query:
- *
- *       { selectorString, id?, tag?, classes?,
- *         exactAttrs?, suffixAttrs?, nthChild? }
- *
- *   When a fragment carries `id`, the id alone already identifies the
- *   element uniquely inside its root — so tag / classes / attrs are all
- *   omitted (they'd be redundant).
+ *   can query — see the `Fragment` typedef below.
  *
  *   CHAIN — fragments joined by ` > ` while walking up the ancestry.
  *   E.g. `main > div.wrap > button.cta` is a 3-link chain describing
  *   "a button.cta inside a div.wrap inside a main."
  *
  *   CANDIDATE — an element that still matches the chain-so-far. Kept
- *   as a list of nodeIdx values (an Int32Array once we start filtering).
- *   Starts as "every element that matches the target's own fragment"
- *   and shrinks with every ancestor step. When it hits 1, we're done.
+ *   as a list of nodeIdx values. Starts as "every element that matches
+ *   the target's own fragment" and is replaced with matching parents
+ *   at every ancestor step. When the list hits length 1, we're done.
  *
  * ALGORITHM (`generateSelector`)
  *
@@ -46,163 +37,38 @@ import {
  *   2. Ask `bit-index.js` "which elements match this fragment?" — the
  *      initial candidate list.
  *   3. If exactly one candidate, return the fragment string.
- *   4. Otherwise walk up: build the parent's fragment, keep only
- *      candidates whose parent matches (`advanceAndFilter`), prepend
- *      the parent fragment to the chain. Repeat.
+ *   4. Otherwise walk up: build the parent's fragment, replace the
+ *      candidate list with parents that match (`matchingParents`),
+ *      prepend the parent fragment to the chain. Repeat.
  *   5. If we walk all the way to the document and still have >1
  *      candidates, return `:root > <rest>` — the outermost link becomes
  *      the document itself, which is guaranteed to be unique.
  *
- * The `_chainCache` in `generateSelector` makes this fast on repetitive
- * pages: when two different targets pass through the same chain suffix
- * (e.g. `body > main > table > tr.row`), the second reuses the first's
- * filtered candidate list instead of redoing the walk.
+ * The `_chainCache` (owned by `candidatesForChain`) makes this fast on
+ * repetitive pages: when two different targets pass through the same
+ * chain suffix (e.g. `body > main > table > tr.row`), the second reuses
+ * the first's filtered candidate list instead of redoing the walk.
+ *
+ * When a fragment carries `id`, the id alone already identifies the
+ * element uniquely inside its root — so `tag` / `classes` / the attr
+ * fields are all omitted (they'd be redundant).
+ *
+ * @typedef {Object} Fragment
+ * @property {String}      selectorString  the rendered form, e.g.
+ *                                         `button.cta:nth-child(3)`
+ * @property {String}      [id]            `#id`; when set, no other field
+ *                                         except `selectorString` is present
+ * @property {String|null} [tag]           lowercase tag selector form
+ * @property {String[]}    [classes]       escaped class names
+ * @property {String[]|null} [exactAttrs]  exact-form atnvs, matched against
+ *                                         `nodeRecord.exactAttrs`
+ * @property {Array<{rawName: String, suffix: String}>|null} [suffixAttrs]
+ *                                         `[href$="…"]`-style attrs, matched
+ *                                         against `nodeRecord.urlAttrs`
+ * @property {Number}      [nthChild]      1-indexed sibling position; only
+ *                                         set when a sibling would otherwise
+ *                                         match this same fragment
  */
-
-/**
- * Build the selector fragment for one element — the one link of the chain
- * that describes just this element, like `button.foo:nth-child(3)`.
- *
- * The output is both the string form (what ends up in the final selector)
- * and the parts broken out (tag / classes / exact attrs / suffix attrs /
- * nth-child) because match-time code needs them separately and would
- * otherwise have to re-parse.
- *
- * The result is cached per element because `generateSelector` walks up the
- * tree and asks about the same ancestors over and over — once per target
- * that shares those ancestors.
- *
- * @param {Element} elm
- * @param {Number}  idx           the nodeIdx of `elm`, or `-1` if unknown
- * @param {Object}  selectorData
- * @returns {Object}              { selectorString, tag, classes, exactAttrs,
- *                                  suffixAttrs, nthChild }  (or { id, selectorString })
- */
-function computeFragment(elm, idx, selectorData) {
-  // Cache by nodeIdx into a plain integer-keyed array. This runs in the
-  // per-iteration hot loop of `generateSelector`, and a typed-array
-  // lookup is measurably cheaper than a WeakMap lookup at that call
-  // volume. `idx` comes from the caller (or `-1` for elements that
-  // weren't in the tree — those don't cache).
-  let cache = selectorData._computeFragmentCache;
-  if (!cache) {
-    cache = selectorData._computeFragmentCache = [];
-  }
-  if (idx >= 0) {
-    const cached = cache[idx];
-    if (cached) {
-      return cached;
-    }
-  }
-
-  const id = getElmId(elm);
-  if (id) {
-    const out = { id, selectorString: id };
-    if (idx >= 0) {
-      cache[idx] = out;
-    }
-    return out;
-  }
-
-  const { selector, tag, features } = getThreeLeastCommonFeatures(
-    elm,
-    selectorData
-  );
-  // Two flavors of attribute selector need different treatment at match
-  // time: `name="value"` (exact match, answered from the precomputed
-  // bitmap) and `name$="value"` (suffix match, answered by comparing
-  // the raw URL). Splitting them here once means the match-time code
-  // doesn't have to reclassify on every check.
-  //
-  // We can't sniff for `$="` inside the atnv — an attribute name that
-  // ends in `$` (e.g. Polymer's `attr$="…"` binding syntax left in
-  // serialized markup) escapes to `\$="…"`, which trips the same
-  // check. `_suffixInfo` is the authoritative record of which atnvs
-  // are suffix-form; we populated it in `collectNodeAttrs`, where the
-  // form was known unambiguously.
-  const classes = [];
-  let exactAttrs = null;
-  let suffixAttrs = null;
-  const suffixInfo = selectorData._suffixInfo;
-  for (const f of features) {
-    if (f.species === 'class') {
-      classes.push(f.name);
-      continue;
-    }
-    const info = suffixInfo.get(f.name);
-    if (info) {
-      if (!suffixAttrs) {
-        suffixAttrs = [];
-      }
-      suffixAttrs.push({ name: info.rawName, suffix: info.suffix });
-    } else {
-      if (!exactAttrs) {
-        exactAttrs = [];
-      }
-      exactAttrs.push(f.name);
-    }
-  }
-
-  // If any of this element's siblings also match the fragment we just
-  // built, the fragment isn't specific enough by itself — we need
-  // `:nth-child(N)` to disambiguate. Normally we answer this from
-  // precomputed data with no per-sibling CSS-engine call.
-  //
-  // Fallback: a sibling that wasn't walked by `getSelectorData` isn't in
-  // `_elmToIdx` (e.g. an unslotted light-DOM child of a shadow host is
-  // dropped from the flat tree, but is still a real DOM sibling for
-  // `:nth-child` purposes). For those we call `matchesSelector` — the
-  // same way the pre-index algorithm did it.
-  const fragmentNoNth = { tag, classes, exactAttrs, suffixAttrs };
-  const siblings = (elm.parentNode && elm.parentNode.children) || null;
-  let selectorString = selector;
-  let nthChild = null;
-  if (siblings) {
-    const perNode = selectorData._perNode;
-    const elmToIdx = selectorData._elmToIdx;
-    let ownNth = 0;
-    for (let i = 0; i < siblings.length; i++) {
-      const sib = siblings[i];
-      if (sib === elm) {
-        ownNth = i + 1;
-        continue;
-      }
-      const sibIdx = elmToIdx.get(sib);
-      let sibMatches;
-      if (sibIdx !== undefined) {
-        sibMatches = fragmentMatchesIdx(fragmentNoNth, sibIdx, perNode);
-      } else {
-        sibMatches = matchesSelector(sib, selector);
-      }
-      if (sibMatches) {
-        nthChild = -1;
-      }
-      if (nthChild !== null && ownNth) {
-        break;
-      }
-    }
-    if (nthChild === -1) {
-      if (!ownNth) {
-        ownNth = 1 + Array.prototype.indexOf.call(siblings, elm);
-      }
-      nthChild = ownNth;
-      selectorString = selector + ':nth-child(' + ownNth + ')';
-    }
-  }
-
-  const out = {
-    selectorString,
-    tag,
-    classes,
-    exactAttrs,
-    suffixAttrs,
-    nthChild
-  };
-  if (idx >= 0) {
-    cache[idx] = out;
-  }
-  return out;
-}
 
 /**
  * Build a unique CSS selector for `elm`.
@@ -225,51 +91,248 @@ function computeFragment(elm, idx, selectorData) {
  * @param {Boolean} [options.toRoot=false]  keep walking up even after uniqueness
  * @returns {String}                        CSS selector
  */
-export default function generateSelector(elm, options) {
+export default function generateSelector(elm, { toRoot = false } = {}) {
   if (!axe._selectorData) {
     throw new Error('Expect axe._selectorData to be set up');
   }
   const selectorData = axe._selectorData;
-  const { toRoot = false } = options;
-
-  const perNode = selectorData._perNode;
   const elmToIdx = selectorData._elmToIdx;
   const targetIdx = elmToIdx.get(elm);
   if (targetIdx === undefined) {
-    // A normal `axe.run` never gets here — every element that ends up in
-    // results was walked at `getSelectorData` time, and the DOM doesn't
-    // change during a run. This branch exists for the "someone called
-    // `getSelector` on a node the tree never saw" case (there's a unit
-    // test that hands us a detached DocumentFragment, for instance).
-    //
-    // We can't trust the id counts we precomputed because they don't
-    // include *this* element — a shared id might look unique in the
-    // snapshot even when it isn't. So verify against the live DOM here.
-    const rawId = elm.getAttribute && elm.getAttribute('id');
-    if (rawId) {
-      const idSel = '#' + escapeSelector(rawId);
-      const root = elm.getRootNode ? elm.getRootNode() : document;
-      if (
-        !idSel.match(/player_uid_/) &&
-        root.querySelectorAll(idSel).length === 1
-      ) {
-        return idSel;
-      }
-    }
-    return getBaseSelector(elm);
+    // Element wasn't found while walking the DOM tree.
+    return getElmId(elm) || getBaseSelector(elm);
   }
 
-  const targetRec = perNode[targetIdx];
-  const rootId = targetRec.rootId;
-  const parentOf = selectorData._parentOf;
-  // Many targets on a repetitive page walk up through the *same* chain of
-  // ancestor fragments for the first several steps. The first target to
-  // reach any given chain string does the filter work; every later target
-  // that reaches the same string just reuses its candidate list.
-  //
-  // Nested per rootId so the inner Map key is just the selector string —
-  // otherwise every lookup would allocate a `rootId + '|' + selector`
-  // string, and this runs a lot.
+  const rootId = selectorData._nodeRecords[targetIdx].rootId;
+  let candidates = null;
+  let selector = '';
+  let curElm = elm;
+  do {
+    const fragment = computeFragment(curElm, selectorData);
+    selector = fragment.selectorString + (selector ? ' > ' + selector : '');
+    candidates = candidatesForChain(
+      selector,
+      fragment,
+      candidates,
+      selectorData,
+      rootId
+    );
+    curElm = curElm.parentElement;
+  } while ((candidates.length > 1 || toRoot) && curElm);
+
+  if (candidates.length !== 1) {
+    return getRootSelector(selector);
+  }
+  return selector;
+}
+
+/**
+ * Build the selector fragment for one element — the one link of the chain
+ * that describes just this element, like `button.foo:nth-child(3)`.
+ *
+ * The output is both the string form (what ends up in the final selector)
+ * and the parts broken out (tag / classes / exact attrs / suffix attrs /
+ * nth-child) because match-time code needs them separately and would
+ * otherwise have to re-parse.
+ *
+ * The result is cached per element because `generateSelector` walks up the
+ * tree and asks about the same ancestors over and over — once per target
+ * that shares those ancestors. Cache by nodeIdx; elements that were never
+ * walked (not in `_elmToIdx`) are not cached.
+ *
+ * @param {Element}      elm
+ * @param {SelectorData} selectorData
+ * @returns {Fragment}
+ */
+function computeFragment(elm, selectorData) {
+  let cache = selectorData._computeFragmentCache;
+  if (!cache) {
+    cache = selectorData._computeFragmentCache = [];
+  }
+  const nodeIdx = selectorData._elmToIdx.get(elm);
+  if (nodeIdx !== undefined) {
+    const cached = cache[nodeIdx];
+    if (cached) {
+      return cached;
+    }
+  }
+
+  const fragment = buildFragment(elm, selectorData);
+  if (nodeIdx !== undefined) {
+    cache[nodeIdx] = fragment;
+  }
+  return fragment;
+}
+
+/**
+ * Build the uncached selector fragment for one element.
+ *
+ * @param {Element}      elm
+ * @param {SelectorData} selectorData
+ * @returns {Fragment}
+ */
+function buildFragment(elm, selectorData) {
+  const id = getElmId(elm);
+  if (id) {
+    return { id, selectorString: id };
+  }
+
+  const { selectorString, tag, features } = getThreeLeastCommonFeatures(
+    elm,
+    selectorData
+  );
+  const { classes, exactAttrs, suffixAttrs } = classifyFeatures(
+    features,
+    selectorData._suffixInfo
+  );
+  return withNthChildIfNeeded(
+    elm,
+    { selectorString, tag, classes, exactAttrs, suffixAttrs },
+    selectorData
+  );
+}
+
+/**
+ * Split picked features into the match-time shape: classes, exact
+ * attribute selectors, and suffix (`$=`) attribute selectors.
+ *
+ * Two flavors of attribute selector need different treatment at match
+ * time: `name="value"` (exact match, answered from the precomputed
+ * bitmap) and `name$="value"` (suffix match, answered by comparing
+ * the raw URL). Splitting them here once means the match-time code
+ * doesn't have to reclassify on every check.
+ *
+ * We can't sniff for `$="` inside the atnv — an attribute name that
+ * ends in `$` (e.g. Polymer's `attr$="…"` binding syntax left in
+ * serialized markup) escapes to `\$="…"`, which trips the same
+ * check. `_suffixInfo` is the authoritative record of which atnvs
+ * are suffix-form; we populated it in `collectNodeAttrs`, where the
+ * form was known unambiguously.
+ *
+ * @param {Feature[]} features
+ * @param {Map<String, {rawName: String, suffix: String}>} suffixInfo
+ * @returns {{classes: String[], exactAttrs: String[]|null, suffixAttrs: Array<{rawName: String, suffix: String}>|null}}
+ */
+function classifyFeatures(features, suffixInfo) {
+  const classes = [];
+  let exactAttrs = null;
+  let suffixAttrs = null;
+  for (let i = 0; i < features.length; i++) {
+    const feature = features[i];
+    if (feature.kind === 'class') {
+      classes.push(feature.name);
+      continue;
+    }
+    const suffixAttr = suffixInfo.get(feature.name);
+    if (suffixAttr) {
+      if (!suffixAttrs) {
+        suffixAttrs = [];
+      }
+      suffixAttrs.push(suffixAttr);
+    } else {
+      if (!exactAttrs) {
+        exactAttrs = [];
+      }
+      exactAttrs.push(feature.name);
+    }
+  }
+  return { classes, exactAttrs, suffixAttrs };
+}
+
+/**
+ * If a sibling also matches this fragment, append `:nth-child(N)` so the
+ * fragment is unique among its DOM siblings.
+ *
+ * Normally answered from precomputed data with no per-sibling CSS-engine
+ * call. Fallback: a sibling that wasn't walked by `getSelectorData` isn't
+ * in `_elmToIdx` (e.g. an unslotted light-DOM child of a shadow host is
+ * dropped from the flat tree, but is still a real DOM sibling for
+ * `:nth-child` purposes). For those we call `matchesSelector` — the same
+ * way the pre-index algorithm did it.
+ *
+ * @param {Element}      elm
+ * @param {Fragment}     fragment
+ * @param {SelectorData} selectorData
+ * @returns {Fragment}   `fragment` unchanged, or a new one with `:nth-child`
+ */
+function withNthChildIfNeeded(elm, fragment, selectorData) {
+  const siblings = (elm.parentNode && elm.parentNode.children) || null;
+  if (!siblings || siblings.length < 2) {
+    return fragment;
+  }
+
+  const { selectorString } = fragment;
+  for (let i = 0; i < siblings.length; i++) {
+    const sibling = siblings[i];
+    if (sibling === elm) {
+      continue;
+    }
+    const siblingIdx = selectorData._elmToIdx.get(sibling);
+    const siblingMatches =
+      siblingIdx !== undefined
+        ? fragmentMatchesIdx(fragment, siblingIdx, selectorData._nodeRecords)
+        : matchesSelector(sibling, selectorString);
+
+    if (siblingMatches) {
+      const ownNth = 1 + Array.prototype.indexOf.call(siblings, elm);
+      return {
+        ...fragment,
+        selectorString: selectorString + ':nth-child(' + ownNth + ')',
+        nthChild: ownNth
+      };
+    }
+  }
+
+  return fragment;
+}
+
+/**
+ * Candidate list for one chain string: cache hit, first fragment, or
+ * matching parents of the previous list.
+ *
+ * `prevCandidates` is `null` on the first step (no chain yet). After
+ * that it is the list from the previous, more-specific chain. The
+ * returned array is stored in `_chainCache` so later targets that reach
+ * the same string skip the work.
+ *
+ * @param {String}        selector
+ * @param {Fragment}      fragment
+ * @param {Number[]|null} prevCandidates
+ * @param {SelectorData}  selectorData
+ * @param {Number}        rootId
+ * @returns {Number[]}
+ */
+function candidatesForChain(
+  selector,
+  fragment,
+  prevCandidates,
+  selectorData,
+  rootId
+) {
+  const rootChain = getRootChainCache(selectorData, rootId);
+  const cached = rootChain.get(selector);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const nextCandidates = prevCandidates
+    ? matchingParents(prevCandidates, fragment, selectorData, rootId)
+    : indicesForFragment(fragment, selectorData, rootId);
+
+  rootChain.set(selector, nextCandidates);
+  return nextCandidates;
+}
+
+/**
+ * Per-rootId cache of "chain string → candidate list". Nested so the
+ * inner Map key is just the selector string — otherwise every lookup
+ * would allocate a `rootId + '|' + selector` string, and this runs a lot.
+ *
+ * @param {SelectorData} selectorData
+ * @param {Number}       rootId
+ * @returns {Map<String, Number[]>}
+ */
+function getRootChainCache(selectorData, rootId) {
   let chainCache = selectorData._chainCache;
   if (!chainCache) {
     chainCache = selectorData._chainCache = [];
@@ -278,73 +341,21 @@ export default function generateSelector(elm, options) {
   if (!rootChain) {
     rootChain = chainCache[rootId] = new Map();
   }
-  let selector = '';
-  let indices = null; // read-only source; may point at cached data
-  let anc = null; // mutable working buffer for in-place filtering
-  let candCount = 0;
-  let curIdx = targetIdx;
-  let curElm = elm;
+  return rootChain;
+}
 
-  do {
-    const frag = computeFragment(curElm, curIdx, selectorData);
-    selector = selector
-      ? frag.selectorString + ' > ' + selector
-      : frag.selectorString;
-
-    const cached = rootChain.get(selector);
-    if (cached !== undefined) {
-      // Another target has already reached this exact chain string —
-      // reuse its filtered candidate list. Treat it as if we just did
-      // level 0: `anc` gets rebuilt from `indices` on the next filter.
-      indices = cached;
-      anc = null;
-      candCount = cached.length;
-    } else if (indices === null) {
-      indices = indicesForFragment(
-        frag,
-        frag.selectorString,
-        selectorData,
-        rootId
-      );
-      candCount = indices.length;
-      rootChain.set(selector, indices);
-    } else {
-      const ancBits = bitsForFragment(
-        frag,
-        frag.selectorString,
-        selectorData,
-        rootId
-      );
-      // On the first ancestor step (or right after a cache hit) `anc`
-      // doesn't exist yet — read from the read-only `indices` array and
-      // write survivors into a fresh `anc`. From then on `anc` is our own
-      // mutable buffer and we filter it in place.
-      const source = anc === null ? indices : anc;
-      if (anc === null) {
-        anc = new Int32Array(candCount);
-      }
-      candCount = advanceAndFilter(anc, source, candCount, parentOf, ancBits);
-      // Save a snapshot so the next target that reaches this same chain
-      // string can jump straight here instead of redoing the walk.
-      rootChain.set(selector, anc.slice(0, candCount));
-    }
-
-    // Move up to the parent for the next iteration. `curElm` uses the DOM
-    // (`parentElement`) because measuring showed that's actually faster
-    // than looking up `parentOf[curIdx]` and then converting back to an
-    // Element via `perNode[idx].elm`. `curIdx` is kept in sync so
-    // `computeFragment`'s per-nodeIdx cache stays hot.
-    curElm = curElm.parentElement;
-    curIdx = curElm ? elmToIdx.get(curElm) : -1;
-    if (curIdx === undefined) {
-      curIdx = -1;
-    }
-  } while ((candCount > 1 || toRoot) && curElm);
-
-  if (candCount === 1) {
-    return selector;
-  } else if (selector.indexOf(' > ') !== -1) {
-    return ':root' + selector.substring(selector.indexOf(' > '));
+/**
+ * Replace the outermost fragment with `:root`. Used when the chain is
+ * still not unique after walking to the document — the document itself
+ * is always unique.
+ *
+ * @param {String} selector
+ * @returns {String}
+ */
+function getRootSelector(selector) {
+  const childPos = selector.indexOf(' > ');
+  if (childPos !== -1) {
+    return ':root' + selector.substring(childPos);
   }
   return ':root';
 }

--- a/lib/core/utils/get-selector/generate.js
+++ b/lib/core/utils/get-selector/generate.js
@@ -26,9 +26,11 @@ import {
  *   "a button.cta inside a div.wrap inside a main."
  *
  *   CANDIDATE — an element that still matches the chain-so-far. Kept
- *   as a list of nodeIdx values. Starts as "every element that matches
- *   the target's own fragment" and is replaced with matching parents
- *   at every ancestor step. When the list hits length 1, we're done.
+ *   as a list of nodeIdx values (`Number[]` from `indicesForFragment`,
+ *   or an `Int32Array` view from `matchingParents`). Starts as "every
+ *   element that matches the target's own fragment" and is replaced
+ *   with matching parents at every ancestor step. When the list hits
+ *   length 1, we're done.
  *
  * ALGORITHM (`generateSelector`)
  *
@@ -253,6 +255,7 @@ function classifyFeatures(features, suffixInfo) {
  * @returns {Fragment}   `fragment` unchanged, or a new one with `:nth-child`
  */
 function withNthChildIfNeeded(elm, fragment, selectorData) {
+  const elmIdx = selectorData._elmToIdx.get(elm);
   const siblings = (elm.parentNode && elm.parentNode.children) || null;
   if (!siblings || siblings.length < 2) {
     return fragment;
@@ -269,7 +272,7 @@ function withNthChildIfNeeded(elm, fragment, selectorData) {
       siblingIdx !== undefined &&
       fragmentMatchesIdx(fragment, siblingIdx, selectorData._nodeRecords)
     ) {
-      const ownNth = 1 + Array.prototype.indexOf.call(siblings, elm);
+      const ownNth = selectorData._nodeRecords[elmIdx].nthChild;
       return {
         ...fragment,
         selectorString: selectorString + ':nth-child(' + ownNth + ')',
@@ -290,12 +293,16 @@ function withNthChildIfNeeded(elm, fragment, selectorData) {
  * returned array is stored in `_chainCache` so later targets that reach
  * the same string skip the work.
  *
+ * `matchingParents` returns a view of a reused buffer, so the cache
+ * stores a copy. The view itself is returned to the walk so the next
+ * ancestor step can filter it in place.
+ *
  * @param {String}        selector
  * @param {Fragment}      fragment
- * @param {Number[]|null} prevCandidates
+ * @param {ArrayLike<Number>|null} prevCandidates
  * @param {SelectorData}  selectorData
  * @param {Number}        rootId
- * @returns {Number[]}
+ * @returns {ArrayLike<Number>}
  */
 function candidatesForChain(
   selector,
@@ -310,11 +317,21 @@ function candidatesForChain(
     return cached;
   }
 
-  const nextCandidates = prevCandidates
-    ? matchingParents(prevCandidates, fragment, selectorData, rootId)
-    : indicesForFragment(fragment, selectorData, rootId);
+  if (!prevCandidates) {
+    const nextCandidates = indicesForFragment(fragment, selectorData, rootId);
+    rootChain.set(selector, nextCandidates);
+    return nextCandidates;
+  }
 
-  rootChain.set(selector, nextCandidates);
+  const nextCandidates = matchingParents(
+    prevCandidates,
+    fragment,
+    selectorData,
+    rootId
+  );
+  // View of a reused buffer — copy for the cache, return the view so
+  // the next ancestor step can filter it in place.
+  rootChain.set(selector, nextCandidates.slice());
   return nextCandidates;
 }
 
@@ -325,7 +342,7 @@ function candidatesForChain(
  *
  * @param {SelectorData} selectorData
  * @param {Number}       rootId
- * @returns {Map<String, Number[]>}
+ * @returns {Map<String, ArrayLike<Number>>}
  */
 function getRootChainCache(selectorData, rootId) {
   let chainCache = selectorData._chainCache;

--- a/lib/core/utils/get-selector/precompute.js
+++ b/lib/core/utils/get-selector/precompute.js
@@ -62,9 +62,11 @@ import { listToBits } from './bit-index';
  *   5. `buildIndexes`           — lists → bitmaps, flatten `_parentOf`,
  *                                 drop non-unique ids from `_idToIdx`
  *
- * Flat-tree and phantom nodes share `indexElement` (counts, lists,
- * NodeRecord) and are indistinguishable once recorded. They differ
- * only in how they were found and in how their parent is resolved.
+ * Flat-tree and phantom nodes share `indexElement` (lists, id tables,
+ * NodeRecord) and are indistinguishable once recorded, apart from the
+ * public frequency counts, which only flat-tree nodes feed. Otherwise
+ * they differ only in how they were found and in how their parent is
+ * resolved.
  *
  * OUTPUT: a `SelectorData` object — see the typedef below.
  *
@@ -73,7 +75,9 @@ import { listToBits } from './bit-index';
  *
  * @typedef {Object} SelectorData
  *
- * Public counts (feature selection in `features.js` reads these):
+ * Public counts (feature selection in `features.js` reads these).
+ * Flattened-tree elements only — see `indexElement` for why phantoms
+ * are left out:
  * @property {Object<String, Number>} classes      per-page count by class name
  * @property {Object<String, Number>} tags         per-page count by nodeName
  * @property {Object<String, Number>} attributes   per-page count by atnv
@@ -249,7 +253,12 @@ function recordFlatTreeElement(node, state) {
 
   selectorData._elmToIdx.set(node, nodeIdx);
   selectorData._nodeRecords.push(
-    indexElement(node, nodeIdx, { parentIdx, rootId }, state)
+    indexElement(
+      node,
+      nodeIdx,
+      { parentIdx, rootId, countFeatures: true },
+      state
+    )
   );
   // Register an open shadow root as its own `_rootMap` entry so the
   // phantom pass walks it. Done here rather than relying on the
@@ -318,22 +327,36 @@ function rootIdFor(root, state) {
 /**
  * Count this element's tag / classes / attrs / id, add it to the
  * reverse-index lists, and return its `NodeRecord`. Shared by
- * flat-tree and phantom nodes — frequency counts include everything
- * flatten-tree dropped, so feature selection sees the live DOM's true
- * distribution rather than just the flat tree's.
+ * flat-tree and phantom nodes; they are indistinguishable afterwards
+ * except in the public frequency counts, which only flat-tree nodes
+ * feed. Selectors are compared across axe runs, so the counts that
+ * drive feature selection have to reflect the same set of elements
+ * axe reports on — a phantom would shift which class or attribute
+ * gets picked and rewrite the selector string. Uniqueness is a
+ * separate question, answered by the bitmaps and id tables, which
+ * phantoms do feed.
  *
  * @param {Element}      node
  * @param {Number}       nodeIdx
  * @param {Object}       placement
  * @param {Number}       placement.parentIdx
  * @param {Number}       placement.rootId
+ * @param {Boolean}      placement.countFeatures  add to the public
+ *                                                frequency maps
  * @param {IndexState} state
  * @returns {NodeRecord}
  */
-function indexElement(node, nodeIdx, { parentIdx, rootId }, state) {
+function indexElement(
+  node,
+  nodeIdx,
+  { parentIdx, rootId, countFeatures },
+  state
+) {
   const { selectorData, tagLists, rootLists, nthIndexCache } = state;
   const nodeName = node.nodeName;
-  selectorData.tags[nodeName] = (selectorData.tags[nodeName] || 0) + 1;
+  if (countFeatures) {
+    selectorData.tags[nodeName] = (selectorData.tags[nodeName] || 0) + 1;
+  }
 
   // `nodeName` is uppercase in HTML but selector strings are lowercase
   // (`button`, not `BUTTON`). Store both: `nodeName` keys the frequency
@@ -342,10 +365,11 @@ function indexElement(node, nodeIdx, { parentIdx, rootId }, state) {
   const tag = getBaseSelector(node);
   pushToList(tagLists, tag, nodeIdx);
 
-  const classes = collectNodeClasses(node, nodeIdx, state);
+  const classes = collectNodeClasses(node, nodeIdx, countFeatures, state);
   const { urlAttrs, featureAttrs, exactAttrs } = collectNodeAttrs(
     node,
     nodeIdx,
+    countFeatures,
     state
   );
 
@@ -385,15 +409,17 @@ function indexElement(node, nodeIdx, { parentIdx, rootId }, state) {
 }
 
 /**
- * Escaped class names on this element, with per-page counts and the
- * class → nodeIdx reverse index updated.
+ * Escaped class names on this element, with the class → nodeIdx
+ * reverse index updated, and the per-page counts too when
+ * `countFeatures` is set.
  *
  * @param {Element}      node
  * @param {Number}       nodeIdx
+ * @param {Boolean}      countFeatures
  * @param {IndexState} state
  * @returns {String[]}
  */
-function collectNodeClasses(node, nodeIdx, state) {
+function collectNodeClasses(node, nodeIdx, countFeatures, state) {
   const classesForNode = [];
   if (!node.classList) {
     return classesForNode;
@@ -401,8 +427,10 @@ function collectNodeClasses(node, nodeIdx, state) {
   const { selectorData, classLists } = state;
   for (const rawClass of node.classList) {
     const className = escapeSelector(rawClass);
-    selectorData.classes[className] =
-      (selectorData.classes[className] || 0) + 1;
+    if (countFeatures) {
+      selectorData.classes[className] =
+        (selectorData.classes[className] || 0) + 1;
+    }
     classesForNode.push(className);
     pushToList(classLists, className, nodeIdx);
   }
@@ -413,7 +441,8 @@ function collectNodeClasses(node, nodeIdx, state) {
  * Read every attribute on the node and record it so later lookups
  * don't have to touch the DOM again:
  *
- *   - `selectorData.attributes` — running counts, one per `name="value"`
+ *   - `selectorData.attributes` — running counts, one per `name="value"`,
+ *     only when `countFeatures` is set
  *   - `featureAttrs` / `exactAttrs` — this element's filter-passing
  *     atnvs (feature selection) and exact-form atnvs (fragment matching)
  *   - `attrLists` — for each exact atnv, which nodes have it
@@ -424,10 +453,11 @@ function collectNodeClasses(node, nodeIdx, state) {
  *
  * @param {Element}      node
  * @param {Number}       nodeIdx
+ * @param {Boolean}      countFeatures
  * @param {IndexState} state
  * @returns {{ urlAttrs: Object|null, featureAttrs: String[], exactAttrs: String[] }}
  */
-function collectNodeAttrs(node, nodeIdx, state) {
+function collectNodeAttrs(node, nodeIdx, countFeatures, state) {
   const featureAttrs = [];
   const exactAttrs = [];
   let urlAttrs = null;
@@ -475,7 +505,10 @@ function collectNodeAttrs(node, nodeIdx, state) {
     // Same atnv implies same name+value, so the filter verdict is the
     // same for every occurrence.
     if (filterAttributes(attr)) {
-      selectorData.attributes[atnv] = (selectorData.attributes[atnv] || 0) + 1;
+      if (countFeatures) {
+        selectorData.attributes[atnv] =
+          (selectorData.attributes[atnv] || 0) + 1;
+      }
       featureAttrs.push(atnv);
       if (!isSuffix) {
         exactAttrs.push(atnv);
@@ -589,7 +622,12 @@ function seedPhantomsFromRoots(state) {
       const parentIdx = phantomParentIdx(elm, rootNode, state);
       selectorData._elmToIdx.set(elm, nodeIdx);
       selectorData._nodeRecords.push(
-        indexElement(elm, nodeIdx, { parentIdx, rootId }, state)
+        indexElement(
+          elm,
+          nodeIdx,
+          { parentIdx, rootId, countFeatures: false },
+          state
+        )
       );
     }
   }

--- a/lib/core/utils/get-selector/precompute.js
+++ b/lib/core/utils/get-selector/precompute.js
@@ -19,143 +19,416 @@ import { listToBits } from './bit-index';
  * DOM Element; `current.actualNode` is the Element, `current.children`
  * is the virtual children.
  *
- * The walk is iterative (not recursive) because deeply-nested pages
+ * The walks are iterative (not recursive) because deeply-nested pages
  * would blow the call stack — `currentLevel` holds the frontier we're
  * popping from, `stack` holds the parent frontiers we'll return to
- * after diving into a subtree.
+ * after diving into a subtree. Parents are recorded before children
+ * so `parentIdxOf` can resolve the parent from `_elmToIdx`.
  *
- * PHANTOM RECORDS. A second, smaller pass runs after the flat-tree
- * walk to catch elements that exist in the real DOM but that
- * flatten-tree drops — specifically, light-DOM children of a shadow
- * host that don't match any `<slot>`. These are invisible to axe's
- * rule pipeline (`select(...)` never returns them, no rule ever
- * reports them), so they never get a selector generated FOR them —
- * but they still exist for `document.querySelectorAll`. If we only
- * counted flat-tree elements when building bitmaps, a fragment that
- * looks unique in the bitmap ("1 img matches `img[src="x.png"]`")
- * could still match 2 elements in the live DOM, and the returned
- * selector would resolve to the wrong one. So we phantom-walk the
- * unslotted subtree of every shadow host and give each element a
- * full `_perNode` record — same shape as real nodes, so downstream
- * code treats them uniformly. They stay OUT of `_elmToIdx` and
- * `_idToIdx` so `getSelector` and `getElmId` never route to a
- * phantom (axe never asked for one, so returning one would be
- * wrong).
+ * DROPPED DOM. A second, smaller pass runs after the flat-tree walk
+ * to catch elements that exist in the real DOM but that flatten-tree
+ * drops. Two groups, both invisible to axe's rule pipeline
+ * (`select(...)` never returns them, no rule ever reports them) so
+ * they never get a selector generated FOR them — but they still exist
+ * for `querySelectorAll`, and a fragment that looks unique in the
+ * bitmap could still match them in the live tree:
  *
- * OUTPUT: a `data` object with:
+ *   1. Unslotted light-DOM children of a shadow host (don't match
+ *      any `<slot>`). Walked from `host.children`, skipping anything
+ *      already in `_elmToIdx`. `rootId` is the host's — light DOM,
+ *      not the shadow tree. `parentIdx` is passed in because the
+ *      parent may itself be unslotted.
+ *   2. `<slot>` elements inside each open shadow root. Flatten-tree
+ *      splices those out (assigned nodes / fallback take their
+ *      place). `querySelectorAll('slot')` finds them even when nested
+ *      under an already-indexed shadow-tree node. `rootId` is the
+ *      shadow root's.
  *
- *   Public counts (feature selection reads these):
- *     .classes / .tags / .attributes — how many times each name
- *       appears across the whole page.
+ * Each remaining element gets a full `_nodeRecords` entry — same
+ * shape as flat-tree nodes, so downstream code treats them uniformly.
+ * They stay OUT of `_elmToIdx` and `_idToIdx` so `getSelector` and
+ * `getElmId` never route to one (axe never asked for one, so
+ * returning one would be wrong).
  *
- *   Per-element records:
- *     _perNode  — array of Rec (see @typedef below), keyed by nodeIdx.
- *     _elmToIdx — WeakMap<Element, nodeIdx> for the reverse lookup.
+ * PIPELINE. `getSelectorData` is four named steps:
+ *   1. `createIndexState`       — empty `selectorData` + accumulators
+ *   2. `walkFlatTree`           — record every flattened-tree element
+ *   3. `addUnslottedElements`   — record unslotted light DOM + slots
+ *   4. `buildIndexes`           — lists → bitmaps, flatten `_parentOf`,
+ *                                 drop non-unique ids from `_idToIdx`
  *
- *   Bitmap indexes (see the top of `bit-index.js` for what a bitmap is):
- *     _tagBits / _classBits / _attrBits — keyed by tag / class / atnv.
- *     _rootBits + _rootMap — per-shadow-root bitmap so selector queries
- *       don't leak across shadow boundaries.
- *     _wordCount — how many Uint32 words each bitmap holds.
+ * Flat-tree, unslotted, and slot nodes share `indexElement` (counts,
+ * lists, NodeRecord). They differ only in routing: flat-tree nodes go
+ * into `_elmToIdx` / `_idToIdx` and queue shadow hosts; dropped ones
+ * do not.
  *
- *   Id lookup (avoids `querySelectorAll('#foo')` at query time):
- *     _idCounts[rootId][idSel] — how many times this id appears in this
- *       root (a non-1 count means the id isn't usable as a selector).
- *     _idToIdx[rootId][idSel]  — the nodeIdx of the sole matching
- *       element (only present when count === 1).
+ * OUTPUT: a `SelectorData` object — see the typedef below.
  *
- *   Ancestor walk helpers:
- *     _parentOf — Int32Array of `rec.parentIdx` for the chain walk.
- *     _suffixInfo — Map<atnv, {rawName, suffix}> for suffix-form
- *       atnvs, so `computeFragment` can classify without sniffing `$="`.
+ * A "bitmap" here is a `Uint32Array` with one bit per node; see the top
+ * of `bit-index.js` for what they are and how they're queried.
  *
- * @typedef {Object} Rec
- * @property {Element}      elm         the real DOM Element
- * @property {String}       nodeName    uppercase HTML name (e.g. "BUTTON") —
- *                                      keys `data.tags` counts
- * @property {String}       tag         lowercase tag selector form
- *                                      (e.g. "button") — keys `_tagBits`
- *                                      and appears in emitted selectors
- * @property {String|null}  id          `#id` selector string, or null
- * @property {String[]}     classes     escaped class names on this element
- * @property {String[]}     attrs       filter-passing atnvs (feed feature counts)
- * @property {String[]}     matchAttrs  exact-form atnvs only (used at match time)
- * @property {Object|null}  urlAttrs    `{ href: rawURL, src: rawURL, ... }`
- *                                      for suffix-form attrs, or null
- * @property {Number}       nthChild    1-indexed position among element
- *                                      siblings; 0 if disconnected
- * @property {Number}       parentIdx   nodeIdx of the parent, or -1
- * @property {Number}       rootId      which root this element lives in
- *                                      (0 = main document, 1+ = shadow roots)
+ * @typedef {Object} SelectorData
+ *
+ * Public counts (feature selection in `features.js` reads these):
+ * @property {Object<String, Number>} classes      per-page count by class name
+ * @property {Object<String, Number>} tags         per-page count by nodeName
+ * @property {Object<String, Number>} attributes   per-page count by atnv
+ *
+ * Per-element records:
+ * @property {NodeRecord[]}            _nodeRecords   keyed by nodeIdx
+ * @property {WeakMap<Element, Number>} _elmToIdx     Element → nodeIdx
+ *
+ * Bitmap indexes:
+ * @property {Object<String, Uint32Array>} _tagBits     which nodes have this tag
+ * @property {Object<String, Uint32Array>} _classBits   ... this class
+ * @property {Object<String, Uint32Array>} _attrBits    ... this exact-form atnv
+ * @property {Uint32Array[]}               _rootBits    which nodes live in
+ *                                         root N, so selector queries don't
+ *                                         leak across shadow boundaries
+ * @property {Map<Node, Number>}           _rootMap     root node → rootId
+ * @property {Number}                      _wordCount   Uint32 words per bitmap
+ *
+ * Id lookup (avoids `querySelectorAll('#foo')` at query time):
+ * @property {Array<Object<String, Number>>} _idCounts  [rootId][idSel] → how
+ *                                         many times this id appears in this
+ *                                         root (a non-1 count means the id
+ *                                         isn't usable as a selector)
+ * @property {Array<Object<String, Number>>} _idToIdx   [rootId][idSel] → the
+ *                                         nodeIdx of the sole matching element
+ *                                         (only present when count === 1)
+ *
+ * Ancestor walk helpers:
+ * @property {Int32Array} _parentOf    `nodeRecord.parentIdx` per nodeIdx, for
+ *                                     the chain walk in `generate.js`
+ * @property {Map<String, {rawName: String, suffix: String}>} _suffixInfo
+ *                                     keyed by atnv, for suffix-form atnvs
+ *                                     only, so `computeFragment` can classify
+ *                                     without sniffing for `$="`
  */
 
 /**
- * Look up (or build on first use) the `child element -> 1-indexed position`
- * map for `domParent`. Building it once per parent keeps the sibling walk
- * linear across a parent with many children; `indexOf` per element would
- * be O(N^2).
+ * Everything the selector generator needs to know about one element,
+ * flattened so match-time code never has to touch the DOM.
  *
- * @param {Element} domParent
- * @param {Map}     cache        Map<Element, Map<Element, Number>>
- * @returns {Map<Element, Number>}
+ * @typedef {Object} NodeRecord
+ * @property {Element}      elm           the real DOM Element
+ * @property {String}       nodeName      uppercase HTML name (e.g. "BUTTON") —
+ *                                        keys `selectorData.tags` counts
+ * @property {String}       tag           lowercase tag selector form
+ *                                        (e.g. "button") — keys `_tagBits`
+ *                                        and appears in emitted selectors
+ * @property {String|null}  id            `#id` selector string, or null
+ * @property {String[]}     classes       escaped class names on this element
+ * @property {String[]}     featureAttrs  filter-passing atnvs, both forms;
+ *                                        feeds feature selection
+ * @property {String[]}     exactAttrs    exact-form atnvs only; compared
+ *                                        against `fragment.exactAttrs`
+ * @property {Object|null}  urlAttrs      raw URL values keyed by raw attribute
+ *                                        name (`{ href: '…', src: '…' }`) for
+ *                                        suffix-form attrs, or null
+ * @property {Number}       nthChild      1-indexed position among element
+ *                                        siblings; 0 if disconnected
+ * @property {Number}       parentIdx     nodeIdx of the parent, or -1
+ * @property {Number}       rootId        which root this element lives in
+ *                                        (0 = main document, 1+ = shadow roots)
  */
-function nthChildMap(domParent, cache) {
-  let nthMap = cache.get(domParent);
-  if (!nthMap) {
-    nthMap = new Map();
-    const kids = domParent.children;
-    for (let k = 0; k < kids.length; k++) {
-      nthMap.set(kids[k], k + 1);
-    }
-    cache.set(domParent, nthMap);
-  }
-  return nthMap;
+
+/**
+ * The mutable state of one `getSelectorData` run: the `SelectorData`
+ * under construction plus the accumulators that only exist during the
+ * walk. Bitmaps can't be sized until the node count is final, so each
+ * `*Lists` map collects member nodeIdx values as plain arrays and
+ * `buildIndexes` converts them at the end.
+ *
+ * @typedef {Object} IndexState
+ * @property {SelectorData}            selectorData
+ * @property {Map<String, Number[]>}   tagLists      nodeIdxs by tag
+ * @property {Map<String, Number[]>}   classLists    nodeIdxs by class name
+ * @property {Map<String, Number[]>}   attrLists     nodeIdxs by exact atnv
+ * @property {Array<Number[]>}         rootLists     nodeIdxs by rootId
+ * @property {Map<Element, Map<Element, Number>>} nthIndexCache
+ * @property {Number[]}                shadowHostIdxs  hosts of open shadow
+ *                                     roots, to revisit for unslotted children
+ */
+
+/**
+ * Walk the whole page once and record everything the selector generator will
+ * ever need to know about it. The point is to move as much work as possible
+ * out of the per-element hot path (`generateSelector`, which runs thousands
+ * of times per axe.run) and into this one-time setup.
+ *
+ * @param {Object} domTree     The root node of the virtual DOM tree
+ * @returns {SelectorData}     Frequency counts + fast-lookup tables
+ */
+export function getSelectorData(domTree) {
+  const state = createIndexState();
+  walkFlatTree(domTree, state);
+  addUnslottedElements(state);
+  buildIndexes(state);
+  return state.selectorData;
 }
 
 /**
- * Read every attribute on the node and record it in several places so later
- * lookups don't have to touch the DOM again:
+ * Allocate the output `SelectorData` plus the walk-only accumulators.
  *
- *   - `data.attributes` — running counts across the whole page, one per
- *     `name="value"` string. Used later to pick "uncommon" features.
- *   - `attrsForNode` / `matchAttrsForNode` — per-element lists of the
- *     `name="value"` strings this element has.
- *   - `attrLists` — for each `name="value"` string, which nodes have it.
- *     This is what we later flip into the fast lookup tables.
- *
- * Returns `urlAttrs`, a map of raw href/src values keyed by attribute name,
- * or null if this element has none. Href/src attributes match by "does the
- * URL end with this string?" — not by exact equality — so we keep the raw
- * value around to check that at query time.
- *
- * @param {Element} node
- * @param {Number}  nodeIdx             this element's node index
- * @param {Object}  data                the object being built by `getSelectorData`
- * @param {Map}     attrLists           atnv string -> Array<nodeIdx>, populated here
- * @param {Array}   attrsForNode        filter-passing atnvs on this element, populated here
- * @param {Array}   matchAttrsForNode   exact-form atnvs on this element, populated here
- * @returns {Object|null}               `{ [attrName]: rawValue }` for href/src attrs
+ * @returns {IndexState}
  */
-function collectNodeAttrs(
+function createIndexState() {
+  return {
+    selectorData: {
+      classes: {},
+      tags: {},
+      attributes: {},
+      _nodeRecords: [],
+      _elmToIdx: new WeakMap(),
+      _tagBits: {},
+      _classBits: {},
+      _attrBits: {},
+      _rootMap: new Map(),
+      _rootBits: [],
+      _idCounts: [],
+      _idToIdx: [],
+      _suffixInfo: new Map(),
+      _wordCount: 0
+    },
+    tagLists: new Map(),
+    classLists: new Map(),
+    attrLists: new Map(),
+    rootLists: [],
+    nthIndexCache: new Map(),
+    shadowHostIdxs: []
+  };
+}
+
+/**
+ * Iterative DFS of the flattened virtual tree. Skip non-elements
+ * (`#text` nodes have no `querySelectorAll`).
+ *
+ * @param {Object}       domTree
+ * @param {IndexState} state
+ */
+function walkFlatTree(domTree, state) {
+  const roots = Array.isArray(domTree) ? domTree : [domTree];
+  let currentLevel = roots.slice();
+  const stack = [];
+
+  while (currentLevel.length) {
+    const current = currentLevel.pop();
+    const node = current.actualNode;
+
+    if (node.querySelectorAll) {
+      recordFlatTreeElement(node, state);
+    }
+    if (current.children.length) {
+      stack.push(currentLevel);
+      currentLevel = current.children.slice();
+    }
+    while (!currentLevel.length && stack.length) {
+      currentLevel = stack.pop();
+    }
+  }
+}
+
+/**
+ * Record a flattened-tree element: index it, route it through
+ * `_elmToIdx` / `_idToIdx`, and queue it for the unslotted pass if it
+ * hosts an open shadow root.
+ *
+ * @param {Element}      node
+ * @param {IndexState} state
+ */
+function recordFlatTreeElement(node, state) {
+  const { selectorData } = state;
+  const nodeIdx = selectorData._nodeRecords.length;
+  const parentIdx = parentIdxOf(node, state);
+  const rootId = ensureRoot(node, state);
+
+  selectorData._elmToIdx.set(node, nodeIdx);
+  selectorData._nodeRecords.push(
+    indexElement(node, nodeIdx, { parentIdx, rootId, shouldMapId: true }, state)
+  );
+  if (node.shadowRoot) {
+    state.shadowHostIdxs.push(nodeIdx);
+  }
+}
+
+/**
+ * DOM parent's nodeIdx, or -1 if the parent was not walked (document,
+ * ShadowRoot, disconnected). Relies on parent-before-child walk order.
+ *
+ * @param {Element}      node
+ * @param {IndexState} state
+ * @returns {Number}
+ */
+function parentIdxOf(node, state) {
+  const domParent = node.parentNode;
+  if (!domParent) {
+    return -1;
+  }
+  const parentIdx = state.selectorData._elmToIdx.get(domParent);
+  return parentIdx !== undefined ? parentIdx : -1;
+}
+
+/**
+ * Numeric id for the node's root (0 = main document, 1+ = shadow
+ * roots), creating the per-root tables on first sight.
+ *
+ * @param {Element}      node
+ * @param {IndexState} state
+ * @returns {Number}
+ */
+function ensureRoot(node, state) {
+  const root =
+    typeof node.getRootNode === 'function' ? node.getRootNode() : document;
+  const { selectorData, rootLists } = state;
+  let rootId = selectorData._rootMap.get(root);
+  if (rootId !== undefined) {
+    return rootId;
+  }
+  rootId = selectorData._rootMap.size;
+  selectorData._rootMap.set(root, rootId);
+  rootLists[rootId] = [];
+  selectorData._idCounts[rootId] = {};
+  selectorData._idToIdx[rootId] = {};
+  return rootId;
+}
+/**
+ * Count this element's tag / classes / attrs / id, add it to the
+ * reverse-index lists, and return its `NodeRecord`. Shared by
+ * flat-tree and dropped nodes — frequency counts include unslotted
+ * light DOM and shadow-tree slots so feature selection sees the live
+ * DOM's true distribution, not just the flat tree's.
+ *
+ * @param {Element}      node
+ * @param {Number}       nodeIdx
+ * @param {Object}       placement
+ * @param {Number}       placement.parentIdx
+ * @param {Number}       placement.rootId
+ * @param {Boolean}      placement.shouldMapId  write `_idToIdx`
+ *                                              (false when unslotted)
+ * @param {IndexState} state
+ * @returns {NodeRecord}
+ */
+function indexElement(
   node,
   nodeIdx,
-  data,
-  attrLists,
-  attrsForNode,
-  matchAttrsForNode
+  { parentIdx, rootId, shouldMapId },
+  state
 ) {
+  const { selectorData, tagLists, rootLists, nthIndexCache } = state;
+  const nodeName = node.nodeName;
+  selectorData.tags[nodeName] = (selectorData.tags[nodeName] || 0) + 1;
+
+  // `nodeName` is uppercase in HTML but selector strings are lowercase
+  // (`button`, not `BUTTON`). Store both: `nodeName` keys the frequency
+  // map, `tag` keys the bitmap so match-time comparisons need no
+  // case conversion.
+  const tag = getBaseSelector(node);
+  pushToList(tagLists, tag, nodeIdx);
+
+  const classes = collectNodeClasses(node, nodeIdx, state);
+  const { urlAttrs, featureAttrs, exactAttrs } = collectNodeAttrs(
+    node,
+    nodeIdx,
+    state
+  );
+
+  let id = null;
+  const rawId = node.getAttribute && node.getAttribute('id');
+  if (rawId) {
+    id = '#' + escapeSelector(rawId);
+    const rootIds = selectorData._idCounts[rootId];
+    rootIds[id] = (rootIds[id] || 0) + 1;
+    // Unslotted elements bump the count (so a flat-tree node with the
+    // same id sees the collision) but stay out of `_idToIdx`.
+    if (shouldMapId) {
+      selectorData._idToIdx[rootId][id] = nodeIdx;
+    }
+  }
+
+  rootLists[rootId].push(nodeIdx);
+
+  let nthChild = 0;
+  const domParent = node.parentNode;
+  if (domParent && domParent.children) {
+    nthChild = nthChildMap(domParent, nthIndexCache).get(node) || 0;
+  }
+
+  return {
+    elm: node,
+    nodeName,
+    tag,
+    id,
+    classes,
+    featureAttrs,
+    exactAttrs,
+    urlAttrs,
+    nthChild,
+    parentIdx,
+    rootId
+  };
+}
+
+/**
+ * Escaped class names on this element, with per-page counts and the
+ * class → nodeIdx reverse index updated.
+ *
+ * @param {Element}      node
+ * @param {Number}       nodeIdx
+ * @param {IndexState} state
+ * @returns {String[]}
+ */
+function collectNodeClasses(node, nodeIdx, state) {
+  const classesForNode = [];
+  if (!node.classList) {
+    return classesForNode;
+  }
+  const { selectorData, classLists } = state;
+  for (const rawClass of node.classList) {
+    const className = escapeSelector(rawClass);
+    selectorData.classes[className] =
+      (selectorData.classes[className] || 0) + 1;
+    classesForNode.push(className);
+    pushToList(classLists, className, nodeIdx);
+  }
+  return classesForNode;
+}
+
+/**
+ * Read every attribute on the node and record it so later lookups
+ * don't have to touch the DOM again:
+ *
+ *   - `selectorData.attributes` — running counts, one per `name="value"`
+ *   - `featureAttrs` / `exactAttrs` — this element's filter-passing
+ *     atnvs (feature selection) and exact-form atnvs (fragment matching)
+ *   - `attrLists` — for each exact atnv, which nodes have it
+ *
+ * Href/src attributes match by "does the URL end with this string?"
+ * rather than exact equality, so we also return `urlAttrs` (raw
+ * values keyed by raw attribute name) to check at query time.
+ *
+ * @param {Element}      node
+ * @param {Number}       nodeIdx
+ * @param {IndexState} state
+ * @returns {{ urlAttrs: Object|null, featureAttrs: String[], exactAttrs: String[] }}
+ */
+function collectNodeAttrs(node, nodeIdx, state) {
+  const featureAttrs = [];
+  const exactAttrs = [];
   let urlAttrs = null;
   if (!node.hasAttributes()) {
-    return urlAttrs;
+    return { urlAttrs, featureAttrs, exactAttrs };
   }
+
+  const { selectorData, attrLists } = state;
   const rawAttrs = getNodeAttributes(node);
   for (let i = 0; i < rawAttrs.length; i++) {
-    const at = rawAttrs[i];
-    const info = getAttributeNameValue(node, at);
-    if (!info) {
+    const attr = rawAttrs[i];
+    const attrSelector = getAttributeNameValue(node, attr);
+    if (!attrSelector) {
       continue;
     }
-    const { atnv, isSuffix, rawName, suffix } = info;
+    const { atnv, isSuffix, rawName, suffix } = attrSelector;
 
     if (isSuffix) {
       // Href/src attributes are selected in CSS by URL suffix (`[href$="X"]`
@@ -171,9 +444,9 @@ function collectNodeAttrs(
       if (!urlAttrs) {
         urlAttrs = {};
       }
-      urlAttrs[rawName] = at.value;
-      if (!data._suffixInfo.has(atnv)) {
-        data._suffixInfo.set(atnv, { rawName, suffix });
+      urlAttrs[rawName] = attr.value;
+      if (!selectorData._suffixInfo.has(atnv)) {
+        selectorData._suffixInfo.set(atnv, { rawName, suffix });
       }
     }
     // Only "interesting" attributes (short values, not on the ignored list)
@@ -186,405 +459,223 @@ function collectNodeAttrs(
     // queried through `_attrBits`, so indexing it would only bloat memory.
     // Same atnv implies same name+value, so the filter verdict is the
     // same for every occurrence.
-    if (filterAttributes(at)) {
-      if (data.attributes[atnv]) {
-        data.attributes[atnv]++;
-      } else {
-        data.attributes[atnv] = 1;
-      }
-      attrsForNode.push(atnv);
+    if (filterAttributes(attr)) {
+      selectorData.attributes[atnv] = (selectorData.attributes[atnv] || 0) + 1;
+      featureAttrs.push(atnv);
       if (!isSuffix) {
-        matchAttrsForNode.push(atnv);
-        let list = attrLists.get(atnv);
-        if (!list) {
-          list = [];
-          attrLists.set(atnv, list);
-        }
-        list.push(nodeIdx);
+        exactAttrs.push(atnv);
+        pushToList(attrLists, atnv, nodeIdx);
       }
     }
   }
-  return urlAttrs;
+  return { urlAttrs, featureAttrs, exactAttrs };
 }
 
 /**
- * Walk the whole page once and record everything the selector generator will
- * ever need to know about it. The point is to move as much work as possible
- * out of the per-element hot path (`generateSelector`, which runs thousands
- * of times per axe.run) and into this one-time setup.
+ * Append `nodeIdx` to the array stored at `map.get(key)`, creating
+ * the array on first use.
  *
- * @param {Object} domTree		The root node of the virtual DOM tree
- * @returns {Object}					Frequency counts + fast-lookup tables
+ * @param {Map}    map
+ * @param {String} key
+ * @param {Number} nodeIdx
  */
-export function getSelectorData(domTree) {
-  const data = {
-    // Per-page frequency counts. `getThreeLeastCommonFeatures` reads these
-    // to decide which features to build a selector out of.
-    classes: {},
-    tags: {},
-    attributes: {},
+function pushToList(map, key, nodeIdx) {
+  let list = map.get(key);
+  if (!list) {
+    list = [];
+    map.set(key, list);
+  }
+  list.push(nodeIdx);
+}
 
-    // One record per element in walk order, keyed by a small integer
-    // "nodeIdx" that we use everywhere else. Holds enough per-element info
-    // that later code never has to touch the DOM: tag, id, classes,
-    // attribute strings, position among element siblings, parent's nodeIdx,
-    // and which root (main document vs. a specific shadow root) it lives in.
-    _perNode: [],
-    // Look up an element's nodeIdx from the DOM Element itself.
-    _elmToIdx: new WeakMap(),
-    // For each tag / class / attribute-value string, a compact bitmap of
-    // which nodeIdx values have it. See `bitsForFragment` for how these
-    // get used — treating them as bitmaps means "which nodes match all of
-    // <tag>, <class>, <attr>?" becomes a fast bit-AND.
-    _tagBits: {},
-    _classBits: {},
-    _attrBits: {},
-    // Each shadow root gets its own numeric id, starting at 0 for the main
-    // document. `_rootBits[rootId]` is the bitmap of nodes that live in
-    // that root. Selectors are always evaluated within a single root
-    // (`getShadowSelector` handles crossing shadow boundaries), so we AND
-    // this into every match to make sure we don't pull in nodes from other
-    // trees that happen to share the same tag/class.
-    _rootMap: new Map(),
-    _rootBits: [],
-    // Id uniqueness is also per-root: `#foo` in the main document is a
-    // different id from `#foo` inside some shadow tree. These maps let
-    // `getElmId` check "is this id used exactly once in this root?"
-    // without a `querySelectorAll('#foo')`.
-    _idCounts: [],
-    _idToIdx: [],
-    // For every suffix-form atnv we've seen (e.g. `href$="foo"`), the raw
-    // attribute name and suffix string that would need to be checked
-    // against `urlAttrs` at match time. Populated in `collectNodeAttrs`.
-    // Read in `computeFragment` to split fragment features into exact vs
-    // suffix without sniffing `$="` inside the atnv (which misfires when
-    // the attribute name itself ends in `$`).
-    _suffixInfo: new Map(),
-    // Number of Uint32 words each bitmap needs (ceil(nodeCount / 32)).
-    _wordCount: 0
-  };
+/**
+ * Look up (or build on first use) the `child element -> 1-indexed position`
+ * map for `domParent`. Building it once per parent keeps the sibling walk
+ * linear across a parent with many children; `indexOf` per element would
+ * be O(N^2).
+ *
+ * @param {Element} domParent
+ * @param {Map}     cache        Map<Element, Map<Element, Number>>
+ * @returns {Map<Element, Number>}
+ */
+function nthChildMap(domParent, cache) {
+  let nthMap = cache.get(domParent);
+  if (!nthMap) {
+    nthMap = new Map();
+    const children = domParent.children;
+    for (let i = 0; i < children.length; i++) {
+      nthMap.set(children[i], i + 1);
+    }
+    cache.set(domParent, nthMap);
+  }
+  return nthMap;
+}
 
-  domTree = Array.isArray(domTree) ? domTree : [domTree];
-  let currentLevel = domTree.slice();
-  const stack = [];
+/**
+ * Copy `nodeRecord.parentIdx` into a typed array. Typed-array reads are
+ * meaningfully cheaper than `nodeRecords[i].parentIdx` in the
+ * per-candidate loop that walks up the tree.
+ *
+ * @param {NodeRecord[]} nodeRecords
+ * @returns {Int32Array}
+ */
+function parentIdxArray(nodeRecords) {
+  const parentOf = new Int32Array(nodeRecords.length);
+  for (let i = 0; i < nodeRecords.length; i++) {
+    parentOf[i] = nodeRecords[i].parentIdx;
+  }
+  return parentOf;
+}
 
-  // During the walk we don't know the final node count yet, so we can't
-  // size the bitmaps. Instead, collect the members as plain arrays and
-  // convert them all in one pass at the end.
-  const tagLists = new Map();
-  const classLists = new Map();
-  const attrLists = new Map();
-  const rootLists = [];
-  // Per-parent map of "which position among element siblings is each
-  // child?". Built once per parent that has at least one indexed child —
-  // avoids a linear `indexOf` per element, which is O(N^2) across a
-  // parent with many children.
-  const nthIndexCache = new Map();
-
-  const perNode = data._perNode;
-  // Shadow hosts we encounter in the flat-tree walk. After that walk
-  // ends we'll revisit each one and phantom-walk its light-DOM subtree
-  // to add any unslotted content to the bitmaps. See PHANTOM RECORDS in
-  // the top-of-file block.
-  const shadowHostList = [];
-
-  while (currentLevel.length) {
-    const current = currentLevel.pop();
-    const node = current.actualNode;
-
-    if (!!node.querySelectorAll) {
-      // ignore #text nodes
-
-      const root =
-        typeof node.getRootNode === 'function' ? node.getRootNode() : document;
-      let rootId = data._rootMap.get(root);
-      if (rootId === undefined) {
-        rootId = data._rootMap.size;
-        data._rootMap.set(root, rootId);
-        rootLists[rootId] = [];
-        data._idCounts[rootId] = {};
-        data._idToIdx[rootId] = {};
+/**
+ * Ids that appear more than once in their root aren't usable as
+ * unique selectors, so drop them from the "id → node" map. Counts
+ * stay — `getElmId` reads those.
+ *
+ * @param {SelectorData} selectorData
+ */
+function pruneDuplicateIds(selectorData) {
+  for (let rootId = 0; rootId < selectorData._idToIdx.length; rootId++) {
+    const counts = selectorData._idCounts[rootId];
+    const idToIdx = selectorData._idToIdx[rootId];
+    for (const idSel in idToIdx) {
+      if (counts[idSel] !== 1) {
+        delete idToIdx[idSel];
       }
+    }
+  }
+}
 
-      // Tally per-page frequency counts. These feed feature selection.
-      const nodeName = node.nodeName;
-      if (data.tags[nodeName]) {
-        data.tags[nodeName]++;
-      } else {
-        data.tags[nodeName] = 1;
-      }
-      // `nodeName` is uppercase in HTML but selector strings are lowercase
-      // (`button`, not `BUTTON`). Store both forms — one to key the
-      // frequency map so `uncommonClasses` etc. can look up counts, and
-      // one to key the tag bitmap so match-time comparisons don't need
-      // any case conversion.
-      const tagSel = getBaseSelector(node);
+/**
+ * For each shadow host from the flat-tree walk, record elements that
+ * flatten-tree dropped: unslotted light DOM, then `<slot>` elements
+ * in the shadow tree. See DROPPED DOM in the top-of-file block.
+ *
+ * @param {IndexState} state
+ */
+function addUnslottedElements(state) {
+  const { selectorData, shadowHostIdxs } = state;
+  const nodeRecords = selectorData._nodeRecords;
+  for (let i = 0; i < shadowHostIdxs.length; i++) {
+    const hostIdx = shadowHostIdxs[i];
+    const host = nodeRecords[hostIdx].elm;
+    walkUnslotted(host.children, hostIdx, nodeRecords[hostIdx].rootId, state);
+    addShadowSlots(host, state);
+  }
+}
 
-      const nodeIdx = perNode.length;
-      data._elmToIdx.set(node, nodeIdx);
-
-      const classesForNode = [];
-      if (node.classList) {
-        for (const cl of node.classList) {
-          const ind = escapeSelector(cl);
-          if (data.classes[ind]) {
-            data.classes[ind]++;
-          } else {
-            data.classes[ind] = 1;
-          }
-          classesForNode.push(ind);
-          let list = classLists.get(ind);
-          if (!list) {
-            list = [];
-            classLists.set(ind, list);
-          }
-          list.push(nodeIdx);
-        }
-      }
-
-      const attrsForNode = []; // filter-passing atnvs — used by uncommonAttributes
-      const matchAttrsForNode = []; // every exact atnv — used by fragment matching
-      const urlAttrs = collectNodeAttrs(
-        node,
+/**
+ * Iterative walk of light-DOM descendants that aren't already in
+ * `_elmToIdx`. Known nodes are skipped (not descended into) rather
+ * than assumed to make their whole subtree unslotted. `parentIdx`
+ * is explicit because an unslotted element's parent may itself be
+ * unslotted. `rootId` is the host's — light DOM, not the shadow tree.
+ *
+ * @param {HTMLCollection} elms
+ * @param {Number}         parentIdx
+ * @param {Number}         rootId
+ * @param {IndexState}   state
+ */
+function walkUnslotted(elms, parentIdx, rootId, state) {
+  const { selectorData } = state;
+  const queue = Array.from(elms, elm => ({ elm, parentIdx }));
+  while (queue.length) {
+    const { elm, parentIdx: nodeParentIdx } = queue.shift();
+    if (selectorData._elmToIdx.has(elm)) {
+      // skip slotted nodes, including named slots which may no be shadowRoot children
+      continue;
+    }
+    const nodeIdx = selectorData._nodeRecords.length;
+    selectorData._nodeRecords.push(
+      indexElement(
+        elm,
         nodeIdx,
-        data,
-        attrLists,
-        attrsForNode,
-        matchAttrsForNode
-      );
-
-      let tagList = tagLists.get(tagSel);
-      if (!tagList) {
-        tagList = [];
-        tagLists.set(tagSel, tagList);
-      }
-      tagList.push(nodeIdx);
-
-      // Build the id in the same escaped `#id` form that `getElmId`
-      // returns, and count it separately for each shadow root (an id can
-      // legitimately be reused across shadow trees).
-      let idSelector = null;
-      const rawId = node.getAttribute && node.getAttribute('id');
-      if (rawId) {
-        idSelector = '#' + escapeSelector(rawId);
-        const rootIds = data._idCounts[rootId];
-        rootIds[idSelector] = (rootIds[idSelector] || 0) + 1;
-        data._idToIdx[rootId][idSelector] = nodeIdx;
-      }
-
-      rootLists[rootId].push(nodeIdx);
-
-      // Precompute two things `generateSelector` uses in its hot loop:
-      // the parent's nodeIdx (so we can walk up without touching the DOM),
-      // and the element's 1-indexed position among its element siblings
-      // (what `:nth-child(N)` uses). Disconnected nodes get 0/-1.
-      const domParent = node.parentNode;
-      let parentIdx = -1;
-      let nthChild = 0;
-      if (domParent) {
-        const pIdx = data._elmToIdx.get(domParent);
-        if (pIdx !== undefined) {
-          parentIdx = pIdx;
-        }
-        if (domParent.children) {
-          nthChild = nthChildMap(domParent, nthIndexCache).get(node) || 0;
-        }
-      }
-
-      perNode.push({
-        elm: node,
-        // Two tag fields for two purposes: `nodeName` (uppercase HTML)
-        // keys the `data.tags` frequency map that feature selection reads,
-        // and `tag` (lowercase HTML / preserved XHTML) is what selectors
-        // actually look like, so match-time comparisons don't need
-        // toLowerCase.
-        nodeName,
-        tag: tagSel,
-        id: idSelector,
-        classes: classesForNode,
-        attrs: attrsForNode,
-        matchAttrs: matchAttrsForNode,
-        urlAttrs, // { attrName: rawValue } for href/src-family attrs, or null
-        nthChild,
-        parentIdx,
-        rootId
-      });
-
-      // If this element hosts an open shadow root, queue it for the
-      // phantom pass — any of its light-DOM children that don't match
-      // a <slot> get dropped from the flat tree and would otherwise be
-      // invisible to uniqueness counting.
-      if (node.shadowRoot) {
-        shadowHostList.push(nodeIdx);
-      }
-    }
-    if (current.children.length) {
-      // "recurse"
-      stack.push(currentLevel);
-      currentLevel = current.children.slice();
-    }
-    while (!currentLevel.length && stack.length) {
-      currentLevel = stack.pop();
+        { parentIdx: nodeParentIdx, rootId, shouldMapId: false },
+        state
+      )
+    );
+    for (const child of elm.children) {
+      queue.push({ elm: child, parentIdx: nodeIdx });
     }
   }
+}
 
-  // Phantom pass — see PHANTOM RECORDS in the top-of-file block for
-  // why. For each shadow host we visited in the flat-tree walk, iterate
-  // its real DOM `.children`. Any child NOT in `_elmToIdx` was dropped
-  // by flatten-tree (unslotted content, or content that only matched a
-  // <slot> we're not walking) and needs a phantom record so its
-  // existence shows up in bitmap counts.
-  for (let h = 0; h < shadowHostList.length; h++) {
-    const hostIdx = shadowHostList[h];
-    const hostElm = perNode[hostIdx].elm;
-    const hostRootId = perNode[hostIdx].rootId;
-    const domKids = hostElm.children;
-    for (let k = 0; k < domKids.length; k++) {
-      if (!data._elmToIdx.has(domKids[k])) {
-        phantomWalk(domKids[k], hostIdx, hostRootId);
-      }
-    }
+/**
+ * Index `<slot>` elements in `host`'s open shadow tree that flatten-tree
+ * skipped. `querySelectorAll` reaches slots nested under already-indexed
+ * shadow-tree nodes. Same dropped-node contract as `walkUnslotted`:
+ * counts and bitmaps, but not `_elmToIdx` / `_idToIdx`.
+ *
+ * @param {Element}      host
+ * @param {IndexState} state
+ */
+function addShadowSlots(host, state) {
+  const shadowRoot = host.shadowRoot;
+  if (!shadowRoot) {
+    return;
   }
-
-  /**
-   * Walk an unslotted subtree, iteratively, and give every element a
-   * full phantom `_perNode` record. Fields match the shape real nodes
-   * push above; the only differences are that phantoms don't go into
-   * `_elmToIdx` (so `getSelector` won't route to one) and don't go
-   * into `_idToIdx` (so `getElmId` won't either).
-   */
-  function phantomWalk(rootElm, rootParentIdx, rootId) {
-    const phantomStack = [{ elm: rootElm, parentIdx: rootParentIdx }];
-    while (phantomStack.length) {
-      const { elm, parentIdx } = phantomStack.pop();
-      const phantomIdx = perNode.length;
-      const nodeName = elm.nodeName;
-      const tagSel = getBaseSelector(elm);
-
-      // Frequency counts include phantoms — feature selection for real
-      // nodes needs to see the DOM's true tag/class/attr distribution,
-      // not the flat tree's. Otherwise a class shared only between a
-      // real target and a phantom looks unique in `data.classes` and
-      // gets picked as a distinguishing feature, when it actually
-      // isn't.
-      data.tags[nodeName] = (data.tags[nodeName] || 0) + 1;
-      let tagList = tagLists.get(tagSel);
-      if (!tagList) {
-        tagList = [];
-        tagLists.set(tagSel, tagList);
-      }
-      tagList.push(phantomIdx);
-
-      const classesForNode = [];
-      if (elm.classList) {
-        for (const cl of elm.classList) {
-          const ind = escapeSelector(cl);
-          data.classes[ind] = (data.classes[ind] || 0) + 1;
-          classesForNode.push(ind);
-          let list = classLists.get(ind);
-          if (!list) {
-            list = [];
-            classLists.set(ind, list);
-          }
-          list.push(phantomIdx);
-        }
-      }
-
-      const attrsForNode = [];
-      const matchAttrsForNode = [];
-      const urlAttrs = collectNodeAttrs(
-        elm,
-        phantomIdx,
-        data,
-        attrLists,
-        attrsForNode,
-        matchAttrsForNode
-      );
-
-      let idSelector = null;
-      const rawId = elm.getAttribute && elm.getAttribute('id');
-      if (rawId) {
-        idSelector = '#' + escapeSelector(rawId);
-        // Bump the id count so `getElmId` on a real node with the same
-        // id sees the collision and correctly refuses to use it — but
-        // don't populate `_idToIdx`, or `getElmId` would route to the
-        // phantom itself.
-        const rootIds = data._idCounts[rootId];
-        rootIds[idSelector] = (rootIds[idSelector] || 0) + 1;
-      }
-
-      rootLists[rootId].push(phantomIdx);
-
-      let nthChild = 0;
-      const domParent = elm.parentNode;
-      if (domParent && domParent.children) {
-        nthChild = nthChildMap(domParent, nthIndexCache).get(elm) || 0;
-      }
-
-      perNode.push({
-        elm,
-        nodeName,
-        tag: tagSel,
-        id: idSelector,
-        classes: classesForNode,
-        attrs: attrsForNode,
-        matchAttrs: matchAttrsForNode,
-        urlAttrs,
-        nthChild,
-        parentIdx,
-        rootId
-      });
-
-      // Descendants of unslotted content are also unslotted — every one
-      // of them belongs on the phantom stack, with its `parentIdx`
-      // pointing at the phantom we just pushed.
-      const kids = elm.children;
-      for (let i = 0; i < kids.length; i++) {
-        phantomStack.push({ elm: kids[i], parentIdx: phantomIdx });
-      }
+  const { selectorData } = state;
+  const slots = shadowRoot.querySelectorAll('slot');
+  for (let i = 0; i < slots.length; i++) {
+    const slot = slots[i];
+    if (selectorData._elmToIdx.has(slot)) {
+      continue;
     }
+    const nodeIdx = selectorData._nodeRecords.length;
+    selectorData._nodeRecords.push(
+      indexElement(
+        slot,
+        nodeIdx,
+        {
+          parentIdx: parentIdxOf(slot, state),
+          rootId: ensureRoot(slot, state),
+          shouldMapId: false
+        },
+        state
+      )
+    );
   }
+}
 
-  const nodeCount = perNode.length;
-  // Each bitmap needs one bit per node, packed 32 to a Uint32.
+/**
+ * Convert the walk's list accumulators into the tables `generate.js`
+ * and `bit-index.js` actually read. Safe to call only after both
+ * walks have finished — bitmap width depends on the final node count.
+ *
+ * @param {IndexState} state
+ */
+function buildIndexes(state) {
+  const { selectorData, tagLists, classLists, attrLists, rootLists } = state;
+  const nodeCount = selectorData._nodeRecords.length;
   const wordCount = Math.max(1, Math.ceil(nodeCount / 32));
-  data._wordCount = wordCount;
+  selectorData._wordCount = wordCount;
+  selectorData._tagBits = bitmapsByKey(tagLists, wordCount);
+  selectorData._classBits = bitmapsByKey(classLists, wordCount);
+  selectorData._attrBits = bitmapsByKey(attrLists, wordCount);
 
-  for (const [k, v] of tagLists) {
-    data._tagBits[k] = listToBits(v, wordCount);
-  }
-  for (const [k, v] of classLists) {
-    data._classBits[k] = listToBits(v, wordCount);
-  }
-  for (const [k, v] of attrLists) {
-    data._attrBits[k] = listToBits(v, wordCount);
-  }
-  for (let r = 0; r < rootLists.length; r++) {
-    data._rootBits[r] = listToBits(rootLists[r] || [], wordCount);
+  selectorData._rootBits = [];
+  for (let rootId = 0; rootId < rootLists.length; rootId++) {
+    selectorData._rootBits[rootId] = listToBits(
+      rootLists[rootId] || [],
+      wordCount
+    );
   }
 
-  // Copy the per-node parentIdx values into a flat typed array. Typed-array
-  // reads are meaningfully cheaper than `perNode[i].parentIdx` in the
-  // per-candidate loop that walks up the tree — every microsecond saved
-  // there shows up in the perf numbers on large pages.
-  const parentOf = new Int32Array(nodeCount);
-  for (let i = 0; i < nodeCount; i++) {
-    parentOf[i] = perNode[i].parentIdx;
-  }
-  data._parentOf = parentOf;
+  selectorData._parentOf = parentIdxArray(selectorData._nodeRecords);
+  pruneDuplicateIds(selectorData);
+}
 
-  // Ids that turned out to appear more than once in their root aren't
-  // usable as unique selectors, so drop them from the "id -> node" map.
-  // We still keep the counts around because `getElmId` reads them.
-  for (let r = 0; r < data._idToIdx.length; r++) {
-    const counts = data._idCounts[r];
-    const map = data._idToIdx[r];
-    for (const key in map) {
-      if (counts[key] !== 1) {
-        delete map[key];
-      }
-    }
+/**
+ * Turn a `key -> nodeIdx[]` map into a `key -> bitmap` lookup table.
+ *
+ * @param {Map<String, Number[]>} nodeIdxsByKey
+ * @param {Number}                wordCount
+ * @returns {Object<String, Uint32Array>}
+ */
+function bitmapsByKey(nodeIdxsByKey, wordCount) {
+  const bitmaps = {};
+  for (const [key, nodeIdxs] of nodeIdxsByKey) {
+    bitmaps[key] = listToBits(nodeIdxs, wordCount);
   }
-
-  return data;
+  return bitmaps;
 }

--- a/lib/core/utils/get-selector/precompute.js
+++ b/lib/core/utils/get-selector/precompute.js
@@ -45,12 +45,14 @@ import { listToBits } from './bit-index';
  * earlier in the same pass — and parent lookup works uniformly.
  *
  * Phantoms get a full `_nodeRecords` entry (same shape as flat-tree
- * nodes, so downstream code treats them uniformly) and go into
- * `_elmToIdx` too, so chain-walking resolves through unslotted
- * subtrees and slot fallback markup alike. The one table they stay
- * OUT of is `_idToIdx`, which is what `getElmId` reads — that gate is
- * what stops a selector query from routing to an element axe never
- * reasoned about.
+ * nodes) and go into every lookup table, so downstream code treats
+ * them uniformly: chain-walking resolves through unslotted subtrees
+ * and slot fallback markup alike, and a `<slot id="x">` can be named
+ * by `#x` just as it could when uniqueness was answered by
+ * `querySelectorAll`. That parity is the requirement — the precomputed
+ * tables have to produce the selector the DOM would have produced, and
+ * `querySelectorAll` has never cared whether flatten-tree kept an
+ * element.
  *
  * PIPELINE. `getSelectorData` is five named steps:
  *   1. `createIndexState`       — empty `selectorData` + accumulators
@@ -61,8 +63,8 @@ import { listToBits } from './bit-index';
  *                                 drop non-unique ids from `_idToIdx`
  *
  * Flat-tree and phantom nodes share `indexElement` (counts, lists,
- * NodeRecord). They differ only in routing: flat-tree nodes populate
- * `_idToIdx`, phantoms don't.
+ * NodeRecord) and are indistinguishable once recorded. They differ
+ * only in how they were found and in how their parent is resolved.
  *
  * OUTPUT: a `SelectorData` object — see the typedef below.
  *
@@ -91,13 +93,17 @@ import { listToBits } from './bit-index';
  * @property {Number}                      _wordCount   Uint32 words per bitmap
  *
  * Id lookup (avoids `querySelectorAll('#foo')` at query time):
+ * @property {Array<Object<String, Number>>} _idToIdx   [rootId][idSel] → the
+ *                                         nodeIdx of the sole matching element.
+ *                                         Every recorded element is eligible,
+ *                                         phantoms included, so this answers
+ *                                         exactly what `querySelectorAll` on
+ *                                         the root would
  * @property {Array<Object<String, Number>>} _idCounts  [rootId][idSel] → how
  *                                         many times this id appears in this
- *                                         root (a non-1 count means the id
- *                                         isn't usable as a selector)
- * @property {Array<Object<String, Number>>} _idToIdx   [rootId][idSel] → the
- *                                         nodeIdx of the sole matching element
- *                                         (only present when count === 1)
+ *                                         root. Only `pruneDuplicateIds`
+ *                                         reads it — it's how `_idToIdx`
+ *                                         learns which entries to drop
  *
  * Ancestor walk helpers:
  * @property {Int32Array} _parentOf    `nodeRecord.parentIdx` per nodeIdx, for
@@ -230,8 +236,7 @@ function walkFlatTree(domTree, state) {
 }
 
 /**
- * Record a flattened-tree element: index it and route it through
- * `_elmToIdx` / `_idToIdx`.
+ * Record a flattened-tree element: index it and enter it in `_elmToIdx`.
  *
  * @param {Element}      node
  * @param {IndexState} state
@@ -244,7 +249,7 @@ function recordFlatTreeElement(node, state) {
 
   selectorData._elmToIdx.set(node, nodeIdx);
   selectorData._nodeRecords.push(
-    indexElement(node, nodeIdx, { parentIdx, rootId, shouldMapId: true }, state)
+    indexElement(node, nodeIdx, { parentIdx, rootId }, state)
   );
   // Register an open shadow root as its own `_rootMap` entry so the
   // phantom pass walks it. Done here rather than relying on the
@@ -322,17 +327,10 @@ function rootIdFor(root, state) {
  * @param {Object}       placement
  * @param {Number}       placement.parentIdx
  * @param {Number}       placement.rootId
- * @param {Boolean}      placement.shouldMapId  write `_idToIdx`
- *                                              (false for phantoms)
  * @param {IndexState} state
  * @returns {NodeRecord}
  */
-function indexElement(
-  node,
-  nodeIdx,
-  { parentIdx, rootId, shouldMapId },
-  state
-) {
+function indexElement(node, nodeIdx, { parentIdx, rootId }, state) {
   const { selectorData, tagLists, rootLists, nthIndexCache } = state;
   const nodeName = node.nodeName;
   selectorData.tags[nodeName] = (selectorData.tags[nodeName] || 0) + 1;
@@ -357,11 +355,10 @@ function indexElement(
     id = '#' + escapeSelector(rawId);
     const rootIds = selectorData._idCounts[rootId];
     rootIds[id] = (rootIds[id] || 0) + 1;
-    // Phantoms bump the count (so a flat-tree node with the same id
-    // sees the collision) but stay out of `_idToIdx`.
-    if (shouldMapId) {
-      selectorData._idToIdx[rootId][id] = nodeIdx;
-    }
+    // Last writer wins, which is fine: an id claimed by more than one
+    // element is dropped wholesale by `pruneDuplicateIds`, so the only
+    // entries that survive are the ones with a single claimant.
+    selectorData._idToIdx[rootId][id] = nodeIdx;
   }
 
   rootLists[rootId].push(nodeIdx);
@@ -547,8 +544,8 @@ function parentIdxArray(nodeRecords) {
 
 /**
  * Ids that appear more than once in their root aren't usable as
- * unique selectors, so drop them from the "id → node" map. Counts
- * stay — `getElmId` reads those.
+ * unique selectors, so drop them from the "id → node" map. This is what
+ * lets `getElmId` treat a hit in `_idToIdx` as proof of uniqueness.
  *
  * @param {SelectorData} selectorData
  */
@@ -570,10 +567,9 @@ function pruneDuplicateIds(selectorData) {
  * exhaustive by construction — see DROPPED DOM in the top-of-file
  * block for why that beats enumerating the drop-sites.
  *
- * Phantoms go into `_elmToIdx` (unlike flat-tree-only nodes, they stay
- * out of `_idToIdx`) so that parent lookup succeeds on
- * phantom-to-phantom chains and the ancestor filter works through
- * unslotted subtrees and slot fallback markup alike.
+ * Phantoms go into `_elmToIdx` and every other lookup table, so parent
+ * lookup succeeds on phantom-to-phantom chains and the ancestor filter
+ * works through unslotted subtrees and slot fallback markup alike.
  *
  * @param {IndexState} state
  */
@@ -591,15 +587,10 @@ function seedPhantomsFromRoots(state) {
       }
       const nodeIdx = selectorData._nodeRecords.length;
       const parentIdx = phantomParentIdx(elm, rootNode, state);
-      selectorData._nodeRecords.push(
-        indexElement(
-          elm,
-          nodeIdx,
-          { parentIdx, rootId, shouldMapId: false },
-          state
-        )
-      );
       selectorData._elmToIdx.set(elm, nodeIdx);
+      selectorData._nodeRecords.push(
+        indexElement(elm, nodeIdx, { parentIdx, rootId }, state)
+      );
     }
   }
 }

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -999,4 +999,87 @@ describe('axe.utils.getSelector', () => {
     assert.lengthOf(matches, 1);
     assert.strictEqual(matches[0], first);
   });
+
+  describe('feature count stability', () => {
+    it('does not count unslotted light DOM towards tag frequency', () => {
+      fixture.innerHTML = html` <div id="unslotted-host">
+          <img src="a.png" alt="a" /><img src="b.png" alt="b" />
+        </div>
+        <img class="logo" src="c.png" />`;
+      fixture
+        .querySelector('#unslotted-host')
+        .attachShadow({ mode: 'open' }).innerHTML = '<slot name="nope"></slot>';
+      fixtureSetup();
+
+      const target = fixture.querySelector('img.logo');
+      assert.equal(axe.utils.getSelector(target), '#fixture > img');
+      assert.equal(axe._selectorData.tags.IMG, 1);
+    });
+
+    it('does not count unslotted light DOM towards class frequency', () => {
+      fixture.innerHTML = html`
+        <section id="unslotted-host">
+          <span class="cta"></span>
+        </section>
+        <div>
+          <span class="cta"></span>
+        </div>
+        <span></span>
+      `;
+      fixture
+        .querySelector('#unslotted-host')
+        .attachShadow({ mode: 'open' }).innerHTML = '<slot name="nope"></slot>';
+      fixtureSetup();
+
+      const target = fixture.querySelector('div > span');
+      assert.equal(axe.utils.getSelector(target), 'div > .cta');
+      assert.equal(axe._selectorData.classes.cta, 1);
+    });
+
+    it('does not count slot elements towards class frequency', () => {
+      const host = document.createElement('div');
+      host.attachShadow({ mode: 'open' }).innerHTML = html`
+        <div>
+          <span class="cta"></span>
+        </div>
+        <span></span>
+        <slot class="cta"></slot>
+      `;
+      fixtureSetup(host);
+
+      const target = host.shadowRoot.querySelector('span.cta');
+      assert.equal(axe.utils.getSelector(target)[1], 'div > .cta');
+      assert.equal(axe._selectorData.classes.cta, 1);
+    });
+
+    it('does not count slot elements towards attribute frequency', () => {
+      const host = document.createElement('div');
+      host.attachShadow({ mode: 'open' }).innerHTML = html`
+        <div><span data-k="v"></span></div>
+        <span></span>
+        <slot data-k="v"></slot>
+      `;
+      fixtureSetup(host);
+
+      const target = host.shadowRoot.querySelector('div > span');
+      assert.equal(axe.utils.getSelector(target)[1], 'span[data-k="v"]');
+      assert.equal(axe._selectorData.attributes['data-k="v"'], 1);
+    });
+
+    it('does not count assigned-slot fallback towards class frequency', () => {
+      const host = document.createElement('div');
+      host.attachShadow({ mode: 'open' }).innerHTML = html`
+        <slot><span class="cta"></span></slot>
+        <div><span class="cta"></span></div>
+        <span></span>
+      `;
+      host.innerHTML = '<em>assigned</em>';
+      fixture.appendChild(host);
+      fixtureSetup();
+
+      const target = host.shadowRoot.querySelector('div > span.cta');
+      assert.equal(axe.utils.getSelector(target)[1], 'div > .cta');
+      assert.equal(axe._selectorData.classes.cta, 1);
+    });
+  });
 });

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -814,6 +814,57 @@ describe('axe.utils.getSelector', () => {
     });
   });
 
+  it('produces a unique selector when a shadow slot shares a class with the target', () => {
+    const host = document.createElement('div');
+    host.attachShadow({ mode: 'open' }).innerHTML = html`
+      <div><span class="cta"></span></div>
+      <span></span><slot class="cta"></slot>
+    `;
+    fixtureSetup(host);
+
+    const target = host.shadowRoot.querySelector('.cta');
+    const sel = axe.utils.getSelector(target);
+    const matches = host.shadowRoot.querySelectorAll(sel[1]);
+    assert.lengthOf(matches, 1, `selector "${sel[1]}" also matched the slot`);
+    assert.strictEqual(matches[0], target);
+  });
+
+  it('produces a unique selector when a nested shadow slot shares a class with the target', () => {
+    const host = document.createElement('div');
+    host.attachShadow({ mode: 'open' }).innerHTML = html`
+      <div>
+        <div><span class="cta"></span></div>
+        <slot class="cta"></slot>
+      </div>
+      <span></span>
+    `;
+    fixtureSetup(host);
+
+    const target = host.shadowRoot.querySelector('span.cta');
+    const sel = axe.utils.getSelector(target);
+    const matches = host.shadowRoot.querySelectorAll(sel[1]);
+    assert.lengthOf(matches, 1, `selector "${sel[1]}" also matched the slot`);
+    assert.strictEqual(matches[0], target);
+  });
+
+  it('produces a unique selector when a shadow slot shares an id with the target', () => {
+    const host = document.createElement('div');
+    host.attachShadow({ mode: 'open' }).innerHTML = html`
+      <div><span id="dup"></span></div>
+      <slot id="dup"></slot>
+    `;
+    fixtureSetup(host);
+
+    const target = host.shadowRoot.querySelector('span');
+    const sel = axe.utils.getSelector(target);
+    const matches = host.shadowRoot.querySelectorAll(sel[1]);
+    assert.lengthOf(matches, 1, `selector "${sel[1]}" also matched the slot`);
+    assert.strictEqual(matches[0], target);
+
+    // Attributes always get the tag name, so no need for
+    // a separate slot[attr] test
+  });
+
   it('produces a unique selector when an unslotted host sibling would collide', () => {
     const hostB = document.createElement('div');
     hostB.attachShadow({ mode: 'open' }).innerHTML =

--- a/test/core/utils/get-selector.js
+++ b/test/core/utils/get-selector.js
@@ -943,6 +943,27 @@ describe('axe.utils.getSelector', () => {
     assert.strictEqual(found[0], target);
   });
 
+  it('produces a unique selector for slot fallback content under a slot with a unique id', () => {
+    const host = document.createElement('div');
+    host.attachShadow({ mode: 'open' }).innerHTML = html`
+      <div><span class="cta"></span></div>
+      <slot id="uniq"><span class="cta"></span></slot>
+    `;
+    fixtureSetup(host);
+    const target = host.shadowRoot.querySelector('#uniq span');
+    const sel = axe.utils.getSelector(target);
+    const matches = host.shadowRoot.querySelectorAll(sel[1]);
+    assert.lengthOf(
+      matches,
+      1,
+      `selector "${sel[1]}" did not match the target`
+    );
+    assert.strictEqual(matches[0], target);
+    // The slot is dropped by flatten-tree, but querySelectorAll can still
+    // see it, so `#uniq` has to stay usable as a fragment.
+    assert.equal(sel[1], '#uniq > span');
+  });
+
   it('produces working selectors for elements whose tag matches an inherited property name across shadow roots', () => {
     fixture.innerHTML =
       '<div><constructor></constructor></div>' +


### PR DESCRIPTION
A readability pass over the `get-selector` rewrite. Mostly renames and
function extraction, plus two behavior changes called out below.

## Renames

The old names leaned on abbreviations that didn't survive re-reading:

| Before | After |
| --- | --- |
| `_perNode` / `rec` | `_nodeRecords` / `nodeRecord` |
| `feature.species` | `feature.kind` |
| `rec.attrs` / `rec.matchAttrs` | `featureAttrs` / `exactAttrs` |
| `at` | `attr` |
| `advanceAndFilter` | `matchingParents` |
| `getMatchCacheEntry` | `getCachedMatch` |
| `data` (in precompute) | `selectorData` |
| `{ selector }` from `getThreeLeastCommonFeatures` | `{ selectorString }` |

The inline shape comments are now JSDoc typedefs — `SelectorData`,
`NodeRecord`, `IndexState`, `Fragment`, `Feature`, `CachedMatch` — so
the fields are documented once and referenced everywhere else.

## Refactors

**`precompute.js`** — `getSelectorData` was one long function with a nested closure. It's now five named steps: `createIndexState`, `walkFlatTree`, `seedPhantomsFromRoots`, `repairMissingParents`, `buildIndexes`. The flat-tree walk and the phantom pass had two near-identical copies of the "read the element, update the tables" logic; they now share `indexElement`, differing only in how the parent is resolved and whether the element feeds the frequency counts.

**`generate.js`** — `computeFragment` split into `buildFragment`, `classifyFeatures` and `withNthChildIfNeeded`, with the cache lookup left in `computeFragment`. The candidate-list bookkeeping in `generateSelector` (three interacting variables: `indices`, `anc`, `candCount`) collapsed into one `candidatesForChain` call per step.

**`bit-index.js`** — `matchingParents` now owns the bitmap lookup and the working buffer instead of taking them as arguments; the buffer lives on `selectorData._candidateBuf` and is reused across walks, with the chain cache storing copies.

`generateSelector`'s `options` argument is now optional.

## Behavior changes

**Phantoms no longer feed the public frequency counts.** Selectors are compared across axe runs, so the counts that drive feature selection have to reflect the same set of elements axe reports on. Letting unslotted light DOM or slot fallback markup into `selectorData.classes` shifts which class gets picked and rewrites the selector string. 
Uniqueness is a separate question, still answered by the bitmaps and id tables, which phantoms do feed.

**Phantoms are now in `_idToIdx`.** They used to only bump `_idCounts`, which meant a `<slot id="uniq">` couldn't be named by `#uniq` even though `querySelectorAll` sees it perfectly well. `getElmId` now resolves through `_idToIdx` (a hit is proof of uniqueness, since `pruneDuplicateIds` drops everything else) and falls back to a live DOM query for elements the walk never recorded.

## Tests

Every selector test that only asserted "matches exactly one element" now also asserts the exact selector string, so a refactor that silently changes the output fails loudly instead of passing. New cases cover slots colliding with the target on a class or an id, slot fallback content under a slot with a unique id, and a `feature count stability` block that pins the frequency counts for unslotted light DOM, slot elements, and assigned-slot fallback.