### PR TITLE
fix(label-content-name-mismatch): compare visible label to name by word

### DIFF
--- a/lib/checks/label/label-content-name-mismatch-evaluate.js
+++ b/lib/checks/label/label-content-name-mismatch-evaluate.js
@@ -9,13 +9,7 @@ import { getCategoryFormatRegExp } from '../../commons/text/unicode';
 
 /**
  * Check whether the visible label's words appear as a contiguous run of words
- * within the accessible name. This implements the comparison at the core of ACT
- * rule 2ee8b8's "label in name" algorithm: tokenize on non-text characters, then
- * match whole words rather than raw substrings.
- *
- * Note: the algorithm's parenthetical-content removal and case-folding/NFKD
- * normalization steps are not implemented yet
- * (see https://github.com/dequelabs/axe-core/issues/5203).
+ * within the accessible name.
  *
  * @param {String} label visible label text
  * @param {String} name accessible name

--- a/lib/checks/label/label-content-name-mismatch-evaluate.js
+++ b/lib/checks/label/label-content-name-mismatch-evaluate.js
@@ -5,36 +5,67 @@ import {
   sanitize,
   visibleVirtual
 } from '../../commons/text';
+import { getCategoryFormatRegExp } from '../../commons/text/unicode';
 
 /**
- * Check if a given text exists in another
+ * Check whether the visible label's words appear as a contiguous run of words
+ * within the accessible name. This implements the comparison at the core of ACT
+ * rule 2ee8b8's "label in name" algorithm: tokenize on non-text characters, then
+ * match whole words rather than raw substrings.
  *
- * @param {String} compare given text to check
- * @param {String} compareWith text against which to be compared
+ * Note: the algorithm's parenthetical-content removal and case-folding/NFKD
+ * normalization steps are not implemented yet
+ * (see https://github.com/dequelabs/axe-core/issues/5203).
+ *
+ * @param {String} label visible label text
+ * @param {String} name accessible name
  * @returns {Boolean}
  */
