### PR TITLE
fix(commons): exclude script/style/noscript/template text from isInTextBlock

### DIFF
--- a/lib/commons/dom/is-in-text-block.js
+++ b/lib/commons/dom/is-in-text-block.js
@@ -76,7 +76,11 @@ function isInTextBlock(
       currNode.style.display === 'none' ||
       currNode.style.overflow === 'hidden' ||
       !['', null, 'none'].includes(currNode.style.float) ||
-      !['', null, 'relative'].includes(currNode.style.position)
+      !['', null, 'relative'].includes(currNode.style.position) ||
+      // Don't count content that isn't rendered/visible text, e.g. a
+      // <script> tag's source code is a text node child but isn't text
+      // content a sighted user would perceive as part of the block
+      ['SCRIPT', 'STYLE', 'NOSCRIPT', 'TEMPLATE'].includes(nodeName)
     ) {
       return false;
 

--- a/test/commons/dom/is-in-text-block.js
+++ b/test/commons/dom/is-in-text-block.js
@@ -65,6 +65,28 @@ describe('dom.isInTextBlock', () => {
     assert.isFalse(isInTextBlock(link));
   });
 
+  it('ignores script content', () => {
+    fixtureSetup(html`
+      <p>
+        <a href="" id="link">link</a>
+        <script>var someScriptText = 'not real text content';</script>
+      </p>
+    `);
+    const link = document.getElementById('link');
+    assert.isFalse(isInTextBlock(link));
+  });
+
+  it('ignores style content', () => {
+    fixtureSetup(html`
+      <p>
+        <a href="" id="link">link</a>
+        <style>.some-style-text { color: red; }</style>
+      </p>
+    `);
+    const link = document.getElementById('link');
+    assert.isFalse(isInTextBlock(link));
+  });
+
   it('ignores floated content', () => {
     fixtureSetup(html`
       <p>


### PR DESCRIPTION
## Current behavior

`isInTextBlock()` (`lib/commons/dom/is-in-text-block.js`) walks all descendant text nodes of an element's nearest block-level ancestor to decide whether the element sits inside a run of surrounding text. The walk does not skip `<script>`, `<style>`, `<noscript>` or `<template>` elements, so their non-rendered content (e.g. a `<script>` tag's inline JS source, which is technically a text-node child) gets counted as if it were visible surrounding text.

This can flip the result incorrectly. For example, a lone `<a>` link that is otherwise the only content in its block should return `false` (not "in a text block"), but adding a `<script>` (or `<style>`) sibling with enough text content flips it to `true`, purely because of the non-rendered text length.

Found while investigating #3739 — `@straker` traced the `inapplicable` result for `target-size` back to exactly this function when a `<script>` tag was present in the test page ([comment](https://github.com/dequelabs/axe-core/issues/3739#issuecomment-3496671050)).

## Verification

Reproduced live against the current published build (axe-core 4.10.2) in a browser:
- `<div><a href="#">link</a></div>` → `isInTextBlock(link)` is `false` (correct).
- Same markup + an appended `<script>` with non-empty `textContent` → flips to `true`.
- Same, but with an *empty* `<script>` → stays `false` — isolating the cause to the swept-in text content, not the element's mere presence.
- Same test with `<style>` instead of `<script>` reproduces identically.

## Fix

Added `SCRIPT`/`STYLE`/`NOSCRIPT`/`TEMPLATE` to the set of nodes the walk treats as "not displayed on screen" (same branch that already excludes `display:none`, `overflow:hidden`, floated and absolutely/fixed-positioned content), so their content is skipped entirely rather than being walked into.

This mirrors the existing `nativelyHidden()` element list already used elsewhere in the codebase (`lib/commons/dom/visibility-methods.js`) for the same class of non-rendered elements, so it's consistent with how axe-core already treats this content elsewhere.

## Tests

Added two regression tests (`ignores script content`, `ignores style content`) next to the existing `ignores hidden content` test in `test/commons/dom/is-in-text-block.js`.

Related to #3739
