### PR TITLE
fix(color-contrast): treat empty low-contrast text inputs as incomplete

### DIFF
--- a/lib/checks/color/color-contrast-enhanced.json
+++ b/lib/checks/color/color-contrast-enhanced.json
@@ -43,6 +43,7 @@
         "outsideViewport": "Element's background color could not be determined because it's outside the viewport",
         "equalRatio": "Element has a 1:1 contrast ratio with the background",
         "shortTextContent": "Element content is too short to determine if it is actual text content",
+        "emptyValue": "Element has no value; test color contrast with a value entered",
         "nonBmp": "Element content contains only non-text characters",
         "pseudoContent": "Element's background color could not be determined due to a pseudo element",
         "colorParse": "Could not parse color string ${data.colorParse}"

--- a/lib/checks/color/color-contrast-evaluate.js
+++ b/lib/checks/color/color-contrast-evaluate.js
@@ -14,6 +14,7 @@ import {
   getTextShadowColors,
   flattenShadowColors
 } from '../../commons/color';
+import { isNativeTextbox } from '../../commons/forms';
 import { memoize } from '../../core/utils';
 
 export default function colorContrastEvaluate(node, options, virtualNode) {
@@ -142,11 +143,14 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
 
   const equalRatio = truncatedResult === 1;
   const shortTextContent = visibleText.length === 1;
+  const emptyValue = isEmptyTextEntry(virtualNode);
   if (equalRatio) {
     missing = incompleteData.set('bgColor', 'equalRatio');
   } else if (!isValid && shortTextContent && !ignoreLength) {
     // Check that the text content is a single character long
     missing = 'shortTextContent';
+  } else if (!isValid && emptyValue) {
+    missing = 'emptyValue';
   }
 
   // need both independently in case both are missing
@@ -167,7 +171,8 @@ export default function colorContrastEvaluate(node, options, virtualNode) {
     fgColor === null ||
     bgColor === null ||
     equalRatio ||
-    (shortTextContent && !ignoreLength && !isValid)
+    (shortTextContent && !ignoreLength && !isValid) ||
+    (emptyValue && !isValid)
   ) {
     missing = null;
     incompleteData.clear();
@@ -248,4 +253,19 @@ function parseUnit(str) {
     value: parseFloat(value),
     unit: unit.toLowerCase()
   };
+}
+
+/**
+ * Whether a native text-entry control has no value to contrast-check.
+ * Empty fields may use different colors once text is entered.
+ * @param {VirtualNode} virtualNode
+ * @return {Boolean}
+ */
+function isEmptyTextEntry(virtualNode) {
+  const { type, value } = virtualNode.props;
+  if (!isNativeTextbox(virtualNode) && type !== 'password') {
+    return false;
+  }
+
+  return sanitize(value) === '';
 }

--- a/lib/checks/color/color-contrast.json
+++ b/lib/checks/color/color-contrast.json
@@ -45,6 +45,7 @@
         "outsideViewport": "Element's background color could not be determined because it's outside the viewport",
         "equalRatio": "Element has a 1:1 contrast ratio with the background",
         "shortTextContent": "Element content is too short to determine if it is actual text content",
+        "emptyValue": "Element has no value; test color contrast with a value entered",
         "nonBmp": "Element content contains only non-text characters",
         "pseudoContent": "Element's background color could not be determined due to a pseudo element",
         "colorParse": "Could not parse color string ${data.colorParse}"

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -651,6 +651,7 @@
         "outsideViewport": "Element's background color could not be determined because it's outside the viewport",
         "equalRatio": "Element has a 1:1 contrast ratio with the background",
         "shortTextContent": "Element content is too short to determine if it is actual text content",
+        "emptyValue": "Element has no value; test color contrast with a value entered",
         "nonBmp": "Element content contains only non-text characters",
         "pseudoContent": "Element's background color could not be determined due to a pseudo element",
         "colorParse": "Could not parse color string ${data.colorParse}"
@@ -679,6 +680,7 @@
         "outsideViewport": "Element's background color could not be determined because it's outside the viewport",
         "equalRatio": "Element has a 1:1 contrast ratio with the background",
         "shortTextContent": "Element content is too short to determine if it is actual text content",
+        "emptyValue": "Element has no value; test color contrast with a value entered",
         "nonBmp": "Element content contains only non-text characters",
         "pseudoContent": "Element's background color could not be determined due to a pseudo element",
         "colorParse": "Could not parse color string ${data.colorParse}"

--- a/test/checks/color/color-contrast.js
+++ b/test/checks/color/color-contrast.js
@@ -946,6 +946,126 @@ x
     });
   });
 