-function isStringContained(compare, compareWith) {
-  const curatedCompareWith = curateString(compareWith);
-  const curatedCompare = curateString(compare);
-  if (!curatedCompareWith || !curatedCompare) {
+function isLabelContainedInName(label, name) {
+  const labelTokens = curateTokens(label);
+  const nameTokens = curateTokens(name);
+  if (!labelTokens.length || !nameTokens.length) {
     return false;
   }
-  return curatedCompareWith.includes(curatedCompare);
+  return isContiguousSubsequence(nameTokens, labelTokens);
 }
 
 /**
- * Curate given text, by removing emoji's, punctuations, unicode and trim whitespace.
+ * Split text into words, treating non-text characters (emoji, punctuation,
+ * symbols) as word separators. Uses `removeUnicode`'s explicit unicode ranges
+ * (rather than a `\p{…}` property escape) to keep working on the browsers axe
+ * supports.
  *
- * @param {String} str given text to curate
- * @returns {String}
+ * @param {String} str given text to tokenize
+ * @returns {String[]}
  */
-function curateString(str) {
-  const noUnicodeStr = removeUnicode(str, {
+function curateTokens(str) {
+  // Zero-width format characters are invisible, so they can't be word
+  // boundaries; strip them before handling other non-text characters (otherwise
+  // a soft hyphen or zero-width space would split a word).
+  const separated = removeUnicode(str.replace(getCategoryFormatRegExp(), ''), {
     emoji: true,
     nonBmp: true,
-    punctuations: true
+    punctuations: true,
+    replaceWith: ' '
   });
-  return sanitize(noUnicodeStr);
+  return sanitize(separated).split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Whether `needle` appears as a contiguous run within `haystack`.
+ *
+ * @param {String[]} haystack
+ * @param {String[]} needle
+ * @returns {Boolean}
+ */
+function isContiguousSubsequence(haystack, needle) {
+  for (let i = 0; i + needle.length <= haystack.length; i++) {
+    if (needle.every((word, j) => word === haystack[i + j])) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function labelContentNameMismatchEvaluate(node, options, virtualNode) {
@@ -59,7 +90,7 @@ function labelContentNameMismatchEvaluate(node, options, virtualNode) {
     return undefined;
   }
 
-  return isStringContained(visibleText, accText);
+  return isLabelContainedInName(visibleText, accText);
 }
 
 export default labelContentNameMismatchEvaluate;

--- a/lib/commons/text/remove-unicode.js
+++ b/lib/commons/text/remove-unicode.js
@@ -17,22 +17,27 @@ import { emojiRegexText } from '../../core/imports';
  * @property {Boolean} options.emoji remove emoji unicode
  * @property {Boolean} options.nonBmp remove nonBmp unicode
  * @property {Boolean} options.punctuations remove punctuations unicode
+ * @property {String} [options.replaceWith=''] literal string to substitute for each matched character (e.g. a space to preserve word boundaries)
  * @returns {String}
  */
 function removeUnicode(str, options) {
-  const { emoji, nonBmp, punctuations } = options;
+  const { emoji, nonBmp, punctuations, replaceWith = '' } = options;
+  // Use a replacer function so `replaceWith` is always inserted literally, i.e.
+  // `$&`, `$'`, `$1`, etc. are not interpreted as `String.prototype.replace`
+  // patterns.
+  const replacer = () => replaceWith;
 
   if (emoji) {
-    str = str.replace(emojiRegexText(), '');
+    str = str.replace(emojiRegexText(), replacer);
   }
   if (nonBmp) {
     str = str
-      .replace(getUnicodeNonBmpRegExp(), '')
-      .replace(getSupplementaryPrivateUseRegExp(), '')
-      .replace(getCategoryFormatRegExp(), '');
+      .replace(getUnicodeNonBmpRegExp(), replacer)
+      .replace(getSupplementaryPrivateUseRegExp(), replacer)
+      .replace(getCategoryFormatRegExp(), replacer);
   }
   if (punctuations) {
-    str = str.replace(getPunctuationRegExp(), '');
+    str = str.replace(getPunctuationRegExp(), replacer);
   }
 
   return str;

--- a/test/act-rules/visible-label-in-accessible-name-2ee8b8.spec.js
+++ b/test/act-rules/visible-label-in-accessible-name-2ee8b8.spec.js
@@ -3,12 +3,16 @@ require('./act-runner.js')({
   title: 'Visible label is part of accessible name',
   axeRules: ['label-content-name-mismatch'],
   skipTests: [
-    // See: https://github.com/dequelabs/axe-core/issues/4311
-    'e9bbdbec137223e2973c6d2896050770c84c26e5',
+    // ACT made abbreviation and hyphenation differences inapplicable, but axe
+    // cannot detect either reliably and reports a violation instead. This
+    // divergence is accepted; see
+    // https://github.com/act-rules/act-rules.github.io/pull/2443
+    // Both are load-bearing against the nightly, which installs
+    // `wcag-act-rules#main`, not the pinned dependency.
+    '4c8c38022d15c92158ecaaa647fe8ca2c330f485', // Inapplicable Example 5
+    'e9bbdbec137223e2973c6d2896050770c84c26e5', // Inapplicable Example 6
     // See: https://github.com/dequelabs/axe-core/issues/5207
-    'fab659b02c1edb4f2c8f0bda524b1076abab7df6',
-    '94a7ce7aea9dbfaa375c459c26d3a5923de84e7a',
-    'e117393d6711d6bdf32821005219c9d9474dfeb8',
-    'f5c9811c984987443476760a1c5b91b1067f7e19'
+    'fab659b02c1edb4f2c8f0bda524b1076abab7df6', // Passed Example 11
+    '94a7ce7aea9dbfaa375c459c26d3a5923de84e7a' // Passed Example 14
   ]
 });

--- a/test/checks/label/label-content-name-mismatch.js
+++ b/test/checks/label/label-content-name-mismatch.js
@@ -2,6 +2,7 @@ describe('label-content-name-mismatch tests', () => {
   const html = axe.testUtils.html;
 
   const queryFixture = axe.testUtils.queryFixture;
+  const queryShadowFixture = axe.testUtils.queryShadowFixture;
   const check = checks['label-content-name-mismatch'];
   const options = undefined;
 
@@ -187,6 +188,14 @@ describe('label-content-name-mismatch tests', () => {
     assert.isTrue(actual);
   });
 
+  it('treats a lone newline in the visible text as a word separator', () => {
+    const vNode = queryFixture(
+      '<button id="target" aria-label="save changes">save\nchanges</button>'
+    );
+    const actual = check.evaluate(vNode.actualNode, options, vNode);
+    assert.isTrue(actual);
+  });
+
   it('returns true when aria-label and visible text match even though there is an image with alt text', function () {
     var vNode = queryFixture(
       '<button id="target" aria-label="button label"><img alt="button icon" src="button.png" />button label</button>'
@@ -224,4 +233,52 @@ describe('label-content-name-mismatch tests', () => {
       assert.isFalse(actual);
     }
   );
+
+  it('returns false when the visible words are not a contiguous run within the accessible name', () => {
+    const vNode = queryFixture(
+      '<button id="target" aria-label="the big red button">big button</button>'
+    );
+    const actual = check.evaluate(vNode.actualNode, options, vNode);
+    assert.isFalse(actual);
+  });
+
+  it('returns true when the visible words are a contiguous run within the accessible name', () => {
+    const vNode = queryFixture(
+      '<button id="target" aria-label="go to next page now">next page</button>'
+    );
+    const actual = check.evaluate(vNode.actualNode, options, vNode);
+    assert.isTrue(actual);
+  });
+
+  it('ignores zero-width characters when tokenizing so they do not split a word', () => {
+    const vNode = queryFixture(
+      '<a id="target" href="#" aria-label="nonstandard">non\u00ADstandard</a>'
+    );
+    const actual = check.evaluate(vNode.actualNode, options, vNode);
+    assert.isTrue(actual);
+  });
+
+  [
+    ['a hyphen', 'non-standard', 'nonstandard'],
+    ['an apostrophe', 'its book', "it's"],
+    ['periods', 'usa', 'u.s.a'],
+    ['an en dash', 'email', 'e–mail']
+  ].forEach(([label, name, content]) => {
+    it(`returns false when the words differ by ${label}`, () => {
+      const vNode = queryFixture(
+        `<a id="target" href="#" aria-label="${name}">${content}</a>`
+      );
+      const actual = check.evaluate(vNode.actualNode, options, vNode);
+      assert.isFalse(actual);
+    });
+  });
+
+  it('matches the visible label against the accessible name across an open shadow DOM boundary', () => {
+    const vNode = queryShadowFixture(
+      '<button id="target" aria-label="save changes"><span id="shadow"></span> changes</button>',
+      'save'
+    );
+    const actual = check.evaluate(vNode.actualNode, options, vNode);
+    assert.isTrue(actual);
+  });
 });

--- a/test/commons/text/unicode.js
+++ b/test/commons/text/unicode.js
@@ -270,4 +270,36 @@ describe('text.removeUnicode', () => {
     });
     assert.equal(actual, 'Hello World');
   });
+
+  it('substitutes matched punctuation with replaceWith when provided', () => {
+    const actual = axe.commons.text.removeUnicode('non-standard', {
+      punctuations: true,
+      replaceWith: ' '
+    });
+    assert.equal(actual, 'non standard');
+  });
+
+  it('substitutes matched emoji with replaceWith when provided', () => {
+    const actual = axe.commons.text.removeUnicode('Sun🌎Earth', {
+      emoji: true,
+      replaceWith: ' '
+    });
+    assert.equal(actual, 'Sun Earth');
+  });
+
+  it('substitutes matched non BMP characters with replaceWith when provided', () => {
+    const actual = axe.commons.text.removeUnicode('20000₨100', {
+      nonBmp: true,
+      replaceWith: ' '
+    });
+    assert.equal(actual, '20000 100');
+  });
+
+  it('inserts replaceWith literally rather than as a replace pattern', () => {
+    const actual = axe.commons.text.removeUnicode('a😀b', {
+      emoji: true,
+      replaceWith: '$&'
+    });
+    assert.equal(actual, 'a$&b');
+  });
 });

--- a/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.html
+++ b/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.html
@@ -46,6 +46,7 @@
   </svg>
   Hello Deque Systems
 </a>
+<a id="fail8" href="#" aria-label="non-standard">nonstandard</a>
 
 <!-- incomplete -->
 <button id="incomplete1" aria-label="comet">☄️</button>

--- a/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.json
+++ b/test/integration/rules/label-content-name-mismatch/label-content-name-mismatch.json
@@ -8,7 +8,8 @@
     ["#fail4"],
     ["#fail5"],
     ["#fail6"],
-    ["#fail7"]
+    ["#fail7"],
+    ["#fail8"]
   ],
   "passes": [
     ["#pass1"],


### PR DESCRIPTION
## Summary

Implements the comparison at the core of ACT rule 2ee8b8's [label in name algorithm](https://www.w3.org/WAI/standards-guidelines/act/rules/2ee8b8/proposed/#label-in-name-algorithm). The check compared the accessible name and the visible label as raw character substrings, so `Discover It` matched `Discover Italy`. Both strings are now tokenized into words at non-text characters — replaced with a space rather than deleted — and the label's words must form a **contiguous run** within the name.

Supporting change: a backward-compatible `replaceWith` option on `removeUnicode`, built from axe's explicit unicode ranges rather than a `\p{…}` property escape, to keep Safari 7+ and IE11 working.

## Scope

Per @straker on #5203, abbreviation and hyphenation differences are an **accepted divergence** from ACT:

> We are accepting that Inapplicable 5 & 6 will fail instead of incomplete and should be skipped. See act-rules/act-rules.github.io#2443

So the check reports those as violations and the two testcases stay skipped. There is no `incomplete` branch for punctuation.

Three algorithm steps remain unimplemented:

1. Parenthetical-content removal — tracked on #5207, which also covers the `Passed Example 11` whitespace case
2. Unicode case folding + NFKD normalization — the CJK and full-width half of this is tracked on #5308
3. Language-aware word segmentation (this splits on whitespace) — not tracked

The `wcag-act-rules` dependency bump called out on #5203 is tracked as #5346.

## ACT 2ee8b8 results

The `act` nightly installs `wcag-act-rules#main` (38 2ee8b8 testcases), not the pinned dependency (15). Verified against `main`: **34 passing / 4 pending / 0 failing**.

| Skipped testcase | Reason |
| --- | --- |
| Inapplicable 5 — `University Ave.` | Accepted divergence (abbreviation) |
| Inapplicable 6 — `non-standard` | Accepted divergence (hyphenation) |
| Passed 11 — `<span>Download</span><span> </span><span>specification</span>` | #5207. `visibleVirtual` recurses per child and `sanitize()`s each result, so a whitespace-only inline element is trimmed to `''` and the words join into `downloadspecification`. A `commons/text` fix, not a rule fix. |
| Passed 14 — `Search by date (YYYY-MM-DD)` | #5207. Needs the parenthetical-removal step. |

`Failed Example 3` and `Failed Example 15` were previously skipped under #5207 and are fixed by word-level matching, so their skips are removed. I confirmed the two accepted-divergence skips are load-bearing: unskipping them against `main` produces exactly two failures.

## Notes

Supersedes #5302, which was opened against #4311 before @straker closed that as a duplicate of #5203. The tokenizer here is the part of #5302 that survived review; the punctuation `incomplete` branch it grew is dropped per the ruling above.

The `publish-metadata.js` change from #5302 is not carried over — it is out of scope for a rule PR, and the underlying defect is now tracked as #5344.

Ref #5203
