### PR TITLE
test(target-size): add regression coverage for wrapped-span false positive

### DIFF
--- a/test/integration/rules/target-size/target-size.html
+++ b/test/integration/rules/target-size/target-size.html
@@ -235,6 +235,20 @@ this should not effect their outcome -->
   </a>
 </p>
 
+<!-- https://github.com/dequelabs/axe-core/issues/4295
+An inline <span> wrapping across multiple lines must not be treated as a
+single merged obscuring rect that fully overlaps everything near it -->
+<div style="max-width: 290px">
+  <p>
+    <a href="#" id="pass-wrapped-span-1">lorem ipsum dolor</a>
+    <a href="#" id="pass-wrapped-span-2">amet</a>
+    <span>et dolore magna aliqua</span>
+  </p>
+  <a href="#" id="pass-wrapped-span-3" style="display: inline-block"
+    >Not obscured by the wrapped span above</a
+  >
+</div>
+
 <!-- Inapplicable -->
 <p>
   The quick <a href="#" id="inapplicable1">brown</a><br />

--- a/test/integration/rules/target-size/target-size.html
+++ b/test/integration/rules/target-size/target-size.html
@@ -240,11 +240,11 @@ An inline <span> wrapping across multiple lines must not be treated as a
 single merged obscuring rect that fully overlaps everything near it -->
 <div style="max-width: 290px">
   <p>
-    <a href="#" id="pass-wrapped-span-1">lorem ipsum dolor</a>
-    <a href="#" id="pass-wrapped-span-2">amet</a>
+    <a href="#" id="ignored-inline-1">lorem ipsum dolor</a>
+    <a href="#" id="ignored-inline-2">amet</a>
     <span>et dolore magna aliqua</span>
   </p>
-  <a href="#" id="pass-wrapped-span-3" style="display: inline-block"
+  <a href="#" id="pass-adjacent-inline" style="display: inline-block"
     >Not obscured by the wrapped span above</a
   >
 </div>

--- a/test/integration/rules/target-size/target-size.json
+++ b/test/integration/rules/target-size/target-size.json
@@ -39,7 +39,7 @@
     ["#pass25"],
     ["#pass-adjacent"],
     ["#pass-fixed"],
-    ["#pass-wrapped-span-3"]
+    ["#pass-adjacent-inline"]
   ],
   "incomplete": [
     ["#incomplete1"],

--- a/test/integration/rules/target-size/target-size.json
+++ b/test/integration/rules/target-size/target-size.json
@@ -38,7 +38,8 @@
     ["#pass24"],
     ["#pass25"],
     ["#pass-adjacent"],
-    ["#pass-fixed"]
+    ["#pass-fixed"],
+    ["#pass-wrapped-span-3"]
   ],
   "incomplete": [
     ["#incomplete1"],


### PR DESCRIPTION
## Background

#4295 reported that a link far away from a paragraph was incorrectly flagged as a `target-size` violation, claiming "0 offset" from two other links inside the paragraph. The maintainer's own debug notes traced it to `get-target-rects.js`: a `<span>` wrapping across two lines was being treated as **one merged obscuring rect** (spanning the full vertical extent of both wrapped lines) instead of one rect per line, so `split-rects` found no non-overlapping space and returned an empty array — which then made the far-away link look fully obscured.

## What I found

I couldn't reproduce the bug. Loaded the exact reported repro in a real browser and confirmed:
- `span.getClientRects()` natively returns one rect **per wrapped line** (4 rects in my test), not one merged rect — so the raw browser API isn't the issue.
- Running current axe-core (4.10.2) against the exact repro via CDN: `target-size` passes with zero violations.

This looks like it's already fixed — most likely as a side effect of some other `get-target-rects`/`split-rects` change since the issue was filed — but there's no test locking this scenario in, so it could regress silently.

## Change

Adds a regression test reproducing the original report exactly (wrapped inline `<span>` inside a narrow container, plus an unrelated link elsewhere on the page) to `test/integration/rules/target-size/`, expecting a pass. No source changes — this is test-only, confirming and protecting behavior that already works.

Closes #4295