+  describe('with empty text entry', () => {
+    it('should return undefined for an empty text input with insufficient contrast', () => {
+      const params = checkSetup(html`
+        <input
+          id="target"
+          type="text"
+          style="background-color: #fff; color: #eee"
+        />
+      `);
+
+      const actual = contrastEvaluate.apply(checkContext, params);
+      assert.isUndefined(actual);
+      assert.equal(checkContext._data.messageKey, 'emptyValue');
+    });
+
+    it('should return undefined for an empty textarea with insufficient contrast', () => {
+      const params = checkSetup(
+        '<textarea id="target" style="background-color: #fff; color: #eee"></textarea>'
+      );
+
+      const actual = contrastEvaluate.apply(checkContext, params);
+      assert.isUndefined(actual);
+      assert.equal(checkContext._data.messageKey, 'emptyValue');
+    });
+
+    it('should return undefined for an empty password input with insufficient contrast', () => {
+      const params = checkSetup(html`
+        <input
+          id="target"
+          type="password"
+          style="background-color: #fff; color: #eee"
+        />
+      `);
+
+      const actual = contrastEvaluate.apply(checkContext, params);
+      assert.isUndefined(actual);
+      assert.equal(checkContext._data.messageKey, 'emptyValue');
+    });
+
+    it('should return undefined for an empty text input with a placeholder and insufficient contrast', () => {
+      const params = checkSetup(html`
+        <style>
+          .placeholder-000::placeholder {
+            color: #000;
+          }
+        </style>
+        <input
+          id="target"
+          type="text"
+          class="placeholder-000"
+          placeholder="Placeholder"
+          style="background-color: #fff; color: #eee"
+        />
+      `);
+
+      const actual = contrastEvaluate.apply(checkContext, params);
+      assert.isUndefined(actual);
+      assert.equal(checkContext._data.messageKey, 'emptyValue');
+    });
+
+    it('should return undefined for a whitespace-only text input with insufficient contrast', () => {
+      const params = checkSetup(html`
+        <input
+          id="target"
+          type="text"
+          value="   "
+          style="background-color: #fff; color: #eee"
+        />
+      `);
+
+      const actual = contrastEvaluate.apply(checkContext, params);
+      assert.isUndefined(actual);
+      assert.equal(checkContext._data.messageKey, 'emptyValue');
+    });
+
+    it('should return true for an empty text input with sufficient contrast', () => {
+      const params = checkSetup(html`
+        <input
+          id="target"
+          type="text"
+          style="background-color: #fff; color: #000"
+        />
+      `);
+
+      assert.isTrue(contrastEvaluate.apply(checkContext, params));
+    });
+
+    it('should return false for a text input with a value and insufficient contrast', () => {
+      const params = checkSetup(html`
+        <input
+          id="target"
+          type="text"
+          value="hello"
+          style="background-color: #fff; color: #eee"
+        />
+      `);
+
+      const actual = contrastEvaluate.apply(checkContext, params);
+      assert.isFalse(actual);
+    });
+
+    it('should return undefined for an empty text input in Shadow DOM with insufficient contrast', () => {
+      const params = checkSetup(html`
+        <div>
+          <template shadowrootmode="open">
+            <input
+              id="target"
+              type="text"
+              style="background-color: #fff; color: #eee"
+            />
+          </template>
+        </div>
+      `);
+
+      const actual = contrastEvaluate.apply(checkContext, params);
+      assert.isUndefined(actual);
+      assert.equal(checkContext._data.messageKey, 'emptyValue');
+    });
+  });
+
   describe('options', () => {
     it('should support options.boldValue', () => {
       const params = checkSetup(

--- a/test/integration/rules/color-contrast/color-contrast.html
+++ b/test/integration/rules/color-contrast/color-contrast.html
@@ -555,3 +555,34 @@ Hello world</textarea>
     </div>
   </div>
 </div>
+
+<!-- empty text inputs: filled-state contrast cannot be known yet -->
+<input id="canttell24" type="text" style="background: #fff; color: #eee" />
+<style>
+  .placeholder-000::placeholder {
+    color: #000;
+  }
+  .placeholder-ddd::placeholder {
+    color: #ddd;
+  }
+</style>
+<input
+  id="canttell25"
+  type="text"
+  placeholder="Placeholder"
+  style="background: #fff; color: #eee"
+  class="placeholder-000"
+/>
+<input
+  id="canttell26"
+  type="text"
+  placeholder="Placeholder"
+  style="background: #fff; color: #eee"
+  class="placeholder-ddd"
+/>
+<input
+  id="fail15"
+  type="text"
+  value="hello"
+  style="background: #fff; color: #eee"
+/>

--- a/test/integration/rules/color-contrast/color-contrast.json
+++ b/test/integration/rules/color-contrast/color-contrast.json
@@ -13,7 +13,8 @@
     ["#fail11"],
     ["#fail12"],
     ["#fail13"],
-    ["#fail14"]
+    ["#fail14"],
+    ["#fail15"]
   ],
   "passes": [
     ["#pass1"],
@@ -69,6 +70,9 @@
     ["#canttell20"],
     ["#canttell21"],
     ["#canttell22"],
-    ["#canttell23"]
+    ["#canttell23"],
+    ["#canttell24"],
+    ["#canttell25"],
+    ["#canttell26"]
   ]
 }


### PR DESCRIPTION
The check now returns incomplete with `emptyValue` when a native text-entry control has no sanitised value and contrast would fail, asking testers to re-run with a value entered. Filled fields with the same colors still fail. Empty fields that already meet the ratio still pass.

Empty text inputs can apply a low-contrast `color` in the empty state and a passing color once a value is entered. color-contrast still matches those fields (intentionally, since PR #2130). The fail was on the empty-state foreground, including when a placeholder was visible.

## Decision

Incomplete-on-fail for empty native textboxes (and password), same shape as `shortTextContent`. The issue called incomplete ideal for this bug and asked for a message that suggests testing with a value set. Matching empty form fields was left in place on purpose in PR #2130, and incomplete-all-empty would flood reports with blank search boxes that already meet 4.5:1.

Alternative: stop matching empty inputs, or incomplete every empty text input including those that already pass. Can switch to unmatched or to incomplete-all-empty.

Placeholder contrast using `::placeholder` color is not implemented here; those cases are incomplete rather than a false fail against the input `color`.

Closes issue #4260
