### PR TITLE
fix(p-as-heading): ignore paragraphs with heading roles

### DIFF
--- a/lib/rules/p-as-heading-matches.js
+++ b/lib/rules/p-as-heading-matches.js
@@ -1,4 +1,10 @@
-function pAsHeadingMatches(node) {
+import { getRole } from '../commons/aria';
+
+export default function pAsHeadingMatches(node, virtualNode) {
+  if (virtualNode && getRole(virtualNode) === 'heading') {
+    return false;
+  }
+
   const children = Array.from(node.parentNode.childNodes);
   const nodeText = node.textContent.trim();
   const isSentence = /[.!?:;](?![.!?:;])/g;
@@ -17,5 +23,3 @@ function pAsHeadingMatches(node) {
 
   return siblingsAfter.length !== 0;
 }
-
-export default pAsHeadingMatches;

--- a/test/integration/rules/p-as-heading/p-as-heading.html
+++ b/test/integration/rules/p-as-heading/p-as-heading.html
@@ -22,6 +22,11 @@
   <p>Some text</p>
 </div>
 
+<div>
+  <p id="inapplicable5" role="heading" aria-level="1">Some text</p>
+  <p>A paragraph!</p>
+</div>
+
 <!-- Passes -->
 <div>
   <p id="passed1">Some text</p>

--- a/test/rule-matches/p-as-heading-matches.js
+++ b/test/rule-matches/p-as-heading-matches.js
@@ -1,6 +1,7 @@
 describe('p-as-heading-matches', () => {
   let rule;
   const fixture = document.getElementById('fixture');
+  const queryFixture = axe.testUtils.queryFixture;
 
   beforeEach(() => {
     rule = axe.utils.getRule('p-as-heading');
@@ -19,6 +20,14 @@ describe('p-as-heading-matches', () => {
     const target = fixture.querySelector('#target');
 
     assert.isTrue(rule.matches(target));
+  });
+
+  it('ignores p elements with a heading role', () => {
+    const virtualNode = queryFixture(
+      '<p id="target" role="heading" aria-level="1">some text</p><p>some other text</p>'
+    );
+
+    assert.isFalse(rule.matches(virtualNode.actualNode, virtualNode));
   });
 
   it('ignores the last p element in a list of children', () => {


### PR DESCRIPTION
Fix the false positive where `p-as-heading` evaluates a paragraph that already resolves to an ARIA heading role.

- use axe-core's `getRole` resolution instead of parsing the `role` attribute directly
- make resolved headings inapplicable before the visual heading heuristics run
- add focused rule-match and rule integration coverage

The new unit and integration cases both fail against the current `develop` implementation and pass with this change.

## Testing

- `npm exec --yes -- pnpm@11.17.0 run build`
- `npm exec --yes -- pnpm@11.17.0 run test:tsc`
- all 44 rule-match test files, passed via explicit file paths
- focused `p-as-heading-matches` unit test
- generated focused `p-as-heading` integration test
- changed-file ESLint and Prettier checks

### Windows test-runner note

The repository aggregate scripts that contain POSIX single-quoted globs do not enumerate files correctly from this Windows/MSYS checkout (for example, `test/core/**/*.js` is passed as a literal pattern). I therefore ran the affected test and the complete rule-match group with explicit file paths; upstream CI can exercise the aggregate Linux commands.

Closes: #5283
