### PR TITLE
fix(checks): make listitem failure messages actionable

### DIFF
--- a/lib/checks/lists/listitem.json
+++ b/lib/checks/lists/listitem.json
@@ -6,8 +6,8 @@
     "messages": {
       "pass": "List item has a <ul>, <ol> or role=\"list\" parent element",
       "fail": {
-        "default": "List item does not have a <ul>, <ol> parent element",
-        "roleNotValid": "List item parent element has a role that is not role=\"list\""
+        "default": "List item does not have a <ul> or <ol> parent element. Ensure the <li> is a direct child of a <ul> or <ol>, or that the parent has role=\"list\".",
+        "roleNotValid": "List item parent element has a role that is not role=\"list\". Ensure the parent element has role=\"list\", or move the <li> inside a <ul> or <ol>."
       }
     }
   }

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -853,8 +853,8 @@
     "listitem": {
       "pass": "List item has a <ul>, <ol> or role=\"list\" parent element",
       "fail": {
-        "default": "List item does not have a <ul>, <ol> parent element",
-        "roleNotValid": "List item parent element has a role that is not role=\"list\""
+        "default": "List item does not have a <ul> or <ol> parent element. Ensure the <li> is a direct child of a <ul> or <ol>, or that the parent has role=\"list\".",
+        "roleNotValid": "List item parent element has a role that is not role=\"list\". Ensure the parent element has role=\"list\", or move the <li> inside a <ul> or <ol>."
       }
     },
     "only-dlitems": {

--- a/test/checks/lists/listitem.js
+++ b/test/checks/lists/listitem.js
@@ -61,6 +61,14 @@ describe('listitem', () => {
     });
   });
 
+  it('should include a fix suggestion in the roleNotValid failureSummary', () => {
+    fixtureSetup('<ol role="menubar"><li id="target">My list item</li></ol>');
+    return axe.run('#fixture', { runOnly: ['listitem'] }).then(results => {
+      const summary = results.violations[0].nodes[0].failureSummary;
+      assert.include(summary, 'Ensure the parent element has role="list"');
+    });
+  });
+
   it('should fail if the listitem has a parent <ol> with changed role', () => {
     const params = checkSetup(
       '<ol role="menubar"><li id="target">My list item</li></ol>'

--- a/test/checks/lists/listitem.js
+++ b/test/checks/lists/listitem.js
@@ -50,6 +50,17 @@ describe('listitem', () => {
     assert.isFalse(result);
   });
 
+  it('should include a fix suggestion in the failureSummary', () => {
+    fixtureSetup('<div><li id="target">My list item</li></div>');
+    return axe.run('#fixture', { runOnly: ['listitem'] }).then(results => {
+      const summary = results.violations[0].nodes[0].failureSummary;
+      assert.include(
+        summary,
+        'Ensure the <li> is a direct child of a <ul> or <ol>'
+      );
+    });
+  });
+
   it('should fail if the listitem has a parent <ol> with changed role', () => {
     const params = checkSetup(
       '<ol role="menubar"><li id="target">My list item</li></ol>'


### PR DESCRIPTION
## Summary

- Make the `listitem` check's fail messages actionable so the auto-generated `failureSummary` tells users how to fix the issue, not just restates the failure condition (e.g. ensure the `<li>` is a direct child of a `<ul>`/`<ol>`, or that the parent has `role="list"`).
- Regenerated `locales/_template.json` from the build (auto-synced from the check metadata).

## Test plan

- `pnpm run build` regenerates `locales/_template.json`.
- Ran `test/checks/lists/listitem.js` via Web Test Runner in headless Chrome: 13/13 tests passing.